### PR TITLE
feat: add user data authorization and multi-tenancy (Phase A)

### DIFF
--- a/apps/tui/src/lib/api.ts
+++ b/apps/tui/src/lib/api.ts
@@ -97,6 +97,7 @@ async function instrumentedFetch(
 export interface LeagueDto {
   id: string;
   name: string;
+  orgId: string | null;
 }
 
 export async function fetchLeagues(

--- a/apps/web/src/app/api/cli/divisions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/divisions/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/salesforce-api", () => ({ getDivisions: vi.fn() }));
+vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
     const { NextResponse } = require("next/server");
@@ -11,10 +12,18 @@ vi.mock("@/lib/api-error", () => ({
 
 import { auth } from "@clerk/nextjs/server";
 import { getDivisions } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockGetDivisions = getDivisions as unknown as ReturnType<typeof vi.fn>;
+const mockResolveOrgContext = resolveOrgContext as unknown as ReturnType<typeof vi.fn>;
+
+const fakeOrgContext = {
+  userId: "u1",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["lg_1"],
+};
 
 describe("GET /api/cli/divisions", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -27,6 +36,7 @@ describe("GET /api/cli/divisions", () => {
 
   it("returns all divisions", async () => {
     mockAuth.mockResolvedValue({ userId: "u1", tokenType: "session_token" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetDivisions.mockResolvedValue([
       { id: "d1", name: "East", leagueId: "lg1" },
       { id: "d2", name: "West", leagueId: "lg1" },
@@ -35,5 +45,6 @@ describe("GET /api/cli/divisions", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveLength(2);
+    expect(mockGetDivisions).toHaveBeenCalledWith(fakeOrgContext.visibleLeagueIds);
   });
 });

--- a/apps/web/src/app/api/cli/divisions/route.ts
+++ b/apps/web/src/app/api/cli/divisions/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getDivisions } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
@@ -18,7 +19,8 @@ export async function GET() {
   }
 
   try {
-    const data = await getDivisions();
+    const orgContext = await resolveOrgContext(authResult.userId);
+    const data = await getDivisions(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/cli/divisions");

--- a/apps/web/src/app/api/cli/import/route.ts
+++ b/apps/web/src/app/api/cli/import/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await bulkImportLeague(parsed.data);
+    const result = await bulkImportLeague(parsed.data, authResult.userId);
     return NextResponse.json(result);
   } catch (error) {
     return handleApiError(error, "/api/cli/import POST");

--- a/apps/web/src/app/api/cli/leagues/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/leagues/__tests__/route.test.ts
@@ -6,6 +6,9 @@ vi.mock("@clerk/nextjs/server", () => ({
 vi.mock("@/lib/salesforce-api", () => ({
   getLeagues: vi.fn(),
 }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: vi.fn(),
+}));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn((_err: unknown, _ctx: string) => {
     const { NextResponse } = require("next/server");
@@ -15,10 +18,18 @@ vi.mock("@/lib/api-error", () => ({
 
 import { auth } from "@clerk/nextjs/server";
 import { getLeagues } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockGetLeagues = getLeagues as unknown as ReturnType<typeof vi.fn>;
+const mockResolveOrgContext = resolveOrgContext as unknown as ReturnType<typeof vi.fn>;
+
+const fakeOrgContext = {
+  userId: "user_123",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["league_1", "league_2"],
+};
 
 describe("GET /api/cli/leagues", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -31,9 +42,10 @@ describe("GET /api/cli/leagues", () => {
 
   it("returns league data for an authenticated request", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123", tokenType: "api_key" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetLeagues.mockResolvedValue([
-      { id: "league_1", name: "Premier League" },
-      { id: "league_2", name: "La Liga" },
+      { id: "league_1", name: "Premier League", orgId: "org_1" },
+      { id: "league_2", name: "La Liga", orgId: null },
     ]);
 
     const res = await GET();
@@ -41,6 +53,7 @@ describe("GET /api/cli/leagues", () => {
     const body = await res.json();
     expect(body).toHaveLength(2);
     expect(body[0].name).toBe("Premier League");
+    expect(mockGetLeagues).toHaveBeenCalledWith(fakeOrgContext.visibleLeagueIds);
   });
 
   it("returns 503 when Salesforce fails", async () => {
@@ -48,6 +61,7 @@ describe("GET /api/cli/leagues", () => {
       userId: "user_123",
       tokenType: "session_token",
     });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetLeagues.mockRejectedValue(new Error("SF connection failed"));
 
     const res = await GET();

--- a/apps/web/src/app/api/cli/leagues/route.ts
+++ b/apps/web/src/app/api/cli/leagues/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getLeagues } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
@@ -24,7 +25,8 @@ export async function GET() {
   }
 
   try {
-    const data = await getLeagues();
+    const orgContext = await resolveOrgContext(authResult.userId);
+    const data = await getLeagues(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/cli/leagues");

--- a/apps/web/src/app/api/cli/players/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/players/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/salesforce-api", () => ({ getPlayersByTeam: vi.fn() }));
+vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
     const { NextResponse } = require("next/server");
@@ -12,10 +13,18 @@ vi.mock("@/lib/api-error", () => ({
 
 import { auth } from "@clerk/nextjs/server";
 import { getPlayersByTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockGetPlayers = getPlayersByTeam as unknown as ReturnType<typeof vi.fn>;
+const mockResolveOrgContext = resolveOrgContext as unknown as ReturnType<typeof vi.fn>;
+
+const fakeOrgContext = {
+  userId: "u1",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["lg_1"],
+};
 
 function req(url: string) {
   return new NextRequest(new URL(url, "http://localhost:3000"));
@@ -38,11 +47,12 @@ describe("GET /api/cli/players", () => {
 
   it("returns players filtered by team", async () => {
     mockAuth.mockResolvedValue({ userId: "u1", tokenType: "api_key" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetPlayers.mockResolvedValue([
       { id: "p1", name: "Player 1", position: "GK", jerseyNumber: 1, status: "Active" },
     ]);
     const res = await GET(req("/api/cli/players?teamId=t1"));
     expect(res.status).toBe(200);
-    expect(mockGetPlayers).toHaveBeenCalledWith("t1");
+    expect(mockGetPlayers).toHaveBeenCalledWith("t1", fakeOrgContext);
   });
 });

--- a/apps/web/src/app/api/cli/players/route.ts
+++ b/apps/web/src/app/api/cli/players/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
 import { getPlayersByTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
@@ -26,7 +27,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const data = await getPlayersByTeam(teamId);
+    const orgContext = await resolveOrgContext(authResult.userId);
+    const data = await getPlayersByTeam(teamId, orgContext);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/cli/players");

--- a/apps/web/src/app/api/cli/seasons/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/seasons/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/salesforce-api", () => ({ getSeasons: vi.fn() }));
+vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
     const { NextResponse } = require("next/server");
@@ -11,10 +12,18 @@ vi.mock("@/lib/api-error", () => ({
 
 import { auth } from "@clerk/nextjs/server";
 import { getSeasons } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
 const mockGetSeasons = getSeasons as unknown as ReturnType<typeof vi.fn>;
+const mockResolveOrgContext = resolveOrgContext as unknown as ReturnType<typeof vi.fn>;
+
+const fakeOrgContext = {
+  userId: "u1",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["lg_1"],
+};
 
 describe("GET /api/cli/seasons", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -27,6 +36,7 @@ describe("GET /api/cli/seasons", () => {
 
   it("returns all seasons", async () => {
     mockAuth.mockResolvedValue({ userId: "u1", tokenType: "api_key" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetSeasons.mockResolvedValue([
       { id: "s1", name: "2025-26", leagueId: "lg1", startDate: "2025-08-01", endDate: "2026-05-31", status: "Active" },
     ]);
@@ -35,5 +45,6 @@ describe("GET /api/cli/seasons", () => {
     const body = await res.json();
     expect(body).toHaveLength(1);
     expect(body[0].name).toBe("2025-26");
+    expect(mockGetSeasons).toHaveBeenCalledWith(fakeOrgContext.visibleLeagueIds);
   });
 });

--- a/apps/web/src/app/api/cli/seasons/route.ts
+++ b/apps/web/src/app/api/cli/seasons/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getSeasons } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
@@ -18,7 +19,8 @@ export async function GET() {
   }
 
   try {
-    const data = await getSeasons();
+    const orgContext = await resolveOrgContext(authResult.userId);
+    const data = await getSeasons(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/cli/seasons");

--- a/apps/web/src/app/api/cli/teams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/teams/__tests__/route.test.ts
@@ -9,6 +9,9 @@ vi.mock("@/lib/salesforce-api", () => ({
   getTeamsByLeague: vi.fn(),
   createTeam: vi.fn(),
 }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: vi.fn(),
+}));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn((_err: unknown, _ctx: string) => {
     const { NextResponse } = require("next/server");
@@ -18,6 +21,7 @@ vi.mock("@/lib/api-error", () => ({
 
 import { auth } from "@clerk/nextjs/server";
 import { getTeams, getTeamsByLeague, createTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { GET, POST } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
@@ -26,6 +30,13 @@ const mockGetTeamsByLeague = getTeamsByLeague as unknown as ReturnType<
   typeof vi.fn
 >;
 const mockCreateTeam = createTeam as unknown as ReturnType<typeof vi.fn>;
+const mockResolveOrgContext = resolveOrgContext as unknown as ReturnType<typeof vi.fn>;
+
+const fakeOrgContext = {
+  userId: "user_1",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["lg_1"],
+};
 
 function makeRequest(url: string) {
   return new NextRequest(new URL(url, "http://localhost:3000"));
@@ -42,13 +53,14 @@ describe("GET /api/cli/teams", () => {
 
   it("returns all teams when no leagueId filter", async () => {
     mockAuth.mockResolvedValue({ userId: "user_1", tokenType: "api_key" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetTeams.mockResolvedValue([
       { id: "t1", name: "Team A", city: "NYC", stadium: "Stadium 1" },
     ]);
 
     const res = await GET(makeRequest("/api/cli/teams"));
     expect(res.status).toBe(200);
-    expect(mockGetTeams).toHaveBeenCalled();
+    expect(mockGetTeams).toHaveBeenCalledWith(fakeOrgContext.visibleLeagueIds);
     expect(mockGetTeamsByLeague).not.toHaveBeenCalled();
   });
 
@@ -57,18 +69,20 @@ describe("GET /api/cli/teams", () => {
       userId: "user_1",
       tokenType: "session_token",
     });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetTeamsByLeague.mockResolvedValue([
       { id: "t2", name: "Team B", city: "LA", stadium: "Stadium 2" },
     ]);
 
     const res = await GET(makeRequest("/api/cli/teams?leagueId=lg_1"));
     expect(res.status).toBe(200);
-    expect(mockGetTeamsByLeague).toHaveBeenCalledWith("lg_1");
+    expect(mockGetTeamsByLeague).toHaveBeenCalledWith("lg_1", fakeOrgContext);
     expect(mockGetTeams).not.toHaveBeenCalled();
   });
 
   it("returns 503 on Salesforce failure", async () => {
     mockAuth.mockResolvedValue({ userId: "user_1", tokenType: "api_key" });
+    mockResolveOrgContext.mockResolvedValue(fakeOrgContext);
     mockGetTeams.mockRejectedValue(new Error("SF down"));
 
     const res = await GET(makeRequest("/api/cli/teams"));

--- a/apps/web/src/app/api/cli/teams/route.ts
+++ b/apps/web/src/app/api/cli/teams/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
 import { getTeams, getTeamsByLeague, createTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
@@ -26,7 +27,10 @@ export async function GET(request: NextRequest) {
   const leagueId = request.nextUrl.searchParams.get("leagueId");
 
   try {
-    const data = leagueId ? await getTeamsByLeague(leagueId) : await getTeams();
+    const orgContext = await resolveOrgContext(authResult.userId);
+    const data = leagueId
+      ? await getTeamsByLeague(leagueId, orgContext)
+      : await getTeams(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/cli/teams GET");

--- a/apps/web/src/app/api/divisions/route.ts
+++ b/apps/web/src/app/api/divisions/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getDivisions } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET() {
@@ -9,7 +10,8 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
-    const data = await getDivisions();
+    const orgContext = await resolveOrgContext(userId);
+    const data = await getDivisions(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/divisions");

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { getSalesforceConnection } from "@/lib/salesforce";
-import { getLeagues } from "@/lib/salesforce-api";
 
 export async function GET() {
   const checks: Record<string, unknown> = {};
@@ -19,8 +18,9 @@ export async function GET() {
   }
 
   try {
-    const leagues = await getLeagues();
-    checks.data = `ok (${leagues.length} leagues)`;
+    const conn = await getSalesforceConnection();
+    const result = await conn.query<{ Id: string }>("SELECT Id FROM League__c LIMIT 1");
+    checks.data = `ok (query returned ${result.totalSize} record(s))`;
   } catch (err) {
     checks.data = `FAILED: ${err instanceof Error ? err.message : String(err)}`;
     return NextResponse.json(checks, { status: 503 });

--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getLeagues } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET() {
@@ -9,7 +10,8 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
-    const data = await getLeagues();
+    const orgContext = await resolveOrgContext(userId);
+    const data = await getLeagues(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/leagues");

--- a/apps/web/src/app/api/players/[id]/route.ts
+++ b/apps/web/src/app/api/players/[id]/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getPlayer, updatePlayer, deletePlayer } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { UpdatePlayerInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";
 import { handleApiError } from "@/lib/api-error";
@@ -15,7 +16,8 @@ export async function GET(
   }
   const { id } = await params;
   try {
-    const data = await getPlayer(id);
+    const orgContext = await resolveOrgContext(userId);
+    const data = await getPlayer(id, orgContext);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, `/api/players/${id}`);
@@ -34,7 +36,8 @@ export async function PUT(
   const { id } = await params;
 
   try {
-    const existing = await getPlayer(id);
+    const orgContext = await resolveOrgContext(userId);
+    const existing = await getPlayer(id, orgContext);
 
     const authorization = await authorizeTeamMutation(existing.teamId);
     if (!authorization.isAuthorized) {
@@ -72,7 +75,8 @@ export async function DELETE(
   const { id } = await params;
 
   try {
-    const existing = await getPlayer(id);
+    const orgContext = await resolveOrgContext(userId);
+    const existing = await getPlayer(id, orgContext);
 
     const authorization = await authorizeTeamMutation(existing.teamId);
     if (!authorization.isAuthorized) {

--- a/apps/web/src/app/api/players/route.ts
+++ b/apps/web/src/app/api/players/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { getPlayers, getPlayersByTeam, createPlayer } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { CreatePlayerInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";
 import { handleApiError } from "@/lib/api-error";
@@ -11,8 +12,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
+    const orgContext = await resolveOrgContext(userId);
     const teamId = request.nextUrl.searchParams.get("teamId");
-    const data = teamId ? await getPlayersByTeam(teamId) : await getPlayers();
+    const data = teamId
+      ? await getPlayersByTeam(teamId, orgContext)
+      : await getPlayers(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/players");

--- a/apps/web/src/app/api/seasons/route.ts
+++ b/apps/web/src/app/api/seasons/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getSeasons } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET() {
@@ -9,7 +10,8 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
-    const data = await getSeasons();
+    const orgContext = await resolveOrgContext(userId);
+    const data = await getSeasons(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/seasons");

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getTeam, getPlayersByTeam, updateTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";
 import { handleApiError } from "@/lib/api-error";
@@ -15,9 +16,10 @@ export async function GET(
   }
   const { id } = await params;
   try {
+    const orgContext = await resolveOrgContext(userId);
     const [team, players] = await Promise.all([
-      getTeam(id),
-      getPlayersByTeam(id),
+      getTeam(id, orgContext),
+      getPlayersByTeam(id, orgContext),
     ]);
     return NextResponse.json({ team, players });
   } catch (error) {

--- a/apps/web/src/app/api/teams/route.ts
+++ b/apps/web/src/app/api/teams/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { getTeams } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET() {
@@ -9,7 +10,8 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
-    const data = await getTeams();
+    const orgContext = await resolveOrgContext(userId);
+    const data = await getTeams(orgContext.visibleLeagueIds);
     return NextResponse.json(data);
   } catch (error) {
     return handleApiError(error, "/api/teams");

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getUserTier, getStripeCustomerId } from "@/lib/authorization";
 import { TIER_CONFIGS } from "@/lib/tiers";
 import { getTeams } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { BillingActions } from "./_components/billing-actions";
@@ -27,7 +28,8 @@ export default async function BillingPage({
   // Fetch usage stats from Salesforce
   let teamCount = 0;
   try {
-    const teams = await getTeams();
+    const orgContext = await resolveOrgContext(userId);
+    const teams = await getTeams(orgContext.visibleLeagueIds);
     teamCount = teams.length;
   } catch {
     // Salesforce errors should not break the billing page

--- a/apps/web/src/app/dashboard/divisions/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/page.tsx
@@ -1,10 +1,19 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getDivisions, getLeagues } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { DivisionsTable } from "./divisions-table";
 
 export default async function DivisionsPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const ids = orgContext.visibleLeagueIds;
+
   const [divisions, leagues] = await Promise.all([
-    getDivisions(),
-    getLeagues(),
+    getDivisions(ids),
+    getLeagues(ids),
   ]);
 
   const leagueMap = new Map(leagues.map((l) => [l.id, l.name]));

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -1,15 +1,24 @@
 import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getLeagues, getDivisions, getTeams } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
 import { Trophy, Layers, Users } from "lucide-react";
 
 export default async function LeaguesPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const ids = orgContext.visibleLeagueIds;
+
   const [leagues, divisions, teams] = await Promise.all([
-    getLeagues(),
-    getDivisions(),
-    getTeams(),
+    getLeagues(ids),
+    getDivisions(ids),
+    getTeams(ids),
   ]);
 
   const divisionsByLeague = new Map<string, typeof divisions>();
@@ -90,7 +99,7 @@ export default async function LeaguesPage() {
                                     </span>
                                     {team.city && (
                                       <span className="text-gray-400">
-                                        \u2014 {team.city}
+                                        &mdash; {team.city}
                                       </span>
                                     )}
                                   </Link>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import {
   getTeams,
   getPlayers,
@@ -6,6 +8,7 @@ import {
   getDivisions,
   getLeagues,
 } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Trophy,
@@ -24,12 +27,18 @@ const statCards = [
 ] as const;
 
 export default async function DashboardPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const ids = orgContext.visibleLeagueIds;
+
   const [leagues, teams, players, seasons, divisions] = await Promise.all([
-    getLeagues(),
-    getTeams(),
-    getPlayers(),
-    getSeasons(),
-    getDivisions(),
+    getLeagues(ids),
+    getTeams(ids),
+    getPlayers(ids),
+    getSeasons(ids),
+    getDivisions(ids),
   ]);
 
   const counts: Record<string, number> = {

--- a/apps/web/src/app/dashboard/players/page.tsx
+++ b/apps/web/src/app/dashboard/players/page.tsx
@@ -1,8 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getPlayers } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { PlayersTable } from "./players-table";
 
 export default async function PlayersPage() {
-  const players = await getPlayers();
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const players = await getPlayers(orgContext.visibleLeagueIds);
 
   return (
     <div>

--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -1,8 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getSeasons } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { SeasonsTable } from "./seasons-table";
 
 export default async function SeasonsPage() {
-  const seasons = await getSeasons();
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const seasons = await getSeasons(orgContext.visibleLeagueIds);
 
   return (
     <div>

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getTeam, getPlayersByTeam } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam } from "@/lib/authorization";
 import TeamManagement from "./team-management";
 
@@ -8,10 +11,15 @@ export default async function TeamDetailPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
   const { id } = await params;
+  const orgContext = await resolveOrgContext(userId);
+
   const [team, players, canManage] = await Promise.all([
-    getTeam(id),
-    getPlayersByTeam(id),
+    getTeam(id, orgContext),
+    getPlayersByTeam(id, orgContext),
     canManageTeam(id),
   ]);
 

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -1,8 +1,15 @@
 import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { getTeams } from "@/lib/salesforce-api";
+import { resolveOrgContext } from "@/lib/org-context";
 
 export default async function TeamsPage() {
-  const teams = await getTeams();
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const orgContext = await resolveOrgContext(userId);
+  const teams = await getTeams(orgContext.visibleLeagueIds);
 
   return (
     <div>

--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetOrganizationMembershipList, mockQuery } = vi.hoisted(() => ({
+  mockGetOrganizationMembershipList: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn().mockResolvedValue({
+    users: {
+      getOrganizationMembershipList: mockGetOrganizationMembershipList,
+    },
+  }),
+}));
+
+vi.mock("../salesforce", () => ({
+  getSalesforceConnection: vi.fn().mockResolvedValue({
+    query: mockQuery,
+  }),
+}));
+
+vi.mock("react", () => ({
+  cache: (fn: Function) => fn,
+}));
+
+import { resolveOrgContext, requireLeagueAccess, requireOrgAdmin, getLeagueOrgId } from "../org-context";
+
+describe("resolveOrgContext", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns visible league IDs for user with org memberships", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        { organization: { id: "org_abc" } },
+        { organization: { id: "org_def" } },
+      ],
+    });
+
+    mockQuery.mockResolvedValue({
+      records: [
+        { Id: "league_1" },
+        { Id: "league_2" },
+        { Id: "league_public" },
+      ],
+    });
+
+    const ctx = await resolveOrgContext("user_123");
+
+    expect(ctx.userId).toBe("user_123");
+    expect(ctx.orgIds).toEqual(["org_abc", "org_def"]);
+    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_2", "league_public"]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("org_abc"),
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("Clerk_Org_Id__c = null"),
+    );
+  });
+
+  it("returns only public leagues when user has no orgs", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
+    mockQuery.mockResolvedValue({
+      records: [{ Id: "league_public" }],
+    });
+
+    const ctx = await resolveOrgContext("user_no_orgs");
+
+    expect(ctx.orgIds).toEqual([]);
+    expect(ctx.visibleLeagueIds).toEqual(["league_public"]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      "SELECT Id FROM League__c WHERE Clerk_Org_Id__c = null",
+    );
+  });
+
+  it("handles pagination of org memberships", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      organization: { id: `org_${i}` },
+    }));
+    const secondPage = [{ organization: { id: "org_100" } }];
+
+    mockGetOrganizationMembershipList
+      .mockResolvedValueOnce({ data: firstPage })
+      .mockResolvedValueOnce({ data: secondPage });
+
+    mockQuery.mockResolvedValue({ records: [] });
+
+    const ctx = await resolveOrgContext("user_many_orgs");
+
+    expect(ctx.orgIds).toHaveLength(101);
+    expect(mockGetOrganizationMembershipList).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("requireLeagueAccess", () => {
+  it("does not throw when league is in visible set", () => {
+    const ctx = {
+      userId: "u1",
+      orgIds: ["org_1"],
+      visibleLeagueIds: ["lg_1", "lg_2"],
+    };
+    expect(() => requireLeagueAccess("lg_1", ctx)).not.toThrow();
+  });
+
+  it("throws when league is not in visible set", () => {
+    const ctx = {
+      userId: "u1",
+      orgIds: ["org_1"],
+      visibleLeagueIds: ["lg_1"],
+    };
+    expect(() => requireLeagueAccess("lg_other", ctx)).toThrow(
+      "You do not have access to this league",
+    );
+  });
+});
+
+describe("requireOrgAdmin", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not throw when user is org admin", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        { organization: { id: "org_abc" }, role: "org:admin" },
+      ],
+    });
+
+    await expect(requireOrgAdmin("org_abc", "user_123")).resolves.toBeUndefined();
+  });
+
+  it("throws when user is not admin", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        { organization: { id: "org_abc" }, role: "org:member" },
+      ],
+    });
+
+    await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
+      "You must be an admin",
+    );
+  });
+
+  it("throws when user is not a member of the org at all", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        { organization: { id: "org_other" }, role: "org:admin" },
+      ],
+    });
+
+    await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
+      "You must be an admin",
+    );
+  });
+});
+
+describe("getLeagueOrgId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns org ID for a league with an org", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Clerk_Org_Id__c: "org_abc" }],
+    });
+
+    const orgId = await getLeagueOrgId("league_1");
+    expect(orgId).toBe("org_abc");
+  });
+
+  it("returns null for a public league", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Clerk_Org_Id__c: null }],
+    });
+
+    const orgId = await getLeagueOrgId("league_public");
+    expect(orgId).toBeNull();
+  });
+
+  it("throws when league not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+
+    await expect(getLeagueOrgId("nonexistent")).rejects.toThrow("League not found");
+  });
+});

--- a/apps/web/src/lib/__tests__/salesforce-api-scoped.test.ts
+++ b/apps/web/src/lib/__tests__/salesforce-api-scoped.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockQuery, mockSobjectCreate, mockSobjectUpdate } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockSobjectCreate: vi.fn(),
+  mockSobjectUpdate: vi.fn(),
+}));
+
+vi.mock("../salesforce", () => ({
+  getSalesforceConnection: vi.fn().mockResolvedValue({
+    query: mockQuery,
+    instanceUrl: "https://test.salesforce.com",
+    request: vi.fn(),
+    sobject: vi.fn().mockReturnValue({
+      create: mockSobjectCreate,
+      update: mockSobjectUpdate,
+    }),
+  }),
+}));
+
+vi.mock("../org-context", () => ({
+  requireOrgAdmin: vi.fn(),
+  requireLeagueAccess: vi.fn().mockImplementation((leagueId: string, ctx: { visibleLeagueIds: string[] }) => {
+    if (!ctx.visibleLeagueIds.includes(leagueId)) {
+      throw new Error("You do not have access to this league");
+    }
+  }),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn().mockResolvedValue({
+    organizations: { createOrganization: vi.fn() },
+    users: { getOrganizationMembershipList: vi.fn() },
+  }),
+}));
+
+import {
+  getLeagues,
+  getLeague,
+  getDivisions,
+  getDivision,
+  getTeams,
+  getTeamsByLeague,
+  getTeam,
+  getPlayers,
+  getPlayer,
+  getPlayersByTeam,
+  getSeasons,
+  getSeason,
+} from "../salesforce-api";
+import type { OrgContext } from "../org-context";
+
+const visibleCtx: OrgContext = {
+  userId: "u1",
+  orgIds: ["org_1"],
+  visibleLeagueIds: ["lg_1", "lg_public"],
+};
+
+const restrictedCtx: OrgContext = {
+  userId: "u2",
+  orgIds: [],
+  visibleLeagueIds: ["lg_public"],
+};
+
+describe("org-scoped reads", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // --- getLeagues ---
+
+  it("getLeagues returns empty array for empty visibleLeagueIds", async () => {
+    const result = await getLeagues([]);
+    expect(result).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("getLeagues queries with visible league IDs", async () => {
+    mockQuery.mockResolvedValue({
+      records: [
+        { Id: "lg_1", Name: "My League", Clerk_Org_Id__c: "org_1" },
+        { Id: "lg_public", Name: "NFL", Clerk_Org_Id__c: null },
+      ],
+    });
+
+    const result = await getLeagues(["lg_1", "lg_public"]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "lg_1", name: "My League", orgId: "org_1" });
+    expect(result[1]).toEqual({ id: "lg_public", name: "NFL", orgId: null });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE Id IN ('lg_1','lg_public')"),
+    );
+  });
+
+  // --- getLeague ---
+
+  it("getLeague throws when league is not in visible set", async () => {
+    await expect(getLeague("lg_other", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  it("getLeague returns league when accessible", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Id: "lg_public", Name: "NFL", Clerk_Org_Id__c: null }],
+    });
+
+    const result = await getLeague("lg_public", restrictedCtx);
+    expect(result).toEqual({ id: "lg_public", name: "NFL", orgId: null });
+  });
+
+  it("getLeague throws when league not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    await expect(getLeague("lg_public", visibleCtx)).rejects.toThrow("League not found");
+  });
+
+  // --- getDivisions ---
+
+  it("getDivisions returns empty array for empty visible set", async () => {
+    const result = await getDivisions([]);
+    expect(result).toEqual([]);
+  });
+
+  it("getDivisions filters by visible league IDs", async () => {
+    mockQuery.mockResolvedValue({
+      records: [{ Id: "d1", Name: "AFC", League__c: "lg_1" }],
+    });
+
+    const result = await getDivisions(["lg_1"]);
+    expect(result).toEqual([{ id: "d1", name: "AFC", leagueId: "lg_1" }]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE League__c IN"),
+    );
+  });
+
+  // --- getDivision ---
+
+  it("getDivision throws when division's league is not visible", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Id: "d1", Name: "AFC", League__c: "lg_other" }],
+    });
+
+    await expect(getDivision("d1", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  // --- getTeams ---
+
+  it("getTeams filters by visible league IDs", async () => {
+    mockQuery.mockResolvedValue({
+      records: [{
+        Id: "t1", Name: "Team A", League__c: "lg_1", City__c: "NYC",
+        Stadium__c: "Stadium 1", Founded_Year__c: 2000, Location__c: "NY",
+        Division__c: "d1", Logo_URL__c: null,
+      }],
+    });
+
+    const result = await getTeams(["lg_1"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Team A");
+    expect(result[0].leagueId).toBe("lg_1");
+  });
+
+  // --- getTeamsByLeague ---
+
+  it("getTeamsByLeague checks league access", async () => {
+    await expect(getTeamsByLeague("lg_other", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  // --- getTeam ---
+
+  it("getTeam checks league access via team's league", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{
+        Id: "t1", Name: "Team A", League__c: "lg_other", City__c: "NYC",
+        Stadium__c: "S", Founded_Year__c: null, Location__c: "",
+        Division__c: "d1", Logo_URL__c: null,
+      }],
+    });
+
+    await expect(getTeam("t1", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  it("getTeam throws when team not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    await expect(getTeam("t_none", visibleCtx)).rejects.toThrow("Team not found");
+  });
+
+  // --- getPlayers ---
+
+  it("getPlayers filters by team's league via relationship query", async () => {
+    mockQuery.mockResolvedValue({
+      records: [{
+        Id: "p1", Name: "Player 1", Team__c: "t1", Position__c: "QB",
+        Jersey_Number__c: 12, Date_of_Birth__c: "1990-01-01", Status__c: "Active",
+        Headshot_URL__c: null,
+      }],
+    });
+
+    const result = await getPlayers(["lg_1"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].position).toBe("QB");
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("Team__r.League__c IN"),
+    );
+  });
+
+  // --- getPlayer ---
+
+  it("getPlayer checks access via team relationship league", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{
+        Id: "p1", Name: "Player 1", Team__c: "t1", Position__c: "QB",
+        Jersey_Number__c: 12, Date_of_Birth__c: null, Status__c: "Active",
+        Headshot_URL__c: null, Team__r: { League__c: "lg_other" },
+      }],
+    });
+
+    await expect(getPlayer("p1", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  it("getPlayer throws when player not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    await expect(getPlayer("p_none", visibleCtx)).rejects.toThrow("Player not found");
+  });
+
+  // --- getPlayersByTeam ---
+
+  it("getPlayersByTeam verifies team's league is accessible", async () => {
+    mockQuery.mockResolvedValueOnce({
+      totalSize: 1,
+      records: [{ League__c: "lg_other" }],
+    });
+
+    await expect(getPlayersByTeam("t1", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  it("getPlayersByTeam throws when team not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    await expect(getPlayersByTeam("t_none", visibleCtx)).rejects.toThrow("Team not found");
+  });
+
+  // --- getSeasons ---
+
+  it("getSeasons returns empty for empty visible set", async () => {
+    const result = await getSeasons([]);
+    expect(result).toEqual([]);
+  });
+
+  it("getSeasons filters by visible league IDs", async () => {
+    mockQuery.mockResolvedValue({
+      records: [{
+        Id: "s1", Name: "2025-26", League__c: "lg_1",
+        Start_Date__c: "2025-08-01", End_Date__c: "2026-05-31", Status__c: "Active",
+      }],
+    });
+
+    const result = await getSeasons(["lg_1"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "s1", name: "2025-26", leagueId: "lg_1",
+      startDate: "2025-08-01", endDate: "2026-05-31", status: "Active",
+    });
+  });
+
+  // --- getSeason ---
+
+  it("getSeason checks league access", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{
+        Id: "s1", Name: "2025-26", League__c: "lg_other",
+        Start_Date__c: null, End_Date__c: null, Status__c: "Upcoming",
+      }],
+    });
+
+    await expect(getSeason("s1", restrictedCtx)).rejects.toThrow(
+      "You do not have access to this league",
+    );
+  });
+
+  it("getSeason throws when season not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    await expect(getSeason("s_none", visibleCtx)).rejects.toThrow("Season not found");
+  });
+});

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -1,0 +1,111 @@
+import { cache } from "react";
+import { clerkClient } from "@clerk/nextjs/server";
+import { getSalesforceConnection } from "./salesforce";
+
+export interface OrgContext {
+  userId: string;
+  orgIds: string[];
+  visibleLeagueIds: string[];
+}
+
+/**
+ * Resolves the authenticated user's org memberships and the Salesforce league IDs
+ * they are allowed to see. Uses React cache() to deduplicate within a single
+ * request/render pass.
+ *
+ * Visible leagues = leagues owned by user's orgs + public leagues (Clerk_Org_Id__c = null).
+ */
+export const resolveOrgContext = cache(
+  async (userId: string): Promise<OrgContext> => {
+    const client = await clerkClient();
+
+    // Get all orgs the user belongs to (handle pagination)
+    const orgIds: string[] = [];
+    let offset = 0;
+    const limit = 100;
+    let hasMore = true;
+
+    while (hasMore) {
+      const memberships =
+        await client.users.getOrganizationMembershipList({
+          userId,
+          limit,
+          offset,
+        });
+      for (const m of memberships.data) {
+        orgIds.push(m.organization.id);
+      }
+      hasMore = memberships.data.length === limit;
+      offset += limit;
+    }
+
+    // Query Salesforce for leagues the user can see
+    const conn = await getSalesforceConnection();
+    let soql: string;
+
+    if (orgIds.length === 0) {
+      // User has no orgs — can only see public leagues
+      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c = null`;
+    } else {
+      const orgIdList = orgIds.map((id) => `'${id}'`).join(",");
+      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdList}) OR Clerk_Org_Id__c = null`;
+    }
+
+    const result = await conn.query<{ Id: string }>(soql);
+    const visibleLeagueIds = result.records.map((r) => r.Id);
+
+    return { userId, orgIds, visibleLeagueIds };
+  },
+);
+
+/**
+ * Check that a specific league is within the user's visible set.
+ * Throws 403 if not.
+ */
+export function requireLeagueAccess(
+  leagueId: string,
+  orgContext: OrgContext,
+): void {
+  if (!orgContext.visibleLeagueIds.includes(leagueId)) {
+    throw new Error("You do not have access to this league");
+  }
+}
+
+/**
+ * Check that the user is an admin of a specific Clerk Organization.
+ * Used for mutations (create team, update player, etc.)
+ */
+export async function requireOrgAdmin(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
+
+  const membership = memberships.data.find(
+    (m) => m.organization.id === orgId,
+  );
+
+  if (!membership || membership.role !== "org:admin") {
+    throw new Error("You must be an admin of this league to make changes");
+  }
+}
+
+/**
+ * Find the Clerk Org ID that owns a given league.
+ * Returns null for public leagues.
+ */
+export async function getLeagueOrgId(
+  leagueId: string,
+): Promise<string | null> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Clerk_Org_Id__c: string | null }>(
+    `SELECT Clerk_Org_Id__c FROM League__c WHERE Id = '${leagueId}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) {
+    throw new Error("League not found");
+  }
+  return result.records[0].Clerk_Org_Id__c ?? null;
+}

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -1,6 +1,6 @@
 import { clerkClient } from "@clerk/nextjs/server";
 import { getSalesforceConnection } from "./salesforce";
-import { requireOrgAdmin } from "./org-context";
+import { requireOrgAdmin, requireLeagueAccess, type OrgContext } from "./org-context";
 import type {
   ApiResponse,
   LeagueDto,
@@ -48,57 +48,186 @@ async function mutate<T>(
   return res.data;
 }
 
-// Leagues
-export function getLeagues(): Promise<LeagueDto[]> {
-  return request<LeagueDto[]>("/leagues");
+// --- Org-scoped read functions (direct SOQL via jsforce) ---
+
+function idList(ids: string[]): string {
+  return ids.map((id) => `'${id}'`).join(",");
 }
 
-export function getLeague(id: string): Promise<LeagueDto> {
-  return request<LeagueDto>(`/leagues/${id}`);
+// Leagues
+export async function getLeagues(visibleLeagueIds: string[]): Promise<LeagueDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string; Name: string; Clerk_Org_Id__c: string | null }>(
+    `SELECT Id, Name, Clerk_Org_Id__c FROM League__c WHERE Id IN (${idList(visibleLeagueIds)})`,
+  );
+  return result.records.map((r) => ({ id: r.Id, name: r.Name, orgId: r.Clerk_Org_Id__c ?? null }));
+}
+
+export async function getLeague(id: string, orgContext: OrgContext): Promise<LeagueDto> {
+  requireLeagueAccess(id, orgContext);
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string; Name: string; Clerk_Org_Id__c: string | null }>(
+    `SELECT Id, Name, Clerk_Org_Id__c FROM League__c WHERE Id = '${id}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) throw new Error("League not found");
+  const r = result.records[0];
+  return { id: r.Id, name: r.Name, orgId: r.Clerk_Org_Id__c ?? null };
 }
 
 // Divisions
-export function getDivisions(): Promise<DivisionDto[]> {
-  return request<DivisionDto[]>("/divisions");
+export async function getDivisions(visibleLeagueIds: string[]): Promise<DivisionDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string; Name: string; League__c: string }>(
+    `SELECT Id, Name, League__c FROM Division__c WHERE League__c IN (${idList(visibleLeagueIds)})`,
+  );
+  return result.records.map((r) => ({ id: r.Id, name: r.Name, leagueId: r.League__c }));
 }
 
-export function getDivision(id: string): Promise<DivisionDto> {
-  return request<DivisionDto>(`/divisions/${id}`);
+export async function getDivision(id: string, orgContext: OrgContext): Promise<DivisionDto> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string; Name: string; League__c: string }>(
+    `SELECT Id, Name, League__c FROM Division__c WHERE Id = '${id}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) throw new Error("Division not found");
+  const r = result.records[0];
+  requireLeagueAccess(r.League__c, orgContext);
+  return { id: r.Id, name: r.Name, leagueId: r.League__c };
 }
 
 // Teams
-export function getTeams(): Promise<TeamDto[]> {
-  return request<TeamDto[]>("/teams");
+type TeamRec = {
+  Id: string; Name: string; League__c: string; City__c: string;
+  Stadium__c: string; Founded_Year__c: number | null;
+  Location__c: string; Division__c: string; Logo_URL__c: string | null;
+};
+
+const TEAM_FIELDS = "Id, Name, League__c, City__c, Stadium__c, Founded_Year__c, Location__c, Division__c, Logo_URL__c";
+
+function teamRecToDto(r: TeamRec): TeamDto {
+  return {
+    id: r.Id, name: r.Name, leagueId: r.League__c, city: r.City__c ?? "",
+    stadium: r.Stadium__c ?? "", foundedYear: r.Founded_Year__c ?? null,
+    location: r.Location__c ?? "", divisionId: r.Division__c ?? "",
+    logoUrl: r.Logo_URL__c ?? null,
+  };
 }
 
-export function getTeamsByLeague(leagueId: string): Promise<TeamDto[]> {
-  return request<TeamDto[]>(`/teams?leagueId=${encodeURIComponent(leagueId)}`);
+export async function getTeams(visibleLeagueIds: string[]): Promise<TeamDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<TeamRec>(
+    `SELECT ${TEAM_FIELDS} FROM Team__c WHERE League__c IN (${idList(visibleLeagueIds)})`,
+  );
+  return result.records.map(teamRecToDto);
 }
 
-export function getTeam(id: string): Promise<TeamDto> {
-  return request<TeamDto>(`/teams/${id}`);
+export async function getTeamsByLeague(leagueId: string, orgContext: OrgContext): Promise<TeamDto[]> {
+  requireLeagueAccess(leagueId, orgContext);
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<TeamRec>(
+    `SELECT ${TEAM_FIELDS} FROM Team__c WHERE League__c = '${leagueId}'`,
+  );
+  return result.records.map(teamRecToDto);
+}
+
+export async function getTeam(id: string, orgContext: OrgContext): Promise<TeamDto> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<TeamRec>(
+    `SELECT ${TEAM_FIELDS} FROM Team__c WHERE Id = '${id}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) throw new Error("Team not found");
+  const r = result.records[0];
+  requireLeagueAccess(r.League__c, orgContext);
+  return teamRecToDto(r);
 }
 
 // Players
-export function getPlayers(): Promise<PlayerDto[]> {
-  return request<PlayerDto[]>("/players");
+type PlayerRec = {
+  Id: string; Name: string; Team__c: string; Position__c: string;
+  Jersey_Number__c: number | null; Date_of_Birth__c: string | null;
+  Status__c: string; Headshot_URL__c: string | null;
+};
+
+const PLAYER_FIELDS = "Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c, Headshot_URL__c";
+
+function playerRecToDto(r: PlayerRec): PlayerDto {
+  return {
+    id: r.Id, name: r.Name, teamId: r.Team__c, position: r.Position__c ?? "",
+    jerseyNumber: r.Jersey_Number__c ?? null, dateOfBirth: r.Date_of_Birth__c ?? null,
+    status: r.Status__c ?? "", headshotUrl: r.Headshot_URL__c ?? null,
+  };
 }
 
-export function getPlayer(id: string): Promise<PlayerDto> {
-  return request<PlayerDto>(`/players/${id}`);
+export async function getPlayers(visibleLeagueIds: string[]): Promise<PlayerDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<PlayerRec>(
+    `SELECT ${PLAYER_FIELDS} FROM Player__c WHERE Team__r.League__c IN (${idList(visibleLeagueIds)})`,
+  );
+  return result.records.map(playerRecToDto);
 }
 
-export function getPlayersByTeam(teamId: string): Promise<PlayerDto[]> {
-  return request<PlayerDto[]>(`/players?teamId=${teamId}`);
+export async function getPlayer(id: string, orgContext: OrgContext): Promise<PlayerDto> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<PlayerRec & { Team__r: { League__c: string } }>(
+    `SELECT ${PLAYER_FIELDS}, Team__r.League__c FROM Player__c WHERE Id = '${id}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) throw new Error("Player not found");
+  const r = result.records[0];
+  requireLeagueAccess(r.Team__r.League__c, orgContext);
+  return playerRecToDto(r);
+}
+
+export async function getPlayersByTeam(teamId: string, orgContext: OrgContext): Promise<PlayerDto[]> {
+  // Verify team's league is accessible
+  const conn = await getSalesforceConnection();
+  const teamResult = await conn.query<{ League__c: string }>(
+    `SELECT League__c FROM Team__c WHERE Id = '${teamId}' LIMIT 1`,
+  );
+  if (teamResult.totalSize === 0) throw new Error("Team not found");
+  requireLeagueAccess(teamResult.records[0].League__c, orgContext);
+
+  const result = await conn.query<PlayerRec>(
+    `SELECT ${PLAYER_FIELDS} FROM Player__c WHERE Team__c = '${teamId}'`,
+  );
+  return result.records.map(playerRecToDto);
 }
 
 // Seasons
-export function getSeasons(): Promise<SeasonDto[]> {
-  return request<SeasonDto[]>("/seasons");
+export async function getSeasons(visibleLeagueIds: string[]): Promise<SeasonDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{
+    Id: string; Name: string; League__c: string;
+    Start_Date__c: string | null; End_Date__c: string | null; Status__c: string;
+  }>(
+    `SELECT Id, Name, League__c, Start_Date__c, End_Date__c, Status__c FROM Season__c WHERE League__c IN (${idList(visibleLeagueIds)})`,
+  );
+  return result.records.map((r) => ({
+    id: r.Id, name: r.Name, leagueId: r.League__c,
+    startDate: r.Start_Date__c ?? null, endDate: r.End_Date__c ?? null,
+    status: r.Status__c ?? "",
+  }));
 }
 
-export function getSeason(id: string): Promise<SeasonDto> {
-  return request<SeasonDto>(`/seasons/${id}`);
+export async function getSeason(id: string, orgContext: OrgContext): Promise<SeasonDto> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{
+    Id: string; Name: string; League__c: string;
+    Start_Date__c: string | null; End_Date__c: string | null; Status__c: string;
+  }>(
+    `SELECT Id, Name, League__c, Start_Date__c, End_Date__c, Status__c FROM Season__c WHERE Id = '${id}' LIMIT 1`,
+  );
+  if (result.totalSize === 0) throw new Error("Season not found");
+  const r = result.records[0];
+  requireLeagueAccess(r.League__c, orgContext);
+  return {
+    id: r.Id, name: r.Name, leagueId: r.League__c,
+    startDate: r.Start_Date__c ?? null, endDate: r.End_Date__c ?? null,
+    status: r.Status__c ?? "",
+  };
 }
 
 // Player mutations
@@ -200,26 +329,9 @@ export async function upsertTeam(input: {
   logoUrl?: string | null;
 }): Promise<{ dto: TeamDto; created: boolean }> {
   const conn = await getSalesforceConnection();
-  type TeamRec = {
-    Id: string; Name: string; League__c: string; City__c: string;
-    Stadium__c: string; Founded_Year__c: number | null;
-    Location__c: string; Division__c: string; Logo_URL__c: string | null;
-  };
   const existing = await conn.query<TeamRec>(
-    `SELECT Id, Name, League__c, City__c, Stadium__c, Founded_Year__c, Location__c, Division__c, Logo_URL__c FROM Team__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND League__c = '${input.leagueId}' LIMIT 1`,
+    `SELECT ${TEAM_FIELDS} FROM Team__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND League__c = '${input.leagueId}' LIMIT 1`,
   );
-
-  const toDto = (rec: TeamRec): TeamDto => ({
-    id: rec.Id,
-    name: rec.Name,
-    leagueId: rec.League__c,
-    city: rec.City__c ?? "",
-    stadium: rec.Stadium__c ?? "",
-    foundedYear: rec.Founded_Year__c ?? null,
-    location: rec.Location__c ?? "",
-    divisionId: rec.Division__c ?? "",
-    logoUrl: rec.Logo_URL__c ?? null,
-  });
 
   if (existing.totalSize > 0) {
     const rec = existing.records[0];
@@ -231,7 +343,7 @@ export async function upsertTeam(input: {
       ...(input.logoUrl !== undefined && { Logo_URL__c: input.logoUrl }),
     });
     const updated = { ...rec, City__c: input.city, Stadium__c: input.stadium, Division__c: input.divisionId, Logo_URL__c: input.logoUrl ?? rec.Logo_URL__c };
-    return { dto: toDto(updated), created: false };
+    return { dto: teamRecToDto(updated), created: false };
   }
 
   const result = await conn.sobject("Team__c").create({
@@ -246,7 +358,7 @@ export async function upsertTeam(input: {
     throw new Error(`Failed to create team: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
   }
   return {
-    dto: toDto({
+    dto: teamRecToDto({
       Id: result.id, Name: input.name, League__c: input.leagueId,
       City__c: input.city, Stadium__c: input.stadium,
       Founded_Year__c: null, Location__c: "", Division__c: input.divisionId,
@@ -266,28 +378,9 @@ export async function upsertPlayer(input: {
   headshotUrl?: string | null;
 }): Promise<{ dto: PlayerDto; created: boolean }> {
   const conn = await getSalesforceConnection();
-  const existing = await conn.query<{
-    Id: string; Name: string; Team__c: string; Position__c: string;
-    Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
-    Headshot_URL__c: string | null;
-  }>(
-    `SELECT Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c, Headshot_URL__c FROM Player__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND Team__c = '${input.teamId}' LIMIT 1`,
+  const existing = await conn.query<PlayerRec>(
+    `SELECT ${PLAYER_FIELDS} FROM Player__c WHERE Name = '${input.name.replace(/'/g, "\\'")}' AND Team__c = '${input.teamId}' LIMIT 1`,
   );
-
-  const toDto = (rec: {
-    Id: string; Name: string; Team__c: string; Position__c: string;
-    Jersey_Number__c: number | null; Date_of_Birth__c: string | null; Status__c: string;
-    Headshot_URL__c: string | null;
-  }): PlayerDto => ({
-    id: rec.Id,
-    name: rec.Name,
-    teamId: rec.Team__c,
-    position: rec.Position__c ?? "",
-    jerseyNumber: rec.Jersey_Number__c ?? null,
-    dateOfBirth: rec.Date_of_Birth__c ?? null,
-    status: rec.Status__c ?? "",
-    headshotUrl: rec.Headshot_URL__c ?? null,
-  });
 
   if (existing.totalSize > 0) {
     const rec = existing.records[0];
@@ -300,7 +393,7 @@ export async function upsertPlayer(input: {
       ...(input.headshotUrl !== undefined && { Headshot_URL__c: input.headshotUrl }),
     });
     return {
-      dto: toDto({
+      dto: playerRecToDto({
         ...rec,
         Position__c: input.position,
         Jersey_Number__c: input.jerseyNumber ?? null,
@@ -325,7 +418,7 @@ export async function upsertPlayer(input: {
     throw new Error(`Failed to create player: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
   }
   return {
-    dto: toDto({
+    dto: playerRecToDto({
       Id: result.id, Name: input.name, Team__c: input.teamId,
       Position__c: input.position, Jersey_Number__c: input.jerseyNumber ?? null,
       Date_of_Birth__c: input.dateOfBirth ?? null, Status__c: input.status,

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -1,4 +1,6 @@
+import { clerkClient } from "@clerk/nextjs/server";
 import { getSalesforceConnection } from "./salesforce";
+import { requireOrgAdmin } from "./org-context";
 import type {
   ApiResponse,
   LeagueDto,
@@ -129,7 +131,10 @@ export function updateTeam(
 
 // --- Upsert functions (direct sObject operations for import) ---
 
-export async function upsertLeague(name: string): Promise<{ dto: LeagueDto; created: boolean }> {
+export async function upsertLeague(
+  name: string,
+  createdByUserId?: string,
+): Promise<{ dto: LeagueDto; created: boolean }> {
   const conn = await getSalesforceConnection();
   const existing = await conn.query<{ Id: string; Name: string; Clerk_Org_Id__c: string | null }>(
     `SELECT Id, Name, Clerk_Org_Id__c FROM League__c WHERE Name = '${name.replace(/'/g, "\\'")}'  LIMIT 1`,
@@ -137,14 +142,32 @@ export async function upsertLeague(name: string): Promise<{ dto: LeagueDto; crea
 
   if (existing.totalSize > 0) {
     const rec = existing.records[0];
+    // If league exists and has an org, verify user is admin of that org
+    if (rec.Clerk_Org_Id__c && createdByUserId) {
+      await requireOrgAdmin(rec.Clerk_Org_Id__c, createdByUserId);
+    }
     return { dto: { id: rec.Id, name: rec.Name, orgId: rec.Clerk_Org_Id__c ?? null }, created: false };
   }
 
-  const result = await conn.sobject("League__c").create({ Name: name });
+  // Create Clerk Organization if we have a user context
+  let orgId: string | null = null;
+  if (createdByUserId) {
+    const client = await clerkClient();
+    const org = await client.organizations.createOrganization({
+      name,
+      createdBy: createdByUserId,
+    });
+    orgId = org.id;
+  }
+
+  const result = await conn.sobject("League__c").create({
+    Name: name,
+    Clerk_Org_Id__c: orgId,
+  });
   if (!result.success) {
     throw new Error(`Failed to create league: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
   }
-  return { dto: { id: result.id, name, orgId: null }, created: true };
+  return { dto: { id: result.id, name, orgId }, created: true };
 }
 
 export async function upsertDivision(
@@ -316,6 +339,7 @@ export async function upsertPlayer(input: {
 
 export async function bulkImportLeague(
   payload: LeagueImportPayload,
+  createdByUserId?: string,
 ): Promise<ImportResult> {
   const errors: ImportError[] = [];
   const created = { leagues: 0, divisions: 0, teams: 0, players: 0 };
@@ -324,7 +348,7 @@ export async function bulkImportLeague(
   // 1. Upsert league
   let leagueId: string;
   try {
-    const leagueResult = await upsertLeague(payload.league.name);
+    const leagueResult = await upsertLeague(payload.league.name, createdByUserId);
     leagueId = leagueResult.dto.id;
     if (leagueResult.created) created.leagues++; else updated.leagues++;
   } catch (err) {

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -131,20 +131,20 @@ export function updateTeam(
 
 export async function upsertLeague(name: string): Promise<{ dto: LeagueDto; created: boolean }> {
   const conn = await getSalesforceConnection();
-  const existing = await conn.query<{ Id: string; Name: string }>(
-    `SELECT Id, Name FROM League__c WHERE Name = '${name.replace(/'/g, "\\'")}'  LIMIT 1`,
+  const existing = await conn.query<{ Id: string; Name: string; Clerk_Org_Id__c: string | null }>(
+    `SELECT Id, Name, Clerk_Org_Id__c FROM League__c WHERE Name = '${name.replace(/'/g, "\\'")}'  LIMIT 1`,
   );
 
   if (existing.totalSize > 0) {
     const rec = existing.records[0];
-    return { dto: { id: rec.Id, name: rec.Name }, created: false };
+    return { dto: { id: rec.Id, name: rec.Name, orgId: rec.Clerk_Org_Id__c ?? null }, created: false };
   }
 
   const result = await conn.sobject("League__c").create({ Name: name });
   if (!result.success) {
     throw new Error(`Failed to create league: ${result.errors?.map((e) => e.message).join(", ") ?? "unknown error"}`);
   }
-  return { dto: { id: result.id, name }, created: true };
+  return { dto: { id: result.id, name, orgId: null }, created: true };
 }
 
 export async function upsertDivision(

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -19,6 +19,7 @@ import type {
 export const LeagueDtoSchema = z.object({
   id: z.string(),
   name: z.string(),
+  orgId: z.string().nullable(),
 }) satisfies z.ZodType<LeagueDto>;
 
 export const DivisionDtoSchema = z.object({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -8,6 +8,7 @@ export interface ApiResponse<T> {
 export interface LeagueDto {
   id: string;
   name: string;
+  orgId: string | null;
 }
 
 export interface DivisionDto {

--- a/sportsmgmt/main/default/objects/League__c/fields/Clerk_Org_Id__c.field-meta.xml
+++ b/sportsmgmt/main/default/objects/League__c/fields/Clerk_Org_Id__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Clerk_Org_Id__c</fullName>
+    <description>Clerk Organization ID that owns this league. Null means the league is public (e.g., NFL).</description>
+    <externalId>true</externalId>
+    <label>Clerk Org ID</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- Adds league-level data isolation via Clerk Organizations (1:1 org-to-league mapping)
- Migrates all 12 read functions from Apex REST to direct SOQL with `visibleLeagueIds` filtering
- Updates all 24 API routes and SSR pages to resolve org context before data access
- Auto-creates Clerk Organization on league import; NFL sync creates public leagues (`Clerk_Org_Id__c = null`)
- New `Clerk_Org_Id__c` field on League__c, `orgId` on LeagueDto/schema

## Changes (3 commits)
1. **A1+A4**: Salesforce `Clerk_Org_Id__c` field + `orgId` on DTOs and Zod schemas
2. **A2+A3**: `resolveOrgContext()`, `requireLeagueAccess()`, `requireOrgAdmin()` + Clerk Org auto-creation on import
3. **A5+A6+A7**: Org-scoped SOQL reads, route/page updates, 32 new authorization tests

## Test plan
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [x] `pnpm --filter web run test:unit` — 126 tests pass (32 new)
- [x] `pnpm --filter tui exec vitest run` — 88 tests pass
- [ ] Manual: import JSON → verify Clerk Org created, league stamped with org ID
- [ ] Manual: second user logs in → cannot see first user's league
- [ ] Manual: NFL sync → league has null org ID → visible to all

🤖 Generated with [Claude Code](https://claude.com/claude-code)