### PR TITLE
feat: add league detail page with email invitations

### DIFF
--- a/apps/web/src/app/api/orgs/[orgId]/invitations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/invitations/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth, mockRequireOrgAdmin, mockGetInvitationList, mockCreateInvitation } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockRequireOrgAdmin: vi.fn(),
+  mockGetInvitationList: vi.fn(),
+  mockCreateInvitation: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  clerkClient: vi.fn().mockResolvedValue({
+    organizations: {
+      getOrganizationInvitationList: mockGetInvitationList,
+      createOrganizationInvitation: mockCreateInvitation,
+    },
+  }),
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requireOrgAdmin: mockRequireOrgAdmin,
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockReturnValue(
+    new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 }),
+  ),
+}));
+
+import { GET, POST } from "../route";
+import { NextRequest } from "next/server";
+
+function makeParams(orgId: string) {
+  return { params: Promise.resolve({ orgId }) };
+}
+
+function makeRequest(body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/orgs/org_1/invitations", {
+    method: body ? "POST" : "GET",
+    ...(body && {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  });
+}
+
+describe("GET /api/orgs/[orgId]/invitations", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockRejectedValue(new Error("You must be an admin of this league to make changes"));
+
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns invitation list for admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockGetInvitationList.mockResolvedValue({
+      data: [
+        { id: "inv_1", emailAddress: "a@b.com", status: "pending", createdAt: 1700000000000 },
+        { id: "inv_2", emailAddress: "c@d.com", status: "accepted", createdAt: 1700100000000 },
+      ],
+    });
+
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body[0]).toEqual({
+      id: "inv_1",
+      emailAddress: "a@b.com",
+      status: "pending",
+      createdAt: 1700000000000,
+    });
+  });
+});
+
+describe("POST /api/orgs/[orgId]/invitations", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await POST(makeRequest({ emailAddress: "a@b.com" }), makeParams("org_1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockRejectedValue(new Error("You must be an admin of this league to make changes"));
+
+    const res = await POST(makeRequest({ emailAddress: "a@b.com" }), makeParams("org_1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ emailAddress: "not-an-email" }), makeParams("org_1"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Valid email address is required");
+  });
+
+  it("returns 201 and creates invitation", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockCreateInvitation.mockResolvedValue({
+      id: "inv_new",
+      emailAddress: "new@example.com",
+      status: "pending",
+      createdAt: 1700200000000,
+    });
+
+    const res = await POST(makeRequest({ emailAddress: "new@example.com" }), makeParams("org_1"));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({
+      id: "inv_new",
+      emailAddress: "new@example.com",
+      status: "pending",
+      createdAt: 1700200000000,
+    });
+    expect(mockCreateInvitation).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      emailAddress: "new@example.com",
+      role: "org:member",
+      inviterUserId: "user_1",
+    });
+  });
+});

--- a/apps/web/src/app/api/orgs/[orgId]/invitations/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/invitations/route.ts
@@ -1,0 +1,88 @@
+import { auth } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgAdmin } from "@/lib/org-context";
+import { handleApiError } from "@/lib/api-error";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const client = await clerkClient();
+    const invitations = await client.organizations.getOrganizationInvitationList({
+      organizationId: orgId,
+    });
+
+    const data = invitations.data.map((inv) => ({
+      id: inv.id,
+      emailAddress: inv.emailAddress,
+      status: inv.status,
+      createdAt: inv.createdAt,
+    }));
+
+    return NextResponse.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/invitations");
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const body = await request.json();
+    const { emailAddress } = body;
+
+    if (!emailAddress || typeof emailAddress !== "string" || !emailAddress.includes("@")) {
+      return NextResponse.json({ error: "Valid email address is required" }, { status: 400 });
+    }
+
+    const client = await clerkClient();
+    const invitation = await client.organizations.createOrganizationInvitation({
+      organizationId: orgId,
+      emailAddress,
+      role: "org:member",
+      inviterUserId: userId,
+    });
+
+    return NextResponse.json(
+      {
+        id: invitation.id,
+        emailAddress: invitation.emailAddress,
+        status: invitation.status,
+        createdAt: invitation.createdAt,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/invitations");
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+
+interface Invitation {
+  id: string;
+  emailAddress: string;
+  status: string;
+  createdAt: string;
+}
+
+export default function InvitationList({ orgId }: { orgId: string }) {
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/orgs/${orgId}/invitations`);
+        if (res.ok) {
+          const data = await res.json();
+          setInvitations(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [orgId]);
+
+  if (loading) return <p className="text-sm text-gray-500">Loading invitations...</p>;
+  if (invitations.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">Pending Invitations</h3>
+      <ul className="space-y-2">
+        {invitations.map((inv) => (
+          <li
+            key={inv.id}
+            className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm"
+          >
+            <span className="text-gray-700">{inv.emailAddress}</span>
+            <div className="flex items-center gap-2">
+              <Badge variant={inv.status === "pending" ? "secondary" : "outline"}>
+                {inv.status}
+              </Badge>
+              <span className="text-xs text-gray-400">
+                {new Date(inv.createdAt).toLocaleDateString()}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function InviteForm({ orgId }: { orgId: string }) {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/invitations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emailAddress: email }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Failed to send invitation");
+      }
+
+      setEmail("");
+      setSuccess(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send invitation");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">Invite Member</h3>
+      <form onSubmit={handleSubmit} className="flex items-end gap-3">
+        <div className="flex-1">
+          <Label htmlFor="invite-email">Email address</Label>
+          <Input
+            id="invite-email"
+            type="email"
+            placeholder="user@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Sending..." : "Send Invite"}
+        </Button>
+      </form>
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      {success && (
+        <p className="mt-2 text-sm text-green-600">Invitation sent successfully!</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getLeague } from "@/lib/salesforce-api";
+import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Trophy } from "lucide-react";
+import InviteForm from "./invite-form";
+import InvitationList from "./invitation-list";
+
+export default async function LeagueDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(id, orgContext);
+
+  // Check if user is admin of this league's org
+  let isAdmin = false;
+  if (league.orgId) {
+    try {
+      await requireOrgAdmin(league.orgId, userId);
+      isAdmin = true;
+    } catch {
+      // Not admin — read-only view
+    }
+  }
+
+  return (
+    <div>
+      <Link
+        href="/dashboard/leagues"
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Leagues
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <Trophy className="h-5 w-5 text-primary" />
+            <CardTitle>{league.name}</CardTitle>
+            {league.orgId ? (
+              <Badge variant="secondary">Organization</Badge>
+            ) : (
+              <Badge variant="outline">Public</Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isAdmin && league.orgId && (
+            <div className="space-y-6">
+              <InviteForm orgId={league.orgId} />
+              <InvitationList orgId={league.orgId} />
+            </div>
+          )}
+          {!isAdmin && (
+            <p className="text-sm text-gray-500">
+              You have read-only access to this league.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -55,7 +55,11 @@ export default async function LeaguesPage() {
                 <CardHeader>
                   <div className="flex items-center gap-3">
                     <Trophy className="h-5 w-5 text-primary" />
-                    <CardTitle>{league.name}</CardTitle>
+                    <CardTitle>
+                      <Link href={`/dashboard/leagues/${league.id}`} className="hover:underline">
+                        {league.name}
+                      </Link>
+                    </CardTitle>
                     <Badge variant="secondary">
                       {leagueDivisions.length} division
                       {leagueDivisions.length !== 1 ? "s" : ""}


### PR DESCRIPTION
## Summary
- League detail page (`/dashboard/leagues/[id]`) showing league info with admin detection
- Invite form for admins to send email invitations via Clerk Organizations API
- Invitation list showing pending/accepted invitations with status badges
- API route (GET/POST) at `/api/orgs/[orgId]/invitations` with auth + admin guards
- League list page now links to league detail pages

## Phase B Story
B1 — Invite by Email (part of multi-tenancy Phase B)

## Test plan
- [ ] 7 new tests for invitation API routes (401, 403, 400, 200, 201)
- [ ] All 133 web tests passing
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>