### PR TITLE
feat(ops): upgrade husky v7 -> v9 (WSM-000050)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint **/{aura,lwc}/**",
     "prettier": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
     "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
-    "prepare": "husky install",
+    "prepare": "husky",
     "precommit": "lint-staged"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "eslint": "^8.11.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.2",
-    "husky": "^7.0.4",
+    "husky": "^9.1.7",
     "lint-staged": "^12.3.7",
     "prettier": "^2.6.0",
     "prettier-plugin-apex": "^1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^26.1.2
         version: 26.9.0(eslint@8.57.1)(jest@27.4.7)(typescript@5.9.3)
       husky:
-        specifier: ^7.0.4
-        version: 7.0.4
+        specifier: ^9.1.7
+        version: 9.1.7
       lint-staged:
         specifier: ^12.3.7
         version: 12.5.0
@@ -4152,9 +4152,9 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
-  husky@7.0.4:
-    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
-    engines: {node: '>=12'}
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   iconv-lite@0.4.24:
@@ -11201,7 +11201,7 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  husky@7.0.4: {}
+  husky@9.1.7: {}
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrades `husky` devDependency from `^7.0.4` to `^9.1.7`
- Simplifies `prepare` script: `husky install` → `husky`
- Removes legacy `.husky/_/` shim folder (v9 regenerates on install)
- No hooks currently exist on disk (they were removed in commit 3b282ed on a prior branch); this PR is a clean-slate prep for WSM-000051 (commitlint hook)

Refs **[WSM-000050 / ARC-151](https://linear.app/arcnology/issue/ARC-151)**.

> [!IMPORTANT]
> **Do not merge this PR until WSM-000049 lands first.**
> The current `.releaserc.json` only bumps `apps/web/package.json`. Merging this `feat:` commit before WSM-000049 extends the exec step would trigger a premature, partial-coverage tag. WSM-000049 must merge first; this PR can merge immediately after.

## Test plan
- [x] `pnpm install` completes and writes `husky@9.1.7` to `node_modules`
- [x] `package.json` `prepare` script updated to v9 form
- [ ] After merge + fresh `pnpm install`, verify husky CLI reports v9 (`node_modules/husky/package.json`)
- [ ] WSM-000051 (commitlint + commit-msg hook) can add hooks without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)