### PR TITLE
fix: enable Corepack before setup-node in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The Semantic Release job failed because `actions/setup-node` with `cache: 'pnpm'` tried to locate pnpm before Corepack was enabled. Swapped the two steps — Corepack first, then setup-node. Matches the working pattern in ci.yml.