### PR TITLE
feat: enforce org admin role for team and player mutations

### DIFF
--- a/apps/web/src/app/api/players/[id]/route.ts
+++ b/apps/web/src/app/api/players/[id]/route.ts
@@ -39,7 +39,7 @@ export async function PUT(
     const orgContext = await resolveOrgContext(userId);
     const existing = await getPlayer(id, orgContext);
 
-    const authorization = await authorizeTeamMutation(existing.teamId);
+    const authorization = await authorizeTeamMutation(existing.teamId, userId);
     if (!authorization.isAuthorized) {
       return NextResponse.json(
         { error: "You are not authorized to manage this team" },
@@ -78,7 +78,7 @@ export async function DELETE(
     const orgContext = await resolveOrgContext(userId);
     const existing = await getPlayer(id, orgContext);
 
-    const authorization = await authorizeTeamMutation(existing.teamId);
+    const authorization = await authorizeTeamMutation(existing.teamId, userId);
     if (!authorization.isAuthorized) {
       return NextResponse.json(
         { error: "You are not authorized to manage this team" },

--- a/apps/web/src/app/api/players/route.ts
+++ b/apps/web/src/app/api/players/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const authorization = await authorizeTeamMutation(parsed.data.teamId);
+  const authorization = await authorizeTeamMutation(parsed.data.teamId, userId);
   if (!authorization.isAuthorized) {
     return NextResponse.json(
       { error: "You are not authorized to manage this team" },

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -38,7 +38,7 @@ export async function PUT(
 
   const { id } = await params;
 
-  const authorization = await authorizeTeamMutation(id);
+  const authorization = await authorizeTeamMutation(id, userId);
   if (!authorization.isAuthorized) {
     return NextResponse.json(
       { error: "You are not authorized to manage this team" },

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function TeamDetailPage({
   const [team, players, canManage] = await Promise.all([
     getTeam(id, orgContext),
     getPlayersByTeam(id, orgContext),
-    canManageTeam(id),
+    canManageTeam(id, userId),
   ]);
 
   return (

--- a/apps/web/src/lib/__tests__/authorization.test.ts
+++ b/apps/web/src/lib/__tests__/authorization.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockQuery,
+  mockGetLeagueOrgId,
+  mockGetOrganizationMembershipList,
+} = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetOrganizationMembershipList: vi.fn(),
+}));
+
+vi.mock("../salesforce", () => ({
+  getSalesforceConnection: vi.fn().mockResolvedValue({
+    query: mockQuery,
+  }),
+}));
+
+vi.mock("../org-context", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn().mockResolvedValue({ userId: "user_1" }),
+  currentUser: vi.fn().mockResolvedValue({ publicMetadata: {} }),
+  clerkClient: vi.fn().mockResolvedValue({
+    users: {
+      getOrganizationMembershipList: mockGetOrganizationMembershipList,
+      getUser: vi.fn().mockResolvedValue({ privateMetadata: {} }),
+    },
+  }),
+}));
+
+import { authorizeTeamMutation, canManageTeam } from "../authorization";
+
+describe("authorizeTeamMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns not authorized when team is not found", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+
+    const result = await authorizeTeamMutation("team_missing", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+  });
+
+  it("returns not authorized for public league (null orgId)", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ League__c: "league_1" }],
+    });
+    mockGetLeagueOrgId.mockResolvedValue(null);
+
+    const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+  });
+
+  it("returns authorized for org admin", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ League__c: "league_1" }],
+    });
+    mockGetLeagueOrgId.mockResolvedValue("org_1");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_1" }, role: "org:admin" }],
+    });
+
+    const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: true });
+  });
+
+  it("returns not authorized for org member (non-admin)", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ League__c: "league_1" }],
+    });
+    mockGetLeagueOrgId.mockResolvedValue("org_1");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_1" }, role: "org:member" }],
+    });
+
+    const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+  });
+
+  it("returns not authorized for non-member of org", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ League__c: "league_1" }],
+    });
+    mockGetLeagueOrgId.mockResolvedValue("org_1");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_other" }, role: "org:admin" }],
+    });
+
+    const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+  });
+});
+
+describe("canManageTeam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when user is authorized", async () => {
+    mockQuery.mockResolvedValue({
+      totalSize: 1,
+      records: [{ League__c: "league_1" }],
+    });
+    mockGetLeagueOrgId.mockResolvedValue("org_1");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_1" }, role: "org:admin" }],
+    });
+
+    const result = await canManageTeam("team_1", "user_1");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when user is not authorized", async () => {
+    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+
+    const result = await canManageTeam("team_missing", "user_1");
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -1,33 +1,68 @@
 import { auth, currentUser, clerkClient } from "@clerk/nextjs/server";
 import type { Tier } from "./tiers";
+import { getLeagueOrgId } from "./org-context";
+import { getSalesforceConnection } from "./salesforce";
 
 export interface AuthorizationResult {
   userId: string;
-  authorizedTeamIds: string[];
   isAuthorized: boolean;
 }
 
+/**
+ * Authorize a mutation on a team. The chain is:
+ * teamId -> Team__c.League__c -> League__c.Clerk_Org_Id__c -> requireOrgAdmin
+ *
+ * Public leagues (null orgId) -> mutations denied (read-only).
+ * Org leagues -> only org:admin can mutate.
+ */
 export async function authorizeTeamMutation(
   teamId: string,
+  userId: string,
 ): Promise<AuthorizationResult> {
-  const { userId } = await auth();
-  if (!userId) {
-    return { userId: "", authorizedTeamIds: [], isAuthorized: false };
+  try {
+    // Get team's league
+    const conn = await getSalesforceConnection();
+    const result = await conn.query<{ League__c: string }>(
+      `SELECT League__c FROM Team__c WHERE Id = '${teamId}' LIMIT 1`,
+    );
+    if (result.totalSize === 0) {
+      return { userId, isAuthorized: false };
+    }
+
+    const leagueId = result.records[0].League__c;
+    const orgId = await getLeagueOrgId(leagueId);
+
+    // Public leagues are read-only
+    if (!orgId) {
+      return { userId, isAuthorized: false };
+    }
+
+    // Check if user is org admin
+    const client = await clerkClient();
+    const memberships = await client.users.getOrganizationMembershipList({
+      userId,
+    });
+    const membership = memberships.data.find(
+      (m) => m.organization.id === orgId,
+    );
+
+    return {
+      userId,
+      isAuthorized: membership?.role === "org:admin",
+    };
+  } catch {
+    return { userId, isAuthorized: false };
   }
-
-  const user = await currentUser();
-  const managedTeamIds =
-    (user?.publicMetadata?.managedTeamIds as string[]) ?? [];
-
-  return {
-    userId,
-    authorizedTeamIds: managedTeamIds,
-    isAuthorized: managedTeamIds.includes(teamId),
-  };
 }
 
-export async function canManageTeam(teamId: string): Promise<boolean> {
-  const result = await authorizeTeamMutation(teamId);
+/**
+ * Check if user can manage a team (for UI display).
+ */
+export async function canManageTeam(
+  teamId: string,
+  userId: string,
+): Promise<boolean> {
+  const result = await authorizeTeamMutation(teamId, userId);
   return result.isAuthorized;
 }
 
@@ -45,7 +80,7 @@ export async function getUserTier(): Promise<Tier> {
  * Reads the current user's Stripe customer ID from privateMetadata.
  * Returns null if the user has never subscribed.
  *
- * Server-only — privateMetadata is never exposed to the client.
+ * Server-only -- privateMetadata is never exposed to the client.
  */
 export async function getStripeCustomerId(): Promise<string | null> {
   const { userId } = await auth();

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -117,6 +117,25 @@ export async function requireOrgAdmin(
 }
 
 /**
+ * Returns the user's role within a specific Clerk Organization,
+ * or null if they are not a member.
+ */
+export async function getUserRoleInOrg(
+  orgId: string,
+  userId: string,
+): Promise<"org:admin" | "org:member" | null> {
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
+  const membership = memberships.data.find(
+    (m) => m.organization.id === orgId,
+  );
+  if (!membership) return null;
+  return membership.role as "org:admin" | "org:member";
+}
+
+/**
  * Find the Clerk Org ID that owns a given league.
  * Returns null for public leagues.
  */


### PR DESCRIPTION
## Summary
- `authorizeTeamMutation` now checks: team -> league -> org -> admin role
- Public league teams are read-only (no mutations allowed)
- Signature change: `authorizeTeamMutation(teamId, userId)` (removed `managedTeamIds` dependency)
- `canManageTeam(teamId, userId)` updated accordingly
- `getUserRoleInOrg` added to org-context
- All 4 mutation routes updated (teams PUT, players POST/PUT/DELETE)
- `teams/[id]` page passes userId to canManageTeam

## Phase B Story
B6 — Role Enforcement (depends on B4)

## Test plan
- [ ] 7 new tests for authorization logic
- [ ] All 166 web tests passing
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>