### PR TITLE
feat: add mutation support for team managers (W-000033)

### DIFF
--- a/apps/web/src/app/api/players/[id]/route.ts
+++ b/apps/web/src/app/api/players/[id]/route.ts
@@ -1,10 +1,12 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getPlayer } from "@/lib/salesforce-api";
+import { getPlayer, updatePlayer, deletePlayer } from "@/lib/salesforce-api";
+import { UpdatePlayerInputSchema } from "@sports-management/api-contracts";
+import { authorizeTeamMutation } from "@/lib/authorization";
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { userId } = await auth();
   if (!userId) {
@@ -13,4 +15,61 @@ export async function GET(
   const { id } = await params;
   const data = await getPlayer(id);
   return NextResponse.json(data);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const existing = await getPlayer(id);
+
+  const authorization = await authorizeTeamMutation(existing.teamId);
+  if (!authorization.isAuthorized) {
+    return NextResponse.json(
+      { error: "You are not authorized to manage this team" },
+      { status: 403 },
+    );
+  }
+
+  const body = await request.json();
+  const parsed = UpdatePlayerInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const data = await updatePlayer(id, parsed.data);
+  return NextResponse.json(data);
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const existing = await getPlayer(id);
+
+  const authorization = await authorizeTeamMutation(existing.teamId);
+  if (!authorization.isAuthorized) {
+    return NextResponse.json(
+      { error: "You are not authorized to manage this team" },
+      { status: 403 },
+    );
+  }
+
+  await deletePlayer(id);
+  return NextResponse.json({ success: true });
 }

--- a/apps/web/src/app/api/players/route.ts
+++ b/apps/web/src/app/api/players/route.ts
@@ -1,6 +1,8 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { getPlayers, getPlayersByTeam } from "@/lib/salesforce-api";
+import { getPlayers, getPlayersByTeam, createPlayer } from "@/lib/salesforce-api";
+import { CreatePlayerInputSchema } from "@sports-management/api-contracts";
+import { authorizeTeamMutation } from "@/lib/authorization";
 
 export async function GET(request: NextRequest) {
   const { userId } = await auth();
@@ -10,4 +12,31 @@ export async function GET(request: NextRequest) {
   const teamId = request.nextUrl.searchParams.get("teamId");
   const data = teamId ? await getPlayersByTeam(teamId) : await getPlayers();
   return NextResponse.json(data);
+}
+
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const parsed = CreatePlayerInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const authorization = await authorizeTeamMutation(parsed.data.teamId);
+  if (!authorization.isAuthorized) {
+    return NextResponse.json(
+      { error: "You are not authorized to manage this team" },
+      { status: 403 },
+    );
+  }
+
+  const data = await createPlayer(parsed.data);
+  return NextResponse.json(data, { status: 201 });
 }

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -1,10 +1,12 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getTeam, getPlayersByTeam } from "@/lib/salesforce-api";
+import { getTeam, getPlayersByTeam, updateTeam } from "@/lib/salesforce-api";
+import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
+import { authorizeTeamMutation } from "@/lib/authorization";
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { userId } = await auth();
   if (!userId) {
@@ -16,4 +18,36 @@ export async function GET(
     getPlayersByTeam(id),
   ]);
   return NextResponse.json({ team, players });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const authorization = await authorizeTeamMutation(id);
+  if (!authorization.isAuthorized) {
+    return NextResponse.json(
+      { error: "You are not authorized to manage this team" },
+      { status: 403 },
+    );
+  }
+
+  const body = await request.json();
+  const parsed = UpdateTeamInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const data = await updateTeam(id, parsed.data);
+  return NextResponse.json(data);
 }

--- a/apps/web/src/app/dashboard/_components/delete-confirm.tsx
+++ b/apps/web/src/app/dashboard/_components/delete-confirm.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+interface DeleteConfirmProps {
+  title: string;
+  message: string;
+  isOpen: boolean;
+  isDeleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteConfirm({
+  title,
+  message,
+  isOpen,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: DeleteConfirmProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        <p className="mt-2 text-sm text-gray-600">{message}</p>
+        <div className="mt-4 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isDeleting}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import type { PlayerDto } from "@sports-management/shared-types";
+import {
+  CreatePlayerInputSchema,
+  UpdatePlayerInputSchema,
+} from "@sports-management/api-contracts";
+
+interface PlayerFormProps {
+  mode: "create" | "edit";
+  teamId: string;
+  player?: PlayerDto;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export default function PlayerForm({
+  mode,
+  teamId,
+  player,
+  onSuccess,
+  onCancel,
+}: PlayerFormProps) {
+  const [name, setName] = useState(player?.name ?? "");
+  const [position, setPosition] = useState(player?.position ?? "");
+  const [jerseyNumber, setJerseyNumber] = useState(
+    player?.jerseyNumber?.toString() ?? "",
+  );
+  const [dateOfBirth, setDateOfBirth] = useState(player?.dateOfBirth ?? "");
+  const [status, setStatus] = useState(player?.status ?? "Active");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const data = {
+        name,
+        teamId,
+        position,
+        jerseyNumber: jerseyNumber ? Number(jerseyNumber) : null,
+        dateOfBirth: dateOfBirth || null,
+        status,
+      };
+
+      if (mode === "create") {
+        const parsed = CreatePlayerInputSchema.safeParse(data);
+        if (!parsed.success) {
+          setError(parsed.error.errors[0].message);
+          return;
+        }
+        const res = await fetch("/api/players", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(parsed.data),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error ?? "Failed to create player");
+        }
+      } else {
+        const parsed = UpdatePlayerInputSchema.safeParse(data);
+        if (!parsed.success) {
+          setError(parsed.error.errors[0].message);
+          return;
+        }
+        const res = await fetch(`/api/players/${player!.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(parsed.data),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error ?? "Failed to update player");
+        }
+      }
+
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900">
+          {mode === "create" ? "Add Player" : "Edit Player"}
+        </h3>
+
+        {error && (
+          <div className="mt-2 rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Name *
+            </label>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Position *
+            </label>
+            <input
+              type="text"
+              required
+              value={position}
+              onChange={(e) => setPosition(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Jersey Number
+            </label>
+            <input
+              type="number"
+              value={jerseyNumber}
+              onChange={(e) => setJerseyNumber(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Date of Birth
+            </label>
+            <input
+              type="date"
+              value={dateOfBirth}
+              onChange={(e) => setDateOfBirth(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Status *
+            </label>
+            <select
+              required
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="Active">Active</option>
+              <option value="Injured">Injured</option>
+              <option value="Inactive">Inactive</option>
+            </select>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={submitting}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting
+                ? "Saving..."
+                : mode === "create"
+                  ? "Add Player"
+                  : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import type { TeamDto } from "@sports-management/shared-types";
+import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
+
+interface TeamEditFormProps {
+  team: TeamDto;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export default function TeamEditForm({
+  team,
+  onSuccess,
+  onCancel,
+}: TeamEditFormProps) {
+  const [name, setName] = useState(team.name);
+  const [city, setCity] = useState(team.city);
+  const [stadium, setStadium] = useState(team.stadium);
+  const [foundedYear, setFoundedYear] = useState(
+    team.foundedYear?.toString() ?? "",
+  );
+  const [location, setLocation] = useState(team.location);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const data = {
+        name,
+        city,
+        stadium,
+        foundedYear: foundedYear ? Number(foundedYear) : null,
+        location,
+      };
+
+      const parsed = UpdateTeamInputSchema.safeParse(data);
+      if (!parsed.success) {
+        setError(parsed.error.errors[0].message);
+        return;
+      }
+
+      const res = await fetch(`/api/teams/${team.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "Failed to update team");
+      }
+
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900">Edit Team</h3>
+
+        {error && (
+          <div className="mt-2 rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              City
+            </label>
+            <input
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Stadium
+            </label>
+            <input
+              type="text"
+              value={stadium}
+              onChange={(e) => setStadium(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Founded Year
+            </label>
+            <input
+              type="number"
+              value={foundedYear}
+              onChange={(e) => setFoundedYear(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Location
+            </label>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={submitting}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting ? "Saving..." : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { getTeam, getPlayersByTeam } from "@/lib/salesforce-api";
+import { canManageTeam } from "@/lib/authorization";
+import TeamManagement from "./team-management";
 
 export default async function TeamDetailPage({
   params,
@@ -7,9 +9,10 @@ export default async function TeamDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const [team, players] = await Promise.all([
+  const [team, players, canManage] = await Promise.all([
     getTeam(id),
     getPlayersByTeam(id),
+    canManageTeam(id),
   ]);
 
   return (
@@ -21,81 +24,7 @@ export default async function TeamDetailPage({
         &larr; Back to Teams
       </Link>
 
-      <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900">{team.name}</h2>
-        <dl className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
-          {team.city && (
-            <div>
-              <dt className="font-medium text-gray-500">City</dt>
-              <dd className="mt-1 text-gray-900">{team.city}</dd>
-            </div>
-          )}
-          {team.stadium && (
-            <div>
-              <dt className="font-medium text-gray-500">Stadium</dt>
-              <dd className="mt-1 text-gray-900">{team.stadium}</dd>
-            </div>
-          )}
-          {team.foundedYear && (
-            <div>
-              <dt className="font-medium text-gray-500">Founded</dt>
-              <dd className="mt-1 text-gray-900">{team.foundedYear}</dd>
-            </div>
-          )}
-          {team.location && (
-            <div>
-              <dt className="font-medium text-gray-500">Location</dt>
-              <dd className="mt-1 text-gray-900">{team.location}</dd>
-            </div>
-          )}
-        </dl>
-      </div>
-
-      <h3 className="mb-4 text-lg font-semibold text-gray-900">
-        Player Roster ({players.length})
-      </h3>
-      {players.length > 0 ? (
-        <div className="overflow-x-auto rounded-lg border border-gray-200">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                  Name
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                  Position
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                  Jersey #
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
-              {players.map((player) => (
-                <tr key={player.id}>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
-                    {player.name}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
-                    {player.position}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
-                    {player.jerseyNumber ?? "—"}
-                  </td>
-                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
-                    {player.status}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-gray-500">No players on this team.</p>
-      )}
+      <TeamManagement team={team} players={players} canManage={canManage} />
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { TeamDto, PlayerDto } from "@sports-management/shared-types";
+import PlayerForm from "../../_components/player-form";
+import TeamEditForm from "../../_components/team-edit-form";
+import DeleteConfirm from "../../_components/delete-confirm";
+
+interface TeamManagementProps {
+  team: TeamDto;
+  players: PlayerDto[];
+  canManage: boolean;
+}
+
+type ModalState =
+  | { type: "none" }
+  | { type: "editTeam" }
+  | { type: "addPlayer" }
+  | { type: "editPlayer"; player: PlayerDto }
+  | { type: "deletePlayer"; player: PlayerDto };
+
+export default function TeamManagement({
+  team,
+  players,
+  canManage,
+}: TeamManagementProps) {
+  const router = useRouter();
+  const [modal, setModal] = useState<ModalState>({ type: "none" });
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  function handleSuccess() {
+    setModal({ type: "none" });
+    router.refresh();
+  }
+
+  async function handleDeletePlayer(playerId: string) {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/players/${playerId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "Failed to delete player");
+      }
+      handleSuccess();
+    } catch {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start justify-between">
+          <h2 className="text-2xl font-bold text-gray-900">{team.name}</h2>
+          {canManage && (
+            <button
+              type="button"
+              onClick={() => setModal({ type: "editTeam" })}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Edit Team
+            </button>
+          )}
+        </div>
+        <dl className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+          {team.city && (
+            <div>
+              <dt className="font-medium text-gray-500">City</dt>
+              <dd className="mt-1 text-gray-900">{team.city}</dd>
+            </div>
+          )}
+          {team.stadium && (
+            <div>
+              <dt className="font-medium text-gray-500">Stadium</dt>
+              <dd className="mt-1 text-gray-900">{team.stadium}</dd>
+            </div>
+          )}
+          {team.foundedYear && (
+            <div>
+              <dt className="font-medium text-gray-500">Founded</dt>
+              <dd className="mt-1 text-gray-900">{team.foundedYear}</dd>
+            </div>
+          )}
+          {team.location && (
+            <div>
+              <dt className="font-medium text-gray-500">Location</dt>
+              <dd className="mt-1 text-gray-900">{team.location}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">
+          Player Roster ({players.length})
+        </h3>
+        {canManage && (
+          <button
+            type="button"
+            onClick={() => setModal({ type: "addPlayer" })}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90"
+          >
+            Add Player
+          </button>
+        )}
+      </div>
+
+      {players.length > 0 ? (
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Name
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Position
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Jersey #
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Status
+                </th>
+                {canManage && (
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Actions
+                  </th>
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {players.map((player) => (
+                <tr key={player.id}>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                    {player.name}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                    {player.position}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                    {player.jerseyNumber ?? "\u2014"}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-600">
+                    {player.status}
+                  </td>
+                  {canManage && (
+                    <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setModal({ type: "editPlayer", player })
+                        }
+                        className="mr-2 text-primary hover:underline"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setModal({ type: "deletePlayer", player })
+                        }
+                        className="text-red-600 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-gray-500">No players on this team.</p>
+      )}
+
+      {modal.type === "editTeam" && (
+        <TeamEditForm
+          team={team}
+          onSuccess={handleSuccess}
+          onCancel={() => setModal({ type: "none" })}
+        />
+      )}
+
+      {modal.type === "addPlayer" && (
+        <PlayerForm
+          mode="create"
+          teamId={team.id}
+          onSuccess={handleSuccess}
+          onCancel={() => setModal({ type: "none" })}
+        />
+      )}
+
+      {modal.type === "editPlayer" && (
+        <PlayerForm
+          mode="edit"
+          teamId={team.id}
+          player={modal.player}
+          onSuccess={handleSuccess}
+          onCancel={() => setModal({ type: "none" })}
+        />
+      )}
+
+      {modal.type === "deletePlayer" && (
+        <DeleteConfirm
+          title="Delete Player"
+          message={`Are you sure you want to delete ${modal.player.name}? This action cannot be undone.`}
+          isOpen
+          isDeleting={isDeleting}
+          onConfirm={() => handleDeletePlayer(modal.player.id)}
+          onCancel={() => setModal({ type: "none" })}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -1,0 +1,31 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+export interface AuthorizationResult {
+  userId: string;
+  authorizedTeamIds: string[];
+  isAuthorized: boolean;
+}
+
+export async function authorizeTeamMutation(
+  teamId: string,
+): Promise<AuthorizationResult> {
+  const { userId } = await auth();
+  if (!userId) {
+    return { userId: "", authorizedTeamIds: [], isAuthorized: false };
+  }
+
+  const user = await currentUser();
+  const managedTeamIds =
+    (user?.publicMetadata?.managedTeamIds as string[]) ?? [];
+
+  return {
+    userId,
+    authorizedTeamIds: managedTeamIds,
+    isAuthorized: managedTeamIds.includes(teamId),
+  };
+}
+
+export async function canManageTeam(teamId: string): Promise<boolean> {
+  const result = await authorizeTeamMutation(teamId);
+  return result.isAuthorized;
+}

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -6,6 +6,9 @@ import type {
   TeamDto,
   PlayerDto,
   SeasonDto,
+  CreatePlayerInput,
+  UpdatePlayerInput,
+  UpdateTeamInput,
 } from "@sports-management/shared-types";
 
 const BASE = "/services/apexrest/sportsmgmt/v1";
@@ -13,6 +16,24 @@ const BASE = "/services/apexrest/sportsmgmt/v1";
 async function request<T>(path: string): Promise<T> {
   const conn = await getSalesforceConnection();
   const res = (await conn.request(`${BASE}${path}`)) as ApiResponse<T>;
+  if (!res.success) {
+    throw new Error(res.message ?? "Salesforce API error");
+  }
+  return res.data;
+}
+
+async function mutate<T>(
+  path: string,
+  method: "POST" | "PUT" | "DELETE",
+  body?: unknown,
+): Promise<T> {
+  const conn = await getSalesforceConnection();
+  const res = (await conn.request({
+    url: `${conn.instanceUrl}${BASE}${path}`,
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: { "Content-Type": "application/json" },
+  })) as ApiResponse<T>;
   if (!res.success) {
     throw new Error(res.message ?? "Salesforce API error");
   }
@@ -66,4 +87,28 @@ export function getSeasons(): Promise<SeasonDto[]> {
 
 export function getSeason(id: string): Promise<SeasonDto> {
   return request<SeasonDto>(`/seasons/${id}`);
+}
+
+// Player mutations
+export function createPlayer(input: CreatePlayerInput): Promise<PlayerDto> {
+  return mutate<PlayerDto>("/players", "POST", input);
+}
+
+export function updatePlayer(
+  id: string,
+  input: UpdatePlayerInput,
+): Promise<PlayerDto> {
+  return mutate<PlayerDto>(`/players/${id}`, "PUT", input);
+}
+
+export function deletePlayer(id: string): Promise<null> {
+  return mutate<null>(`/players/${id}`, "DELETE");
+}
+
+// Team mutations
+export function updateTeam(
+  id: string,
+  input: UpdateTeamInput,
+): Promise<TeamDto> {
+  return mutate<TeamDto>(`/teams/${id}`, "PUT", input);
 }

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -6,6 +6,9 @@ import type {
   TeamDto,
   PlayerDto,
   SeasonDto,
+  CreatePlayerInput,
+  UpdatePlayerInput,
+  UpdateTeamInput,
 } from "@sports-management/shared-types";
 
 // --- Entity schemas ---
@@ -50,6 +53,35 @@ export const SeasonDtoSchema = z.object({
   endDate: z.string().nullable(),
   status: z.string(),
 }) satisfies z.ZodType<SeasonDto>;
+
+// --- Mutation input schemas ---
+
+export const CreatePlayerInputSchema = z.object({
+  name: z.string().min(1),
+  teamId: z.string().min(1),
+  position: z.string().min(1),
+  jerseyNumber: z.number().nullable().optional(),
+  dateOfBirth: z.string().nullable().optional(),
+  status: z.string().min(1),
+}) satisfies z.ZodType<CreatePlayerInput>;
+
+export const UpdatePlayerInputSchema = z.object({
+  name: z.string().min(1).optional(),
+  teamId: z.string().min(1).optional(),
+  position: z.string().min(1).optional(),
+  jerseyNumber: z.number().nullable().optional(),
+  dateOfBirth: z.string().nullable().optional(),
+  status: z.string().min(1).optional(),
+}) satisfies z.ZodType<UpdatePlayerInput>;
+
+export const UpdateTeamInputSchema = z.object({
+  name: z.string().min(1).optional(),
+  city: z.string().min(1).optional(),
+  stadium: z.string().min(1).optional(),
+  foundedYear: z.number().nullable().optional(),
+  location: z.string().min(1).optional(),
+  divisionId: z.string().min(1).optional(),
+}) satisfies z.ZodType<UpdateTeamInput>;
 
 // --- API envelope factory ---
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -45,3 +45,32 @@ export interface SeasonDto {
   endDate: string | null;
   status: string;
 }
+
+// --- Mutation input types ---
+
+export interface CreatePlayerInput {
+  name: string;
+  teamId: string;
+  position: string;
+  jerseyNumber?: number | null;
+  dateOfBirth?: string | null;
+  status: string;
+}
+
+export interface UpdatePlayerInput {
+  name?: string;
+  teamId?: string;
+  position?: string;
+  jerseyNumber?: number | null;
+  dateOfBirth?: string | null;
+  status?: string;
+}
+
+export interface UpdateTeamInput {
+  name?: string;
+  city?: string;
+  stadium?: string;
+  foundedYear?: number | null;
+  location?: string;
+  divisionId?: string;
+}

--- a/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/PlayerRestResource.cls
@@ -42,4 +42,109 @@ global with sharing class PlayerRestResource {
                 RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
         }
     }
+
+    @HttpPost
+    global static void doPost() {
+        RestResponse res = RestContext.response;
+        try {
+            Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+                RestContext.request.requestBody.toString());
+
+            String name = (String)body.get('name');
+            String teamId = (String)body.get('teamId');
+            if (String.isBlank(name) || String.isBlank(teamId)) {
+                res.statusCode = 400;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.error('name and teamId are required', 'VALIDATION_ERROR')));
+                return;
+            }
+
+            String position = (String)body.get('position');
+            Decimal jerseyNumber = body.get('jerseyNumber') != null
+                ? Decimal.valueOf(String.valueOf(body.get('jerseyNumber'))) : null;
+            Date dateOfBirth = body.get('dateOfBirth') != null
+                ? Date.valueOf((String)body.get('dateOfBirth')) : null;
+            String status = (String)body.get('status');
+
+            PlayerWrapper wrapper = new PlayerWrapper(
+                null, name, teamId, position, jerseyNumber, dateOfBirth, status);
+            Id newId = service.createPlayer(wrapper);
+
+            IPlayer created = service.getPlayerByIdAsInterface(newId);
+            res.statusCode = 201;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.success(RestResponseDto.createPlayerDto(created))));
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+
+    @HttpPut
+    global static void doPut() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/players');
+            if (String.isBlank(recordId)) {
+                res.statusCode = 400;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.error('Player ID is required in the URL', 'VALIDATION_ERROR')));
+                return;
+            }
+
+            Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+                RestContext.request.requestBody.toString());
+
+            Player__c record = new Player__c(Id = recordId);
+            if (body.containsKey('name')) record.Name = (String)body.get('name');
+            if (body.containsKey('position')) record.Position__c = (String)body.get('position');
+            if (body.containsKey('jerseyNumber')) {
+                record.Jersey_Number__c = body.get('jerseyNumber') != null
+                    ? Decimal.valueOf(String.valueOf(body.get('jerseyNumber'))) : null;
+            }
+            if (body.containsKey('dateOfBirth')) {
+                record.Date_of_Birth__c = body.get('dateOfBirth') != null
+                    ? Date.valueOf((String)body.get('dateOfBirth')) : null;
+            }
+            if (body.containsKey('status')) record.Status__c = (String)body.get('status');
+            if (body.containsKey('teamId')) record.Team__c = (String)body.get('teamId');
+
+            service.updatePlayer(record);
+
+            IPlayer updated = service.getPlayerByIdAsInterface(recordId);
+            res.statusCode = 200;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.success(RestResponseDto.createPlayerDto(updated))));
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
+
+    @HttpDelete
+    global static void doDelete() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/players');
+            if (String.isBlank(recordId)) {
+                res.statusCode = 400;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.error('Player ID is required in the URL', 'VALIDATION_ERROR')));
+                return;
+            }
+
+            service.deletePlayer(recordId);
+            res.statusCode = 200;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.success(null)));
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
 }

--- a/sportsmgmt/main/default/classes/rest/TeamRestResource.cls
+++ b/sportsmgmt/main/default/classes/rest/TeamRestResource.cls
@@ -42,4 +42,44 @@ global with sharing class TeamRestResource {
                 RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
         }
     }
+
+    @HttpPut
+    global static void doPut() {
+        RestResponse res = RestContext.response;
+        try {
+            String recordId = RestUtils.extractIdFromUri(
+                RestContext.request.requestURI, '/sportsmgmt/v1/teams');
+            if (String.isBlank(recordId)) {
+                res.statusCode = 400;
+                res.responseBody = Blob.valueOf(JSON.serialize(
+                    RestResponseDto.error('Team ID is required in the URL', 'VALIDATION_ERROR')));
+                return;
+            }
+
+            Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+                RestContext.request.requestBody.toString());
+
+            Team__c record = new Team__c(Id = recordId);
+            if (body.containsKey('name')) record.Name = (String)body.get('name');
+            if (body.containsKey('city')) record.City__c = (String)body.get('city');
+            if (body.containsKey('stadium')) record.Stadium__c = (String)body.get('stadium');
+            if (body.containsKey('foundedYear')) {
+                record.Founded_Year__c = body.get('foundedYear') != null
+                    ? Decimal.valueOf(String.valueOf(body.get('foundedYear'))) : null;
+            }
+            if (body.containsKey('location')) record.Location__c = (String)body.get('location');
+            if (body.containsKey('divisionId')) record.Division__c = (String)body.get('divisionId');
+
+            service.updateTeam(record);
+
+            Team__c updated = service.getTeam(recordId);
+            res.statusCode = 200;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.success(RestResponseDto.createTeamDto(updated))));
+        } catch (Exception e) {
+            res.statusCode = 500;
+            res.responseBody = Blob.valueOf(JSON.serialize(
+                RestResponseDto.error(e.getMessage(), 'INTERNAL_ERROR')));
+        }
+    }
 }

--- a/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/PlayerRestResourceTest.cls
@@ -132,4 +132,170 @@ private class PlayerRestResourceTest {
         RestResponse res = RestContext.response;
         Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
     }
+
+    @IsTest
+    static void testCreatePlayer_Success() {
+        // Given
+        Team__c team = [SELECT Id FROM Team__c LIMIT 1];
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'name' => 'New Player',
+            'teamId' => team.Id,
+            'position' => 'Midfielder',
+            'jerseyNumber' => 7,
+            'dateOfBirth' => '1995-03-10',
+            'status' => 'Active'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doPost();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(201, res.statusCode, 'Should return 201');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('New Player', data.get('name'), 'Should return correct name');
+        Assert.areEqual('Midfielder', data.get('position'), 'Should return correct position');
+    }
+
+    @IsTest
+    static void testCreatePlayer_MissingName() {
+        // Given
+        Team__c team = [SELECT Id FROM Team__c LIMIT 1];
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'teamId' => team.Id,
+            'position' => 'Midfielder'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doPost();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(400, res.statusCode, 'Should return 400 for missing name');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isFalse((Boolean)body.get('success'), 'Should not be successful');
+    }
+
+    @IsTest
+    static void testUpdatePlayer_Success() {
+        // Given
+        Player__c player = [SELECT Id FROM Player__c WHERE Name = 'Player Alpha' LIMIT 1];
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'name' => 'Player Alpha Updated',
+            'position' => 'Goalkeeper'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players/' + player.Id;
+        req.httpMethod = 'PUT';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doPut();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Player Alpha Updated', data.get('name'), 'Should return updated name');
+        Assert.areEqual('Goalkeeper', data.get('position'), 'Should return updated position');
+    }
+
+    @IsTest
+    static void testUpdatePlayer_NoId() {
+        // Given
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'name' => 'Updated Name'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'PUT';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doPut();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(400, res.statusCode, 'Should return 400 for missing ID');
+    }
+
+    @IsTest
+    static void testDeletePlayer_Success() {
+        // Given
+        Player__c player = [SELECT Id FROM Player__c WHERE Name = 'Player Beta' LIMIT 1];
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players/' + player.Id;
+        req.httpMethod = 'DELETE';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doDelete();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+
+        List<Player__c> remaining = [SELECT Id FROM Player__c WHERE Id = :player.Id];
+        Assert.areEqual(0, remaining.size(), 'Player should be deleted');
+    }
+
+    @IsTest
+    static void testDeletePlayer_NoId() {
+        // Given
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/players';
+        req.httpMethod = 'DELETE';
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        PlayerRestResource.doDelete();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(400, res.statusCode, 'Should return 400 for missing ID');
+    }
 }

--- a/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls
+++ b/sportsmgmt/main/default/classes/tests/TeamRestResourceTest.cls
@@ -132,4 +132,62 @@ private class TeamRestResourceTest {
         RestResponse res = RestContext.response;
         Assert.isTrue(res.statusCode == 404 || res.statusCode == 500, 'Should return error status');
     }
+
+    @IsTest
+    static void testUpdateTeam_Success() {
+        // Given
+        Team__c team = [SELECT Id FROM Team__c WHERE Name = 'Test Team Alpha' LIMIT 1];
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'name' => 'Updated Team Alpha',
+            'city' => 'New City',
+            'stadium' => 'New Stadium'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams/' + team.Id;
+        req.httpMethod = 'PUT';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doPut();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(200, res.statusCode, 'Should return 200');
+        Map<String, Object> body = (Map<String, Object>)JSON.deserializeUntyped(
+            res.responseBody.toString());
+        Assert.isTrue((Boolean)body.get('success'), 'Should be successful');
+        Map<String, Object> data = (Map<String, Object>)body.get('data');
+        Assert.areEqual('Updated Team Alpha', data.get('name'), 'Should return updated name');
+        Assert.areEqual('New City', data.get('city'), 'Should return updated city');
+        Assert.areEqual('New Stadium', data.get('stadium'), 'Should return updated stadium');
+    }
+
+    @IsTest
+    static void testUpdateTeam_NoId() {
+        // Given
+        Map<String, Object> requestBody = new Map<String, Object>{
+            'name' => 'Updated Name'
+        };
+
+        RestRequest req = new RestRequest();
+        req.requestURI = '/services/apexrest/sportsmgmt/v1/teams';
+        req.httpMethod = 'PUT';
+        req.requestBody = Blob.valueOf(JSON.serialize(requestBody));
+        RestContext.request = req;
+        RestContext.response = new RestResponse();
+
+        // When
+        Test.startTest();
+        TeamRestResource.doPut();
+        Test.stopTest();
+
+        // Then
+        RestResponse res = RestContext.response;
+        Assert.areEqual(400, res.statusCode, 'Should return 400 for missing ID');
+    }
 }

--- a/sportsmgmt/main/default/permissionsets/External_App_Integration.permissionset-meta.xml
+++ b/sportsmgmt/main/default/permissionsets/External_App_Integration.permissionset-meta.xml
@@ -14,11 +14,11 @@
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
 
-    <!-- Team__c: Read Only -->
+    <!-- Team__c: Read + Edit -->
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>
-        <allowEdit>false</allowEdit>
+        <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Team__c</object>
@@ -47,35 +47,35 @@
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
 
-    <!-- Player__c: Read Only -->
+    <!-- Player__c: Create + Edit + Delete -->
     <objectPermissions>
-        <allowCreate>false</allowCreate>
-        <allowDelete>false</allowDelete>
-        <allowEdit>false</allowEdit>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Player__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
 
-    <!-- Team__c Fields (Read Only) -->
+    <!-- Team__c Fields (Editable) -->
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Team__c.City__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Team__c.Stadium__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Team__c.Founded_Year__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Team__c.Division__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -87,24 +87,24 @@
         <readable>true</readable>
     </fieldPermissions>
 
-    <!-- Player__c Fields (Read Only) -->
+    <!-- Player__c Fields (Editable) -->
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Player__c.Position__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Player__c.Jersey_Number__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Player__c.Date_of_Birth__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Player__c.Status__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
## Summary
- Add `doPost`/`doPut`/`doDelete` to `PlayerRestResource` and `doPut` to `TeamRestResource` for full CRUD via Apex REST
- Update `External_App_Integration` permission set: Player__c create/edit/delete, Team__c edit, all writable fields editable
- Add `CreatePlayerInput`, `UpdatePlayerInput`, `UpdateTeamInput` types in `shared-types` and Zod schemas in `api-contracts`
- Add BFF mutation routes (`POST /api/players`, `PUT/DELETE /api/players/[id]`, `PUT /api/teams/[id]`) with Clerk-based authorization via `publicMetadata.managedTeamIds`
- Create client-side management UI: `TeamManagement` orchestrator, `PlayerForm`, `TeamEditForm`, and `DeleteConfirm` dialog components

## Test plan
- [x] `sf project deploy start --source-dir sportsmgmt` — deploy succeeds
- [x] `sf apex test run --wait 10` — 233 tests pass (100% pass rate)
- [x] `pnpm turbo build` — all packages build successfully
- [x] `pnpm turbo type-check` — all type checks pass
- [x] `pnpm exec jest --config jest.config.js` — 37 Jest tests pass
- [ ] Manually verify: set `managedTeamIds` in Clerk user metadata, confirm Add/Edit/Delete player and Edit team work in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)