### PR TITLE
feat: Apex REST API endpoints and External App Integration permission set (W-000030)

### DIFF
--- a/sportsmgmt/main/default/classes/rest/DivisionRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/DivisionRestResource.cls
@@ -1,0 +1,45 @@
+/**
+ * @description REST resource for Division data
+ * @author Sports Management Team
+ * @date 2024
+ */
+@RestResource(urlMapping='/sportsmgmt/v1/divisions/*')
+global with sharing class DivisionRestResource {
+    @TestVisible private static DivisionService service = new DivisionService();
+
+    @HttpGet
+    global static void doGet() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/divisions');
+            if (recordId != null) {
+                IDivision division = service.getDivisionByIdAsInterface(recordId);
+                if (division == null) {
+                    res.statusCode = 404;
+                    res.responseBody = Blob.valueOf(JSON.serialize(
+                        RestResponseDto.error('Division not found', 'NOT_FOUND')));
+                    return;
+                }
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createDivisionDto(division))));
+            } else if (RestContext.request.params.containsKey('leagueId')) {
+                String leagueId = RestContext.request.params.get('leagueId');
+                List<IDivision> divisions = service.getDivisionsByLeagueAsInterface(leagueId);
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createDivisionDtoList(divisions))));
+            } else {
+                List<IDivision> divisions = service.getAllDivisionsAsInterface();
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createDivisionDtoList(divisions))));
+            }
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/DivisionRestResource.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/DivisionRestResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/LeagueRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/LeagueRestResource.cls
@@ -1,0 +1,39 @@
+/**
+ * @description REST resource for League data
+ * @author Sports Management Team
+ * @date 2024
+ */
+@RestResource(urlMapping='/sportsmgmt/v1/leagues/*')
+global with sharing class LeagueRestResource {
+    @TestVisible private static LeagueService service = new LeagueService();
+
+    @HttpGet
+    global static void doGet() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/leagues');
+            if (recordId != null) {
+                ILeague league = service.getLeagueByIdAsInterface(recordId);
+                if (league == null) {
+                    res.statusCode = 404;
+                    res.responseBody = Blob.valueOf(JSON.serialize(
+                        RestResponseDto.error('League not found', 'NOT_FOUND')));
+                    return;
+                }
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createLeagueDto(league))));
+            } else {
+                List<ILeague> leagues = service.getAllLeaguesAsInterface();
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createLeagueDtoList(leagues))));
+            }
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/LeagueRestResource.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/LeagueRestResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls
@@ -1,0 +1,45 @@
+/**
+ * @description REST resource for Player data
+ * @author Sports Management Team
+ * @date 2024
+ */
+@RestResource(urlMapping='/sportsmgmt/v1/players/*')
+global with sharing class PlayerRestResource {
+    @TestVisible private static PlayerService service = new PlayerService();
+
+    @HttpGet
+    global static void doGet() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/players');
+            if (recordId != null) {
+                IPlayer player = service.getPlayerByIdAsInterface(recordId);
+                if (player == null) {
+                    res.statusCode = 404;
+                    res.responseBody = Blob.valueOf(JSON.serialize(
+                        RestResponseDto.error('Player not found', 'NOT_FOUND')));
+                    return;
+                }
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createPlayerDto(player))));
+            } else if (RestContext.request.params.containsKey('teamId')) {
+                String teamId = RestContext.request.params.get('teamId');
+                List<IPlayer> players = service.getPlayersByTeamAsInterface(teamId);
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createPlayerDtoList(players))));
+            } else {
+                List<IPlayer> players = service.getAllPlayersAsInterface();
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createPlayerDtoList(players))));
+            }
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/RestResponseDto.cls
+++ b/sportsmgmt/main/default/classes/rest/RestResponseDto.cls
@@ -1,0 +1,176 @@
+/**
+ * @description Standard REST API response envelope with DTO inner classes
+ * @author Sports Management Team
+ * @date 2024
+ */
+public with sharing class RestResponseDto {
+    public Boolean success;
+    public Object data;
+    public String message;
+    public String errorCode;
+
+    public static RestResponseDto success(Object data) {
+        RestResponseDto response = new RestResponseDto();
+        response.success = true;
+        response.data = data;
+        return response;
+    }
+
+    public static RestResponseDto error(String message, String errorCode) {
+        RestResponseDto response = new RestResponseDto();
+        response.success = false;
+        response.message = message;
+        response.errorCode = errorCode;
+        return response;
+    }
+
+    // ── League DTO factory methods ──
+
+    public static LeagueDto createLeagueDto(ILeague league) {
+        LeagueDto dto = new LeagueDto();
+        dto.id = league.getId();
+        dto.name = league.getName();
+        return dto;
+    }
+
+    public static List<LeagueDto> createLeagueDtoList(List<ILeague> leagues) {
+        List<LeagueDto> dtos = new List<LeagueDto>();
+        for (ILeague league : leagues) {
+            dtos.add(createLeagueDto(league));
+        }
+        return dtos;
+    }
+
+    // ── Division DTO factory methods ──
+
+    public static DivisionDto createDivisionDto(IDivision division) {
+        DivisionDto dto = new DivisionDto();
+        dto.id = division.getId();
+        dto.name = division.getName();
+        dto.leagueId = division.getLeagueId();
+        return dto;
+    }
+
+    public static List<DivisionDto> createDivisionDtoList(List<IDivision> divisions) {
+        List<DivisionDto> dtos = new List<DivisionDto>();
+        for (IDivision division : divisions) {
+            dtos.add(createDivisionDto(division));
+        }
+        return dtos;
+    }
+
+    // ── Team DTO factory methods ──
+
+    public static TeamDto createTeamDto(Team__c team) {
+        TeamDto dto = new TeamDto();
+        dto.id = team.Id;
+        dto.name = team.Name;
+        dto.leagueId = team.League__c;
+        dto.city = team.City__c;
+        dto.stadium = team.Stadium__c;
+        dto.foundedYear = team.Founded_Year__c;
+        dto.location = team.Location__c;
+        dto.divisionId = team.Division__c;
+        return dto;
+    }
+
+    public static List<TeamDto> createTeamDtoList(List<Team__c> teams) {
+        List<TeamDto> dtos = new List<TeamDto>();
+        for (Team__c team : teams) {
+            dtos.add(createTeamDto(team));
+        }
+        return dtos;
+    }
+
+    // ── Player DTO factory methods ──
+
+    public static PlayerDto createPlayerDto(IPlayer player) {
+        PlayerDto dto = new PlayerDto();
+        dto.id = player.getId();
+        dto.name = player.getName();
+        dto.teamId = player.getTeamId();
+        dto.position = player.getPosition();
+        dto.jerseyNumber = player.getJerseyNumber();
+        dto.dateOfBirth = player.getDateOfBirth() != null
+            ? String.valueOf(player.getDateOfBirth())
+            : null;
+        dto.status = player.getStatus();
+        return dto;
+    }
+
+    public static List<PlayerDto> createPlayerDtoList(List<IPlayer> players) {
+        List<PlayerDto> dtos = new List<PlayerDto>();
+        for (IPlayer player : players) {
+            dtos.add(createPlayerDto(player));
+        }
+        return dtos;
+    }
+
+    // ── Season DTO factory methods ──
+
+    public static SeasonDto createSeasonDto(ISeason season) {
+        SeasonDto dto = new SeasonDto();
+        dto.id = season.getId();
+        dto.name = season.getName();
+        dto.leagueId = season.getLeagueId();
+        dto.startDate = season.getStartDate() != null
+            ? String.valueOf(season.getStartDate())
+            : null;
+        dto.endDate = season.getEndDate() != null
+            ? String.valueOf(season.getEndDate())
+            : null;
+        dto.status = season.getStatus();
+        return dto;
+    }
+
+    public static List<SeasonDto> createSeasonDtoList(List<ISeason> seasons) {
+        List<SeasonDto> dtos = new List<SeasonDto>();
+        for (ISeason season : seasons) {
+            dtos.add(createSeasonDto(season));
+        }
+        return dtos;
+    }
+
+    // ── Inner DTO classes ──
+
+    public class LeagueDto {
+        public String id;
+        public String name;
+    }
+
+    public class DivisionDto {
+        public String id;
+        public String name;
+        public String leagueId;
+    }
+
+    public class TeamDto {
+        public String id;
+        public String name;
+        public String leagueId;
+        public String city;
+        public String stadium;
+        public Decimal foundedYear;
+        public String location;
+        public String divisionId;
+    }
+
+    public class PlayerDto {
+        public String id;
+        public String name;
+        public String teamId;
+        public String position;
+        public Decimal jerseyNumber;
+        public String dateOfBirth;
+        public String status;
+    }
+
+    public class SeasonDto {
+        public String id;
+        public String name;
+        public String leagueId;
+        public String startDate;
+        public String endDate;
+        public String status;
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/RestResponseDto.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/RestResponseDto.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/RestUtils.cls
+++ b/sportsmgmt/main/default/classes/rest/RestUtils.cls
@@ -1,0 +1,39 @@
+/**
+ * @description Shared utility class for REST resource URI parsing
+ * @author Sports Management Team
+ * @date 2024
+ */
+public with sharing class RestUtils {
+
+    /**
+     * Extracts a record ID from a REST request URI.
+     * @param requestUri The full request URI (e.g., /services/apexrest/sportsmgmt/v1/leagues/a01...)
+     * @param basePath The base path to strip (e.g., /sportsmgmt/v1/leagues)
+     * @return The extracted ID string, or null if no ID segment exists
+     */
+    public static String extractIdFromUri(String requestUri, String basePath) {
+        if (String.isBlank(requestUri) || String.isBlank(basePath)) {
+            return null;
+        }
+
+        // Find the basePath in the URI and extract everything after it
+        Integer baseIndex = requestUri.indexOf(basePath);
+        if (baseIndex < 0) {
+            return null;
+        }
+
+        String remainder = requestUri.substring(baseIndex + basePath.length());
+
+        // Remove leading slash
+        if (remainder.startsWith('/')) {
+            remainder = remainder.substring(1);
+        }
+
+        // Remove trailing slash
+        if (remainder.endsWith('/')) {
+            remainder = remainder.substring(0, remainder.length() - 1);
+        }
+
+        return String.isBlank(remainder) ? null : remainder;
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/RestUtils.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/RestUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/SeasonRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/SeasonRestResource.cls
@@ -1,0 +1,45 @@
+/**
+ * @description REST resource for Season data
+ * @author Sports Management Team
+ * @date 2024
+ */
+@RestResource(urlMapping='/sportsmgmt/v1/seasons/*')
+global with sharing class SeasonRestResource {
+    @TestVisible private static SeasonService service = new SeasonService();
+
+    @HttpGet
+    global static void doGet() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/seasons');
+            if (recordId != null) {
+                ISeason season = service.getSeasonByIdAsInterface(recordId);
+                if (season == null) {
+                    res.statusCode = 404;
+                    res.responseBody = Blob.valueOf(JSON.serialize(
+                        RestResponseDto.error('Season not found', 'NOT_FOUND')));
+                    return;
+                }
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createSeasonDto(season))));
+            } else if (RestContext.request.params.containsKey('leagueId')) {
+                String leagueId = RestContext.request.params.get('leagueId');
+                List<ISeason> seasons = service.getSeasonsByLeagueAsInterface(leagueId);
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createSeasonDtoList(seasons))));
+            } else {
+                List<ISeason> seasons = service.getAllSeasonsAsInterface();
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createSeasonDtoList(seasons))));
+            }
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/SeasonRestResource.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/SeasonRestResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/rest/TeamRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/TeamRestResource.cls
@@ -1,0 +1,45 @@
+/**
+ * @description REST resource for Team data
+ * @author Sports Management Team
+ * @date 2024
+ */
+@RestResource(urlMapping='/sportsmgmt/v1/teams/*')
+global with sharing class TeamRestResource {
+    @TestVisible private static TeamService service = new TeamService();
+
+    @HttpGet
+    global static void doGet() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/teams');
+            if (recordId != null) {
+                Team__c team = service.getTeam(recordId);
+                if (team == null) {
+                    res.statusCode = 404;
+                    res.responseBody = Blob.valueOf(JSON.serialize(
+                        RestResponseDto.error('Team not found', 'NOT_FOUND')));
+                    return;
+                }
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createTeamDto(team))));
+            } else if (RestContext.request.params.containsKey('leagueId')) {
+                String leagueId = RestContext.request.params.get('leagueId');
+                List<Team__c> teams = service.listTeamsByLeague(leagueId);
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createTeamDtoList(teams))));
+            } else {
+                List<Team__c> teams = service.getAllTeams();
+                res.statusCode = 200;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.success(RestResponseDto.createTeamDtoList(teams))));
+            }
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+}

--- a/sportsmgmt/main/default/classes/rest/TeamRestResource.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/rest/TeamRestResource.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/service/LeagueRepository.cls
+++ b/sportsmgmt/main/default/classes/service/LeagueRepository.cls
@@ -1,0 +1,26 @@
+/**
+ * @description Repository class for League__c read operations
+ * @author Sports Management Team
+ * @date 2024
+ */
+public virtual with sharing class LeagueRepository {
+
+    /**
+     * Retrieves a League__c record by Id.
+     */
+    public virtual League__c retrieve(Id leagueId) {
+        if (leagueId == null) {
+            throw new LeagueRepositoryException('League Id cannot be null');
+        }
+        return [SELECT Id, Name FROM League__c WHERE Id = :leagueId LIMIT 1];
+    }
+
+    /**
+     * Returns all leagues ordered by name.
+     */
+    public virtual List<League__c> getAllLeagues() {
+        return [SELECT Id, Name FROM League__c ORDER BY Name LIMIT 50];
+    }
+
+    public class LeagueRepositoryException extends Exception {}
+}

--- a/sportsmgmt/main/default/classes/service/LeagueRepository.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/service/LeagueRepository.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/service/LeagueService.cls
+++ b/sportsmgmt/main/default/classes/service/LeagueService.cls
@@ -1,0 +1,50 @@
+/**
+ * @description Service class for League management with dependency injection support
+ * @author Sports Management Team
+ * @date 2024
+ */
+public virtual with sharing class LeagueService {
+    private LeagueRepository repository;
+
+    /**
+     * Default constructor uses the standard repository implementation.
+     */
+    public LeagueService() {
+        this(new LeagueRepository());
+    }
+
+    /**
+     * Constructor for dependency injection (e.g., for tests).
+     */
+    public LeagueService(LeagueRepository repo) {
+        if (repo == null) {
+            throw new LeagueServiceException('Repository cannot be null');
+        }
+        this.repository = repo;
+    }
+
+    /**
+     * Gets all leagues wrapped in ILeague interface.
+     */
+    public virtual List<ILeague> getAllLeaguesAsInterface() {
+        List<League__c> leagues = repository.getAllLeagues();
+        List<ILeague> wrappedLeagues = new List<ILeague>();
+        for (League__c league : leagues) {
+            wrappedLeagues.add(new LeagueWrapper(league));
+        }
+        return wrappedLeagues;
+    }
+
+    /**
+     * Gets a league by Id wrapped in ILeague interface.
+     */
+    public virtual ILeague getLeagueByIdAsInterface(String leagueId) {
+        if (String.isBlank(leagueId)) {
+            return null;
+        }
+        League__c league = repository.retrieve(leagueId);
+        return league != null ? new LeagueWrapper(league) : null;
+    }
+
+    public class LeagueServiceException extends Exception {}
+}

--- a/sportsmgmt/main/default/classes/service/LeagueService.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/service/LeagueService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/DivisionRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/DivisionRestResourceTest.cls
@@ -1,0 +1,112 @@
+/**
+ * @description Test class for DivisionRestResource
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class DivisionRestResourceTest {
+
+    @TestSetup
+    static void setupTestData() {
+        League__c league = new League__c(Name = 'Test League');
+        insert league;
+
+        List<Division__c> divisions = new List<Division__c>{
+            new Division__c(Name = 'Eastern Division', League__c = league.Id),
+            new Division__c(Name = 'Western Division', League__c = league.Id)
+        };
+        insert divisions;
+    }
+
+    @IsTest
+    static void testGetAllDivisions() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/divisions';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        DivisionRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 divisions');
+    }
+
+    @IsTest
+    static void testGetDivisionById() {
+        // Given
+        Division__c division = [SELECT Id FROM Division__c WHERE Name = 'Eastern Division' LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/divisions/' + division.Id;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        DivisionRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Eastern Division', data.get('name'), 'Should return correct division');
+    }
+
+    @IsTest
+    static void testGetDivisionsByLeagueId() {
+        // Given
+        League__c league = [SELECT Id FROM League__c LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/divisions';
+        req.httpMethod = 'GET';
+        req.params.put('leagueId', league.Id);
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        DivisionRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 divisions for this league');
+    }
+
+    @IsTest
+    static void testGetDivisionById_NotFound() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/divisions/a02000000000099AAA';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        DivisionRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/DivisionRestResourceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/DivisionRestResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/LeagueRepositoryTest.cls
+++ b/sportsmgmt/main/default/classes/tests/LeagueRepositoryTest.cls
@@ -1,0 +1,88 @@
+/**
+ * @description Test class for LeagueRepository with proper test data setup
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class LeagueRepositoryTest {
+
+    @TestSetup
+    static void setupTestData() {
+        List<League__c> testLeagues = new List<League__c>{
+            new League__c(Name = 'Alpha League'),
+            new League__c(Name = 'Beta League')
+        };
+        insert testLeagues;
+    }
+
+    @IsTest
+    static void testRetrieve_ValidId() {
+        // Given
+        League__c testLeague = [SELECT Id FROM League__c WHERE Name = 'Alpha League' LIMIT 1];
+        LeagueRepository repo = new LeagueRepository();
+
+        // When
+        Test.startTest();
+        League__c result = repo.retrieve(testLeague.Id);
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should return league');
+        Assert.areEqual(testLeague.Id, result.Id, 'Should return correct league');
+        Assert.areEqual('Alpha League', result.Name, 'Should return correct name');
+    }
+
+    @IsTest
+    static void testRetrieve_NullId() {
+        // Given
+        LeagueRepository repo = new LeagueRepository();
+
+        // When/Then
+        Test.startTest();
+        try {
+            repo.retrieve(null);
+            Assert.fail('Should throw exception for null ID');
+        } catch (LeagueRepository.LeagueRepositoryException e) {
+            Assert.areEqual('League Id cannot be null', e.getMessage(), 'Should have correct error message');
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testGetAllLeagues() {
+        // Given
+        LeagueRepository repo = new LeagueRepository();
+
+        // When
+        Test.startTest();
+        List<League__c> result = repo.getAllLeagues();
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should return list of leagues');
+        Assert.areEqual(2, result.size(), 'Should return 2 test leagues');
+        // Verify ordering by name
+        Assert.areEqual('Alpha League', result[0].Name, 'Should be ordered by name');
+        Assert.areEqual('Beta League', result[1].Name, 'Should be ordered by name');
+    }
+
+    @IsTest
+    static void testBulkOperations() {
+        // Given
+        List<League__c> bulkLeagues = new List<League__c>();
+        for (Integer i = 1; i <= 10; i++) {
+            bulkLeagues.add(new League__c(Name = 'Bulk League ' + i));
+        }
+        insert bulkLeagues;
+
+        LeagueRepository repo = new LeagueRepository();
+
+        // When
+        Test.startTest();
+        List<League__c> result = repo.getAllLeagues();
+        Test.stopTest();
+
+        // Then
+        Assert.areEqual(12, result.size(), 'Should return all 12 leagues (2 setup + 10 bulk)');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/LeagueRepositoryTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/LeagueRepositoryTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/LeagueRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/LeagueRestResourceTest.cls
@@ -1,0 +1,85 @@
+/**
+ * @description Test class for LeagueRestResource
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class LeagueRestResourceTest {
+
+    @TestSetup
+    static void setupTestData() {
+        List<League__c> leagues = new List<League__c>{
+            new League__c(Name = 'Alpha League'),
+            new League__c(Name = 'Beta League')
+        };
+        insert leagues;
+    }
+
+    @IsTest
+    static void testGetAllLeagues() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/leagues';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        LeagueRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 leagues');
+    }
+
+    @IsTest
+    static void testGetLeagueById() {
+        // Given
+        League__c league = [SELECT Id FROM League__c WHERE Name = 'Alpha League' LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/leagues/' + league.Id;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        LeagueRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Alpha League', data.get('name'), 'Should return correct league name');
+    }
+
+    @IsTest
+    static void testGetLeagueById_NotFound() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/leagues/a01000000000099AAA';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        LeagueRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/LeagueRestResourceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/LeagueRestResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/LeagueServiceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/LeagueServiceTest.cls
@@ -1,0 +1,186 @@
+/**
+ * @description Test class for LeagueService with dependency injection mocking
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class LeagueServiceTest {
+
+    /**
+     * @description Mock repository for testing service layer in isolation
+     */
+    private class MockLeagueRepository extends LeagueRepository {
+        public List<League__c> mockLeagues;
+        public Boolean shouldThrowException = false;
+
+        public MockLeagueRepository() {
+            this.mockLeagues = new List<League__c>();
+        }
+
+        public override League__c retrieve(Id leagueId) {
+            if (shouldThrowException) {
+                throw new LeagueRepositoryException('Mock repository error');
+            }
+            return mockLeagues.isEmpty() ? null : mockLeagues[0];
+        }
+
+        public override List<League__c> getAllLeagues() {
+            if (shouldThrowException) {
+                throw new LeagueRepositoryException('Mock repository error');
+            }
+            return mockLeagues;
+        }
+    }
+
+    @IsTest
+    static void testGetAllLeaguesAsInterface_Success() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        List<League__c> mockLeagues = (List<League__c>)JSON.deserialize(
+            '[' +
+            '  {"sobjectType": "League__c", "Id": "a01000000000001AAA", "Name": "Mock League Alpha"},' +
+            '  {"sobjectType": "League__c", "Id": "a01000000000002AAA", "Name": "Mock League Beta"}' +
+            ']',
+            List<League__c>.class
+        );
+        mockRepo.mockLeagues = mockLeagues;
+        LeagueService service = new LeagueService(mockRepo);
+
+        // When
+        Test.startTest();
+        List<ILeague> result = service.getAllLeaguesAsInterface();
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should return list of ILeague objects');
+        Assert.areEqual(2, result.size(), 'Should return 2 mock leagues');
+        Assert.areEqual('Mock League Alpha', result[0].getName(), 'Should return correct league name');
+    }
+
+    @IsTest
+    static void testGetAllLeaguesAsInterface_EmptyResult() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        mockRepo.mockLeagues = new List<League__c>();
+        LeagueService service = new LeagueService(mockRepo);
+
+        // When
+        Test.startTest();
+        List<ILeague> result = service.getAllLeaguesAsInterface();
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should return empty list, not null');
+        Assert.areEqual(0, result.size(), 'Should return empty list');
+    }
+
+    @IsTest
+    static void testGetLeagueByIdAsInterface_ValidId() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        League__c mockLeague = (League__c)JSON.deserialize(
+            '{"sobjectType": "League__c", "Id": "a01000000000001AAA", "Name": "Mock League Alpha"}',
+            League__c.class
+        );
+        mockRepo.mockLeagues.add(mockLeague);
+        LeagueService service = new LeagueService(mockRepo);
+        String leagueId = 'a01000000000001AAA';
+
+        // When
+        Test.startTest();
+        ILeague result = service.getLeagueByIdAsInterface(leagueId);
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should return ILeague object');
+        Assert.areEqual(leagueId, result.getId(), 'Should return correct league ID');
+        Assert.areEqual('Mock League Alpha', result.getName(), 'Should return correct league name');
+    }
+
+    @IsTest
+    static void testGetLeagueByIdAsInterface_NullId() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        LeagueService service = new LeagueService(mockRepo);
+
+        // When
+        Test.startTest();
+        ILeague resultNull = service.getLeagueByIdAsInterface(null);
+        ILeague resultBlank = service.getLeagueByIdAsInterface('');
+        Test.stopTest();
+
+        // Then
+        Assert.isNull(resultNull, 'Should return null for null ID');
+        Assert.isNull(resultBlank, 'Should return null for blank ID');
+    }
+
+    @IsTest
+    static void testExceptionPropagation_DatabaseError() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        mockRepo.shouldThrowException = true;
+        LeagueService service = new LeagueService(mockRepo);
+
+        // When/Then
+        Test.startTest();
+        try {
+            service.getAllLeaguesAsInterface();
+            Assert.fail('Should propagate exception from repository');
+        } catch (LeagueRepository.LeagueRepositoryException e) {
+            Assert.areEqual('Mock repository error', e.getMessage(), 'Should propagate correct error message');
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testDependencyInjection_NullRepository() {
+        // When/Then
+        Test.startTest();
+        try {
+            LeagueService service = new LeagueService(null);
+            Assert.fail('Should throw exception for null repository');
+        } catch (LeagueService.LeagueServiceException e) {
+            Assert.areEqual('Repository cannot be null', e.getMessage(), 'Should have correct error message');
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testLeagueWrapper_ILeagueImplementation() {
+        // Given
+        League__c mockLeague = (League__c)JSON.deserialize(
+            '{"sobjectType": "League__c", "Id": "a01000000000001AAA", "Name": "Test League"}',
+            League__c.class
+        );
+
+        // When
+        ILeague wrapper = new LeagueWrapper(mockLeague);
+
+        // Then
+        Assert.areEqual(mockLeague.Id, wrapper.getId(), 'Wrapper should return correct ID');
+        Assert.areEqual(mockLeague.Name, wrapper.getName(), 'Wrapper should return correct name');
+    }
+
+    @IsTest
+    static void testBulkOperations_LargeDataSets() {
+        // Given
+        MockLeagueRepository mockRepo = new MockLeagueRepository();
+        List<League__c> bulkLeagues = new List<League__c>();
+        for (Integer i = 1; i <= 200; i++) {
+            bulkLeagues.add(new League__c(Name = 'Bulk League ' + i));
+        }
+        mockRepo.mockLeagues = bulkLeagues;
+        LeagueService service = new LeagueService(mockRepo);
+
+        // When
+        Test.startTest();
+        List<ILeague> result = service.getAllLeaguesAsInterface();
+        Test.stopTest();
+
+        // Then
+        Assert.isNotNull(result, 'Should handle bulk operations');
+        Assert.areEqual(200, result.size(), 'Should return all 200 leagues');
+        Assert.isTrue(Limits.getQueries() <= Limits.getLimitQueries(), 'Should not exceed SOQL query limits');
+        Assert.isTrue(Limits.getCpuTime() <= Limits.getLimitCpuTime(), 'Should not exceed CPU time limits');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/LeagueServiceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/LeagueServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls
@@ -1,0 +1,135 @@
+/**
+ * @description Test class for PlayerRestResource
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class PlayerRestResourceTest {
+
+    @TestSetup
+    static void setupTestData() {
+        League__c league = new League__c(Name = 'Test League');
+        insert league;
+
+        Team__c team = new Team__c(
+            Name = 'Test Team',
+            City__c = 'Test City',
+            Location__c = 'Test City, State',
+            League__c = league.Id
+        );
+        insert team;
+
+        List<Player__c> players = new List<Player__c>{
+            new Player__c(
+                Name = 'Player Alpha',
+                Team__c = team.Id,
+                Position__c = 'Forward',
+                Jersey_Number__c = 10,
+                Date_of_Birth__c = Date.newInstance(1990, 5, 15),
+                Status__c = 'Active'
+            ),
+            new Player__c(
+                Name = 'Player Beta',
+                Team__c = team.Id,
+                Position__c = 'Defender',
+                Jersey_Number__c = 5,
+                Date_of_Birth__c = Date.newInstance(1992, 8, 20),
+                Status__c = 'Active'
+            )
+        };
+        insert players;
+    }
+
+    @IsTest
+    static void testGetAllPlayers() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 players');
+    }
+
+    @IsTest
+    static void testGetPlayerById() {
+        // Given
+        Player__c player = [SELECT Id FROM Player__c WHERE Name = 'Player Alpha' LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players/' + player.Id;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Player Alpha', data.get('name'), 'Should return correct player name');
+        Assert.areEqual('Forward', data.get('position'), 'Should return correct position');
+    }
+
+    @IsTest
+    static void testGetPlayersByTeamId() {
+        // Given
+        Team__c team = [SELECT Id FROM Team__c LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'GET';
+        req.params.put('teamId', team.Id);
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 players for this team');
+    }
+
+    @IsTest
+    static void testGetPlayerById_NotFound() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players/a03000000000099AAA';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/RestResponseDtoTest.cls
+++ b/sportsmgmt/main/default/classes/tests/RestResponseDtoTest.cls
@@ -1,0 +1,244 @@
+/**
+ * @description Test class for RestResponseDto and all DTO inner classes
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class RestResponseDtoTest {
+
+    @IsTest
+    static void testSuccessFactory() {
+        // When
+        RestResponseDto response = RestResponseDto.success('test data');
+
+        // Then
+        Assert.isTrue(response.success, 'Should be success');
+        Assert.areEqual('test data', response.data, 'Should contain data');
+        Assert.isNull(response.message, 'Should have no message');
+        Assert.isNull(response.errorCode, 'Should have no error code');
+    }
+
+    @IsTest
+    static void testErrorFactory() {
+        // When
+        RestResponseDto response = RestResponseDto.error('Something went wrong', 'INTERNAL_ERROR');
+
+        // Then
+        Assert.isFalse(response.success, 'Should not be success');
+        Assert.isNull(response.data, 'Should have no data');
+        Assert.areEqual('Something went wrong', response.message, 'Should contain message');
+        Assert.areEqual('INTERNAL_ERROR', response.errorCode, 'Should contain error code');
+    }
+
+    @IsTest
+    static void testLeagueDto() {
+        // Given
+        ILeague league = new LeagueWrapper('a01000000000001AAA', 'Test League');
+
+        // When
+        RestResponseDto.LeagueDto dto = RestResponseDto.createLeagueDto(league);
+
+        // Then
+        Assert.areEqual('a01000000000001AAA', dto.id, 'Should have correct ID');
+        Assert.areEqual('Test League', dto.name, 'Should have correct name');
+    }
+
+    @IsTest
+    static void testLeagueDtoList() {
+        // Given
+        List<ILeague> leagues = new List<ILeague>{
+            new LeagueWrapper('a01000000000001AAA', 'League A'),
+            new LeagueWrapper('a01000000000002AAA', 'League B')
+        };
+
+        // When
+        List<RestResponseDto.LeagueDto> dtos = RestResponseDto.createLeagueDtoList(leagues);
+
+        // Then
+        Assert.areEqual(2, dtos.size(), 'Should return 2 DTOs');
+        Assert.areEqual('League A', dtos[0].name, 'Should have correct name');
+    }
+
+    @IsTest
+    static void testDivisionDto() {
+        // Given
+        IDivision division = new DivisionWrapper('a02000000000001AAA', 'East', 'a01000000000001AAA');
+
+        // When
+        RestResponseDto.DivisionDto dto = RestResponseDto.createDivisionDto(division);
+
+        // Then
+        Assert.areEqual('a02000000000001AAA', dto.id, 'Should have correct ID');
+        Assert.areEqual('East', dto.name, 'Should have correct name');
+        Assert.areEqual('a01000000000001AAA', dto.leagueId, 'Should have correct league ID');
+    }
+
+    @IsTest
+    static void testDivisionDtoList() {
+        // Given
+        List<IDivision> divisions = new List<IDivision>{
+            new DivisionWrapper('a02000000000001AAA', 'East', 'a01000000000001AAA'),
+            new DivisionWrapper('a02000000000002AAA', 'West', 'a01000000000001AAA')
+        };
+
+        // When
+        List<RestResponseDto.DivisionDto> dtos = RestResponseDto.createDivisionDtoList(divisions);
+
+        // Then
+        Assert.areEqual(2, dtos.size(), 'Should return 2 DTOs');
+    }
+
+    @IsTest
+    static void testTeamDto() {
+        // Given
+        Team__c team = new Team__c(
+            Name = 'Test Team',
+            City__c = 'Test City',
+            Stadium__c = 'Test Stadium',
+            Founded_Year__c = 2020,
+            Location__c = 'Test City, State'
+        );
+
+        // When
+        RestResponseDto.TeamDto dto = RestResponseDto.createTeamDto(team);
+
+        // Then
+        Assert.areEqual('Test Team', dto.name, 'Should have correct name');
+        Assert.areEqual('Test City', dto.city, 'Should have correct city');
+        Assert.areEqual('Test Stadium', dto.stadium, 'Should have correct stadium');
+        Assert.areEqual(2020, dto.foundedYear, 'Should have correct founded year');
+        Assert.areEqual('Test City, State', dto.location, 'Should have correct location');
+    }
+
+    @IsTest
+    static void testTeamDtoList() {
+        // Given
+        List<Team__c> teams = new List<Team__c>{
+            new Team__c(Name = 'Team A'),
+            new Team__c(Name = 'Team B')
+        };
+
+        // When
+        List<RestResponseDto.TeamDto> dtos = RestResponseDto.createTeamDtoList(teams);
+
+        // Then
+        Assert.areEqual(2, dtos.size(), 'Should return 2 DTOs');
+    }
+
+    @IsTest
+    static void testPlayerDto() {
+        // Given
+        Player__c player = new Player__c(
+            Name = 'John Doe',
+            Position__c = 'Forward',
+            Jersey_Number__c = 10,
+            Date_of_Birth__c = Date.newInstance(1990, 5, 15),
+            Status__c = 'Active'
+        );
+        IPlayer playerInterface = new PlayerWrapper(player);
+
+        // When
+        RestResponseDto.PlayerDto dto = RestResponseDto.createPlayerDto(playerInterface);
+
+        // Then
+        Assert.areEqual('John Doe', dto.name, 'Should have correct name');
+        Assert.areEqual('Forward', dto.position, 'Should have correct position');
+        Assert.areEqual(10, dto.jerseyNumber, 'Should have correct jersey number');
+        Assert.areEqual('1990-05-15', dto.dateOfBirth, 'Should have ISO 8601 date');
+        Assert.areEqual('Active', dto.status, 'Should have correct status');
+    }
+
+    @IsTest
+    static void testPlayerDtoList() {
+        // Given
+        List<IPlayer> players = new List<IPlayer>{
+            new PlayerWrapper(new Player__c(Name = 'Player A')),
+            new PlayerWrapper(new Player__c(Name = 'Player B'))
+        };
+
+        // When
+        List<RestResponseDto.PlayerDto> dtos = RestResponseDto.createPlayerDtoList(players);
+
+        // Then
+        Assert.areEqual(2, dtos.size(), 'Should return 2 DTOs');
+    }
+
+    @IsTest
+    static void testPlayerDto_NullDateOfBirth() {
+        // Given
+        Player__c player = new Player__c(Name = 'No DOB Player');
+        IPlayer playerInterface = new PlayerWrapper(player);
+
+        // When
+        RestResponseDto.PlayerDto dto = RestResponseDto.createPlayerDto(playerInterface);
+
+        // Then
+        Assert.isNull(dto.dateOfBirth, 'Should handle null date of birth');
+    }
+
+    @IsTest
+    static void testSeasonDto() {
+        // Given
+        Season__c season = new Season__c(
+            Name = '2024 Season',
+            Start_Date__c = Date.newInstance(2024, 1, 1),
+            End_Date__c = Date.newInstance(2024, 12, 31),
+            Status__c = 'Active'
+        );
+        ISeason seasonInterface = new SeasonWrapper(season);
+
+        // When
+        RestResponseDto.SeasonDto dto = RestResponseDto.createSeasonDto(seasonInterface);
+
+        // Then
+        Assert.areEqual('2024 Season', dto.name, 'Should have correct name');
+        Assert.areEqual('2024-01-01', dto.startDate, 'Should have ISO 8601 start date');
+        Assert.areEqual('2024-12-31', dto.endDate, 'Should have ISO 8601 end date');
+        Assert.areEqual('Active', dto.status, 'Should have correct status');
+    }
+
+    @IsTest
+    static void testSeasonDtoList() {
+        // Given
+        List<ISeason> seasons = new List<ISeason>{
+            new SeasonWrapper(new Season__c(Name = 'Season A')),
+            new SeasonWrapper(new Season__c(Name = 'Season B'))
+        };
+
+        // When
+        List<RestResponseDto.SeasonDto> dtos = RestResponseDto.createSeasonDtoList(seasons);
+
+        // Then
+        Assert.areEqual(2, dtos.size(), 'Should return 2 DTOs');
+    }
+
+    @IsTest
+    static void testSeasonDto_NullDates() {
+        // Given
+        Season__c season = new Season__c(Name = 'No Dates Season');
+        ISeason seasonInterface = new SeasonWrapper(season);
+
+        // When
+        RestResponseDto.SeasonDto dto = RestResponseDto.createSeasonDto(seasonInterface);
+
+        // Then
+        Assert.isNull(dto.startDate, 'Should handle null start date');
+        Assert.isNull(dto.endDate, 'Should handle null end date');
+    }
+
+    @IsTest
+    static void testJsonSerializationStructure() {
+        // Given
+        RestResponseDto response = RestResponseDto.success(
+            new List<RestResponseDto.LeagueDto>()
+        );
+
+        // When
+        String jsonStr = JSON.serialize(response);
+        Map<String, Object> parsed = (Map<String, Object>)JSON.deserializeUntyped(jsonStr);
+
+        // Then
+        Assert.isTrue((Boolean)parsed.get('success'), 'JSON should have success field');
+        Assert.isNotNull(parsed.get('data'), 'JSON should have data field');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/RestResponseDtoTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/RestResponseDtoTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/SeasonRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/SeasonRestResourceTest.cls
@@ -1,0 +1,125 @@
+/**
+ * @description Test class for SeasonRestResource
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class SeasonRestResourceTest {
+
+    @TestSetup
+    static void setupTestData() {
+        League__c league = new League__c(Name = 'Test League');
+        insert league;
+
+        List<Season__c> seasons = new List<Season__c>{
+            new Season__c(
+                Name = '2024 Season',
+                League__c = league.Id,
+                Start_Date__c = Date.newInstance(2024, 1, 1),
+                End_Date__c = Date.newInstance(2024, 12, 31),
+                Status__c = 'Active'
+            ),
+            new Season__c(
+                Name = '2023 Season',
+                League__c = league.Id,
+                Start_Date__c = Date.newInstance(2023, 1, 1),
+                End_Date__c = Date.newInstance(2023, 12, 31),
+                Status__c = 'Completed'
+            )
+        };
+        insert seasons;
+    }
+
+    @IsTest
+    static void testGetAllSeasons() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/seasons';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        SeasonRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 seasons');
+    }
+
+    @IsTest
+    static void testGetSeasonById() {
+        // Given
+        Season__c season = [SELECT Id FROM Season__c WHERE Name = '2024 Season' LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/seasons/' + season.Id;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        SeasonRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('2024 Season', data.get('name'), 'Should return correct season name');
+        Assert.areEqual('Active', data.get('status'), 'Should return correct status');
+    }
+
+    @IsTest
+    static void testGetSeasonsByLeagueId() {
+        // Given
+        League__c league = [SELECT Id FROM League__c LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/seasons';
+        req.httpMethod = 'GET';
+        req.params.put('leagueId', league.Id);
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        SeasonRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 seasons for this league');
+    }
+
+    @IsTest
+    static void testGetSeasonById_NotFound() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/seasons/a04000000000099AAA';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        SeasonRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/SeasonRestResourceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/SeasonRestResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls
@@ -1,0 +1,135 @@
+/**
+ * @description Test class for TeamRestResource
+ * @author Sports Management Team
+ * @date 2024
+ */
+@IsTest
+private class TeamRestResourceTest {
+
+    @TestSetup
+    static void setupTestData() {
+        League__c league = new League__c(Name = 'Test League');
+        insert league;
+
+        Division__c division = new Division__c(Name = 'Test Division', League__c = league.Id);
+        insert division;
+
+        List<Team__c> teams = new List<Team__c>{
+            new Team__c(
+                Name = 'Test Team Alpha',
+                City__c = 'Alpha City',
+                Stadium__c = 'Alpha Stadium',
+                Founded_Year__c = 2020,
+                Location__c = 'Alpha City, State',
+                League__c = league.Id,
+                Division__c = division.Id
+            ),
+            new Team__c(
+                Name = 'Test Team Beta',
+                City__c = 'Beta City',
+                Stadium__c = 'Beta Stadium',
+                Founded_Year__c = 2021,
+                Location__c = 'Beta City, State',
+                League__c = league.Id
+            )
+        };
+        insert teams;
+    }
+
+    @IsTest
+    static void testGetAllTeams() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 teams');
+    }
+
+    @IsTest
+    static void testGetTeamById_VerifyAllFields() {
+        // Given
+        Team__c team = [SELECT Id FROM Team__c WHERE Name = 'Test Team Alpha' LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams/' + team.Id;
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Test Team Alpha', data.get('name'), 'Should have correct name');
+        Assert.areEqual('Alpha City', data.get('city'), 'Should have correct city');
+        Assert.areEqual('Alpha Stadium', data.get('stadium'), 'Should have correct stadium');
+        Assert.areEqual(2020, (Integer)((Decimal)data.get('foundedYear')).intValue(), 'Should have correct founded year');
+        Assert.areEqual('Alpha City, State', data.get('location'), 'Should have correct location');
+        Assert.isNotNull(data.get('divisionId'), 'Should have division ID');
+    }
+
+    @IsTest
+    static void testGetTeamsByLeagueId() {
+        // Given
+        League__c league = [SELECT Id FROM League__c LIMIT 1];
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams';
+        req.httpMethod = 'GET';
+        req.params.put('leagueId', league.Id);
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        List<Object> data = (List<Object>)body.get('data');
+        Assert.areEqual(2, data.size(), 'Should return 2 teams for this league');
+    }
+
+    @IsTest
+    static void testGetTeamById_NotFound() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams/a00000000000099AAA';
+        req.httpMethod = 'GET';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doGet();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
+    }
+}

--- a/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/util/ILeague.cls
+++ b/sportsmgmt/main/default/classes/util/ILeague.cls
@@ -1,0 +1,16 @@
+/**
+ * @description Interface for League objects to support service layer abstraction
+ * @author Sports Management Team
+ * @date 2024
+ */
+public interface ILeague {
+    /**
+     * Gets the record Id of the league.
+     */
+    Id getId();
+
+    /**
+     * Gets the name of the league.
+     */
+    String getName();
+}

--- a/sportsmgmt/main/default/classes/util/ILeague.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/util/ILeague.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/classes/util/LeagueWrapper.cls
+++ b/sportsmgmt/main/default/classes/util/LeagueWrapper.cls
@@ -1,0 +1,51 @@
+/**
+ * @description Wrapper class for League__c records implementing ILeague interface
+ * @author Sports Management Team
+ * @date 2024
+ */
+public class LeagueWrapper implements ILeague {
+    private League__c originalRecord;
+    private Id leagueId;
+    private String leagueName;
+
+    /**
+     * Constructor that takes a League__c record and wraps it
+     */
+    public LeagueWrapper(League__c league) {
+        if (league != null) {
+            this.originalRecord = league;
+            this.leagueId = league.Id;
+            this.leagueName = league.Name;
+        }
+    }
+
+    /**
+     * Constructor for creating new league instances
+     */
+    public LeagueWrapper(Id id, String name) {
+        this.leagueId = id;
+        this.leagueName = name;
+        this.originalRecord = null;
+    }
+
+    /**
+     * Gets the record Id of the league.
+     */
+    public Id getId() {
+        return this.leagueId;
+    }
+
+    /**
+     * Gets the name of the league.
+     */
+    public String getName() {
+        return this.leagueName;
+    }
+
+    /**
+     * Gets the original League__c record if available
+     */
+    public League__c getOriginalRecord() {
+        return this.originalRecord;
+    }
+}

--- a/sportsmgmt/main/default/classes/util/LeagueWrapper.cls-meta.xml
+++ b/sportsmgmt/main/default/classes/util/LeagueWrapper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sportsmgmt/main/default/permissionsets/External_App_Integration.permissionset-meta.xml
+++ b/sportsmgmt/main/default/permissionsets/External_App_Integration.permissionset-meta.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>API-only read access for external application integration (e.g., Next.js frontend via jsforce)</description>
+    <label>External App Integration</label>
+
+    <!-- League__c: Read Only -->
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>League__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+
+    <!-- Team__c: Read Only -->
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Team__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+
+    <!-- Division__c: Read Only -->
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Division__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+
+    <!-- Season__c: Read Only -->
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Season__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+
+    <!-- Player__c: Read Only -->
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Player__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+
+    <!-- Team__c Fields (Read Only) -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Team__c.City__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Team__c.Stadium__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Team__c.Founded_Year__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Team__c.Division__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+
+    <!-- Season__c Fields (Read Only) -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Season__c.Status__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+
+    <!-- Player__c Fields (Read Only) -->
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Player__c.Position__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Player__c.Jersey_Number__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Player__c.Date_of_Birth__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Player__c.Status__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+
+    <!-- Apex Class Access for REST Resources -->
+    <classAccesses>
+        <apexClass>LeagueRestResource</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DivisionRestResource</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>TeamRestResource</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>PlayerRestResource</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>SeasonRestResource</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+
+    <!-- Apex Class Access for Shared Utilities -->
+    <classAccesses>
+        <apexClass>RestResponseDto</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>RestUtils</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+
+    <!-- Apex Class Access for Service Classes -->
+    <classAccesses>
+        <apexClass>LeagueService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>LeagueRepository</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DivisionService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>DivisionRepository</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>TeamService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>TeamRepository</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>PlayerService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>PlayerRepository</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>SeasonService</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>SeasonRepository</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+</PermissionSet>


### PR DESCRIPTION
## Summary
- **League service layer**: Added `ILeague`, `LeagueWrapper`, `LeagueRepository`, `LeagueService` to fill the missing service layer for League__c, maintaining architectural consistency with the other 4 objects
- **REST API**: Created 5 REST resource classes (`/sportsmgmt/v1/leagues|divisions|teams|players|seasons/*`) with standard response envelope (`RestResponseDto`), supporting GET all, GET by ID, and filtered GET (by leagueId/teamId)
- **Permission set**: Added `External_App_Integration` with read-only object/field permissions and Apex class access for all REST and service classes (API-only, no tab visibility)

## What's included (39 new files)
- 4 League service layer classes + 4 meta.xml
- 7 REST classes (5 resources + RestResponseDto + RestUtils) + 7 meta.xml
- 8 test classes + 8 meta.xml
- 1 permission set

## Test plan
- [x] Deployed to scratch org successfully (97 components)
- [x] All 225 Apex tests pass (100% pass rate)
- [x] All 37 LWC Jest tests pass
- [x] New REST classes have 83-100% code coverage
- [ ] Manual verification: `GET /services/apexrest/sportsmgmt/v1/leagues` returns JSON with success envelope
- [ ] Assign `External_App_Integration` permission set to connected app user

🤖 Generated with [Claude Code](https://claude.com/claude-code)