### PR TITLE
feat: add JSON data import for leagues, teams, and players

### DIFF
--- a/apps/tui/src/cli.tsx
+++ b/apps/tui/src/cli.tsx
@@ -7,11 +7,12 @@ const cli = meow(
     $ pnpm tui [command]
 
   Commands
-    login          Authenticate with sprtsmng by pasting an API key
+    login                Authenticate with sprtsmng by pasting an API key
     leagues              Browse leagues (list view)
     seasons              Browse seasons
     divisions            Browse divisions
     import-teams <csv>   Bulk import teams from a CSV file
+    import-json <json>   Import leagues, teams, and players from a JSON file
     (no command)         Launch the interactive TUI
 
   Environment
@@ -41,6 +42,20 @@ if (command === "login") {
   const { runImportTeams } = await import("./commands/import-teams.js");
   try {
     await runImportTeams(csvPath);
+    process.exit(0);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+} else if (command === "import-json") {
+  const jsonPath = cli.input[1];
+  if (!jsonPath) {
+    console.error("Usage: pnpm tui import-json <path-to-json>");
+    process.exit(1);
+  }
+  const { runImportJson } = await import("./commands/import-json.js");
+  try {
+    await runImportJson(jsonPath);
     process.exit(0);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/apps/tui/src/commands/import-json.ts
+++ b/apps/tui/src/commands/import-json.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import { getApiBaseUrl } from "../lib/config.js";
+import { importJson } from "../lib/api.js";
+import { readCredentials } from "../lib/credentials.js";
+
+export async function runImportJson(jsonPath: string): Promise<void> {
+  const creds = await readCredentials();
+  if (!creds) {
+    throw new Error("Not authenticated. Run 'pnpm tui login' first.");
+  }
+
+  // Read JSON file
+  let raw: string;
+  try {
+    raw = await readFile(jsonPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Cannot read file: ${jsonPath} (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  // Parse JSON
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    throw new Error("File is not valid JSON.");
+  }
+
+  // Validate against schema
+  const parsed = LeagueImportSchema.safeParse(json);
+  if (!parsed.success) {
+    const issues = parsed.error.issues;
+    console.error(`\nValidation failed (${issues.length} error(s)):\n`);
+    for (const issue of issues) {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      console.error(`  ${path}: ${issue.message}`);
+    }
+    console.error();
+    throw new Error("Fix the errors above and try again.");
+  }
+
+  // Preview
+  const data = parsed.data;
+  let teamCount = 0;
+  let playerCount = 0;
+  for (const div of data.divisions) {
+    teamCount += div.teams.length;
+    for (const team of div.teams) {
+      playerCount += team.players.length;
+    }
+  }
+
+  console.log(`\nImport preview:\n`);
+  console.log(`  League:    ${data.league.name}`);
+  console.log(`  Divisions: ${data.divisions.length}`);
+  console.log(`  Teams:     ${teamCount}`);
+  console.log(`  Players:   ${playerCount}`);
+  console.log();
+
+  // Confirm
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let answer: string;
+  try {
+    answer = (await rl.question("Proceed with import? [y/N] ")).trim().toLowerCase();
+  } finally {
+    rl.close();
+  }
+
+  if (answer !== "y" && answer !== "yes") {
+    console.log("Cancelled.");
+    return;
+  }
+
+  // Import
+  const baseUrl = getApiBaseUrl();
+  console.log("\nImporting...");
+  const result = await importJson(baseUrl, creds.apiKey, json);
+
+  // Summary
+  console.log("\nImport complete:");
+  console.log(`  Leagues:   ${result.created.leagues} created, ${result.updated.leagues} updated`);
+  console.log(`  Divisions: ${result.created.divisions} created, ${result.updated.divisions} updated`);
+  console.log(`  Teams:     ${result.created.teams} created, ${result.updated.teams} updated`);
+  console.log(`  Players:   ${result.created.players} created, ${result.updated.players} updated`);
+
+  if (result.errors.length > 0) {
+    console.log(`\n  Errors (${result.errors.length}):`);
+    for (const err of result.errors) {
+      console.log(`    ${err.entity} "${err.name}": ${err.message}`);
+    }
+  }
+}

--- a/apps/tui/src/lib/api.ts
+++ b/apps/tui/src/lib/api.ts
@@ -263,3 +263,30 @@ export async function verifyApiKey(
   );
   return (await res.json()) as WhoamiResponse;
 }
+
+export interface ImportResultDto {
+  leagueId: string;
+  created: { leagues: number; divisions: number; teams: number; players: number };
+  updated: { leagues: number; divisions: number; teams: number; players: number };
+  errors: Array<{ entity: string; name: string; message: string }>;
+}
+
+export async function importJson(
+  baseUrl: string,
+  apiKey: string,
+  payload: unknown,
+): Promise<ImportResultDto> {
+  const res = await instrumentedFetch(
+    `${baseUrl}/api/cli/import`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    "Failed to import data",
+  );
+  return (await res.json()) as ImportResultDto;
+}

--- a/apps/web/src/app/api/cli/import/route.ts
+++ b/apps/web/src/app/api/cli/import/route.ts
@@ -1,0 +1,57 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse, type NextRequest } from "next/server";
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import { bulkImportLeague } from "@/lib/salesforce-api";
+import { handleApiError } from "@/lib/api-error";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/cli/import
+ *
+ * Validates a nested JSON import payload against LeagueImportSchema,
+ * then upserts all entities (league, divisions, teams, players) into Salesforce.
+ * Returns an ImportResult with created/updated counts and any entity-level errors.
+ *
+ * Accepts both session cookies and Clerk API keys.
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await auth({
+    acceptsToken: ["session_token", "api_key"],
+  });
+
+  if (authResult.tokenType === null) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  if (!authResult.userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = LeagueImportSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        details: parsed.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await bulkImportLeague(parsed.data);
+    return NextResponse.json(result);
+  } catch (error) {
+    return handleApiError(error, "/api/cli/import POST");
+  }
+}

--- a/apps/web/src/app/dashboard/_components/sidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Calendar,
   Layers,
   Trophy,
+  Upload,
   CreditCard,
 } from "lucide-react";
 import NavLink from "./nav-link";
@@ -18,6 +19,7 @@ const navItems = [
   { href: "/dashboard/players", label: "Players", icon: UserCircle },
   { href: "/dashboard/seasons", label: "Seasons", icon: Calendar },
   { href: "/dashboard/divisions", label: "Divisions", icon: Layers },
+  { href: "/dashboard/import", label: "Import", icon: Upload },
   { href: "/dashboard/billing", label: "Billing", icon: CreditCard },
 ];
 

--- a/apps/web/src/app/dashboard/import/_components/import-form.tsx
+++ b/apps/web/src/app/dashboard/import/_components/import-form.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import type { ImportResult } from "@sports-management/shared-types";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Upload, FileJson, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+
+type ValidationError = {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
+};
+
+interface Preview {
+  leagueName: string;
+  divisionCount: number;
+  teamCount: number;
+  playerCount: number;
+}
+
+type FormState =
+  | { step: "idle" }
+  | { step: "invalid"; fileName: string; errors: ValidationError }
+  | { step: "preview"; fileName: string; preview: Preview; rawPayload: unknown }
+  | { step: "importing"; fileName: string }
+  | { step: "done"; fileName: string; result: ImportResult };
+
+function computePreview(data: ReturnType<typeof LeagueImportSchema.parse>): Preview {
+  let teamCount = 0;
+  let playerCount = 0;
+  for (const div of data.divisions) {
+    teamCount += div.teams.length;
+    for (const team of div.teams) {
+      playerCount += team.players.length;
+    }
+  }
+  return {
+    leagueName: data.league.name,
+    divisionCount: data.divisions.length,
+    teamCount,
+    playerCount,
+  };
+}
+
+export function ImportForm() {
+  const [state, setState] = useState<FormState>({ step: "idle" });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback((file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      let json: unknown;
+      try {
+        json = JSON.parse(e.target?.result as string);
+      } catch {
+        setState({
+          step: "invalid",
+          fileName: file.name,
+          errors: { formErrors: ["File is not valid JSON"], fieldErrors: {} },
+        });
+        return;
+      }
+
+      const parsed = LeagueImportSchema.safeParse(json);
+      if (!parsed.success) {
+        setState({
+          step: "invalid",
+          fileName: file.name,
+          errors: parsed.error.flatten(),
+        });
+        return;
+      }
+
+      setState({
+        step: "preview",
+        fileName: file.name,
+        preview: computePreview(parsed.data),
+        rawPayload: json,
+      });
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (file) handleFile(file);
+    },
+    [handleFile],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFile(file);
+    },
+    [handleFile],
+  );
+
+  const handleImport = useCallback(async () => {
+    if (state.step !== "preview") return;
+    const { fileName, rawPayload } = state;
+
+    setState({ step: "importing", fileName });
+
+    try {
+      const res = await fetch("/api/cli/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(rawPayload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(
+          body?.error ?? `Import failed: ${res.status} ${res.statusText}`,
+        );
+      }
+
+      const result: ImportResult = await res.json();
+      setState({ step: "done", fileName, result });
+
+      if (result.errors.length > 0) {
+        toast.warning(
+          `Import completed with ${result.errors.length} error(s)`,
+        );
+      } else {
+        toast.success("Import completed successfully");
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Import failed");
+      setState({ step: "idle" });
+    }
+  }, [state]);
+
+  const handleReset = useCallback(() => {
+    setState({ step: "idle" });
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {/* File Upload Area */}
+      <Card>
+        <CardHeader>
+          <CardTitle>JSON Import</CardTitle>
+          <CardDescription>
+            Upload a JSON file containing league, division, team, and player
+            data. Existing records are matched by name and updated.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => fileInputRef.current?.click()}
+            className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-8 transition-colors hover:border-primary hover:bg-gray-50"
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click();
+            }}
+            aria-label="Upload JSON file"
+          >
+            <Upload className="mb-3 h-8 w-8 text-gray-400" />
+            <p className="text-sm text-gray-600">
+              Drop a <code>.json</code> file here or click to browse
+            </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleInputChange}
+              className="hidden"
+              aria-label="Choose JSON file"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Validation Errors */}
+      {state.step === "invalid" && (
+        <Card className="border-red-200">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-red-700">
+              <AlertCircle className="h-5 w-5" />
+              Validation Failed
+            </CardTitle>
+            <CardDescription>
+              <FileJson className="mr-1 inline h-4 w-4" />
+              {state.fileName}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div role="alert" className="space-y-2">
+              {state.errors.formErrors.map((err, i) => (
+                <p key={i} className="text-sm text-red-600">
+                  {err}
+                </p>
+              ))}
+              {Object.entries(state.errors.fieldErrors).map(([field, errs]) =>
+                errs.map((err, i) => (
+                  <p key={`${field}-${i}`} className="text-sm text-red-600">
+                    <code className="mr-1 rounded bg-red-50 px-1 text-xs">
+                      {field}
+                    </code>
+                    {err}
+                  </p>
+                )),
+              )}
+            </div>
+            <Button variant="outline" className="mt-4" onClick={handleReset}>
+              Try another file
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Preview */}
+      {state.step === "preview" && (
+        <Card className="border-primary/30">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileJson className="h-5 w-5" />
+              Ready to Import
+            </CardTitle>
+            <CardDescription>{state.fileName}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <div className="rounded-md bg-gray-50 p-3 text-center">
+                <p className="text-2xl font-bold">{state.preview.leagueName}</p>
+                <p className="text-xs text-gray-500">League</p>
+              </div>
+              <div className="rounded-md bg-gray-50 p-3 text-center">
+                <p className="text-2xl font-bold">{state.preview.divisionCount}</p>
+                <p className="text-xs text-gray-500">Divisions</p>
+              </div>
+              <div className="rounded-md bg-gray-50 p-3 text-center">
+                <p className="text-2xl font-bold">{state.preview.teamCount}</p>
+                <p className="text-xs text-gray-500">Teams</p>
+              </div>
+              <div className="rounded-md bg-gray-50 p-3 text-center">
+                <p className="text-2xl font-bold">{state.preview.playerCount}</p>
+                <p className="text-xs text-gray-500">Players</p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleImport}>Start Import</Button>
+              <Button variant="outline" onClick={handleReset}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Importing */}
+      {state.step === "importing" && (
+        <Card>
+          <CardContent className="flex items-center gap-3 py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" />
+            <p className="text-sm text-gray-600">
+              Importing data from {state.fileName}...
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Result */}
+      {state.step === "done" && (
+        <Card className="border-green-200">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-green-700">
+              <CheckCircle2 className="h-5 w-5" />
+              Import Complete
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {(["leagues", "divisions", "teams", "players"] as const).map(
+                (entity) => (
+                  <div key={entity} className="rounded-md bg-gray-50 p-3">
+                    <p className="text-xs font-medium capitalize text-gray-500">
+                      {entity}
+                    </p>
+                    <p className="text-sm">
+                      <span className="font-semibold text-green-700">
+                        {state.result.created[entity]} created
+                      </span>
+                      {", "}
+                      <span className="text-gray-600">
+                        {state.result.updated[entity]} updated
+                      </span>
+                    </p>
+                  </div>
+                ),
+              )}
+            </div>
+
+            {state.result.errors.length > 0 && (
+              <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3">
+                <p className="mb-2 text-sm font-medium text-red-700">
+                  {state.result.errors.length} error(s) during import:
+                </p>
+                {state.result.errors.map((err, i) => (
+                  <p key={i} className="text-sm text-red-600">
+                    {err.entity} &quot;{err.name}&quot;: {err.message}
+                  </p>
+                ))}
+              </div>
+            )}
+
+            <Button variant="outline" onClick={handleReset}>
+              Import another file
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -1,0 +1,12 @@
+import { ImportForm } from "./_components/import-form";
+
+export default function ImportPage() {
+  return (
+    <div>
+      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+        Import Data
+      </h2>
+      <ImportForm />
+    </div>
+  );
+}

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -10,7 +10,10 @@ import type {
   UpdatePlayerInput,
   CreateTeamInput,
   UpdateTeamInput,
+  ImportResult,
+  ImportError,
 } from "@sports-management/shared-types";
+import type { LeagueImportPayload } from "@sports-management/api-contracts";
 
 const BASE = "/services/apexrest/sportsmgmt/v1";
 
@@ -122,4 +125,248 @@ export function updateTeam(
   input: UpdateTeamInput,
 ): Promise<TeamDto> {
   return mutate<TeamDto>(`/teams/${id}`, "PUT", input);
+}
+
+// --- Upsert functions (direct sObject operations for import) ---
+
+export async function upsertLeague(name: string): Promise<{ dto: LeagueDto; created: boolean }> {
+  const conn = await getSalesforceConnection();
+  const existing = await conn.query<{ Id: string; Name: string }>(
+    `SELECT Id, Name FROM League__c WHERE Name = '${name.replace(/'/g, "\\'")}'  LIMIT 1`,
+  );
+
+  if (existing.totalSize > 0) {
+    const rec = existing.records[0];
+    return { dto: { id: rec.Id, name: rec.Name }, created: false };
+  }
+
+  const result = await conn.sobject("League__c").create({ Name: name });
+  if (!result.success) {
+    throw new Error(`Failed to create league: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
+  }
+  return { dto: { id: result.id, name }, created: true };
+}
+
+export async function upsertDivision(
+  name: string,
+  leagueId: string,
+): Promise<{ dto: DivisionDto; created: boolean }> {
+  const conn = await getSalesforceConnection();
+  const existing = await conn.query<{ Id: string; Name: string; League__c: string }>(
+    `SELECT Id, Name, League__c FROM Division__c WHERE Name = '${name.replace(/'/g, "\\'")}' AND League__c = '${leagueId}' LIMIT 1`,
+  );
+
+  if (existing.totalSize > 0) {
+    const rec = existing.records[0];
+    return { dto: { id: rec.Id, name: rec.Name, leagueId: rec.League__c }, created: false };
+  }
+
+  const result = await conn.sobject("Division__c").create({ Name: name, League__c: leagueId });
+  if (!result.success) {
+    throw new Error(`Failed to create division: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
+  }
+  return { dto: { id: result.id, name, leagueId }, created: true };
+}
+
+export async function upsertTeam(input: {
+  name: string;
+  city: string;
+  stadium: string;
+  leagueId: string;
+  divisionId: string;
+}): Promise<{ dto: TeamDto; created: boolean }> {
+  const conn = await getSalesforceConnection();
+  const existing = await conn.query<{
+    Id: string; Name: string; League__c: string; City__c: string;
+    Stadium__c: string; Founded_Year__c: number | null;
+    Location__c: string; Division__c: string;
+  }>(
+    `SELECT Id, Name, League__c, City__c, Stadium__c, Founded_Year__c, Location__c, Division__c FROM Team__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND League__c = '${input.leagueId}' LIMIT 1`,
+  );
+
+  const toDto = (rec: {
+    Id: string; Name: string; League__c: string; City__c: string;
+    Stadium__c: string; Founded_Year__c: number | null;
+    Location__c: string; Division__c: string;
+  }): TeamDto => ({
+    id: rec.Id,
+    name: rec.Name,
+    leagueId: rec.League__c,
+    city: rec.City__c ?? "",
+    stadium: rec.Stadium__c ?? "",
+    foundedYear: rec.Founded_Year__c ?? null,
+    location: rec.Location__c ?? "",
+    divisionId: rec.Division__c ?? "",
+  });
+
+  if (existing.totalSize > 0) {
+    const rec = existing.records[0];
+    await conn.sobject("Team__c").update({
+      Id: rec.Id,
+      City__c: input.city,
+      Stadium__c: input.stadium,
+      Division__c: input.divisionId,
+    });
+    const updated = { ...rec, City__c: input.city, Stadium__c: input.stadium, Division__c: input.divisionId };
+    return { dto: toDto(updated), created: false };
+  }
+
+  const result = await conn.sobject("Team__c").create({
+    Name: input.name,
+    League__c: input.leagueId,
+    City__c: input.city,
+    Stadium__c: input.stadium,
+    Division__c: input.divisionId,
+  });
+  if (!result.success) {
+    throw new Error(`Failed to create team: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
+  }
+  return {
+    dto: toDto({
+      Id: result.id, Name: input.name, League__c: input.leagueId,
+      City__c: input.city, Stadium__c: input.stadium,
+      Founded_Year__c: null, Location__c: "", Division__c: input.divisionId,
+    }),
+    created: true,
+  };
+}
+
+export async function upsertPlayer(input: {
+  name: string;
+  teamId: string;
+  position: string;
+  jerseyNumber?: number | null;
+  dateOfBirth?: string | null;
+  status: string;
+}): Promise<{ dto: PlayerDto; created: boolean }> {
+  const conn = await getSalesforceConnection();
+  const existing = await conn.query<{
+    Id: string; Name: string; Team__c: string; Position__c: string;
+    Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
+  }>(
+    `SELECT Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c FROM Player__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND Team__c = '${input.teamId}' LIMIT 1`,
+  );
+
+  const toDto = (rec: {
+    Id: string; Name: string; Team__c: string; Position__c: string;
+    Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
+  }): PlayerDto => ({
+    id: rec.Id,
+    name: rec.Name,
+    teamId: rec.Team__c,
+    position: rec.Position__c ?? "",
+    jerseyNumber: rec.Jersey_Number__c ?? null,
+    dateOfBirth: rec.Date_of_Birth__c ?? null,
+    status: rec.Status__c ?? "",
+  });
+
+  if (existing.totalSize > 0) {
+    const rec = existing.records[0];
+    await conn.sobject("Player__c").update({
+      Id: rec.Id,
+      Position__c: input.position,
+      Jersey_Number__c: input.jerseyNumber ?? null,
+      Date_of_Birth__c: input.dateOfBirth ?? null,
+      Status__c: input.status,
+    });
+    return {
+      dto: toDto({
+        ...rec,
+        Position__c: input.position,
+        Jersey_Number__c: input.jerseyNumber ?? null,
+        Date_of_Birth__c: input.dateOfBirth ?? null,
+        Status__c: input.status,
+      }),
+      created: false,
+    };
+  }
+
+  const result = await conn.sobject("Player__c").create({
+    Name: input.name,
+    Team__c: input.teamId,
+    Position__c: input.position,
+    Jersey_Number__c: input.jerseyNumber ?? null,
+    Date_of_Birth__c: input.dateOfBirth ?? null,
+    Status__c: input.status,
+  });
+  if (!result.success) {
+    throw new Error(`Failed to create player: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
+  }
+  return {
+    dto: toDto({
+      Id: result.id, Name: input.name, Team__c: input.teamId,
+      Position__c: input.position, Jersey_Number__c: input.jerseyNumber ?? null,
+      Date_of_Birth__c: input.dateOfBirth ?? null, Status__c: input.status,
+    }),
+    created: true,
+  };
+}
+
+// --- Bulk import orchestrator ---
+
+export async function bulkImportLeague(
+  payload: LeagueImportPayload,
+): Promise<ImportResult> {
+  const errors: ImportError[] = [];
+  const created = { leagues: 0, divisions: 0, teams: 0, players: 0 };
+  const updated = { leagues: 0, divisions: 0, teams: 0, players: 0 };
+
+  // 1. Upsert league
+  let leagueId: string;
+  try {
+    const leagueResult = await upsertLeague(payload.league.name);
+    leagueId = leagueResult.dto.id;
+    if (leagueResult.created) created.leagues++; else updated.leagues++;
+  } catch (err) {
+    throw new Error(`Failed to upsert league "${payload.league.name}": ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 2. Upsert divisions, then teams within each division, then players within each team
+  for (const div of payload.divisions) {
+    let divisionId: string;
+    try {
+      const divResult = await upsertDivision(div.name, leagueId);
+      divisionId = divResult.dto.id;
+      if (divResult.created) created.divisions++; else updated.divisions++;
+    } catch (err) {
+      errors.push({ entity: "division", name: div.name, message: err instanceof Error ? err.message : String(err) });
+      continue; // skip teams in this division
+    }
+
+    for (const team of div.teams) {
+      let teamId: string;
+      try {
+        const teamResult = await upsertTeam({
+          name: team.name,
+          city: team.city,
+          stadium: team.stadium,
+          leagueId,
+          divisionId,
+        });
+        teamId = teamResult.dto.id;
+        if (teamResult.created) created.teams++; else updated.teams++;
+      } catch (err) {
+        errors.push({ entity: "team", name: team.name, message: err instanceof Error ? err.message : String(err) });
+        continue; // skip players on this team
+      }
+
+      for (const player of team.players) {
+        try {
+          const playerResult = await upsertPlayer({
+            name: player.name,
+            teamId,
+            position: player.position,
+            jerseyNumber: player.jerseyNumber,
+            dateOfBirth: player.dateOfBirth,
+            status: player.status,
+          });
+          if (playerResult.created) created.players++; else updated.players++;
+        } catch (err) {
+          errors.push({ entity: "player", name: player.name, message: err instanceof Error ? err.message : String(err) });
+        }
+      }
+    }
+  }
+
+  return { leagueId, created, updated, errors };
 }

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -11,13 +11,15 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@sports-management/shared-types": "workspace:*",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/api-contracts/src/__tests__/import-schema.test.ts
+++ b/packages/api-contracts/src/__tests__/import-schema.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { LeagueImportSchema } from "../import-schema.js";
+
+const validPayload = {
+  league: { name: "NFL" },
+  divisions: [
+    {
+      name: "NFC East",
+      teams: [
+        {
+          name: "Dallas Cowboys",
+          city: "Dallas",
+          stadium: "AT&T Stadium",
+          players: [
+            { name: "Dak Prescott", position: "QB", jerseyNumber: 4 },
+            { name: "CeeDee Lamb", position: "WR", jerseyNumber: 88, status: "Active" },
+          ],
+        },
+        {
+          name: "Philadelphia Eagles",
+          city: "Philadelphia",
+          stadium: "Lincoln Financial Field",
+        },
+      ],
+    },
+    {
+      name: "AFC East",
+      teams: [
+        {
+          name: "New England Patriots",
+          city: "Foxborough",
+          stadium: "Gillette Stadium",
+          players: [
+            { name: "Drake Maye", position: "QB", jerseyNumber: 10, dateOfBirth: "2002-09-30" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("LeagueImportSchema", () => {
+  it("accepts a valid nested payload", () => {
+    const result = LeagueImportSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.league.name).toBe("NFL");
+      expect(result.data.divisions).toHaveLength(2);
+      expect(result.data.divisions[0].teams).toHaveLength(2);
+      expect(result.data.divisions[0].teams[0].players).toHaveLength(2);
+    }
+  });
+
+  it("defaults player status to Active when omitted", () => {
+    const result = LeagueImportSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const player = result.data.divisions[0].teams[0].players[0];
+      expect(player.status).toBe("Active");
+    }
+  });
+
+  it("defaults players to empty array when omitted", () => {
+    const result = LeagueImportSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const eagles = result.data.divisions[0].teams[1];
+      expect(eagles.players).toEqual([]);
+    }
+  });
+
+  it("rejects when league name is missing", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "" },
+      divisions: validPayload.divisions,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when league object is missing", () => {
+    const result = LeagueImportSchema.safeParse({
+      divisions: validPayload.divisions,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when divisions array is empty", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "NFL" },
+      divisions: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.map((i) => i.message).join(", ");
+      expect(msg).toContain("At least one division is required");
+    }
+  });
+
+  it("rejects when a division has no teams", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "NFL" },
+      divisions: [{ name: "NFC East", teams: [] }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.map((i) => i.message).join(", ");
+      expect(msg).toContain("Each division must have at least one team");
+    }
+  });
+
+  it("rejects when team is missing required fields", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "NFL" },
+      divisions: [
+        {
+          name: "NFC East",
+          teams: [{ name: "Cowboys" }], // missing city + stadium
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("divisions.0.teams.0.city");
+      expect(paths).toContain("divisions.0.teams.0.stadium");
+    }
+  });
+
+  it("rejects when player is missing required fields", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "NFL" },
+      divisions: [
+        {
+          name: "NFC East",
+          teams: [
+            {
+              name: "Cowboys",
+              city: "Dallas",
+              stadium: "AT&T Stadium",
+              players: [{ name: "" }], // empty name + missing position
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("divisions.0.teams.0.players.0.name");
+      expect(paths).toContain("divisions.0.teams.0.players.0.position");
+    }
+  });
+
+  it("collects multiple errors across the tree", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "" },
+      divisions: [
+        {
+          name: "",
+          teams: [
+            {
+              name: "",
+              city: "",
+              stadium: "AT&T Stadium",
+              players: [{ name: "", position: "" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Should have errors for: league.name, divisions[0].name, team.name, team.city, player.name, player.position
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(6);
+    }
+  });
+
+  it("strips unknown fields", () => {
+    const result = LeagueImportSchema.safeParse({
+      league: { name: "NFL", unknown: "field" },
+      divisions: [
+        {
+          name: "NFC East",
+          extra: true,
+          teams: [
+            {
+              name: "Cowboys",
+              city: "Dallas",
+              stadium: "AT&T Stadium",
+              foo: "bar",
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data.league as Record<string, unknown>)["unknown"]).toBeUndefined();
+    }
+  });
+});

--- a/packages/api-contracts/src/import-schema.ts
+++ b/packages/api-contracts/src/import-schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const PlayerImportSchema = z.object({
+  name: z.string().min(1),
+  position: z.string().min(1),
+  jerseyNumber: z.number().nullable().optional(),
+  dateOfBirth: z.string().nullable().optional(),
+  status: z.string().min(1).optional().default("Active"),
+});
+
+const TeamImportSchema = z.object({
+  name: z.string().min(1),
+  city: z.string().min(1),
+  stadium: z.string().min(1),
+  players: z.array(PlayerImportSchema).optional().default([]),
+});
+
+const DivisionImportSchema = z.object({
+  name: z.string().min(1),
+  teams: z.array(TeamImportSchema).min(1, "Each division must have at least one team"),
+});
+
+export const LeagueImportSchema = z.object({
+  league: z.object({
+    name: z.string().min(1),
+  }),
+  divisions: z
+    .array(DivisionImportSchema)
+    .min(1, "At least one division is required"),
+});
+
+export type LeagueImportPayload = z.infer<typeof LeagueImportSchema>;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -6,6 +6,9 @@ import type {
   TeamDto,
   PlayerDto,
   SeasonDto,
+  CreateLeagueInput,
+  CreateDivisionInput,
+  CreateTeamInput,
   CreatePlayerInput,
   UpdatePlayerInput,
   UpdateTeamInput,
@@ -56,6 +59,22 @@ export const SeasonDtoSchema = z.object({
 
 // --- Mutation input schemas ---
 
+export const CreateLeagueInputSchema = z.object({
+  name: z.string().min(1),
+}) satisfies z.ZodType<CreateLeagueInput>;
+
+export const CreateDivisionInputSchema = z.object({
+  name: z.string().min(1),
+  leagueId: z.string().min(1),
+}) satisfies z.ZodType<CreateDivisionInput>;
+
+export const CreateTeamInputSchema = z.object({
+  name: z.string().min(1),
+  leagueId: z.string().min(1),
+  city: z.string().min(1),
+  stadium: z.string().min(1),
+}) satisfies z.ZodType<CreateTeamInput>;
+
 export const CreatePlayerInputSchema = z.object({
   name: z.string().min(1),
   teamId: z.string().min(1),
@@ -82,6 +101,13 @@ export const UpdateTeamInputSchema = z.object({
   location: z.string().min(1).optional(),
   divisionId: z.string().min(1).optional(),
 }) satisfies z.ZodType<UpdateTeamInput>;
+
+// --- Import schema ---
+
+export {
+  LeagueImportSchema,
+  type LeagueImportPayload,
+} from "./import-schema.js";
 
 // --- API envelope factory ---
 

--- a/packages/api-contracts/vitest.config.ts
+++ b/packages/api-contracts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -66,6 +66,15 @@ export interface UpdatePlayerInput {
   status?: string;
 }
 
+export interface CreateLeagueInput {
+  name: string;
+}
+
+export interface CreateDivisionInput {
+  name: string;
+  leagueId: string;
+}
+
 export interface CreateTeamInput {
   name: string;
   leagueId: string;
@@ -80,6 +89,28 @@ export interface UpdateTeamInput {
   foundedYear?: number | null;
   location?: string;
   divisionId?: string;
+}
+
+// --- Import types ---
+
+export interface ImportResultCounts {
+  leagues: number;
+  divisions: number;
+  teams: number;
+  players: number;
+}
+
+export interface ImportError {
+  entity: string;
+  name: string;
+  message: string;
+}
+
+export interface ImportResult {
+  leagueId: string;
+  created: ImportResultCounts;
+  updated: ImportResultCounts;
+  errors: ImportError[];
 }
 
 // --- Subscription tier types ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(jsdom@16.7.0)(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   packages/shared-types:
     devDependencies:


### PR DESCRIPTION
## Summary
- Nested JSON file import (league > divisions > teams > players) with Zod validation
- Bulk upsert Salesforce functions using jsforce direct sObject operations (query by name, create or update)
- `POST /api/cli/import` BFF endpoint with full validation error reporting
- `/dashboard/import` page with drag-and-drop file upload, preview card, and import result display
- `pnpm tui import-json <path>` TUI command with validation, preview, confirmation, and summary

## Changes
- `packages/shared-types` — `CreateLeagueInput`, `CreateDivisionInput`, `ImportResult` types
- `packages/api-contracts` — `LeagueImportSchema`, `CreateLeagueInputSchema`, `CreateDivisionInputSchema`, `CreateTeamInputSchema` + vitest setup
- `apps/web/src/lib/salesforce-api.ts` — `upsertLeague`, `upsertDivision`, `upsertTeam`, `upsertPlayer`, `bulkImportLeague`
- `apps/web/src/app/api/cli/import/route.ts` — Import BFF endpoint
- `apps/web/src/app/dashboard/import/` — Import page + form component
- `apps/web/src/app/dashboard/_components/sidebar.tsx` — Import nav item
- `apps/tui/src/commands/import-json.ts` — TUI import command
- `apps/tui/src/cli.tsx` + `apps/tui/src/lib/api.ts` — CLI dispatch + API function

## Test plan
- [x] 11 new import schema validation tests (api-contracts)
- [x] 74 existing web tests pass
- [x] 88 existing TUI tests pass
- [x] Type-check clean across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)