### PR TITLE
docs(sprints): Sprint 0 verification close-out (WSM-000056)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 | [sprints/SPRINT_2025_09_PLAN.md](sprints/SPRINT_2025_09_PLAN.md) | External frontend and monorepo |
 | [sprints/SPRINT_2025_10_PLAN.md](sprints/SPRINT_2025_10_PLAN.md) | Frontend enhancement with shadcn/ui (W-000034 through W-000040) |
 | [sprints/SPRINT_2025_10_E2E_PLAN.md](sprints/SPRINT_2025_10_E2E_PLAN.md) | E2E test coverage for Sprint 2025.10 stories |
+| [sprints/SPRINT_0_VERIFICATION.md](sprints/SPRINT_0_VERIFICATION.md) | Sprint 0 platform-foundation close-out: release automation, commit enforcement, branching (WSM-000047..WSM-000056) |
 
 ## Architecture and Decisions
 

--- a/docs/sprints/SPRINT_0_VERIFICATION.md
+++ b/docs/sprints/SPRINT_0_VERIFICATION.md
@@ -1,0 +1,80 @@
+# Sprint 0 — Verification Report
+
+> **Status:** Closed (WSM-000056).
+> **Closed:** 2026-04-21
+> **First repo-wide release tag:** `v0.2.0` (2026-04-21 14:24 UTC)
+> **Latest tag at closure:** `v0.3.0`
+
+Sprint 0 delivered release automation, commit enforcement, and the branching
+codification that all six roster-management sprints depend on. This document
+audits each acceptance criterion from the
+[Sprint 0 plan](../../../.claude/plans/synthetic-wandering-storm.md) against
+observable repo state.
+
+## Criteria Matrix
+
+| # | Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| 1 | `git commit -m "update code"` rejected locally | `.husky/commit-msg` invokes `pnpm commitlint --edit`, which flags `type-empty` on a subjectless message | ✓ |
+| 2 | PR with non-conventional commit fails CI | `.github/workflows/ci.yml` `commitlint` job runs on `pull_request`, re-validates every commit in the PR range — bypasses `--no-verify` | ✓ |
+| 3 | All workspace versions in lockstep | `jq -r .version` across all 5 `package.json` files returns a single line `0.3.0` | ✓ |
+| 4 | Annotated tag cut by Release workflow | `v0.2.0` and `v0.3.0` are both annotated tags authored by `semantic-release-bot` | ✓ |
+| 5 | GitHub Release has auto-generated notes | `gh release view v0.3.0` body contains conventional-commits changelog linking to PR #94 and the source commit | ✓ |
+| 6 | Direct `git push origin main` rejected | Branch protection on `main` enforced — `allow_force_pushes: false`, CODEOWNERS review required (count 0). Admin override required via `--admin` | ✓ (with documented admin bypass) |
+| 7 | Merge blocked while required CI checks red | Option B rule set does **not** require status checks (§7 deferred), but the UI still shows red ✕ next to the merge button for visibility; branch protection tightening is tracked in BRANCH_PROTECTION.md §7 | ⚠ partial — see §3 below |
+| 8 | CONTRIBUTING + RELEASE_STRATEGY + BRANCH_PROTECTION merged and linked | All three exist at expected paths and are surfaced from `docs/README.md` "Development" section | ✓ |
+| 9 | Husky v9 installed with simplified `prepare` | `node_modules/husky/package.json` → `9.1.7`; root `prepare` script is `husky` (not `husky install`) | ✓ |
+| 10 | All Sprint 0 Linear issues closed | WSM-000047 epic + WSM-000048..WSM-000056 — tracked in Linear team ARC (manual confirmation) | ☐ manual |
+
+## Release-flow Evidence
+
+Three semantic-release cycles, all successful, covered the required commit types:
+
+| Tag | Triggering commit | Bump rule |
+| --- | --- | --- |
+| `v0.2.0` | `feat(ops): add commitlint + commit-msg hook (WSM-000051)` | `feat:` → minor |
+| `v0.3.0` | `feat(ci): add commitlint PR job (WSM-000052) (#94)` | `feat:` → minor |
+| (no bump) | `docs(dev): add CONTRIBUTING.md + finalize RELEASE_STRATEGY (WSM-000053) (#95)` | `docs:` → no release |
+
+The `fix:` patch path has not been exercised organically in this sprint — it
+will be proved the next time a genuine bug fix ships post-Sprint-0, at which
+point semantic-release should cut `v0.3.1` (or higher if feats land first).
+
+## Deferred Hardening
+
+Two Sprint 0 rule points were intentionally softened and are tracked for a
+follow-up pass:
+
+1. **Required status checks on `main`** — currently `null`. Blocked by the
+   `release.yml` GitHub-token push cycle; unblocker is a GitHub App with
+   `contents: write` (BRANCH_PROTECTION.md §3 Option A).
+2. **Required approving reviews ≥ 1** — currently `0`. Blocked by solo-
+   maintainer reality; unblocker is adding a second maintainer.
+
+Neither blocks the 6-sprint roster management plan starting at WSM-000002.
+
+## Rollback Incident (2026-04-21)
+
+First semantic-release run on an empty-tag repo computed `v1.0.0` (default
+first-release). That tag was rolled back manually:
+
+```
+gh release delete v1.0.0 --yes --cleanup-tag
+git revert --no-edit 5965af0         # revert the chore(release): v1.0.0 commit
+git tag -a v0.1.0 -m "baseline"
+git push --tags
+```
+
+The revert commit message contains the substring `chore(release):`, which the
+`release.yml` guard matches, so the revert itself did not retrigger a release
+— desirable, and documented in BRANCH_PROTECTION.md §4. From `v0.1.0` onward,
+semantic-release computes from that baseline (0.1.0 → 0.2.0 → 0.3.0, correctly).
+
+## Handoff to Sprint 1
+
+Sprint 1 (roster phase 0, starting at WSM-000002) may now assume:
+- Every merged PR on `main` cuts a release if its squash title warrants one.
+- Every PR is commitlint-validated in CI on both layers (hook + job).
+- CONTRIBUTING.md is the canonical reference for branch names + commit format.
+- v1.0.0 is reserved for the May 2026 soft launch per the GTM plan — major
+  bumps before then are blocked by review.


### PR DESCRIPTION
## Summary
- Audits every Sprint 0 acceptance criterion against observable repo state
- Records the three semantic-release cycles so far (v0.2.0 ← WSM-000051, v0.3.0 ← WSM-000052, plus docs PR #95 no-bump)
- Flags the two intentionally-deferred hardening knobs (required status checks, approving-review count) with their unblockers
- Documents the v1.0.0 rollback incident and why \`release.yml\`'s guard skips revert commits

## Linear
WSM-000056 — closes Sprint 0 / epic WSM-000047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)