### PR TITLE
feat: add member management for league organizations

### DIFF
--- a/apps/web/src/app/api/orgs/[orgId]/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/members/__tests__/route.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockAuth,
+  mockRequireOrgAdmin,
+  mockGetMembershipList,
+  mockUpdateMembership,
+  mockDeleteMembership,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockRequireOrgAdmin: vi.fn(),
+  mockGetMembershipList: vi.fn(),
+  mockUpdateMembership: vi.fn(),
+  mockDeleteMembership: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  clerkClient: vi.fn().mockResolvedValue({
+    organizations: {
+      getOrganizationMembershipList: mockGetMembershipList,
+      updateOrganizationMembership: mockUpdateMembership,
+      deleteOrganizationMembership: mockDeleteMembership,
+    },
+  }),
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requireOrgAdmin: mockRequireOrgAdmin,
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockReturnValue(
+    new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+    }),
+  ),
+}));
+
+import { GET, PATCH, DELETE } from "../route";
+
+const mockMembers = {
+  data: [
+    {
+      publicUserData: {
+        userId: "user_1",
+        identifier: "admin@test.com",
+        firstName: "Admin",
+        lastName: "User",
+        imageUrl: "",
+      },
+      role: "org:admin",
+      createdAt: Date.now(),
+    },
+    {
+      publicUserData: {
+        userId: "user_2",
+        identifier: "member@test.com",
+        firstName: "Member",
+        lastName: "User",
+        imageUrl: "",
+      },
+      role: "org:member",
+      createdAt: Date.now(),
+    },
+  ],
+};
+
+function makeParams(orgId: string) {
+  return { params: Promise.resolve({ orgId }) };
+}
+
+function makeRequest(body?: unknown): NextRequest {
+  if (body) {
+    return new NextRequest("http://localhost/api/orgs/org_1/members", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new NextRequest("http://localhost/api/orgs/org_1/members");
+}
+
+describe("Members API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockGetMembershipList.mockResolvedValue(mockMembers);
+  });
+
+  describe("GET", () => {
+    it("returns 401 when unauthenticated", async () => {
+      mockAuth.mockResolvedValue({ userId: null });
+      const res = await GET(makeRequest(), makeParams("org_1"));
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 for non-admin", async () => {
+      mockRequireOrgAdmin.mockRejectedValue(
+        new Error("You must be an admin of this league to make changes"),
+      );
+      const res = await GET(makeRequest(), makeParams("org_1"));
+      expect(res.status).toBe(403);
+    });
+
+    it("returns member list", async () => {
+      const res = await GET(makeRequest(), makeParams("org_1"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(2);
+      expect(data[0].email).toBe("admin@test.com");
+      expect(data[1].role).toBe("org:member");
+    });
+  });
+
+  describe("PATCH", () => {
+    it("returns 400 for invalid params", async () => {
+      const res = await PATCH(
+        makeRequest({ memberUserId: "user_2" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when demoting last admin", async () => {
+      const res = await PATCH(
+        makeRequest({ memberUserId: "user_1", role: "org:member" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Cannot demote the last admin");
+    });
+
+    it("returns 200 on role update", async () => {
+      mockUpdateMembership.mockResolvedValue({});
+      const res = await PATCH(
+        makeRequest({ memberUserId: "user_2", role: "org:admin" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("returns 400 when removing last admin", async () => {
+      const res = await DELETE(
+        makeRequest({ memberUserId: "user_1" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Cannot remove the last admin");
+    });
+
+    it("returns 200 on member removal", async () => {
+      mockDeleteMembership.mockResolvedValue({});
+      const res = await DELETE(
+        makeRequest({ memberUserId: "user_2" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -1,0 +1,169 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgAdmin } from "@/lib/org-context";
+import { handleApiError } from "@/lib/api-error";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const client = await clerkClient();
+    const memberships =
+      await client.organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+      });
+
+    const data = memberships.data.map((m) => ({
+      userId: m.publicUserData?.userId ?? "",
+      email: m.publicUserData?.identifier ?? "",
+      firstName: m.publicUserData?.firstName ?? "",
+      lastName: m.publicUserData?.lastName ?? "",
+      imageUrl: m.publicUserData?.imageUrl ?? "",
+      role: m.role,
+      createdAt: m.createdAt,
+    }));
+
+    return NextResponse.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/members");
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const { memberUserId, role } = await request.json();
+
+    if (!memberUserId || !role || !["org:admin", "org:member"].includes(role)) {
+      return NextResponse.json(
+        { error: "Valid memberUserId and role required" },
+        { status: 400 },
+      );
+    }
+
+    // Prevent demoting last admin
+    if (role === "org:member") {
+      const client = await clerkClient();
+      const memberships =
+        await client.organizations.getOrganizationMembershipList({
+          organizationId: orgId,
+        });
+      const adminCount = memberships.data.filter(
+        (m) => m.role === "org:admin",
+      ).length;
+      if (adminCount <= 1) {
+        const targetIsAdmin = memberships.data.find(
+          (m) =>
+            m.publicUserData?.userId === memberUserId &&
+            m.role === "org:admin",
+        );
+        if (targetIsAdmin) {
+          return NextResponse.json(
+            { error: "Cannot demote the last admin" },
+            { status: 400 },
+          );
+        }
+      }
+    }
+
+    const client = await clerkClient();
+    await client.organizations.updateOrganizationMembership({
+      organizationId: orgId,
+      userId: memberUserId,
+      role,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/members");
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const { memberUserId } = await request.json();
+
+    if (!memberUserId) {
+      return NextResponse.json(
+        { error: "memberUserId is required" },
+        { status: 400 },
+      );
+    }
+
+    // Prevent removing last admin
+    const client = await clerkClient();
+    const memberships =
+      await client.organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+      });
+    const adminCount = memberships.data.filter(
+      (m) => m.role === "org:admin",
+    ).length;
+    if (adminCount <= 1) {
+      const targetIsAdmin = memberships.data.find(
+        (m) =>
+          m.publicUserData?.userId === memberUserId && m.role === "org:admin",
+      );
+      if (targetIsAdmin) {
+        return NextResponse.json(
+          { error: "Cannot remove the last admin" },
+          { status: 400 },
+        );
+      }
+    }
+
+    await client.organizations.deleteOrganizationMembership({
+      organizationId: orgId,
+      userId: memberUserId,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/members");
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface Member {
+  userId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  imageUrl: string;
+  role: string;
+  createdAt: number;
+}
+
+export default function MemberList({ orgId }: { orgId: string }) {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/orgs/${orgId}/members`);
+        if (res.ok) {
+          const data = await res.json();
+          setMembers(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [orgId]);
+
+  async function handleRoleChange(memberUserId: string, newRole: string) {
+    setActionLoading(memberUserId);
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/members`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memberUserId, role: newRole }),
+      });
+      if (res.ok) {
+        setMembers((prev) =>
+          prev.map((m) =>
+            m.userId === memberUserId ? { ...m, role: newRole } : m,
+          ),
+        );
+      } else {
+        const data = await res.json();
+        alert(data.error ?? "Failed to update role");
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function handleRemove(memberUserId: string) {
+    if (!confirm("Are you sure you want to remove this member?")) return;
+
+    setActionLoading(memberUserId);
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/members`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memberUserId }),
+      });
+      if (res.ok) {
+        setMembers((prev) => prev.filter((m) => m.userId !== memberUserId));
+      } else {
+        const data = await res.json();
+        alert(data.error ?? "Failed to remove member");
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  if (loading)
+    return <p className="text-sm text-gray-500">Loading members...</p>;
+  if (members.length === 0)
+    return <p className="text-sm text-gray-500">No members found.</p>;
+
+  return (
+    <div className="space-y-3">
+      {members.map((member) => {
+        const isLoading = actionLoading === member.userId;
+        const displayName =
+          [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+          member.email;
+
+        return (
+          <div
+            key={member.userId}
+            className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3"
+          >
+            <div className="flex items-center gap-3">
+              {member.imageUrl && (
+                <img
+                  src={member.imageUrl}
+                  alt=""
+                  className="h-8 w-8 rounded-full"
+                />
+              )}
+              <div>
+                <p className="text-sm font-medium text-gray-900">
+                  {displayName}
+                </p>
+                <p className="text-xs text-gray-500">{member.email}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={
+                  member.role === "org:admin" ? "default" : "secondary"
+                }
+              >
+                {member.role === "org:admin" ? "Admin" : "Member"}
+              </Badge>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isLoading}
+                onClick={() =>
+                  handleRoleChange(
+                    member.userId,
+                    member.role === "org:admin" ? "org:member" : "org:admin",
+                  )
+                }
+              >
+                {member.role === "org:admin" ? "Demote" : "Promote"}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isLoading}
+                onClick={() => handleRemove(member.userId)}
+                className="text-red-600 hover:text-red-700"
+              >
+                Remove
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getLeague } from "@/lib/salesforce-api";
+import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
+import MemberList from "./member-list";
+
+export default async function MembersPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(id, orgContext);
+
+  if (!league.orgId) {
+    redirect(`/dashboard/leagues/${id}`);
+  }
+
+  // Verify admin access
+  try {
+    await requireOrgAdmin(league.orgId, userId);
+  } catch {
+    redirect(`/dashboard/leagues/${id}`);
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${id}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to {league.name}
+      </Link>
+
+      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+        Members — {league.name}
+      </h2>
+
+      <MemberList orgId={league.orgId} />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -60,6 +60,12 @@ export default async function LeagueDetailPage({
               <InviteForm orgId={league.orgId} />
               <InvitationList orgId={league.orgId} />
               <InviteLinkSection orgId={league.orgId} />
+              <Link
+                href={`/dashboard/leagues/${id}/members`}
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                Manage Members &rarr;
+              </Link>
             </div>
           )}
           {!isAdmin && (


### PR DESCRIPTION
## Summary
- Members API (GET/PATCH/DELETE) at `/api/orgs/[orgId]/members`
- Members page at `/dashboard/leagues/[id]/members` with admin gate
- Member list with role promotion/demotion, removal, and last-admin guards
- "Manage Members" link on league detail page for admins

## Phase B Story
B4 — Member Management (depends on B1)

## Test plan
- [ ] 8 new tests for members API (401, 403, list, invalid params, last-admin guards, role update, removal)
- [ ] All 153 web tests passing
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>