### PR TITLE
Fix jest paths and missing dependency

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,14 +3,14 @@ const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
 module.exports = {
     ...jestConfig,
     moduleNameMapper: {
-        '^@salesforce/apex$': '<rootDir>/force-app/test/jest-mocks/apex',
-        '^@salesforce/schema$': '<rootDir>/force-app/test/jest-mocks/schema',
+        '^@salesforce/apex$': '<rootDir>/sportsmgmt/test/jest-mocks/apex',
+        '^@salesforce/schema$': '<rootDir>/sportsmgmt/test/jest-mocks/schema',
         '^lightning/navigation$':
-            '<rootDir>/force-app/test/jest-mocks/lightning/navigation',
+            '<rootDir>/sportsmgmt/test/jest-mocks/lightning/navigation',
         '^lightning/platformShowToastEvent$':
-            '<rootDir>/force-app/test/jest-mocks/lightning/platformShowToastEvent',
+            '<rootDir>/sportsmgmt/test/jest-mocks/lightning/platformShowToastEvent',
         '^lightning/messageService$':
-            '<rootDir>/force-app/test/jest-mocks/lightning/messageService'
+            '<rootDir>/sportsmgmt/test/jest-mocks/lightning/messageService'
     },
     setupFiles: ['jest-canvas-mock'],
     testTimeout: 10000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -446,6 +446,7 @@
         "eslint-plugin-jest": "^28.8.1",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
+        "jest-canvas-mock": "^2.5.0",
         "lint-staged": "^15.3.0",
         "prettier": "^3.4.2",
         "prettier-plugin-apex": "^2.2.2"
@@ -3761,6 +3762,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -5866,6 +5874,17 @@
         }
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
@@ -7077,6 +7096,16 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "jest": "^29.7.0",
     "lint-staged": "^15.3.0",
     "prettier": "^3.4.2",
-    "prettier-plugin-apex": "^2.2.2"
+    "prettier-plugin-apex": "^2.2.2",
+    "jest-canvas-mock": "^2.5.0"
   },
   "lint-staged": {
     "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [


### PR DESCRIPTION
## Summary
- fix moduleNameMapper paths in `jest.config.js`
- add missing `jest-canvas-mock` devDependency
- update lockfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849eccaeb2c8326a54b588fa01aefee