### PR TITLE
feat(ci): add commitlint PR job (WSM-000052)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate PR commit messages
+        run: pnpm commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }} --verbose
+
   ci:
     name: Lint, Type-check, Test & Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `commitlint` job to `.github/workflows/ci.yml` that runs on `pull_request` events
- Validates every commit in the PR range against the conventional-commits type allowlist
- Closes the `--no-verify` bypass loophole in local `.husky/commit-msg`

## Gherkin (from plan)
- **Happy path** — PR with conventional commits → job passes
- **Misuse** — PR includes `update code` commit → job fails with `type-empty`/`subject-empty`
- **Validation** — `wip:` or other unknown type → job fails with `type-enum`

## Linear
WSM-000052 — unblocks WSM-000055 and WSM-000056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)