### PR TITLE
feat: add public league discovery with opt-in subscriptions

### DIFF
--- a/apps/web/src/app/api/leagues/public/__tests__/route.test.ts
+++ b/apps/web/src/app/api/leagues/public/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth, mockQuery } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/salesforce", () => ({
+  getSalesforceConnection: vi.fn().mockResolvedValue({
+    query: mockQuery,
+  }),
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockImplementation((error: unknown, route: string) => {
+    const { NextResponse } = require("next/server");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }),
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/leagues/public", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with public leagues", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockQuery.mockResolvedValue({
+      records: [
+        { Id: "lg_1", Name: "NFL", Clerk_Org_Id__c: null },
+        { Id: "lg_2", Name: "NBA", Clerk_Org_Id__c: null },
+      ],
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual([
+      { id: "lg_1", name: "NFL", orgId: null },
+      { id: "lg_2", name: "NBA", orgId: null },
+    ]);
+  });
+});

--- a/apps/web/src/app/api/leagues/public/route.ts
+++ b/apps/web/src/app/api/leagues/public/route.ts
@@ -1,0 +1,18 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import { getPublicLeagues } from "@/lib/salesforce-api";
+import { handleApiError } from "@/lib/api-error";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const leagues = await getPublicLeagues();
+    return NextResponse.json(leagues);
+  } catch (error) {
+    return handleApiError(error, "/api/leagues/public");
+  }
+}

--- a/apps/web/src/app/api/leagues/subscribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/leagues/subscribe/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAuth, mockQuery, mockGetUser, mockUpdateUser } = vi.hoisted(
+  () => ({
+    mockAuth: vi.fn(),
+    mockQuery: vi.fn(),
+    mockGetUser: vi.fn(),
+    mockUpdateUser: vi.fn(),
+  }),
+);
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  clerkClient: vi.fn().mockResolvedValue({
+    users: {
+      getUser: mockGetUser,
+      updateUser: mockUpdateUser,
+    },
+  }),
+}));
+
+vi.mock("@/lib/salesforce", () => ({
+  getSalesforceConnection: vi.fn().mockResolvedValue({
+    query: mockQuery,
+  }),
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockImplementation((error: unknown, route: string) => {
+    const { NextResponse } = require("next/server");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }),
+}));
+
+import { POST, DELETE } from "../route";
+import { NextRequest } from "next/server";
+
+function makeRequest(body: unknown, method = "POST"): NextRequest {
+  return new NextRequest("http://localhost/api/leagues/subscribe", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/leagues/subscribe", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const res = await POST(makeRequest({ leagueId: "lg_1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when leagueId is missing", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when league is not public", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+
+    const res = await POST(makeRequest({ leagueId: "lg_private" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 and subscribes successfully", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Id: "lg_pub" }],
+    });
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: [] },
+    });
+    mockUpdateUser.mockResolvedValue({});
+
+    const res = await POST(makeRequest({ leagueId: "lg_pub" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.message).toBe("Subscribed");
+    expect(mockUpdateUser).toHaveBeenCalledWith("user_1", {
+      publicMetadata: { subscribedLeagueIds: ["lg_pub"] },
+    });
+  });
+
+  it("returns 200 when already subscribed (idempotent)", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ Id: "lg_pub" }],
+    });
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: ["lg_pub"] },
+    });
+
+    const res = await POST(makeRequest({ leagueId: "lg_pub" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.message).toBe("Already subscribed");
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/leagues/subscribe", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const res = await DELETE(makeRequest({ leagueId: "lg_1" }, "DELETE"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 and unsubscribes successfully", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: ["lg_pub", "lg_other"] },
+    });
+    mockUpdateUser.mockResolvedValue({});
+
+    const res = await DELETE(makeRequest({ leagueId: "lg_pub" }, "DELETE"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.message).toBe("Unsubscribed");
+    expect(mockUpdateUser).toHaveBeenCalledWith("user_1", {
+      publicMetadata: { subscribedLeagueIds: ["lg_other"] },
+    });
+  });
+});

--- a/apps/web/src/app/api/leagues/subscribe/route.ts
+++ b/apps/web/src/app/api/leagues/subscribe/route.ts
@@ -1,0 +1,90 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { getSalesforceConnection } from "@/lib/salesforce";
+import { handleApiError } from "@/lib/api-error";
+
+async function verifyPublicLeague(leagueId: string): Promise<boolean> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string }>(
+    `SELECT Id FROM League__c WHERE Id = '${leagueId}' AND Clerk_Org_Id__c = null LIMIT 1`,
+  );
+  return result.totalSize > 0;
+}
+
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { leagueId } = await request.json();
+    if (!leagueId || typeof leagueId !== "string") {
+      return NextResponse.json(
+        { error: "leagueId is required" },
+        { status: 400 },
+      );
+    }
+
+    const isPublic = await verifyPublicLeague(leagueId);
+    if (!isPublic) {
+      return NextResponse.json(
+        { error: "League not found or not public" },
+        { status: 404 },
+      );
+    }
+
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const current =
+      (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
+
+    if (current.includes(leagueId)) {
+      return NextResponse.json({ message: "Already subscribed" });
+    }
+
+    await client.users.updateUser(userId, {
+      publicMetadata: {
+        ...user.publicMetadata,
+        subscribedLeagueIds: [...current, leagueId],
+      },
+    });
+
+    return NextResponse.json({ message: "Subscribed" });
+  } catch (error) {
+    return handleApiError(error, "/api/leagues/subscribe");
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { leagueId } = await request.json();
+    if (!leagueId || typeof leagueId !== "string") {
+      return NextResponse.json(
+        { error: "leagueId is required" },
+        { status: 400 },
+      );
+    }
+
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const current =
+      (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
+
+    await client.users.updateUser(userId, {
+      publicMetadata: {
+        ...user.publicMetadata,
+        subscribedLeagueIds: current.filter((id) => id !== leagueId),
+      },
+    });
+
+    return NextResponse.json({ message: "Unsubscribed" });
+  } catch (error) {
+    return handleApiError(error, "/api/leagues/subscribe");
+  }
+}

--- a/apps/web/src/app/dashboard/_components/sidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Calendar,
   Layers,
   Trophy,
+  Compass,
   Upload,
   CreditCard,
 } from "lucide-react";
@@ -15,6 +16,7 @@ import NavLink from "./nav-link";
 const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
   { href: "/dashboard/leagues", label: "Leagues", icon: Trophy },
+  { href: "/dashboard/discover", label: "Discover", icon: Compass },
   { href: "/dashboard/teams", label: "Teams", icon: Users },
   { href: "/dashboard/players", label: "Players", icon: UserCircle },
   { href: "/dashboard/seasons", label: "Seasons", icon: Calendar },

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Trophy } from "lucide-react";
+
+interface League {
+  id: string;
+  name: string;
+  orgId: string | null;
+}
+
+export default function DiscoverLeagues({
+  leagues,
+  subscribedIds,
+}: {
+  leagues: League[];
+  subscribedIds: string[];
+}) {
+  const router = useRouter();
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [currentSubscribed, setCurrentSubscribed] =
+    useState<string[]>(subscribedIds);
+
+  async function handleToggle(leagueId: string, isSubscribed: boolean) {
+    setLoadingId(leagueId);
+    try {
+      const res = await fetch("/api/leagues/subscribe", {
+        method: isSubscribed ? "DELETE" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ leagueId }),
+      });
+
+      if (res.ok) {
+        setCurrentSubscribed((prev) =>
+          isSubscribed
+            ? prev.filter((id) => id !== leagueId)
+            : [...prev, leagueId],
+        );
+        router.refresh();
+      }
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  if (leagues.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">No public leagues available.</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {leagues.map((league) => {
+        const isSubscribed = currentSubscribed.includes(league.id);
+        const isLoading = loadingId === league.id;
+
+        return (
+          <Card key={league.id}>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Trophy className="h-4 w-4 text-primary" />
+                <CardTitle className="text-base">{league.name}</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center justify-between">
+                <Badge variant="outline">Public</Badge>
+                <Button
+                  size="sm"
+                  variant={isSubscribed ? "outline" : "default"}
+                  disabled={isLoading}
+                  onClick={() => handleToggle(league.id, isSubscribed)}
+                >
+                  {isLoading
+                    ? "..."
+                    : isSubscribed
+                      ? "Unsubscribe"
+                      : "Subscribe"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/discover/page.tsx
+++ b/apps/web/src/app/dashboard/discover/page.tsx
@@ -1,0 +1,31 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getPublicLeagues } from "@/lib/salesforce-api";
+import DiscoverLeagues from "./discover-leagues";
+
+export default async function DiscoverPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const subscribedLeagueIds =
+    (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
+
+  const publicLeagues = await getPublicLeagues();
+
+  return (
+    <div>
+      <h2 className="mb-2 text-lg font-semibold text-gray-900">
+        Discover Leagues
+      </h2>
+      <p className="mb-6 text-sm text-gray-500">
+        Browse public leagues and add them to your dashboard.
+      </p>
+      <DiscoverLeagues
+        leagues={publicLeagues}
+        subscribedIds={subscribedLeagueIds}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetOrganizationMembershipList, mockQuery } = vi.hoisted(() => ({
-  mockGetOrganizationMembershipList: vi.fn(),
-  mockQuery: vi.fn(),
-}));
+const { mockGetOrganizationMembershipList, mockQuery, mockGetUser } =
+  vi.hoisted(() => ({
+    mockGetOrganizationMembershipList: vi.fn(),
+    mockQuery: vi.fn(),
+    mockGetUser: vi.fn(),
+  }));
 
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn().mockResolvedValue({
     users: {
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
+      getUser: mockGetUser,
     },
   }),
 }));
@@ -23,7 +26,12 @@ vi.mock("react", () => ({
   cache: (fn: Function) => fn,
 }));
 
-import { resolveOrgContext, requireLeagueAccess, requireOrgAdmin, getLeagueOrgId } from "../org-context";
+import {
+  resolveOrgContext,
+  requireLeagueAccess,
+  requireOrgAdmin,
+  getLeagueOrgId,
+} from "../org-context";
 
 describe("resolveOrgContext", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -36,39 +44,87 @@ describe("resolveOrgContext", () => {
       ],
     });
 
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: [] },
+    });
+
     mockQuery.mockResolvedValue({
-      records: [
-        { Id: "league_1" },
-        { Id: "league_2" },
-        { Id: "league_public" },
-      ],
+      records: [{ Id: "league_1" }, { Id: "league_2" }],
     });
 
     const ctx = await resolveOrgContext("user_123");
 
     expect(ctx.userId).toBe("user_123");
     expect(ctx.orgIds).toEqual(["org_abc", "org_def"]);
-    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_2", "league_public"]);
+    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_2"]);
+    expect(ctx.subscribedLeagueIds).toEqual([]);
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining("org_abc"),
     );
-    expect(mockQuery).toHaveBeenCalledWith(
+    expect(mockQuery).not.toHaveBeenCalledWith(
       expect.stringContaining("Clerk_Org_Id__c = null"),
     );
   });
 
-  it("returns only public leagues when user has no orgs", async () => {
+  it("returns empty visibleLeagueIds when no orgs and no subscriptions", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
-    mockQuery.mockResolvedValue({
-      records: [{ Id: "league_public" }],
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: [] },
     });
 
     const ctx = await resolveOrgContext("user_no_orgs");
 
     expect(ctx.orgIds).toEqual([]);
-    expect(ctx.visibleLeagueIds).toEqual(["league_public"]);
+    expect(ctx.visibleLeagueIds).toEqual([]);
+    expect(ctx.subscribedLeagueIds).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("includes subscribed public league IDs in visible set", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: ["league_pub_1", "league_pub_2"] },
+    });
+
+    mockQuery.mockResolvedValue({
+      records: [{ Id: "league_pub_1" }, { Id: "league_pub_2" }],
+    });
+
+    const ctx = await resolveOrgContext("user_with_subs");
+
+    expect(ctx.orgIds).toEqual([]);
+    expect(ctx.visibleLeagueIds).toEqual(["league_pub_1", "league_pub_2"]);
+    expect(ctx.subscribedLeagueIds).toEqual([
+      "league_pub_1",
+      "league_pub_2",
+    ]);
     expect(mockQuery).toHaveBeenCalledWith(
-      "SELECT Id FROM League__c WHERE Clerk_Org_Id__c = null",
+      expect.stringContaining("Id IN"),
+    );
+  });
+
+  it("combines org leagues and subscribed leagues", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_abc" } }],
+    });
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: ["league_pub_1"] },
+    });
+
+    mockQuery.mockResolvedValue({
+      records: [{ Id: "league_1" }, { Id: "league_pub_1" }],
+    });
+
+    const ctx = await resolveOrgContext("user_both");
+
+    expect(ctx.orgIds).toEqual(["org_abc"]);
+    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_pub_1"]);
+    expect(ctx.subscribedLeagueIds).toEqual(["league_pub_1"]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("Clerk_Org_Id__c IN"),
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("Id IN"),
     );
   });
 
@@ -82,12 +138,26 @@ describe("resolveOrgContext", () => {
       .mockResolvedValueOnce({ data: firstPage })
       .mockResolvedValueOnce({ data: secondPage });
 
+    mockGetUser.mockResolvedValue({
+      publicMetadata: { subscribedLeagueIds: [] },
+    });
+
     mockQuery.mockResolvedValue({ records: [] });
 
     const ctx = await resolveOrgContext("user_many_orgs");
 
     expect(ctx.orgIds).toHaveLength(101);
     expect(mockGetOrganizationMembershipList).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles missing publicMetadata gracefully", async () => {
+    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
+    mockGetUser.mockResolvedValue({ publicMetadata: {} });
+
+    const ctx = await resolveOrgContext("user_no_metadata");
+
+    expect(ctx.subscribedLeagueIds).toEqual([]);
+    expect(ctx.visibleLeagueIds).toEqual([]);
   });
 });
 
@@ -97,6 +167,7 @@ describe("requireLeagueAccess", () => {
       userId: "u1",
       orgIds: ["org_1"],
       visibleLeagueIds: ["lg_1", "lg_2"],
+      subscribedLeagueIds: [],
     };
     expect(() => requireLeagueAccess("lg_1", ctx)).not.toThrow();
   });
@@ -106,6 +177,7 @@ describe("requireLeagueAccess", () => {
       userId: "u1",
       orgIds: ["org_1"],
       visibleLeagueIds: ["lg_1"],
+      subscribedLeagueIds: [],
     };
     expect(() => requireLeagueAccess("lg_other", ctx)).toThrow(
       "You do not have access to this league",
@@ -118,19 +190,17 @@ describe("requireOrgAdmin", () => {
 
   it("does not throw when user is org admin", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({
-      data: [
-        { organization: { id: "org_abc" }, role: "org:admin" },
-      ],
+      data: [{ organization: { id: "org_abc" }, role: "org:admin" }],
     });
 
-    await expect(requireOrgAdmin("org_abc", "user_123")).resolves.toBeUndefined();
+    await expect(
+      requireOrgAdmin("org_abc", "user_123"),
+    ).resolves.toBeUndefined();
   });
 
   it("throws when user is not admin", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({
-      data: [
-        { organization: { id: "org_abc" }, role: "org:member" },
-      ],
+      data: [{ organization: { id: "org_abc" }, role: "org:member" }],
     });
 
     await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
@@ -140,9 +210,7 @@ describe("requireOrgAdmin", () => {
 
   it("throws when user is not a member of the org at all", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({
-      data: [
-        { organization: { id: "org_other" }, role: "org:admin" },
-      ],
+      data: [{ organization: { id: "org_other" }, role: "org:admin" }],
     });
 
     await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
@@ -177,6 +245,8 @@ describe("getLeagueOrgId", () => {
   it("throws when league not found", async () => {
     mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
 
-    await expect(getLeagueOrgId("nonexistent")).rejects.toThrow("League not found");
+    await expect(getLeagueOrgId("nonexistent")).rejects.toThrow(
+      "League not found",
+    );
   });
 });

--- a/apps/web/src/lib/__tests__/salesforce-api-scoped.test.ts
+++ b/apps/web/src/lib/__tests__/salesforce-api-scoped.test.ts
@@ -54,12 +54,14 @@ const visibleCtx: OrgContext = {
   userId: "u1",
   orgIds: ["org_1"],
   visibleLeagueIds: ["lg_1", "lg_public"],
+  subscribedLeagueIds: [],
 };
 
 const restrictedCtx: OrgContext = {
   userId: "u2",
   orgIds: [],
   visibleLeagueIds: ["lg_public"],
+  subscribedLeagueIds: [],
 };
 
 describe("org-scoped reads", () => {

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -6,6 +6,7 @@ export interface OrgContext {
   userId: string;
   orgIds: string[];
   visibleLeagueIds: string[];
+  subscribedLeagueIds: string[];
 }
 
 /**
@@ -13,7 +14,9 @@ export interface OrgContext {
  * they are allowed to see. Uses React cache() to deduplicate within a single
  * request/render pass.
  *
- * Visible leagues = leagues owned by user's orgs + public leagues (Clerk_Org_Id__c = null).
+ * Visible leagues = leagues owned by user's orgs + explicitly subscribed public leagues.
+ * Public leagues (Clerk_Org_Id__c = null) are opt-in only via subscribedLeagueIds
+ * stored in Clerk user publicMetadata.
  */
 export const resolveOrgContext = cache(
   async (userId: string): Promise<OrgContext> => {
@@ -39,24 +42,44 @@ export const resolveOrgContext = cache(
       offset += limit;
     }
 
-    // Query Salesforce for leagues the user can see
+    // Get subscribed public league IDs from Clerk user metadata
+    const user = await client.users.getUser(userId);
+    const subscribedLeagueIds =
+      (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
+
+    // Build SOQL based on what the user has access to
+    const hasOrgs = orgIds.length > 0;
+    const hasSubs = subscribedLeagueIds.length > 0;
+
+    if (!hasOrgs && !hasSubs) {
+      return { userId, orgIds, visibleLeagueIds: [], subscribedLeagueIds };
+    }
+
     const conn = await getSalesforceConnection();
     let soql: string;
 
-    if (orgIds.length === 0) {
-      // User has no orgs — can only see public leagues
-      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c = null`;
+    if (hasOrgs && hasSubs) {
+      const orgIdStr = idList(orgIds);
+      const subIdStr = idList(subscribedLeagueIds);
+      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr}) OR Id IN (${subIdStr})`;
+    } else if (hasOrgs) {
+      const orgIdStr = idList(orgIds);
+      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr})`;
     } else {
-      const orgIdList = orgIds.map((id) => `'${id}'`).join(",");
-      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdList}) OR Clerk_Org_Id__c = null`;
+      const subIdStr = idList(subscribedLeagueIds);
+      soql = `SELECT Id FROM League__c WHERE Id IN (${subIdStr})`;
     }
 
     const result = await conn.query<{ Id: string }>(soql);
     const visibleLeagueIds = result.records.map((r) => r.Id);
 
-    return { userId, orgIds, visibleLeagueIds };
+    return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
   },
 );
+
+function idList(ids: string[]): string {
+  return ids.map((id) => `'${id}'`).join(",");
+}
 
 /**
  * Check that a specific league is within the user's visible set.

--- a/apps/web/src/lib/salesforce-api.ts
+++ b/apps/web/src/lib/salesforce-api.ts
@@ -54,6 +54,15 @@ function idList(ids: string[]): string {
   return ids.map((id) => `'${id}'`).join(",");
 }
 
+// Public leagues (no org context required)
+export async function getPublicLeagues(): Promise<LeagueDto[]> {
+  const conn = await getSalesforceConnection();
+  const result = await conn.query<{ Id: string; Name: string; Clerk_Org_Id__c: string | null }>(
+    "SELECT Id, Name, Clerk_Org_Id__c FROM League__c WHERE Clerk_Org_Id__c = null",
+  );
+  return result.records.map((r) => ({ id: r.Id, name: r.Name, orgId: r.Clerk_Org_Id__c ?? null }));
+}
+
 // Leagues
 export async function getLeagues(visibleLeagueIds: string[]): Promise<LeagueDto[]> {
   if (visibleLeagueIds.length === 0) return [];


### PR DESCRIPTION
## Summary
- Discover page (`/dashboard/discover`) to browse and subscribe to public leagues
- Subscribe/unsubscribe API routes storing IDs in Clerk user `publicMetadata`
- **Breaking change**: Public leagues no longer auto-visible — users must opt-in via Discover page
- `resolveOrgContext` now returns `subscribedLeagueIds`, SOQL uses `OR Id IN (...)` instead of `OR Clerk_Org_Id__c = null`
- `getPublicLeagues()` added to salesforce-api
- "Discover" nav item added to sidebar with Compass icon

## Phase B Story
B5 — Browse & Add Public Leagues (part of multi-tenancy Phase B)

## Test plan
- [ ] 8 new tests (subscribe API: 6, public leagues API: 2)
- [ ] Updated org-context tests for new subscription model
- [ ] All 138 web tests passing
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>