### PR TITLE
feat(release): align workspace versions to 0.1.0 lockstep (WSM-000049)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,10 +31,16 @@
       "npmPublish": false
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "jq --arg v \"${nextRelease.version}\" '.version = $v' apps/web/package.json > apps/web/package.json.tmp && mv apps/web/package.json.tmp apps/web/package.json"
+      "prepareCmd": "for f in apps/web/package.json apps/tui/package.json packages/api-contracts/package.json packages/shared-types/package.json; do jq --arg v \"${nextRelease.version}\" '.version = $v' \"$f\" > \"$f.tmp\" && mv \"$f.tmp\" \"$f\"; done"
     }],
     ["@semantic-release/git", {
-      "assets": ["package.json", "apps/web/package.json"],
+      "assets": [
+        "package.json",
+        "apps/web/package.json",
+        "apps/tui/package.json",
+        "packages/api-contracts/package.json",
+        "packages/shared-types/package.json"
+      ],
       "message": "chore(release): v${nextRelease.version}\n\n${nextRelease.notes}"
     }],
     "@semantic-release/github"

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sports-management/tui",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sports-management",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "packageManager": "pnpm@9.15.4",
   "description": "Sports League Management application for Salesforce",
   "type": "module",


### PR DESCRIPTION
## Summary
- Resets root \`package.json\` from \`1.0.0\` → \`0.1.0\` (honest pre-launch baseline)
- Bumps \`apps/tui/package.json\` from \`0.0.0\` → \`0.1.0\`
- Extends \`.releaserc.json\` \`prepareCmd\` to loop over all four workspaces (\`apps/web\`, \`apps/tui\`, \`packages/api-contracts\`, \`packages/shared-types\`)
- Extends \`@semantic-release/git\` \`assets\` list to commit all five \`package.json\` files (root + four workspaces)
- Bumps \`.github/workflows/release.yml\` Node runtime from 20 → 22 (semantic-release@25 requires \`^22.14.0 || >= 24.10.0\`; the last 3 release.yml runs all failed for this reason)

After merge, all five \`package.json\` versions will report \`0.1.0\` and the next merge with a \`feat:\` or \`fix:\` PR title will trigger semantic-release to bump every workspace together.

Refs **[WSM-000049 / ARC-150](https://linear.app/arcnology/issue/ARC-150)**.

## Verification (after merge)
\`\`\`bash
jq -r .version package.json apps/web/package.json apps/tui/package.json packages/*/package.json | sort -u
# expected: single line 0.1.0
\`\`\`

## Test plan
- [x] Local: all 5 workspace package.json files report version 0.1.0
- [x] \`jq . .releaserc.json\` parses cleanly
- [ ] After merge: release.yml runs without the Node-version error
- [ ] After merge: WSM-000051 + WSM-000056 unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)