### PR TITLE
chore: gitignore certificates and private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ $RECYCLE.BIN/
 # Local environment variables
 .env
 
+# Certificates and private keys
+*.key
+*.crt
+*.pem
+
 # Python Salesforce Functions
 **/__pycache__/
 **/.venv/


### PR DESCRIPTION
Prevents accidental commit of server.key, server.crt, and .pem files used for Salesforce JWT bearer flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to reduce accidental commits of sensitive key/cert artifacts, with no runtime behavior changes.
> 
> **Overview**
> Adds ignore patterns for certificate and private key files (e.g., `*.key`, `*.crt`, `*.pem`) in `.gitignore` to prevent committing TLS/JWT credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a09ebed4674dcf0b6b65845bcc99539cda7a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->