### PR TITLE
feat: add live NFL sync via ESPN API

### DIFF
--- a/apps/tui/src/cli.tsx
+++ b/apps/tui/src/cli.tsx
@@ -13,6 +13,7 @@ const cli = meow(
     divisions            Browse divisions
     import-teams <csv>   Bulk import teams from a CSV file
     import-json <json>   Import leagues, teams, and players from a JSON file
+    sync-nfl             Sync all NFL teams and rosters from ESPN
     (no command)         Launch the interactive TUI
 
   Environment
@@ -56,6 +57,15 @@ if (command === "login") {
   const { runImportJson } = await import("./commands/import-json.js");
   try {
     await runImportJson(jsonPath);
+    process.exit(0);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+} else if (command === "sync-nfl") {
+  const { runSyncNfl } = await import("./commands/sync-nfl.js");
+  try {
+    await runSyncNfl();
     process.exit(0);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/apps/tui/src/commands/sync-nfl.ts
+++ b/apps/tui/src/commands/sync-nfl.ts
@@ -1,0 +1,48 @@
+import { getApiBaseUrl } from "../lib/config.js";
+import { syncNfl } from "../lib/api.js";
+import { readCredentials } from "../lib/credentials.js";
+
+export async function runSyncNfl(): Promise<void> {
+  const creds = await readCredentials();
+  if (!creds) {
+    throw new Error("Not authenticated. Run 'pnpm tui login' first.");
+  }
+
+  const baseUrl = getApiBaseUrl();
+  console.log("\nSyncing NFL data from ESPN...\n");
+
+  const report = await syncNfl(baseUrl, creds.apiKey);
+
+  // Duration
+  const seconds = Math.round(report.durationMs / 1000);
+  console.log(`Completed in ${seconds}s`);
+  console.log(`  Started:   ${report.startedAt}`);
+  console.log(`  Completed: ${report.completedAt}`);
+
+  // Import result
+  if (report.importResult) {
+    const { created, updated } = report.importResult;
+    console.log(`\nResults:`);
+    console.log(`  Leagues:   ${created.leagues} created, ${updated.leagues} updated`);
+    console.log(`  Divisions: ${created.divisions} created, ${updated.divisions} updated`);
+    console.log(`  Teams:     ${created.teams} created, ${updated.teams} updated`);
+    console.log(`  Players:   ${created.players} created, ${updated.players} updated`);
+
+    if (report.importResult.errors.length > 0) {
+      console.log(`\n  Import errors (${report.importResult.errors.length}):`);
+      for (const err of report.importResult.errors) {
+        console.log(`    ${err.entity} "${err.name}": ${err.message}`);
+      }
+    }
+  } else {
+    console.log("\nNo import result — sync may have been skipped or failed.");
+  }
+
+  // Adapter errors
+  if (report.adapterErrors.length > 0) {
+    console.log(`\n  Adapter errors (${report.adapterErrors.length}):`);
+    for (const err of report.adapterErrors) {
+      console.log(`    ${err}`);
+    }
+  }
+}

--- a/apps/tui/src/lib/api.ts
+++ b/apps/tui/src/lib/api.ts
@@ -290,3 +290,26 @@ export async function importJson(
   );
   return (await res.json()) as ImportResultDto;
 }
+
+export interface SyncReportDto {
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  importResult: ImportResultDto | null;
+  adapterErrors: string[];
+}
+
+export async function syncNfl(
+  baseUrl: string,
+  apiKey: string,
+): Promise<SyncReportDto> {
+  const res = await instrumentedFetch(
+    `${baseUrl}/api/cli/import/nfl-sync`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    },
+    "Failed to sync NFL data",
+  );
+  return (await res.json()) as SyncReportDto;
+}

--- a/apps/web/src/app/api/cli/import/nfl-sync/route.ts
+++ b/apps/web/src/app/api/cli/import/nfl-sync/route.ts
@@ -1,0 +1,24 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import { syncNfl } from "@/lib/sync/nfl-sync";
+import { handleApiError } from "@/lib/api-error";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function POST() {
+  const authResult = await auth({
+    acceptsToken: ["session_token", "api_key"],
+  });
+
+  if (authResult.tokenType === null || !authResult.userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const report = await syncNfl({ skipToggleCheck: true });
+    return NextResponse.json(report);
+  } catch (error) {
+    return handleApiError(error, "/api/cli/import/nfl-sync POST");
+  }
+}

--- a/apps/web/src/app/api/cron/nfl-sync/route.ts
+++ b/apps/web/src/app/api/cron/nfl-sync/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { syncNfl } from "@/lib/sync/nfl-sync";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 min — full 32-team sync
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const report = await syncNfl();
+  return Response.json(report);
+}

--- a/apps/web/src/app/api/import/nfl-sync-config/route.ts
+++ b/apps/web/src/app/api/import/nfl-sync-config/route.ts
@@ -1,0 +1,48 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse, type NextRequest } from "next/server";
+import { readSyncConfig, updateSyncEnabled } from "@/lib/sync/nfl-sync";
+import { handleApiError } from "@/lib/api-error";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const config = await readSyncConfig();
+    return NextResponse.json(config);
+  } catch (error) {
+    return handleApiError(error, "/api/import/nfl-sync-config GET");
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: { syncEnabled: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body.syncEnabled !== "boolean") {
+    return NextResponse.json(
+      { error: "syncEnabled must be a boolean" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await updateSyncEnabled(body.syncEnabled);
+    return NextResponse.json({ syncEnabled: body.syncEnabled });
+  } catch (error) {
+    return handleApiError(error, "/api/import/nfl-sync-config PUT");
+  }
+}

--- a/apps/web/src/app/api/import/nfl-sync/route.ts
+++ b/apps/web/src/app/api/import/nfl-sync/route.ts
@@ -1,0 +1,21 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import { syncNfl } from "@/lib/sync/nfl-sync";
+import { handleApiError } from "@/lib/api-error";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function POST() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const report = await syncNfl({ skipToggleCheck: true });
+    return NextResponse.json(report);
+  } catch (error) {
+    return handleApiError(error, "/api/import/nfl-sync POST");
+  }
+}

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import type { SyncConfig, SyncReport } from "@sports-management/shared-types";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Loader2,
+  RefreshCw,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+} from "lucide-react";
+
+type CardState =
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; config: SyncConfig; syncing: boolean };
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function SyncReportDisplay({ report }: { report: SyncReport }) {
+  const hasImportResult = report.importResult !== null;
+  const hasErrors =
+    (report.importResult?.errors?.length ?? 0) > 0 ||
+    report.adapterErrors.length > 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm text-gray-500">
+        <Clock className="h-4 w-4" />
+        <span>{formatDate(report.completedAt)}</span>
+        <span className="text-gray-300">|</span>
+        <span>{formatDuration(report.durationMs)}</span>
+      </div>
+
+      {hasImportResult && report.importResult && (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {(["leagues", "divisions", "teams", "players"] as const).map(
+            (entity) => (
+              <div key={entity} className="rounded-md bg-gray-50 p-2 text-center">
+                <p className="text-xs font-medium capitalize text-gray-500">
+                  {entity}
+                </p>
+                <p className="text-sm">
+                  <span className="font-semibold text-green-700">
+                    {report.importResult!.created[entity]}
+                  </span>
+                  {" / "}
+                  <span className="text-gray-600">
+                    {report.importResult!.updated[entity]}
+                  </span>
+                </p>
+                <p className="text-[10px] text-gray-400">created / updated</p>
+              </div>
+            ),
+          )}
+        </div>
+      )}
+
+      {hasErrors && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-2">
+          <p className="text-xs font-medium text-red-700">
+            {report.adapterErrors.length > 0 &&
+              report.adapterErrors.map((e, i) => (
+                <span key={i} className="block">
+                  {e}
+                </span>
+              ))}
+            {(report.importResult?.errors ?? []).map((e, i) => (
+              <span key={i} className="block">
+                {e.entity} &quot;{e.name}&quot;: {e.message}
+              </span>
+            ))}
+          </p>
+        </div>
+      )}
+
+      {!hasImportResult && report.adapterErrors.length === 0 && (
+        <p className="text-sm text-gray-500">No data returned from sync.</p>
+      )}
+    </div>
+  );
+}
+
+export function NflSyncCard() {
+  const [state, setState] = useState<CardState>({ phase: "loading" });
+
+  const loadConfig = useCallback(async () => {
+    try {
+      const res = await fetch("/api/import/nfl-sync-config");
+      if (!res.ok) throw new Error(`Failed to load config: ${res.status}`);
+      const config: SyncConfig = await res.json();
+      setState({ phase: "ready", config, syncing: false });
+    } catch (err) {
+      setState({
+        phase: "error",
+        message: err instanceof Error ? err.message : "Failed to load config",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleToggle = useCallback(async () => {
+    if (state.phase !== "ready") return;
+    const newEnabled = !state.config.syncEnabled;
+
+    // Optimistic update
+    setState({
+      ...state,
+      config: { ...state.config, syncEnabled: newEnabled },
+    });
+
+    try {
+      const res = await fetch("/api/import/nfl-sync-config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ syncEnabled: newEnabled }),
+      });
+      if (!res.ok) throw new Error("Failed to update toggle");
+      toast.success(
+        `Nightly sync ${newEnabled ? "enabled" : "disabled"}`,
+      );
+    } catch {
+      // Revert
+      setState({
+        ...state,
+        config: { ...state.config, syncEnabled: !newEnabled },
+      });
+      toast.error("Failed to update sync toggle");
+    }
+  }, [state]);
+
+  const handleSyncNow = useCallback(async () => {
+    if (state.phase !== "ready") return;
+    setState({ ...state, syncing: true });
+
+    try {
+      const res = await fetch("/api/import/nfl-sync", { method: "POST" });
+      if (!res.ok) throw new Error(`Sync failed: ${res.status}`);
+      const report: SyncReport = await res.json();
+
+      setState({
+        phase: "ready",
+        config: { ...state.config, lastSyncReport: report },
+        syncing: false,
+      });
+
+      if (
+        report.adapterErrors.length > 0 ||
+        (report.importResult?.errors?.length ?? 0) > 0
+      ) {
+        toast.warning("Sync completed with errors");
+      } else {
+        toast.success("NFL sync completed successfully");
+      }
+    } catch (err) {
+      setState({ ...state, syncing: false });
+      toast.error(
+        err instanceof Error ? err.message : "Sync failed",
+      );
+    }
+  }, [state]);
+
+  if (state.phase === "loading") {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-3 py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-primary" />
+          <p className="text-sm text-gray-600">Loading sync config...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (state.phase === "error") {
+    return (
+      <Card className="border-red-200">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-red-700">
+            <AlertCircle className="h-5 w-5" />
+            NFL Live Data
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-red-600">{state.message}</p>
+          <Button variant="outline" className="mt-3" onClick={loadConfig}>
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { config, syncing } = state;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <RefreshCw className="h-5 w-5" />
+              NFL Live Data
+            </CardTitle>
+            <CardDescription>
+              Sync all 32 NFL teams and rosters from ESPN
+            </CardDescription>
+          </div>
+          <button
+            role="switch"
+            aria-checked={config.syncEnabled}
+            onClick={handleToggle}
+            disabled={syncing}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+              config.syncEnabled ? "bg-primary" : "bg-gray-200"
+            }`}
+          >
+            <span
+              className={`pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg transition-transform ${
+                config.syncEnabled ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Button onClick={handleSyncNow} disabled={syncing} size="sm">
+            {syncing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Syncing...
+              </>
+            ) : (
+              "Sync Now"
+            )}
+          </Button>
+          <span className="text-xs text-gray-500">
+            {config.syncEnabled
+              ? "Nightly sync enabled (4 AM UTC)"
+              : "Nightly sync disabled"}
+          </span>
+        </div>
+
+        {config.lastSyncReport ? (
+          <div>
+            <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              Last Sync
+            </h4>
+            <SyncReportDisplay report={config.lastSyncReport} />
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">
+            No sync has been run yet. Click &quot;Sync Now&quot; to import NFL data.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -1,4 +1,5 @@
 import { ImportForm } from "./_components/import-form";
+import { NflSyncCard } from "./_components/nfl-sync-card";
 
 export default function ImportPage() {
   return (
@@ -6,7 +7,10 @@ export default function ImportPage() {
       <h2 className="mb-6 text-lg font-semibold text-gray-900">
         Import Data
       </h2>
-      <ImportForm />
+      <div className="space-y-8">
+        <NflSyncCard />
+        <ImportForm />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/adapters/__fixtures__/espn-groups.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-groups.json
@@ -1,0 +1,31 @@
+{
+  "groups": [
+    {
+      "name": "American Football Conference",
+      "abbreviation": "AFC",
+      "children": [
+        {
+          "name": "AFC East",
+          "abbreviation": "EAST",
+          "teams": [
+            { "id": "2", "displayName": "Buffalo Bills" },
+            { "id": "15", "displayName": "Miami Dolphins" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "National Football Conference",
+      "abbreviation": "NFC",
+      "children": [
+        {
+          "name": "NFC West",
+          "abbreviation": "WEST",
+          "teams": [
+            { "id": "25", "displayName": "San Francisco 49ers" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-roster-15.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-roster-15.json
@@ -1,0 +1,30 @@
+{
+  "athletes": [
+    {
+      "position": "offense",
+      "items": [
+        {
+          "fullName": "Tua Tagovailoa",
+          "jersey": "1",
+          "dateOfBirth": "1998-03-02T07:00Z",
+          "position": { "abbreviation": "QB" },
+          "status": { "name": "Active" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/4241479.png" }
+        }
+      ]
+    },
+    {
+      "position": "defense",
+      "items": [
+        {
+          "fullName": "Jaelan Phillips",
+          "jersey": "15",
+          "dateOfBirth": "1999-09-28T07:00Z",
+          "position": { "abbreviation": "DE" },
+          "status": { "name": "Injured Reserve" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/4361423.png" }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-roster-2.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-roster-2.json
@@ -1,0 +1,38 @@
+{
+  "athletes": [
+    {
+      "position": "offense",
+      "items": [
+        {
+          "fullName": "Josh Allen",
+          "jersey": "17",
+          "dateOfBirth": "1996-05-21T07:00Z",
+          "position": { "abbreviation": "QB" },
+          "status": { "name": "Active" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/3918298.png" }
+        },
+        {
+          "fullName": "James Cook",
+          "jersey": "4",
+          "dateOfBirth": "1999-09-25T07:00Z",
+          "position": { "abbreviation": "RB" },
+          "status": { "name": "Active" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/4362628.png" }
+        }
+      ]
+    },
+    {
+      "position": "defense",
+      "items": [
+        {
+          "fullName": "Ed Oliver",
+          "jersey": "91",
+          "dateOfBirth": "1997-12-12T07:00Z",
+          "position": { "abbreviation": "DT" },
+          "status": { "name": "Active" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/3917315.png" }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-roster-25.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-roster-25.json
@@ -1,0 +1,17 @@
+{
+  "athletes": [
+    {
+      "position": "offense",
+      "items": [
+        {
+          "fullName": "Brock Purdy",
+          "jersey": "13",
+          "dateOfBirth": "1999-12-09T07:00Z",
+          "position": { "abbreviation": "QB" },
+          "status": { "name": "Active" },
+          "headshot": { "href": "https://a.espncdn.com/i/headshots/nfl/players/full/4432577.png" }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-15.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-15.json
@@ -1,0 +1,15 @@
+{
+  "team": {
+    "id": "15",
+    "displayName": "Miami Dolphins",
+    "name": "Dolphins",
+    "location": "Miami",
+    "abbreviation": "MIA",
+    "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/mia.png" }],
+    "franchise": {
+      "venue": {
+        "fullName": "Hard Rock Stadium"
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-2.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-2.json
@@ -1,0 +1,15 @@
+{
+  "team": {
+    "id": "2",
+    "displayName": "Buffalo Bills",
+    "name": "Bills",
+    "location": "Buffalo",
+    "abbreviation": "BUF",
+    "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/buf.png" }],
+    "franchise": {
+      "venue": {
+        "fullName": "Highmark Stadium"
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-25.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-team-detail-25.json
@@ -1,0 +1,15 @@
+{
+  "team": {
+    "id": "25",
+    "displayName": "San Francisco 49ers",
+    "name": "49ers",
+    "location": "San Francisco",
+    "abbreviation": "SF",
+    "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/sf.png" }],
+    "franchise": {
+      "venue": {
+        "fullName": "Levi's Stadium"
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/adapters/__fixtures__/espn-teams.json
+++ b/apps/web/src/lib/adapters/__fixtures__/espn-teams.json
@@ -1,0 +1,42 @@
+{
+  "sports": [
+    {
+      "leagues": [
+        {
+          "teams": [
+            {
+              "team": {
+                "id": "2",
+                "displayName": "Buffalo Bills",
+                "name": "Bills",
+                "location": "Buffalo",
+                "abbreviation": "BUF",
+                "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/buf.png" }]
+              }
+            },
+            {
+              "team": {
+                "id": "15",
+                "displayName": "Miami Dolphins",
+                "name": "Dolphins",
+                "location": "Miami",
+                "abbreviation": "MIA",
+                "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/mia.png" }]
+              }
+            },
+            {
+              "team": {
+                "id": "25",
+                "displayName": "San Francisco 49ers",
+                "name": "49ers",
+                "location": "San Francisco",
+                "abbreviation": "SF",
+                "logos": [{ "href": "https://a.espncdn.com/i/teamlogos/nfl/500/sf.png" }]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/src/lib/adapters/__tests__/espn-nfl.test.ts
+++ b/apps/web/src/lib/adapters/__tests__/espn-nfl.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EspnNflAdapter } from "../espn-nfl";
+import groupsFixture from "../__fixtures__/espn-groups.json";
+import teamsFixture from "../__fixtures__/espn-teams.json";
+import teamDetail2 from "../__fixtures__/espn-team-detail-2.json";
+import teamDetail15 from "../__fixtures__/espn-team-detail-15.json";
+import teamDetail25 from "../__fixtures__/espn-team-detail-25.json";
+import roster2 from "../__fixtures__/espn-roster-2.json";
+import roster15 from "../__fixtures__/espn-roster-15.json";
+import roster25 from "../__fixtures__/espn-roster-25.json";
+
+const teamDetails: Record<string, unknown> = {
+  "2": teamDetail2,
+  "15": teamDetail15,
+  "25": teamDetail25,
+};
+
+const rosters: Record<string, unknown> = {
+  "2": roster2,
+  "15": roster15,
+  "25": roster25,
+};
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function mockFetchResponses() {
+  mockFetch.mockImplementation(async (url: string) => {
+    if (url.includes("/groups")) {
+      return { ok: true, json: async () => groupsFixture };
+    }
+    if (url.includes("/teams/") && url.includes("/roster")) {
+      const id = url.match(/teams\/(\d+)\/roster/)?.[1];
+      return { ok: true, json: async () => rosters[id!] ?? { athletes: [] } };
+    }
+    if (url.match(/teams\/\d+$/)) {
+      const id = url.match(/teams\/(\d+)$/)?.[1];
+      return { ok: true, json: async () => teamDetails[id!] };
+    }
+    if (url.includes("/teams")) {
+      return { ok: true, json: async () => teamsFixture };
+    }
+    return { ok: false, status: 404 };
+  });
+}
+
+describe("EspnNflAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchResponses();
+  });
+
+  it("returns NFL league with correct name", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+    expect(result.league.name).toBe("NFL");
+  });
+
+  it("maps divisions from groups endpoint", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+    const divNames = result.divisions.map((d) => d.name);
+    expect(divNames).toContain("AFC East");
+    expect(divNames).toContain("NFC West");
+    expect(result.divisions).toHaveLength(2);
+  });
+
+  it("maps teams within divisions", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const afcEast = result.divisions.find((d) => d.name === "AFC East")!;
+    expect(afcEast.teams).toHaveLength(2);
+    expect(afcEast.teams[0].name).toBe("Buffalo Bills");
+    expect(afcEast.teams[1].name).toBe("Miami Dolphins");
+
+    const nfcWest = result.divisions.find((d) => d.name === "NFC West")!;
+    expect(nfcWest.teams).toHaveLength(1);
+    expect(nfcWest.teams[0].name).toBe("San Francisco 49ers");
+  });
+
+  it("maps team city, stadium, and logo URL", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+
+    expect(bills.city).toBe("Buffalo");
+    expect(bills.stadium).toBe("Highmark Stadium");
+    expect(bills.logoUrl).toBe(
+      "https://a.espncdn.com/i/teamlogos/nfl/500/buf.png",
+    );
+  });
+
+  it("maps players from roster with all fields", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+
+    expect(bills.players).toHaveLength(3); // 2 offense + 1 defense
+
+    const allen = bills.players.find((p) => p.name === "Josh Allen")!;
+    expect(allen.position).toBe("QB");
+    expect(allen.jerseyNumber).toBe(17);
+    expect(allen.dateOfBirth).toBe("1996-05-21");
+    expect(allen.status).toBe("Active");
+    expect(allen.headshotUrl).toBe(
+      "https://a.espncdn.com/i/headshots/nfl/players/full/3918298.png",
+    );
+  });
+
+  it("flattens offense and defense roster groups", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+
+    const positions = bills.players.map((p) => p.position);
+    expect(positions).toContain("QB");
+    expect(positions).toContain("RB");
+    expect(positions).toContain("DT");
+  });
+
+  it("maps Injured Reserve status", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const dolphins = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Miami Dolphins")!;
+
+    const phillips = dolphins.players.find(
+      (p) => p.name === "Jaelan Phillips",
+    )!;
+    expect(phillips.status).toBe("Injured Reserve");
+  });
+
+  it("handles roster fetch failure gracefully", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes("/groups")) {
+        return { ok: true, json: async () => groupsFixture };
+      }
+      if (url.includes("/roster")) {
+        return { ok: false, status: 500 };
+      }
+      if (url.match(/teams\/\d+$/)) {
+        const id = url.match(/teams\/(\d+)$/)?.[1];
+        return { ok: true, json: async () => teamDetails[id!] };
+      }
+      if (url.includes("/teams")) {
+        return { ok: true, json: async () => teamsFixture };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    // Teams still present, just with empty rosters
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+    expect(bills.players).toHaveLength(0);
+  });
+
+  it("handles team detail fetch failure gracefully", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes("/groups")) {
+        return { ok: true, json: async () => groupsFixture };
+      }
+      if (url.match(/teams\/\d+$/) && url.includes("/2")) {
+        return { ok: false, status: 500 };
+      }
+      if (url.match(/teams\/\d+$/)) {
+        const id = url.match(/teams\/(\d+)$/)?.[1];
+        return { ok: true, json: async () => teamDetails[id!] };
+      }
+      if (url.includes("/roster")) {
+        const id = url.match(/teams\/(\d+)\/roster/)?.[1];
+        return { ok: true, json: async () => rosters[id!] ?? { athletes: [] } };
+      }
+      if (url.includes("/teams")) {
+        return { ok: true, json: async () => teamsFixture };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    // Bills still present with empty stadium
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+    expect(bills.stadium).toBe("");
+  });
+
+  it("strips time portion from dateOfBirth", async () => {
+    const adapter = new EspnNflAdapter();
+    const result = await adapter.fetchLeagueData();
+
+    const bills = result.divisions
+      .find((d) => d.name === "AFC East")!
+      .teams.find((t) => t.name === "Buffalo Bills")!;
+
+    for (const player of bills.players) {
+      if (player.dateOfBirth) {
+        expect(player.dateOfBirth).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/adapters/espn-nfl.ts
+++ b/apps/web/src/lib/adapters/espn-nfl.ts
@@ -1,0 +1,160 @@
+import type { LeagueImportPayload } from "@sports-management/api-contracts";
+import type { IDataSourceAdapter } from "./types";
+
+const TEAMS_URL =
+  "https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams";
+const GROUPS_URL =
+  "https://site.api.espn.com/apis/site/v2/sports/football/nfl/groups";
+const ROSTER_URL = (teamId: string) =>
+  `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${teamId}/roster`;
+const TEAM_DETAIL_URL = (teamId: string) =>
+  `https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/${teamId}`;
+
+const DELAY_MS = 200;
+
+// --- ESPN response types ---
+
+interface EspnTeamRef {
+  id: string;
+  displayName: string;
+  name: string;
+  location: string;
+  abbreviation: string;
+  logos?: { href: string }[];
+}
+
+interface EspnGroupChild {
+  name: string; // e.g. "AFC East"
+  teams: { id: string; displayName: string }[];
+}
+
+interface EspnGroupsResponse {
+  groups: {
+    name: string; // "American Football Conference" / "National Football Conference"
+    abbreviation: string;
+    children: EspnGroupChild[];
+  }[];
+}
+
+interface EspnTeamsResponse {
+  sports: {
+    leagues: {
+      teams: { team: EspnTeamRef }[];
+    }[];
+  }[];
+}
+
+interface EspnTeamDetailResponse {
+  team: EspnTeamRef & {
+    franchise?: {
+      venue?: { fullName?: string };
+    };
+  };
+}
+
+interface EspnRosterResponse {
+  athletes: {
+    position: string; // "offense", "defense", etc.
+    items: {
+      fullName: string;
+      jersey?: string;
+      dateOfBirth?: string;
+      position: { abbreviation: string };
+      status?: { name: string };
+      headshot?: { href: string };
+    }[];
+  }[];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`ESPN API ${res.status}: ${url}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export class EspnNflAdapter implements IDataSourceAdapter {
+  async fetchLeagueData(): Promise<LeagueImportPayload> {
+    // 1. Fetch groups (divisions) to get team-to-division mapping
+    const groupsData = await fetchJson<EspnGroupsResponse>(GROUPS_URL);
+
+    // 2. Fetch all teams for full team data (logos, location)
+    const teamsData = await fetchJson<EspnTeamsResponse>(TEAMS_URL);
+    const teamMap = new Map<string, EspnTeamRef>();
+    for (const { team } of teamsData.sports[0].leagues[0].teams) {
+      teamMap.set(team.id, team);
+    }
+
+    // 3. Build divisions with teams and rosters
+    const divisions: LeagueImportPayload["divisions"] = [];
+
+    for (const conference of groupsData.groups) {
+      for (const division of conference.children) {
+        const divisionName = division.name; // "AFC East", "NFC West", etc.
+
+        const teams: LeagueImportPayload["divisions"][number]["teams"] = [];
+
+        for (const groupTeam of division.teams) {
+          const teamRef = teamMap.get(groupTeam.id);
+          if (!teamRef) continue;
+
+          // Fetch team detail for venue/stadium
+          let stadium = "";
+          try {
+            const detail = await fetchJson<EspnTeamDetailResponse>(
+              TEAM_DETAIL_URL(groupTeam.id),
+            );
+            stadium = detail.team.franchise?.venue?.fullName ?? "";
+          } catch {
+            // Non-fatal — proceed without stadium
+          }
+
+          // Fetch roster
+          let players: LeagueImportPayload["divisions"][number]["teams"][number]["players"] =
+            [];
+          try {
+            const rosterData = await fetchJson<EspnRosterResponse>(
+              ROSTER_URL(groupTeam.id),
+            );
+            players = rosterData.athletes.flatMap((group) =>
+              group.items.map((athlete) => ({
+                name: athlete.fullName,
+                position: athlete.position.abbreviation,
+                jerseyNumber: athlete.jersey ? parseInt(athlete.jersey, 10) : null,
+                dateOfBirth: athlete.dateOfBirth
+                  ? athlete.dateOfBirth.split("T")[0]
+                  : null,
+                status: athlete.status?.name ?? "Active",
+                headshotUrl: athlete.headshot?.href ?? null,
+              })),
+            );
+          } catch {
+            // Non-fatal — team added with empty roster
+          }
+
+          teams.push({
+            name: teamRef.displayName,
+            city: teamRef.location,
+            stadium,
+            logoUrl: teamRef.logos?.[0]?.href ?? null,
+            players,
+          });
+
+          await sleep(DELAY_MS);
+        }
+
+        divisions.push({ name: divisionName, teams });
+      }
+    }
+
+    return {
+      league: { name: "NFL" },
+      divisions,
+    };
+  }
+}

--- a/apps/web/src/lib/adapters/types.ts
+++ b/apps/web/src/lib/adapters/types.ts
@@ -1,0 +1,5 @@
+import type { LeagueImportPayload } from "@sports-management/api-contracts";
+
+export interface IDataSourceAdapter {
+  fetchLeagueData(): Promise<LeagueImportPayload>;
+}

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -174,21 +174,19 @@ export async function upsertTeam(input: {
   stadium: string;
   leagueId: string;
   divisionId: string;
+  logoUrl?: string | null;
 }): Promise<{ dto: TeamDto; created: boolean }> {
   const conn = await getSalesforceConnection();
-  const existing = await conn.query<{
+  type TeamRec = {
     Id: string; Name: string; League__c: string; City__c: string;
     Stadium__c: string; Founded_Year__c: number | null;
-    Location__c: string; Division__c: string;
-  }>(
-    `SELECT Id, Name, League__c, City__c, Stadium__c, Founded_Year__c, Location__c, Division__c FROM Team__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND League__c = '${input.leagueId}' LIMIT 1`,
+    Location__c: string; Division__c: string; Logo_URL__c: string | null;
+  };
+  const existing = await conn.query<TeamRec>(
+    `SELECT Id, Name, League__c, City__c, Stadium__c, Founded_Year__c, Location__c, Division__c, Logo_URL__c FROM Team__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND League__c = '${input.leagueId}' LIMIT 1`,
   );
 
-  const toDto = (rec: {
-    Id: string; Name: string; League__c: string; City__c: string;
-    Stadium__c: string; Founded_Year__c: number | null;
-    Location__c: string; Division__c: string;
-  }): TeamDto => ({
+  const toDto = (rec: TeamRec): TeamDto => ({
     id: rec.Id,
     name: rec.Name,
     leagueId: rec.League__c,
@@ -197,6 +195,7 @@ export async function upsertTeam(input: {
     foundedYear: rec.Founded_Year__c ?? null,
     location: rec.Location__c ?? "",
     divisionId: rec.Division__c ?? "",
+    logoUrl: rec.Logo_URL__c ?? null,
   });
 
   if (existing.totalSize > 0) {
@@ -206,8 +205,9 @@ export async function upsertTeam(input: {
       City__c: input.city,
       Stadium__c: input.stadium,
       Division__c: input.divisionId,
+      ...(input.logoUrl !== undefined && { Logo_URL__c: input.logoUrl }),
     });
-    const updated = { ...rec, City__c: input.city, Stadium__c: input.stadium, Division__c: input.divisionId };
+    const updated = { ...rec, City__c: input.city, Stadium__c: input.stadium, Division__c: input.divisionId, Logo_URL__c: input.logoUrl ?? rec.Logo_URL__c };
     return { dto: toDto(updated), created: false };
   }
 
@@ -217,6 +217,7 @@ export async function upsertTeam(input: {
     City__c: input.city,
     Stadium__c: input.stadium,
     Division__c: input.divisionId,
+    Logo_URL__c: input.logoUrl ?? null,
   });
   if (!result.success) {
     throw new Error(`Failed to create team: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
@@ -226,6 +227,7 @@ export async function upsertTeam(input: {
       Id: result.id, Name: input.name, League__c: input.leagueId,
       City__c: input.city, Stadium__c: input.stadium,
       Founded_Year__c: null, Location__c: "", Division__c: input.divisionId,
+      Logo_URL__c: input.logoUrl ?? null,
     }),
     created: true,
   };
@@ -238,18 +240,21 @@ export async function upsertPlayer(input: {
   jerseyNumber?: number | null;
   dateOfBirth?: string | null;
   status: string;
+  headshotUrl?: string | null;
 }): Promise<{ dto: PlayerDto; created: boolean }> {
   const conn = await getSalesforceConnection();
   const existing = await conn.query<{
     Id: string; Name: string; Team__c: string; Position__c: string;
     Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
+    Headshot_URL__c: string | null;
   }>(
-    `SELECT Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c FROM Player__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND Team__c = '${input.teamId}' LIMIT 1`,
+    `SELECT Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c, Headshot_URL__c FROM Player__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND Team__c = '${input.teamId}' LIMIT 1`,
   );
 
   const toDto = (rec: {
     Id: string; Name: string; Team__c: string; Position__c: string;
     Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
+    Headshot_URL__c: string | null;
   }): PlayerDto => ({
     id: rec.Id,
     name: rec.Name,
@@ -258,6 +263,7 @@ export async function upsertPlayer(input: {
     jerseyNumber: rec.Jersey_Number__c ?? null,
     dateOfBirth: rec.Date_of_Birth__c ?? null,
     status: rec.Status__c ?? "",
+    headshotUrl: rec.Headshot_URL__c ?? null,
   });
 
   if (existing.totalSize > 0) {
@@ -268,6 +274,7 @@ export async function upsertPlayer(input: {
       Jersey_Number__c: input.jerseyNumber ?? null,
       Date_of_Birth__c: input.dateOfBirth ?? null,
       Status__c: input.status,
+      ...(input.headshotUrl !== undefined && { Headshot_URL__c: input.headshotUrl }),
     });
     return {
       dto: toDto({
@@ -276,6 +283,7 @@ export async function upsertPlayer(input: {
         Jersey_Number__c: input.jerseyNumber ?? null,
         Date_of_Birth__c: input.dateOfBirth ?? null,
         Status__c: input.status,
+        Headshot_URL__c: input.headshotUrl ?? rec.Headshot_URL__c,
       }),
       created: false,
     };
@@ -288,6 +296,7 @@ export async function upsertPlayer(input: {
     Jersey_Number__c: input.jerseyNumber ?? null,
     Date_of_Birth__c: input.dateOfBirth ?? null,
     Status__c: input.status,
+    Headshot_URL__c: input.headshotUrl ?? null,
   });
   if (!result.success) {
     throw new Error(`Failed to create player: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
@@ -297,6 +306,7 @@ export async function upsertPlayer(input: {
       Id: result.id, Name: input.name, Team__c: input.teamId,
       Position__c: input.position, Jersey_Number__c: input.jerseyNumber ?? null,
       Date_of_Birth__c: input.dateOfBirth ?? null, Status__c: input.status,
+      Headshot_URL__c: input.headshotUrl ?? null,
     }),
     created: true,
   };
@@ -342,6 +352,7 @@ export async function bulkImportLeague(
           stadium: team.stadium,
           leagueId,
           divisionId,
+          logoUrl: team.logoUrl,
         });
         teamId = teamResult.dto.id;
         if (teamResult.created) created.teams++; else updated.teams++;
@@ -359,6 +370,7 @@ export async function bulkImportLeague(
             jerseyNumber: player.jerseyNumber,
             dateOfBirth: player.dateOfBirth,
             status: player.status,
+            headshotUrl: player.headshotUrl,
           });
           if (playerResult.created) created.players++; else updated.players++;
         } catch (err) {

--- a/apps/web/src/lib/sync/__tests__/nfl-sync.test.ts
+++ b/apps/web/src/lib/sync/__tests__/nfl-sync.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ImportResult } from "@sports-management/shared-types";
+
+// Mock salesforce connection
+const mockQuery = vi.fn();
+const mockSobjectCreate = vi.fn();
+const mockSobjectUpdate = vi.fn();
+const mockSobject = vi.fn(() => ({
+  create: mockSobjectCreate,
+  update: mockSobjectUpdate,
+}));
+const mockConn = {
+  query: mockQuery,
+  sobject: mockSobject,
+  instanceUrl: "https://test.salesforce.com",
+  request: vi.fn(),
+};
+
+vi.mock("../../salesforce", () => ({
+  getSalesforceConnection: vi.fn(() => Promise.resolve(mockConn)),
+}));
+
+// Mock bulkImportLeague
+const mockImportResult: ImportResult = {
+  leagueId: "a00FAKE",
+  created: { leagues: 1, divisions: 2, teams: 3, players: 10 },
+  updated: { leagues: 0, divisions: 0, teams: 0, players: 0 },
+  errors: [],
+};
+
+vi.mock("../../salesforce-api", () => ({
+  bulkImportLeague: vi.fn(() => Promise.resolve(mockImportResult)),
+}));
+
+// Mock ESPN adapter
+const mockFetchLeagueData = vi.fn();
+vi.mock("../../adapters/espn-nfl", () => ({
+  EspnNflAdapter: class {
+    fetchLeagueData = mockFetchLeagueData;
+  },
+}));
+
+import { syncNfl, readSyncConfig, updateSyncEnabled } from "../nfl-sync";
+import { bulkImportLeague } from "../../salesforce-api";
+
+describe("NFL Sync Service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchLeagueData.mockResolvedValue({
+      league: { name: "NFL" },
+      divisions: [],
+    });
+    mockSobjectCreate.mockResolvedValue({ success: true, id: "a00NEW" });
+    mockSobjectUpdate.mockResolvedValue({ success: true });
+  });
+
+  describe("readSyncConfig", () => {
+    it("returns disabled config when no record exists", async () => {
+      mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+      const config = await readSyncConfig();
+      expect(config.syncEnabled).toBe(false);
+      expect(config.lastSyncReport).toBeNull();
+    });
+
+    it("reads enabled config with last sync report", async () => {
+      const report = {
+        startedAt: "2026-04-13T00:00:00Z",
+        completedAt: "2026-04-13T00:01:00Z",
+        durationMs: 60000,
+        importResult: mockImportResult,
+        adapterErrors: [],
+      };
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [
+          {
+            Id: "a00CONFIG",
+            Sync_Enabled__c: true,
+            Last_Sync_Report__c: JSON.stringify(report),
+          },
+        ],
+      });
+
+      const config = await readSyncConfig();
+      expect(config.syncEnabled).toBe(true);
+      expect(config.lastSyncReport).toEqual(report);
+    });
+
+    it("handles corrupted report JSON gracefully", async () => {
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [
+          {
+            Id: "a00CONFIG",
+            Sync_Enabled__c: true,
+            Last_Sync_Report__c: "not-json",
+          },
+        ],
+      });
+
+      const config = await readSyncConfig();
+      expect(config.syncEnabled).toBe(true);
+      expect(config.lastSyncReport).toBeNull();
+    });
+  });
+
+  describe("updateSyncEnabled", () => {
+    it("creates config record if none exists", async () => {
+      mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+      await updateSyncEnabled(true);
+      expect(mockSobject).toHaveBeenCalledWith("NFL_Sync_Config__c");
+      expect(mockSobjectCreate).toHaveBeenCalledWith({
+        Sync_Enabled__c: true,
+      });
+    });
+
+    it("updates existing config record", async () => {
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [{ Id: "a00CONFIG" }],
+      });
+      await updateSyncEnabled(false);
+      expect(mockSobjectUpdate).toHaveBeenCalledWith({
+        Id: "a00CONFIG",
+        Sync_Enabled__c: false,
+      });
+    });
+  });
+
+  describe("syncNfl", () => {
+    it("returns early when sync is disabled", async () => {
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [
+          {
+            Id: "a00CONFIG",
+            Sync_Enabled__c: false,
+            Last_Sync_Report__c: null,
+          },
+        ],
+      });
+
+      const report = await syncNfl();
+      expect(report.importResult).toBeNull();
+      expect(report.adapterErrors).toContain("Sync is disabled");
+      expect(mockFetchLeagueData).not.toHaveBeenCalled();
+    });
+
+    it("skips toggle check when skipToggleCheck is true", async () => {
+      // First call: readSyncConfig query (skipped with skipToggleCheck)
+      // Only query calls will be for writeSyncReport
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [{ Id: "a00CONFIG" }],
+      });
+
+      const report = await syncNfl({ skipToggleCheck: true });
+      expect(report.importResult).toEqual(mockImportResult);
+      expect(mockFetchLeagueData).toHaveBeenCalled();
+    });
+
+    it("runs full sync when enabled", async () => {
+      // readSyncConfig query
+      mockQuery.mockResolvedValueOnce({
+        totalSize: 1,
+        records: [
+          {
+            Id: "a00CONFIG",
+            Sync_Enabled__c: true,
+            Last_Sync_Report__c: null,
+          },
+        ],
+      });
+      // writeSyncReport query
+      mockQuery.mockResolvedValueOnce({
+        totalSize: 1,
+        records: [{ Id: "a00CONFIG" }],
+      });
+
+      const report = await syncNfl();
+      expect(report.importResult).toEqual(mockImportResult);
+      expect(report.adapterErrors).toHaveLength(0);
+      expect(report.durationMs).toBeGreaterThanOrEqual(0);
+      expect(bulkImportLeague).toHaveBeenCalled();
+    });
+
+    it("captures adapter errors in report", async () => {
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [{ Id: "a00CONFIG" }],
+      });
+      mockFetchLeagueData.mockRejectedValue(new Error("ESPN API down"));
+
+      const report = await syncNfl({ skipToggleCheck: true });
+      expect(report.importResult).toBeNull();
+      expect(report.adapterErrors).toContain("ESPN API down");
+    });
+
+    it("writes sync report to Salesforce on completion", async () => {
+      mockQuery.mockResolvedValue({
+        totalSize: 1,
+        records: [{ Id: "a00CONFIG" }],
+      });
+
+      await syncNfl({ skipToggleCheck: true });
+
+      // Verify update was called with Last_Sync_Report__c
+      expect(mockSobjectUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Id: "a00CONFIG",
+          Last_Sync_Report__c: expect.any(String),
+        }),
+      );
+
+      const reportJson = mockSobjectUpdate.mock.calls.find(
+        (call) => call[0].Last_Sync_Report__c,
+      )?.[0].Last_Sync_Report__c;
+      const savedReport = JSON.parse(reportJson);
+      expect(savedReport.importResult).toEqual(mockImportResult);
+    });
+  });
+});

--- a/apps/web/src/lib/sync/nfl-sync.ts
+++ b/apps/web/src/lib/sync/nfl-sync.ts
@@ -1,0 +1,134 @@
+import type { SyncReport, SyncConfig } from "@sports-management/shared-types";
+import { getSalesforceConnection } from "../salesforce";
+import { bulkImportLeague } from "../salesforce-api";
+import { EspnNflAdapter } from "../adapters/espn-nfl";
+
+interface SyncConfigRecord {
+  Id: string;
+  Sync_Enabled__c: boolean;
+  Last_Sync_Report__c: string | null;
+}
+
+export async function readSyncConfig(): Promise<SyncConfig> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<SyncConfigRecord>(
+    "SELECT Id, Sync_Enabled__c, Last_Sync_Report__c FROM NFL_Sync_Config__c LIMIT 1",
+  );
+
+  if (result.totalSize === 0) {
+    return { syncEnabled: false, lastSyncReport: null };
+  }
+
+  const rec = result.records[0];
+  let lastSyncReport: SyncReport | null = null;
+  if (rec.Last_Sync_Report__c) {
+    try {
+      lastSyncReport = JSON.parse(rec.Last_Sync_Report__c) as SyncReport;
+    } catch {
+      // Corrupted report — treat as null
+    }
+  }
+
+  return {
+    syncEnabled: rec.Sync_Enabled__c,
+    lastSyncReport,
+  };
+}
+
+export async function updateSyncEnabled(enabled: boolean): Promise<void> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string }>(
+    "SELECT Id FROM NFL_Sync_Config__c LIMIT 1",
+  );
+
+  if (result.totalSize === 0) {
+    await conn.sobject("NFL_Sync_Config__c").create({
+      Sync_Enabled__c: enabled,
+    });
+  } else {
+    await conn.sobject("NFL_Sync_Config__c").update({
+      Id: result.records[0].Id,
+      Sync_Enabled__c: enabled,
+    });
+  }
+}
+
+async function writeSyncReport(report: SyncReport): Promise<void> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string }>(
+    "SELECT Id FROM NFL_Sync_Config__c LIMIT 1",
+  );
+
+  const reportJson = JSON.stringify(report);
+
+  if (result.totalSize === 0) {
+    await conn.sobject("NFL_Sync_Config__c").create({
+      Sync_Enabled__c: false,
+      Last_Sync_Report__c: reportJson,
+    });
+  } else {
+    await conn.sobject("NFL_Sync_Config__c").update({
+      Id: result.records[0].Id,
+      Last_Sync_Report__c: reportJson,
+    });
+  }
+}
+
+export async function syncNfl(options?: {
+  skipToggleCheck?: boolean;
+}): Promise<SyncReport> {
+  const startedAt = new Date().toISOString();
+  const adapterErrors: string[] = [];
+
+  // Check toggle unless explicitly skipped (e.g. manual "Sync Now")
+  if (!options?.skipToggleCheck) {
+    const config = await readSyncConfig();
+    if (!config.syncEnabled) {
+      const report: SyncReport = {
+        startedAt,
+        completedAt: new Date().toISOString(),
+        durationMs: 0,
+        importResult: null,
+        adapterErrors: ["Sync is disabled"],
+      };
+      await writeSyncReport(report);
+      return report;
+    }
+  }
+
+  let report: SyncReport;
+
+  try {
+    const adapter = new EspnNflAdapter();
+    const payload = await adapter.fetchLeagueData();
+    const importResult = await bulkImportLeague(payload);
+
+    const completedAt = new Date().toISOString();
+    report = {
+      startedAt,
+      completedAt,
+      durationMs:
+        new Date(completedAt).getTime() - new Date(startedAt).getTime(),
+      importResult,
+      adapterErrors,
+    };
+  } catch (err) {
+    const completedAt = new Date().toISOString();
+    report = {
+      startedAt,
+      completedAt,
+      durationMs:
+        new Date(completedAt).getTime() - new Date(startedAt).getTime(),
+      importResult: null,
+      adapterErrors: [err instanceof Error ? err.message : String(err)],
+    };
+  }
+
+  try {
+    await writeSyncReport(report);
+  } catch {
+    // Don't fail the sync if report persistence fails
+  }
+
+  return report;
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,3 +1,9 @@
 {
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "crons": [
+    {
+      "path": "/api/cron/nfl-sync",
+      "schedule": "0 4 * * *"
+    }
+  ]
 }

--- a/packages/api-contracts/src/import-schema.ts
+++ b/packages/api-contracts/src/import-schema.ts
@@ -6,12 +6,14 @@ const PlayerImportSchema = z.object({
   jerseyNumber: z.number().nullable().optional(),
   dateOfBirth: z.string().nullable().optional(),
   status: z.string().min(1).optional().default("Active"),
+  headshotUrl: z.string().url().nullable().optional(),
 });
 
 const TeamImportSchema = z.object({
   name: z.string().min(1),
   city: z.string().min(1),
   stadium: z.string().min(1),
+  logoUrl: z.string().url().nullable().optional(),
   players: z.array(PlayerImportSchema).optional().default([]),
 });
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -36,6 +36,7 @@ export const TeamDtoSchema = z.object({
   foundedYear: z.number().nullable(),
   location: z.string(),
   divisionId: z.string(),
+  logoUrl: z.string().nullable(),
 }) satisfies z.ZodType<TeamDto>;
 
 export const PlayerDtoSchema = z.object({
@@ -46,6 +47,7 @@ export const PlayerDtoSchema = z.object({
   jerseyNumber: z.number().nullable(),
   dateOfBirth: z.string().nullable(),
   status: z.string(),
+  headshotUrl: z.string().nullable(),
 }) satisfies z.ZodType<PlayerDto>;
 
 export const SeasonDtoSchema = z.object({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,6 +25,7 @@ export interface TeamDto {
   foundedYear: number | null;
   location: string;
   divisionId: string;
+  logoUrl: string | null;
 }
 
 export interface PlayerDto {
@@ -35,6 +36,7 @@ export interface PlayerDto {
   jerseyNumber: number | null;
   dateOfBirth: string | null;
   status: string;
+  headshotUrl: string | null;
 }
 
 export interface SeasonDto {
@@ -111,6 +113,21 @@ export interface ImportResult {
   created: ImportResultCounts;
   updated: ImportResultCounts;
   errors: ImportError[];
+}
+
+// --- Sync types ---
+
+export interface SyncReport {
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  importResult: ImportResult | null;
+  adapterErrors: string[];
+}
+
+export interface SyncConfig {
+  syncEnabled: boolean;
+  lastSyncReport: SyncReport | null;
 }
 
 // --- Subscription tier types ---

--- a/sportsmgmt/main/default/objects/NFL_Sync_Config__c/NFL_Sync_Config__c.object-meta.xml
+++ b/sportsmgmt/main/default/objects/NFL_Sync_Config__c/NFL_Sync_Config__c.object-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>Hierarchy</customSettingsType>
+    <description>Configuration and status tracking for NFL data sync</description>
+    <enableFeeds>false</enableFeeds>
+    <label>NFL Sync Config</label>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/sportsmgmt/main/default/objects/NFL_Sync_Config__c/fields/Last_Sync_Report__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/NFL_Sync_Config__c/fields/Last_Sync_Report__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Last_Sync_Report__c</fullName>
+    <description>JSON-serialized report from the last NFL sync run</description>
+    <externalId>false</externalId>
+    <label>Last Sync Report</label>
+    <length>131072</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/sportsmgmt/main/default/objects/NFL_Sync_Config__c/fields/Sync_Enabled__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/NFL_Sync_Config__c/fields/Sync_Enabled__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Sync_Enabled__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the nightly NFL sync is enabled</description>
+    <externalId>false</externalId>
+    <label>Sync Enabled</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/sportsmgmt/main/default/objects/Player__c/fields/Headshot_URL__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/Player__c/fields/Headshot_URL__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Headshot_URL__c</fullName>
+    <description>URL to the player headshot image</description>
+    <externalId>false</externalId>
+    <label>Headshot URL</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Url</type>
+</CustomField>

--- a/sportsmgmt/main/default/objects/Player__c/fields/Status__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/Player__c/fields/Status__c.field-meta.xml
@@ -28,6 +28,26 @@
                 <default>false</default>
                 <label>Inactive</label>
             </value>
+            <value>
+                <fullName>Injured Reserve</fullName>
+                <default>false</default>
+                <label>Injured Reserve</label>
+            </value>
+            <value>
+                <fullName>Practice Squad</fullName>
+                <default>false</default>
+                <label>Practice Squad</label>
+            </value>
+            <value>
+                <fullName>Suspended</fullName>
+                <default>false</default>
+                <label>Suspended</label>
+            </value>
+            <value>
+                <fullName>Physically Unable to Perform</fullName>
+                <default>false</default>
+                <label>Physically Unable to Perform</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/sportsmgmt/main/default/objects/Team__c/fields/Logo_URL__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/Team__c/fields/Logo_URL__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_URL__c</fullName>
+    <description>URL to the team logo image</description>
+    <externalId>false</externalId>
+    <label>Logo URL</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Url</type>
+</CustomField>

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,8 @@
     "RESEND_API_KEY",
     "RESEND_FROM_EMAIL",
     "NEXT_PUBLIC_APP_URL",
-    "SPRTSMNG_API_URL"
+    "SPRTSMNG_API_URL",
+    "CRON_SECRET"
   ],
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**"] },


### PR DESCRIPTION
## Summary
- Add Salesforce metadata: `Logo_URL__c` (Team), `Headshot_URL__c` (Player), extended Status__c picklist, `NFL_Sync_Config__c` Custom Setting
- Implement `IDataSourceAdapter` interface and `EspnNflAdapter` that fetches all 32 NFL teams + full rosters from ESPN public API
- Add `NflSyncService` orchestrator: reads sync toggle, calls adapter, runs `bulkImportLeague`, persists `SyncReport` to Custom Setting
- Add Vercel cron at `/api/cron/nfl-sync` (daily 4 AM UTC, secured by `CRON_SECRET`)
- Add "NFL Live Data" card on `/dashboard/import` with sync toggle, "Sync Now" button, and last sync status
- Add `pnpm tui sync-nfl` command via `/api/cli/import/nfl-sync`
- Update DTOs, Zod schemas, and import schema with image URL fields (backwards-compatible)

## Stories
- ARC-NFL-00: Salesforce metadata + DTO updates
- ARC-NFL-01: ESPN data adapter with adapter pattern
- ARC-NFL-02: NFL sync service with config persistence
- ARC-NFL-03: Vercel cron job for nightly sync
- ARC-NFL-04: Web UI sync card with toggle and status
- ARC-NFL-05: TUI sync-nfl command

## Test plan
- [x] 94 unit tests passing (20 new: 10 ESPN adapter, 10 sync service)
- [x] `pnpm turbo build` clean — no type errors
- [ ] Manual: "Sync Now" on /dashboard/import → verify 32 NFL teams in Salesforce
- [ ] Manual: `pnpm tui sync-nfl` → same result
- [ ] Manual: Toggle sync off → verify cron skips
- [ ] Manual: `sf project deploy start` → Salesforce metadata deploys
- [ ] Set `CRON_SECRET` env var in Vercel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)