### PR TITLE
feat: add admin approval for join requests

### DIFF
--- a/apps/web/src/app/api/orgs/[orgId]/requests/[requestUserId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/requests/[requestUserId]/__tests__/route.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockRequireOrgAdmin,
+  mockRemovePendingRequest,
+  mockCreateOrganizationMembership,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockRequireOrgAdmin: vi.fn(),
+  mockRemovePendingRequest: vi.fn(),
+  mockCreateOrganizationMembership: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  clerkClient: vi.fn().mockResolvedValue({
+    organizations: {
+      createOrganizationMembership: mockCreateOrganizationMembership,
+    },
+  }),
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requireOrgAdmin: mockRequireOrgAdmin,
+}));
+
+vi.mock("@/lib/org-requests", () => ({
+  removePendingRequest: mockRemovePendingRequest,
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockReturnValue(
+    new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 }),
+  ),
+}));
+
+import { POST, DELETE } from "../route";
+import { NextRequest } from "next/server";
+
+function makeParams(orgId: string, requestUserId: string) {
+  return { params: Promise.resolve({ orgId, requestUserId }) };
+}
+
+function makeRequest(method: string) {
+  return new NextRequest(
+    `http://localhost/api/orgs/org_1/requests/user_2`,
+    { method },
+  );
+}
+
+describe("POST /api/orgs/[orgId]/requests/[requestUserId] (approve)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await POST(makeRequest("POST"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockRejectedValue(
+      new Error("You must be an admin of this league to make changes"),
+    );
+
+    const res = await POST(makeRequest("POST"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(403);
+  });
+
+  it("approves request and creates membership", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockCreateOrganizationMembership.mockResolvedValue({});
+    mockRemovePendingRequest.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest("POST"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("approved");
+    expect(mockCreateOrganizationMembership).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      userId: "user_2",
+      role: "org:member",
+    });
+    expect(mockRemovePendingRequest).toHaveBeenCalledWith("org_1", "user_2");
+  });
+});
+
+describe("DELETE /api/orgs/[orgId]/requests/[requestUserId] (reject)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await DELETE(makeRequest("DELETE"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockRejectedValue(
+      new Error("You must be an admin of this league to make changes"),
+    );
+
+    const res = await DELETE(makeRequest("DELETE"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects request and removes pending request", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockRemovePendingRequest.mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest("DELETE"), makeParams("org_1", "user_2"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("rejected");
+    expect(mockRemovePendingRequest).toHaveBeenCalledWith("org_1", "user_2");
+  });
+});

--- a/apps/web/src/app/api/orgs/[orgId]/requests/[requestUserId]/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/requests/[requestUserId]/route.ts
@@ -1,0 +1,66 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgAdmin } from "@/lib/org-context";
+import { removePendingRequest } from "@/lib/org-requests";
+import { handleApiError } from "@/lib/api-error";
+
+// Approve request
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; requestUserId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId, requestUserId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    const client = await clerkClient();
+    await client.organizations.createOrganizationMembership({
+      organizationId: orgId,
+      userId: requestUserId,
+      role: "org:member",
+    });
+
+    await removePendingRequest(orgId, requestUserId);
+
+    return NextResponse.json({ status: "approved" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/requests/[requestUserId]");
+  }
+}
+
+// Reject request
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; requestUserId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId, requestUserId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+
+    await removePendingRequest(orgId, requestUserId);
+
+    return NextResponse.json({ status: "rejected" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/requests/[requestUserId]");
+  }
+}

--- a/apps/web/src/app/api/orgs/[orgId]/requests/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/requests/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockRequireOrgAdmin,
+  mockGetPendingRequests,
+  mockAddPendingRequest,
+  mockGetOrganizationMembershipList,
+  mockGetUser,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockRequireOrgAdmin: vi.fn(),
+  mockGetPendingRequests: vi.fn(),
+  mockAddPendingRequest: vi.fn(),
+  mockGetOrganizationMembershipList: vi.fn(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+  clerkClient: vi.fn().mockResolvedValue({
+    users: {
+      getOrganizationMembershipList: mockGetOrganizationMembershipList,
+      getUser: mockGetUser,
+    },
+  }),
+}));
+
+vi.mock("@/lib/org-context", () => ({
+  requireOrgAdmin: mockRequireOrgAdmin,
+}));
+
+vi.mock("@/lib/org-requests", () => ({
+  getPendingRequests: mockGetPendingRequests,
+  addPendingRequest: mockAddPendingRequest,
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  handleApiError: vi.fn().mockReturnValue(
+    new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 }),
+  ),
+}));
+
+import { GET, POST } from "../route";
+import { NextRequest } from "next/server";
+
+function makeParams(orgId: string) {
+  return { params: Promise.resolve({ orgId }) };
+}
+
+function makeRequest(method: string = "GET") {
+  return new NextRequest(`http://localhost/api/orgs/org_1/requests`, {
+    method,
+    ...(method === "POST" && {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  });
+}
+
+describe("GET /api/orgs/[orgId]/requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockRejectedValue(
+      new Error("You must be an admin of this league to make changes"),
+    );
+
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns pending requests for admin", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockRequireOrgAdmin.mockResolvedValue(undefined);
+    mockGetPendingRequests.mockResolvedValue([
+      { userId: "user_2", email: "a@b.com", requestedAt: "2025-01-01T00:00:00.000Z" },
+    ]);
+
+    const res = await GET(makeRequest(), makeParams("org_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toEqual({
+      userId: "user_2",
+      email: "a@b.com",
+      requestedAt: "2025-01-01T00:00:00.000Z",
+    });
+  });
+});
+
+describe("POST /api/orgs/[orgId]/requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await POST(makeRequest("POST"), makeParams("org_1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when already a member", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_1" } }],
+    });
+
+    const res = await POST(makeRequest("POST"), makeParams("org_1"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Already a member");
+  });
+
+  it("returns 201 and submits request", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
+    mockGetUser.mockResolvedValue({
+      emailAddresses: [{ emailAddress: "test@example.com" }],
+    });
+    mockAddPendingRequest.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest("POST"), makeParams("org_1"));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.message).toBe("Request submitted");
+    expect(mockAddPendingRequest).toHaveBeenCalledWith("org_1", "user_1", "test@example.com");
+  });
+});

--- a/apps/web/src/app/api/orgs/[orgId]/requests/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/requests/route.ts
@@ -1,0 +1,61 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgAdmin } from "@/lib/org-context";
+import { getPendingRequests, addPendingRequest } from "@/lib/org-requests";
+import { handleApiError } from "@/lib/api-error";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    await requireOrgAdmin(orgId, userId);
+    const requests = await getPendingRequests(orgId);
+    return NextResponse.json(requests);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("must be an admin")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleApiError(error, "/api/orgs/[orgId]/requests");
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId } = await params;
+
+  try {
+    // Check user is not already a member
+    const client = await clerkClient();
+    const memberships = await client.users.getOrganizationMembershipList({ userId });
+    const alreadyMember = memberships.data.some((m) => m.organization.id === orgId);
+    if (alreadyMember) {
+      return NextResponse.json({ error: "Already a member" }, { status: 400 });
+    }
+
+    // Get user email for the request record
+    const user = await client.users.getUser(userId);
+    const email = user.emailAddresses?.[0]?.emailAddress ?? "";
+
+    await addPendingRequest(orgId, userId, email);
+
+    return NextResponse.json({ message: "Request submitted" }, { status: 201 });
+  } catch (error) {
+    return handleApiError(error, "/api/orgs/[orgId]/requests");
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -60,12 +60,20 @@ export default async function LeagueDetailPage({
               <InviteForm orgId={league.orgId} />
               <InvitationList orgId={league.orgId} />
               <InviteLinkSection orgId={league.orgId} />
-              <Link
-                href={`/dashboard/leagues/${id}/members`}
-                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-              >
-                Manage Members &rarr;
-              </Link>
+              <div className="flex gap-4">
+                <Link
+                  href={`/dashboard/leagues/${id}/members`}
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  Manage Members &rarr;
+                </Link>
+                <Link
+                  href={`/dashboard/leagues/${id}/requests`}
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  Join Requests &rarr;
+                </Link>
+              </div>
             </div>
           )}
           {!isAdmin && (

--- a/apps/web/src/app/dashboard/leagues/[id]/requests/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/requests/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getLeague } from "@/lib/salesforce-api";
+import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
+import RequestsTable from "./requests-table";
+
+export default async function RequestsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(id, orgContext);
+
+  if (!league.orgId) {
+    redirect(`/dashboard/leagues/${id}`);
+  }
+
+  try {
+    await requireOrgAdmin(league.orgId, userId);
+  } catch {
+    redirect(`/dashboard/leagues/${id}`);
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${id}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to {league.name}
+      </Link>
+
+      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+        Join Requests — {league.name}
+      </h2>
+
+      <RequestsTable orgId={league.orgId} />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface PendingRequest {
+  userId: string;
+  email: string;
+  requestedAt: string;
+}
+
+export default function RequestsTable({ orgId }: { orgId: string }) {
+  const router = useRouter();
+  const [requests, setRequests] = useState<PendingRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/orgs/${orgId}/requests`);
+        if (res.ok) {
+          const data = await res.json();
+          setRequests(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [orgId]);
+
+  async function handleApprove(requestUserId: string) {
+    setActionLoading(requestUserId);
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/requests/${requestUserId}`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        setRequests((prev) => prev.filter((r) => r.userId !== requestUserId));
+        router.refresh();
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function handleReject(requestUserId: string) {
+    setActionLoading(requestUserId);
+    try {
+      const res = await fetch(`/api/orgs/${orgId}/requests/${requestUserId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setRequests((prev) => prev.filter((r) => r.userId !== requestUserId));
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  if (loading) return <p className="text-sm text-gray-500">Loading requests...</p>;
+
+  if (requests.length === 0) {
+    return <p className="text-sm text-gray-500">No pending requests.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {requests.map((req) => {
+        const isLoading = actionLoading === req.userId;
+        return (
+          <div
+            key={req.userId}
+            className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3"
+          >
+            <div>
+              <p className="text-sm font-medium text-gray-900">{req.email}</p>
+              <p className="text-xs text-gray-500">
+                Requested {new Date(req.requestedAt).toLocaleDateString()}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">Pending</Badge>
+              <Button
+                size="sm"
+                disabled={isLoading}
+                onClick={() => handleApprove(req.userId)}
+              >
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isLoading}
+                onClick={() => handleReject(req.userId)}
+              >
+                Reject
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/lib/org-requests.ts
+++ b/apps/web/src/lib/org-requests.ts
@@ -1,0 +1,50 @@
+import { clerkClient } from "@clerk/nextjs/server";
+
+export interface PendingRequest {
+  userId: string;
+  email: string;
+  requestedAt: string;
+}
+
+export async function getPendingRequests(orgId: string): Promise<PendingRequest[]> {
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({ organizationId: orgId });
+  return (org.publicMetadata?.pendingRequests as PendingRequest[]) ?? [];
+}
+
+export async function addPendingRequest(
+  orgId: string,
+  userId: string,
+  email: string,
+): Promise<void> {
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({ organizationId: orgId });
+  const existing = (org.publicMetadata?.pendingRequests as PendingRequest[]) ?? [];
+
+  // Don't add duplicates
+  if (existing.some((r) => r.userId === userId)) return;
+
+  const updated = [
+    ...existing,
+    { userId, email, requestedAt: new Date().toISOString() },
+  ];
+
+  await client.organizations.updateOrganization(orgId, {
+    publicMetadata: { ...org.publicMetadata, pendingRequests: updated },
+  });
+}
+
+export async function removePendingRequest(
+  orgId: string,
+  requestUserId: string,
+): Promise<void> {
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({ organizationId: orgId });
+  const existing = (org.publicMetadata?.pendingRequests as PendingRequest[]) ?? [];
+
+  const updated = existing.filter((r) => r.userId !== requestUserId);
+
+  await client.organizations.updateOrganization(orgId, {
+    publicMetadata: { ...org.publicMetadata, pendingRequests: updated },
+  });
+}


### PR DESCRIPTION
## Summary
- Pending request management via Clerk org `publicMetadata.pendingRequests`
- Submit join request API (POST `/api/orgs/[orgId]/requests`)
- Admin-only request listing (GET)
- Approve/reject APIs (POST/DELETE `/api/orgs/[orgId]/requests/[requestUserId]`)
- Requests page with approve/reject UI
- Join Requests link on league detail page

## Phase B Story
B3 — Admin Approval (depends on B2)

## Test plan
- [ ] 12 new tests for request and approval APIs
- [ ] All 171 web tests passing
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>