### PR TITLE
feat(web): add depth_chart_v1 flag with page/api guards (WSM-000003)

### DIFF
--- a/apps/web/convex.json
+++ b/apps/web/convex.json
@@ -1,0 +1,3 @@
+{
+  "functions": "convex/"
+}

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -1,0 +1,49 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as sports from "../sports.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  sports: typeof sports;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/apps/web/convex/_generated/api.js
+++ b/apps/web/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/apps/web/convex/_generated/dataModel.d.ts
+++ b/apps/web/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/apps/web/convex/_generated/server.d.ts
+++ b/apps/web/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/apps/web/convex/_generated/server.js
+++ b/apps/web/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -1,0 +1,74 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  leagues: defineTable({
+    name: v.string(),
+    orgId: v.union(v.string(), v.null()),
+    isPublic: v.boolean(),
+    inviteToken: v.union(v.string(), v.null()),
+  })
+    .index("by_name", ["name"])
+    .index("by_orgId", ["orgId"])
+    .index("by_isPublic", ["isPublic"])
+    .index("by_inviteToken", ["inviteToken"]),
+
+  divisions: defineTable({
+    name: v.string(),
+    leagueId: v.id("leagues"),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_leagueId_name", ["leagueId", "name"]),
+
+  teams: defineTable({
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    divisionId: v.union(v.id("divisions"), v.null()),
+    city: v.string(),
+    stadium: v.string(),
+    foundedYear: v.union(v.number(), v.null()),
+    location: v.string(),
+    logoUrl: v.union(v.string(), v.null()),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_divisionId", ["divisionId"])
+    .index("by_leagueId_name", ["leagueId", "name"]),
+
+  players: defineTable({
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    teamId: v.id("teams"),
+    position: v.string(),
+    jerseyNumber: v.union(v.number(), v.null()),
+    dateOfBirth: v.union(v.string(), v.null()),
+    status: v.string(),
+    headshotUrl: v.union(v.string(), v.null()),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_teamId", ["teamId"])
+    .index("by_teamId_name", ["teamId", "name"]),
+
+  seasons: defineTable({
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    startDate: v.union(v.string(), v.null()),
+    endDate: v.union(v.string(), v.null()),
+    status: v.string(),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_leagueId_name", ["leagueId", "name"]),
+
+  leagueSubscriptions: defineTable({
+    userId: v.string(),
+    leagueId: v.id("leagues"),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_leagueId", ["userId", "leagueId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  syncConfigs: defineTable({
+    key: v.string(),
+    syncEnabled: v.boolean(),
+    lastSyncReportJson: v.union(v.string(), v.null()),
+  }).index("by_key", ["key"]),
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,0 +1,1147 @@
+import { mutationGeneric, queryGeneric } from "convex/server";
+import { v } from "convex/values";
+
+function uniqueById<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    result.push(item);
+  }
+  return result;
+}
+
+function sortByName<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function toLeagueDto(doc: {
+  _id: string;
+  name: string;
+  orgId: string | null;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    orgId: doc.orgId ?? null,
+  };
+}
+
+function toDivisionDto(doc: {
+  _id: string;
+  name: string;
+  leagueId: string;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    leagueId: doc.leagueId,
+  };
+}
+
+function toTeamDto(doc: {
+  _id: string;
+  name: string;
+  leagueId: string;
+  city: string;
+  stadium: string;
+  foundedYear: number | null;
+  location: string;
+  divisionId: string | null;
+  logoUrl: string | null;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    leagueId: doc.leagueId,
+    city: doc.city,
+    stadium: doc.stadium,
+    foundedYear: doc.foundedYear ?? null,
+    location: doc.location,
+    divisionId: doc.divisionId ?? "",
+    logoUrl: doc.logoUrl ?? null,
+  };
+}
+
+function toPlayerDto(doc: {
+  _id: string;
+  name: string;
+  teamId: string;
+  position: string;
+  jerseyNumber: number | null;
+  dateOfBirth: string | null;
+  status: string;
+  headshotUrl: string | null;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    teamId: doc.teamId,
+    position: doc.position,
+    jerseyNumber: doc.jerseyNumber ?? null,
+    dateOfBirth: doc.dateOfBirth ?? null,
+    status: doc.status,
+    headshotUrl: doc.headshotUrl ?? null,
+  };
+}
+
+function toSeasonDto(doc: {
+  _id: string;
+  name: string;
+  leagueId: string;
+  startDate: string | null;
+  endDate: string | null;
+  status: string;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    leagueId: doc.leagueId,
+    startDate: doc.startDate ?? null,
+    endDate: doc.endDate ?? null,
+    status: doc.status,
+  };
+}
+
+export const getVisibleLeagueContext = queryGeneric({
+  args: {
+    orgIds: v.array(v.string()),
+    userId: v.string(),
+  },
+  returns: v.object({
+    visibleLeagueIds: v.array(v.string()),
+    subscribedLeagueIds: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const subscriptionDocs = await ctx.db
+      .query("leagueSubscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .collect();
+
+    const subscribedLeagueIds = subscriptionDocs.map((doc) => doc.leagueId);
+    const orgLeagueDocs = await Promise.all(
+      args.orgIds.map((orgId) =>
+        ctx.db
+          .query("leagues")
+          .withIndex("by_orgId", (q) => q.eq("orgId", orgId))
+          .collect(),
+      ),
+    );
+
+    const visibleLeagueIds = Array.from(
+      new Set([
+        ...subscribedLeagueIds,
+        ...orgLeagueDocs.flat().map((league) => league._id),
+      ]),
+    );
+
+    return {
+      visibleLeagueIds,
+      subscribedLeagueIds,
+    };
+  },
+});
+
+export const listPublicLeagues = queryGeneric({
+  args: {},
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      orgId: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx) => {
+    const docs = await ctx.db
+      .query("leagues")
+      .withIndex("by_isPublic", (q) => q.eq("isPublic", true))
+      .collect();
+    return sortByName(docs.map(toLeagueDto));
+  },
+});
+
+export const getLeagueByInviteToken = queryGeneric({
+  args: { token: v.string() },
+  returns: v.union(
+    v.object({
+      leagueId: v.string(),
+      orgId: v.union(v.string(), v.null()),
+      name: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db
+      .query("leagues")
+      .withIndex("by_inviteToken", (q) => q.eq("inviteToken", args.token))
+      .unique();
+
+    if (!doc) return null;
+
+    return {
+      leagueId: doc._id,
+      orgId: doc.orgId ?? null,
+      name: doc.name,
+    };
+  },
+});
+
+export const getLeagueForOrg = queryGeneric({
+  args: { orgId: v.string() },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      token: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db
+      .query("leagues")
+      .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))
+      .unique();
+
+    if (!doc) return null;
+    return { id: doc._id, token: doc.inviteToken ?? null };
+  },
+});
+
+export const getLeagueOrgId = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.leagueId);
+    if (!doc) return null;
+    return doc.orgId ?? null;
+  },
+});
+
+export const listLeagues = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      orgId: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(args.leagueIds.map((id) => ctx.db.get(id)));
+    return sortByName(docs.filter(Boolean).map(toLeagueDto));
+  },
+});
+
+export const getLeague = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      orgId: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.leagueId);
+    return doc ? toLeagueDto(doc) : null;
+  },
+});
+
+export const getLeagueByName = queryGeneric({
+  args: { name: v.string() },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      orgId: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db
+      .query("leagues")
+      .withIndex("by_name", (q) => q.eq("name", args.name))
+      .unique();
+    return doc ? toLeagueDto(doc) : null;
+  },
+});
+
+export const listDivisions = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(
+      args.leagueIds.map((leagueId) =>
+        ctx.db
+          .query("divisions")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+          .collect(),
+      ),
+    );
+    return sortByName(uniqueById(docs.flat().map(toDivisionDto)));
+  },
+});
+
+export const getDivision = queryGeneric({
+  args: { divisionId: v.id("divisions") },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.divisionId);
+    return doc ? toDivisionDto(doc) : null;
+  },
+});
+
+export const listTeams = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      city: v.string(),
+      stadium: v.string(),
+      foundedYear: v.union(v.number(), v.null()),
+      location: v.string(),
+      divisionId: v.string(),
+      logoUrl: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(
+      args.leagueIds.map((leagueId) =>
+        ctx.db
+          .query("teams")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+          .collect(),
+      ),
+    );
+    return sortByName(uniqueById(docs.flat().map(toTeamDto)));
+  },
+});
+
+export const listTeamsByLeague = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      city: v.string(),
+      stadium: v.string(),
+      foundedYear: v.union(v.number(), v.null()),
+      location: v.string(),
+      divisionId: v.string(),
+      logoUrl: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    return sortByName(docs.map(toTeamDto));
+  },
+});
+
+export const getTeam = queryGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      city: v.string(),
+      stadium: v.string(),
+      foundedYear: v.union(v.number(), v.null()),
+      location: v.string(),
+      divisionId: v.string(),
+      logoUrl: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.teamId);
+    return doc ? toTeamDto(doc) : null;
+  },
+});
+
+export const getTeamLeagueId = queryGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.teamId);
+    return doc?.leagueId ?? null;
+  },
+});
+
+export const listPlayers = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      teamId: v.string(),
+      position: v.string(),
+      jerseyNumber: v.union(v.number(), v.null()),
+      dateOfBirth: v.union(v.string(), v.null()),
+      status: v.string(),
+      headshotUrl: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(
+      args.leagueIds.map((leagueId) =>
+        ctx.db
+          .query("players")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+          .collect(),
+      ),
+    );
+    return sortByName(uniqueById(docs.flat().map(toPlayerDto)));
+  },
+});
+
+export const listPlayersByTeam = queryGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      teamId: v.string(),
+      position: v.string(),
+      jerseyNumber: v.union(v.number(), v.null()),
+      dateOfBirth: v.union(v.string(), v.null()),
+      status: v.string(),
+      headshotUrl: v.union(v.string(), v.null()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    return sortByName(docs.map(toPlayerDto));
+  },
+});
+
+export const getPlayer = queryGeneric({
+  args: { playerId: v.id("players") },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      teamId: v.string(),
+      position: v.string(),
+      jerseyNumber: v.union(v.number(), v.null()),
+      dateOfBirth: v.union(v.string(), v.null()),
+      status: v.string(),
+      headshotUrl: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.playerId);
+    return doc ? toPlayerDto(doc) : null;
+  },
+});
+
+export const listSeasons = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      startDate: v.union(v.string(), v.null()),
+      endDate: v.union(v.string(), v.null()),
+      status: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(
+      args.leagueIds.map((leagueId) =>
+        ctx.db
+          .query("seasons")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+          .collect(),
+      ),
+    );
+    return sortByName(uniqueById(docs.flat().map(toSeasonDto)));
+  },
+});
+
+export const getSeason = queryGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      startDate: v.union(v.string(), v.null()),
+      endDate: v.union(v.string(), v.null()),
+      status: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.seasonId);
+    return doc ? toSeasonDto(doc) : null;
+  },
+});
+
+export const getSyncConfig = queryGeneric({
+  args: {},
+  returns: v.object({
+    syncEnabled: v.boolean(),
+    lastSyncReportJson: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx) => {
+    const doc = await ctx.db
+      .query("syncConfigs")
+      .withIndex("by_key", (q) => q.eq("key", "nfl"))
+      .unique();
+
+    return {
+      syncEnabled: doc?.syncEnabled ?? false,
+      lastSyncReportJson: doc?.lastSyncReportJson ?? null,
+    };
+  },
+});
+
+export const healthSummary = queryGeneric({
+  args: {},
+  returns: v.object({
+    leagues: v.number(),
+    divisions: v.number(),
+    teams: v.number(),
+    players: v.number(),
+    seasons: v.number(),
+  }),
+  handler: async (ctx) => {
+    const [leagues, divisions, teams, players, seasons] = await Promise.all([
+      ctx.db.query("leagues").collect(),
+      ctx.db.query("divisions").collect(),
+      ctx.db.query("teams").collect(),
+      ctx.db.query("players").collect(),
+      ctx.db.query("seasons").collect(),
+    ]);
+    return {
+      leagues: leagues.length,
+      divisions: divisions.length,
+      teams: teams.length,
+      players: players.length,
+      seasons: seasons.length,
+    };
+  },
+});
+
+export const upsertLeague = mutationGeneric({
+  args: {
+    name: v.string(),
+    orgId: v.union(v.string(), v.null()),
+  },
+  returns: v.object({
+    dto: v.object({
+      id: v.string(),
+      name: v.string(),
+      orgId: v.union(v.string(), v.null()),
+    }),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("leagues")
+      .withIndex("by_name", (q) => q.eq("name", args.name))
+      .unique();
+
+    if (existing) {
+      return { dto: toLeagueDto(existing), created: false };
+    }
+
+    const leagueId = await ctx.db.insert("leagues", {
+      name: args.name,
+      orgId: args.orgId,
+      isPublic: args.orgId === null,
+      inviteToken: null,
+    });
+
+    return {
+      dto: {
+        id: leagueId,
+        name: args.name,
+        orgId: args.orgId,
+      },
+      created: true,
+    };
+  },
+});
+
+export const upsertDivision = mutationGeneric({
+  args: {
+    name: v.string(),
+    leagueId: v.id("leagues"),
+  },
+  returns: v.object({
+    dto: v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+    }),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing =
+      (
+        await ctx.db
+          .query("divisions")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect()
+      ).find((division) => division.name === args.name) ?? null;
+
+    if (existing) {
+      return { dto: toDivisionDto(existing), created: false };
+    }
+
+    const divisionId = await ctx.db.insert("divisions", args);
+    return {
+      dto: { id: divisionId, name: args.name, leagueId: args.leagueId },
+      created: true,
+    };
+  },
+});
+
+export const upsertTeam = mutationGeneric({
+  args: {
+    name: v.string(),
+    city: v.string(),
+    stadium: v.string(),
+    leagueId: v.id("leagues"),
+    divisionId: v.union(v.id("divisions"), v.null()),
+    logoUrl: v.union(v.string(), v.null()),
+  },
+  returns: v.object({
+    dto: v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      city: v.string(),
+      stadium: v.string(),
+      foundedYear: v.union(v.number(), v.null()),
+      location: v.string(),
+      divisionId: v.string(),
+      logoUrl: v.union(v.string(), v.null()),
+    }),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing =
+      (
+        await ctx.db
+          .query("teams")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect()
+      ).find((team) => team.name === args.name) ?? null;
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        city: args.city,
+        stadium: args.stadium,
+        location: args.city,
+        divisionId: args.divisionId,
+        logoUrl: args.logoUrl,
+      });
+      return {
+        dto: toTeamDto({
+          ...existing,
+          city: args.city,
+          stadium: args.stadium,
+          location: args.city,
+          divisionId: args.divisionId,
+          logoUrl: args.logoUrl,
+        }),
+        created: false,
+      };
+    }
+
+    const teamId = await ctx.db.insert("teams", {
+      name: args.name,
+      leagueId: args.leagueId,
+      divisionId: args.divisionId,
+      city: args.city,
+      stadium: args.stadium,
+      foundedYear: null,
+      location: args.city,
+      logoUrl: args.logoUrl,
+    });
+
+    return {
+      dto: {
+        id: teamId,
+        name: args.name,
+        leagueId: args.leagueId,
+        city: args.city,
+        stadium: args.stadium,
+        foundedYear: null,
+        location: args.city,
+        divisionId: args.divisionId ?? "",
+        logoUrl: args.logoUrl,
+      },
+      created: true,
+    };
+  },
+});
+
+export const upsertPlayer = mutationGeneric({
+  args: {
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    teamId: v.id("teams"),
+    position: v.string(),
+    jerseyNumber: v.union(v.number(), v.null()),
+    dateOfBirth: v.union(v.string(), v.null()),
+    status: v.string(),
+    headshotUrl: v.union(v.string(), v.null()),
+  },
+  returns: v.object({
+    dto: v.object({
+      id: v.string(),
+      name: v.string(),
+      teamId: v.string(),
+      position: v.string(),
+      jerseyNumber: v.union(v.number(), v.null()),
+      dateOfBirth: v.union(v.string(), v.null()),
+      status: v.string(),
+      headshotUrl: v.union(v.string(), v.null()),
+    }),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing =
+      (
+        await ctx.db
+          .query("players")
+          .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+          .collect()
+      ).find((player) => player.name === args.name) ?? null;
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        leagueId: args.leagueId,
+        position: args.position,
+        jerseyNumber: args.jerseyNumber,
+        dateOfBirth: args.dateOfBirth,
+        status: args.status,
+        headshotUrl: args.headshotUrl,
+      });
+      return {
+        dto: toPlayerDto({
+          ...existing,
+          leagueId: args.leagueId,
+          position: args.position,
+          jerseyNumber: args.jerseyNumber,
+          dateOfBirth: args.dateOfBirth,
+          status: args.status,
+          headshotUrl: args.headshotUrl,
+        }),
+        created: false,
+      };
+    }
+
+    const playerId = await ctx.db.insert("players", args);
+    return {
+      dto: {
+        id: playerId,
+        name: args.name,
+        teamId: args.teamId,
+        position: args.position,
+        jerseyNumber: args.jerseyNumber,
+        dateOfBirth: args.dateOfBirth,
+        status: args.status,
+        headshotUrl: args.headshotUrl,
+      },
+      created: true,
+    };
+  },
+});
+
+export const createTeam = mutationGeneric({
+  args: {
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    city: v.string(),
+    stadium: v.string(),
+  },
+  returns: v.object({
+    id: v.string(),
+    name: v.string(),
+    leagueId: v.string(),
+    city: v.string(),
+    stadium: v.string(),
+    foundedYear: v.union(v.number(), v.null()),
+    location: v.string(),
+    divisionId: v.string(),
+    logoUrl: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const teamId = await ctx.db.insert("teams", {
+      name: args.name,
+      leagueId: args.leagueId,
+      divisionId: null,
+      city: args.city,
+      stadium: args.stadium,
+      foundedYear: null,
+      location: args.city,
+      logoUrl: null,
+    });
+    return {
+      id: teamId,
+      name: args.name,
+      leagueId: args.leagueId,
+      city: args.city,
+      stadium: args.stadium,
+      foundedYear: null,
+      location: args.city,
+      divisionId: "",
+      logoUrl: null,
+    };
+  },
+});
+
+export const updateTeam = mutationGeneric({
+  args: {
+    teamId: v.id("teams"),
+    name: v.optional(v.string()),
+    city: v.optional(v.string()),
+    stadium: v.optional(v.string()),
+    foundedYear: v.optional(v.union(v.number(), v.null())),
+    location: v.optional(v.string()),
+    divisionId: v.optional(v.id("divisions")),
+  },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      city: v.string(),
+      stadium: v.string(),
+      foundedYear: v.union(v.number(), v.null()),
+      location: v.string(),
+      divisionId: v.string(),
+      logoUrl: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.teamId);
+    if (!existing) return null;
+
+    const patch = {
+      ...(args.name !== undefined ? { name: args.name } : {}),
+      ...(args.city !== undefined ? { city: args.city } : {}),
+      ...(args.stadium !== undefined ? { stadium: args.stadium } : {}),
+      ...(args.foundedYear !== undefined ? { foundedYear: args.foundedYear } : {}),
+      ...(args.location !== undefined ? { location: args.location } : {}),
+      ...(args.divisionId !== undefined ? { divisionId: args.divisionId } : {}),
+    };
+    await ctx.db.patch(args.teamId, patch);
+
+    return toTeamDto({
+      ...existing,
+      ...patch,
+    });
+  },
+});
+
+export const createPlayer = mutationGeneric({
+  args: {
+    name: v.string(),
+    teamId: v.id("teams"),
+    position: v.string(),
+    jerseyNumber: v.union(v.number(), v.null()),
+    dateOfBirth: v.union(v.string(), v.null()),
+    status: v.string(),
+  },
+  returns: v.object({
+    id: v.string(),
+    name: v.string(),
+    teamId: v.string(),
+    position: v.string(),
+    jerseyNumber: v.union(v.number(), v.null()),
+    dateOfBirth: v.union(v.string(), v.null()),
+    status: v.string(),
+    headshotUrl: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) {
+      throw new Error("Team not found");
+    }
+
+    const playerId = await ctx.db.insert("players", {
+      ...args,
+      leagueId: team.leagueId,
+      headshotUrl: null,
+    });
+
+    return {
+      id: playerId,
+      name: args.name,
+      teamId: args.teamId,
+      position: args.position,
+      jerseyNumber: args.jerseyNumber,
+      dateOfBirth: args.dateOfBirth,
+      status: args.status,
+      headshotUrl: null,
+    };
+  },
+});
+
+export const updatePlayer = mutationGeneric({
+  args: {
+    playerId: v.id("players"),
+    name: v.optional(v.string()),
+    teamId: v.optional(v.id("teams")),
+    position: v.optional(v.string()),
+    jerseyNumber: v.optional(v.union(v.number(), v.null())),
+    dateOfBirth: v.optional(v.union(v.string(), v.null())),
+    status: v.optional(v.string()),
+  },
+  returns: v.union(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      teamId: v.string(),
+      position: v.string(),
+      jerseyNumber: v.union(v.number(), v.null()),
+      dateOfBirth: v.union(v.string(), v.null()),
+      status: v.string(),
+      headshotUrl: v.union(v.string(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.playerId);
+    if (!existing) return null;
+
+    let leagueId = existing.leagueId;
+    if (args.teamId !== undefined) {
+      const team = await ctx.db.get(args.teamId);
+      if (!team) {
+        throw new Error("Team not found");
+      }
+      leagueId = team.leagueId;
+    }
+
+    const patch = {
+      ...(args.name !== undefined ? { name: args.name } : {}),
+      ...(args.teamId !== undefined ? { teamId: args.teamId } : {}),
+      ...(args.position !== undefined ? { position: args.position } : {}),
+      ...(args.jerseyNumber !== undefined ? { jerseyNumber: args.jerseyNumber } : {}),
+      ...(args.dateOfBirth !== undefined ? { dateOfBirth: args.dateOfBirth } : {}),
+      ...(args.status !== undefined ? { status: args.status } : {}),
+      ...(args.teamId !== undefined ? { leagueId } : {}),
+    };
+
+    await ctx.db.patch(args.playerId, patch);
+    return toPlayerDto({
+      ...existing,
+      ...patch,
+    });
+  },
+});
+
+export const deletePlayer = mutationGeneric({
+  args: { playerId: v.id("players") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.delete(args.playerId);
+    return null;
+  },
+});
+
+export const upsertSeason = mutationGeneric({
+  args: {
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    startDate: v.union(v.string(), v.null()),
+    endDate: v.union(v.string(), v.null()),
+    status: v.string(),
+  },
+  returns: v.object({
+    dto: v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      startDate: v.union(v.string(), v.null()),
+      endDate: v.union(v.string(), v.null()),
+      status: v.string(),
+    }),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing =
+      (
+        await ctx.db
+          .query("seasons")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect()
+      ).find((season) => season.name === args.name) ?? null;
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        startDate: args.startDate,
+        endDate: args.endDate,
+        status: args.status,
+      });
+      return {
+        dto: toSeasonDto({
+          ...existing,
+          startDate: args.startDate,
+          endDate: args.endDate,
+          status: args.status,
+        }),
+        created: false,
+      };
+    }
+
+    const seasonId = await ctx.db.insert("seasons", args);
+    return {
+      dto: {
+        id: seasonId,
+        name: args.name,
+        leagueId: args.leagueId,
+        startDate: args.startDate,
+        endDate: args.endDate,
+        status: args.status,
+      },
+      created: true,
+    };
+  },
+});
+
+export const setLeagueInviteToken = mutationGeneric({
+  args: {
+    leagueId: v.id("leagues"),
+    token: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.leagueId, {
+      inviteToken: args.token,
+    });
+    return null;
+  },
+});
+
+export const subscribeToLeague = mutationGeneric({
+  args: {
+    userId: v.string(),
+    leagueId: v.id("leagues"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league || !league.isPublic) {
+      throw new Error("League not found or not public");
+    }
+
+    const existing =
+      (
+        await ctx.db
+          .query("leagueSubscriptions")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect()
+      ).find((subscription) => subscription.leagueId === args.leagueId) ?? null;
+
+    if (!existing) {
+      await ctx.db.insert("leagueSubscriptions", args);
+    }
+    return null;
+  },
+});
+
+export const unsubscribeFromLeague = mutationGeneric({
+  args: {
+    userId: v.string(),
+    leagueId: v.id("leagues"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing =
+      (
+        await ctx.db
+          .query("leagueSubscriptions")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect()
+      ).find((subscription) => subscription.leagueId === args.leagueId) ?? null;
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+    return null;
+  },
+});
+
+export const setSyncEnabled = mutationGeneric({
+  args: { enabled: v.boolean() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("syncConfigs")
+      .withIndex("by_key", (q) => q.eq("key", "nfl"))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        syncEnabled: args.enabled,
+      });
+    } else {
+      await ctx.db.insert("syncConfigs", {
+        key: "nfl",
+        syncEnabled: args.enabled,
+        lastSyncReportJson: null,
+      });
+    }
+    return null;
+  },
+});
+
+export const writeSyncReport = mutationGeneric({
+  args: {
+    reportJson: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("syncConfigs")
+      .withIndex("by_key", (q) => q.eq("key", "nfl"))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        lastSyncReportJson: args.reportJson,
+      });
+    } else {
+      await ctx.db.insert("syncConfigs", {
+        key: "nfl",
+        syncEnabled: false,
+        lastSyncReportJson: args.reportJson,
+      });
+    }
+    return null;
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@sports-management/api-contracts": "workspace:*",
     "@sports-management/shared-types": "workspace:*",
     "@vercel/analytics": "^2.0.1",
+    "convex": "^1.19.0",
     "@vercel/og": "^0.11.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@sports-management/shared-types": "workspace:*",
     "@vercel/analytics": "^2.0.1",
     "convex": "^1.19.0",
+    "flags": "^4.0.6",
     "@vercel/og": "^0.11.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/scripts/backfill-salesforce-to-convex.mts
+++ b/apps/web/scripts/backfill-salesforce-to-convex.mts
@@ -1,0 +1,271 @@
+/**
+ * One-off migration: Salesforce -> Convex.
+ *
+ * Usage from apps/web:
+ *   pnpm dlx dotenv-cli -e .env.local -- pnpm dlx tsx scripts/backfill-salesforce-to-convex.mts
+ */
+import type { LeagueImportPayload } from "@sports-management/api-contracts";
+import {
+  bulkImportLeague,
+  setLeagueInviteToken,
+  updateSyncEnabled,
+  upsertSeason,
+  writeSyncReport,
+} from "../src/lib/data-api.ts";
+import { getSalesforceConnection } from "../src/lib/salesforce.ts";
+
+type LeagueRecord = {
+  Id: string;
+  Name: string;
+  Clerk_Org_Id__c: string | null;
+  Invite_Token__c: string | null;
+};
+
+type DivisionRecord = {
+  Id: string;
+  Name: string;
+  League__c: string;
+};
+
+type TeamRecord = {
+  Id: string;
+  Name: string;
+  League__c: string;
+  Division__c: string | null;
+  City__c: string | null;
+  Stadium__c: string | null;
+  Logo_URL__c: string | null;
+};
+
+type PlayerRecord = {
+  Id: string;
+  Name: string;
+  Team__c: string;
+  Position__c: string | null;
+  Jersey_Number__c: number | null;
+  Date_of_Birth__c: string | null;
+  Status__c: string | null;
+  Headshot_URL__c: string | null;
+};
+
+type SeasonRecord = {
+  Id: string;
+  Name: string;
+  League__c: string;
+  Start_Date__c: string | null;
+  End_Date__c: string | null;
+  Status__c: string | null;
+};
+
+type SyncConfigRecord = {
+  Sync_Enabled__c: boolean;
+  Last_Sync_Report__c: string | null;
+};
+
+function safeDivisionName(name: string | null | undefined): string {
+  return name?.trim() || "Imported";
+}
+
+async function main() {
+  const conn = await getSalesforceConnection();
+
+  const [leaguesResult, divisionsResult, teamsResult, playersResult, seasonsResult] =
+    await Promise.all([
+      conn.query<LeagueRecord>(
+        "SELECT Id, Name, Clerk_Org_Id__c, Invite_Token__c FROM League__c",
+      ),
+      conn.query<DivisionRecord>("SELECT Id, Name, League__c FROM Division__c"),
+      conn.query<TeamRecord>(
+        "SELECT Id, Name, League__c, Division__c, City__c, Stadium__c, Logo_URL__c FROM Team__c",
+      ),
+      conn.query<PlayerRecord>(
+        "SELECT Id, Name, Team__c, Position__c, Jersey_Number__c, Date_of_Birth__c, Status__c, Headshot_URL__c FROM Player__c",
+      ),
+      conn.query<SeasonRecord>(
+        "SELECT Id, Name, League__c, Start_Date__c, End_Date__c, Status__c FROM Season__c",
+      ),
+    ]);
+
+  let syncConfigResult:
+    | {
+        totalSize: number;
+        records: SyncConfigRecord[];
+      }
+    | null = null;
+
+  const globalDescribe = await conn.describeGlobal();
+  const hasSyncConfigObject = globalDescribe.sobjects.some(
+    (object) => object.name === "NFL_Sync_Config__c",
+  );
+
+  if (hasSyncConfigObject) {
+    syncConfigResult = await conn.query<SyncConfigRecord>(
+      "SELECT Sync_Enabled__c, Last_Sync_Report__c FROM NFL_Sync_Config__c LIMIT 1",
+    );
+  }
+
+  const leagues = leaguesResult.records;
+  const divisions = divisionsResult.records;
+  const teams = teamsResult.records;
+  const players = playersResult.records;
+  const seasons = seasonsResult.records;
+
+  const divisionsByLeague = new Map<string, DivisionRecord[]>();
+  for (const division of divisions) {
+    const existing = divisionsByLeague.get(division.League__c) ?? [];
+    existing.push(division);
+    divisionsByLeague.set(division.League__c, existing);
+  }
+
+  const teamsByLeague = new Map<string, TeamRecord[]>();
+  for (const team of teams) {
+    const existing = teamsByLeague.get(team.League__c) ?? [];
+    existing.push(team);
+    teamsByLeague.set(team.League__c, existing);
+  }
+
+  const playersByTeam = new Map<string, PlayerRecord[]>();
+  for (const player of players) {
+    const existing = playersByTeam.get(player.Team__c) ?? [];
+    existing.push(player);
+    playersByTeam.set(player.Team__c, existing);
+  }
+
+  const seasonsByLeague = new Map<string, SeasonRecord[]>();
+  for (const season of seasons) {
+    const existing = seasonsByLeague.get(season.League__c) ?? [];
+    existing.push(season);
+    seasonsByLeague.set(season.League__c, existing);
+  }
+
+  const teamCountByDivision = new Map<string, TeamRecord[]>();
+  for (const team of teams) {
+    const key = team.Division__c ?? `league:${team.League__c}`;
+    const existing = teamCountByDivision.get(key) ?? [];
+    existing.push(team);
+    teamCountByDivision.set(key, existing);
+  }
+
+  const migrationSummary: Array<{
+    leagueName: string;
+    importedLeagueId: string;
+    result: Awaited<ReturnType<typeof bulkImportLeague>>;
+  }> = [];
+
+  for (const league of leagues) {
+    const leagueDivisions = divisionsByLeague.get(league.Id) ?? [];
+    const leagueTeams = teamsByLeague.get(league.Id) ?? [];
+
+    const payloadDivisions: LeagueImportPayload["divisions"] =
+      leagueDivisions.length > 0
+        ? leagueDivisions
+            .map((division) => ({
+              name: safeDivisionName(division.Name),
+              teams:
+                (teamCountByDivision.get(division.Id) ?? []).map((team) => ({
+                  name: team.Name,
+                  city: team.City__c ?? "",
+                  stadium: team.Stadium__c ?? "",
+                  logoUrl: team.Logo_URL__c ?? null,
+                  players: (playersByTeam.get(team.Id) ?? []).map((player) => ({
+                    name: player.Name,
+                    position: player.Position__c ?? "Unknown",
+                    jerseyNumber: player.Jersey_Number__c ?? null,
+                    dateOfBirth: player.Date_of_Birth__c ?? null,
+                    status: player.Status__c ?? "Active",
+                    headshotUrl: player.Headshot_URL__c ?? null,
+                  })),
+                })),
+            }))
+            .filter((division) => division.teams.length > 0)
+        : [];
+
+    if (payloadDivisions.length === 0 && leagueTeams.length > 0) {
+      payloadDivisions.push({
+        name: "Imported",
+        teams: leagueTeams.map((team) => ({
+          name: team.Name,
+          city: team.City__c ?? "",
+          stadium: team.Stadium__c ?? "",
+          logoUrl: team.Logo_URL__c ?? null,
+          players: (playersByTeam.get(team.Id) ?? []).map((player) => ({
+            name: player.Name,
+            position: player.Position__c ?? "Unknown",
+            jerseyNumber: player.Jersey_Number__c ?? null,
+            dateOfBirth: player.Date_of_Birth__c ?? null,
+            status: player.Status__c ?? "Active",
+            headshotUrl: player.Headshot_URL__c ?? null,
+          })),
+        })),
+      });
+    }
+
+    if (payloadDivisions.length === 0) {
+      continue;
+    }
+
+    const payload: LeagueImportPayload = {
+      league: { name: league.Name },
+      divisions: payloadDivisions,
+    };
+
+    const result = await bulkImportLeague(
+      payload,
+      undefined,
+      league.Clerk_Org_Id__c ?? null,
+    );
+
+    if (league.Invite_Token__c) {
+      await setLeagueInviteToken(result.leagueId, league.Invite_Token__c);
+    }
+
+    const leagueSeasons = seasonsByLeague.get(league.Id) ?? [];
+    for (const season of leagueSeasons) {
+      await upsertSeason({
+        name: season.Name,
+        leagueId: result.leagueId,
+        startDate: season.Start_Date__c ?? null,
+        endDate: season.End_Date__c ?? null,
+        status: season.Status__c ?? "",
+      });
+    }
+
+    migrationSummary.push({
+      leagueName: league.Name,
+      importedLeagueId: result.leagueId,
+      result,
+    });
+  }
+
+  if (syncConfigResult && syncConfigResult.totalSize > 0) {
+    const record = syncConfigResult.records[0];
+    await updateSyncEnabled(record.Sync_Enabled__c);
+    if (record.Last_Sync_Report__c) {
+      try {
+        await writeSyncReport(JSON.parse(record.Last_Sync_Report__c));
+      } catch {
+        // Ignore malformed legacy sync reports.
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        migratedLeagues: migrationSummary.length,
+        sourceCounts: {
+          leagues: leagues.length,
+          divisions: divisions.length,
+          teams: teams.length,
+          players: players.length,
+          seasons: seasons.length,
+        },
+        migrationSummary,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/apps/web/scripts/run-nfl-sync-once.mts
+++ b/apps/web/scripts/run-nfl-sync-once.mts
@@ -1,0 +1,9 @@
+/**
+ * One-off: NFL ESPN → Salesforce import (same as POST /api/import/nfl-sync).
+ * Usage from apps/web: pnpm dlx dotenv-cli -e .env.local -- pnpm dlx tsx scripts/run-nfl-sync-once.mts
+ */
+import { syncNfl } from "../src/lib/sync/nfl-sync.ts";
+
+const report = await syncNfl({ skipToggleCheck: true });
+console.log(JSON.stringify(report, null, 2));
+process.exit(report.importResult === null ? 1 : 0);

--- a/apps/web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/web/src/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,6 @@
+import { createFlagsDiscoveryEndpoint, getProviderData } from "flags/next";
+import { depthChartV1 } from "@/lib/flags";
+
+export const GET = createFlagsDiscoveryEndpoint(() =>
+  getProviderData({ depthChartV1 }),
+);

--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("flags/next", () => ({
+  flag: <T,>(def: {
+    key: string;
+    decide: () => T | Promise<T>;
+    defaultValue?: T;
+    description?: string;
+  }) => {
+    const fn = async () => def.decide();
+    return Object.assign(fn, def);
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    const err = new Error("NEXT_NOT_FOUND");
+    (err as Error & { digest?: string }).digest = "NEXT_NOT_FOUND";
+    throw err;
+  }),
+}));
+
+import { depthChartV1, pageGuard, apiGuard } from "../flags";
+
+describe("depthChartV1 flag declaration", () => {
+  it("uses the canonical key", () => {
+    expect(depthChartV1.key).toBe("depth_chart_v1");
+  });
+
+  it("has a description for the Vercel Toolbar", () => {
+    expect(depthChartV1.description).toMatch(/depth.chart/i);
+  });
+});
+
+describe("pageGuard", () => {
+  it("resolves when the flag is on", async () => {
+    await expect(pageGuard(async () => true)).resolves.toBeUndefined();
+  });
+
+  it("calls notFound() when the flag is off", async () => {
+    await expect(pageGuard(async () => false)).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+});
+
+describe("apiGuard", () => {
+  it("returns null when the flag is on", async () => {
+    await expect(apiGuard(async () => true)).resolves.toBeNull();
+  });
+
+  it("returns a 403 flag_disabled response when the flag is off", async () => {
+    const res = await apiGuard(async () => false);
+    expect(res).toBeInstanceOf(Response);
+    expect(res?.status).toBe(403);
+    expect(await res?.json()).toEqual({ error: "flag_disabled" });
+  });
+});

--- a/apps/web/src/lib/convex-client.ts
+++ b/apps/web/src/lib/convex-client.ts
@@ -1,0 +1,27 @@
+import { ConvexHttpClient } from "convex/browser";
+
+export function getConvexClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+
+  if (!url) {
+    throw new Error(
+      "Missing Convex deployment URL. Set NEXT_PUBLIC_CONVEX_URL.",
+    );
+  }
+
+  const isLocalDeployment =
+    url.includes("127.0.0.1") || url.includes("localhost");
+
+  if (!adminKey && !isLocalDeployment) {
+    throw new Error("Missing Convex admin key. Set CONVEX_ADMIN_KEY.");
+  }
+
+  const client = new ConvexHttpClient(url);
+  if (adminKey) {
+    (client as ConvexHttpClient & {
+      setAdminAuth?: (key: string) => void;
+    }).setAdminAuth?.(adminKey);
+  }
+  return client;
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -1,0 +1,571 @@
+import { makeFunctionReference } from "convex/server";
+import type {
+  CreatePlayerInput,
+  CreateTeamInput,
+  DivisionDto,
+  ImportError,
+  ImportResult,
+  LeagueDto,
+  PlayerDto,
+  SeasonDto,
+  SyncConfig,
+  SyncReport,
+  TeamDto,
+  UpdatePlayerInput,
+  UpdateTeamInput,
+} from "@sports-management/shared-types";
+import type { LeagueImportPayload } from "@sports-management/api-contracts";
+import { getConvexClient } from "./convex-client";
+import type { OrgContext } from "./org-context";
+
+async function getClerkServerClient() {
+  const clerkModule = (await import("@clerk/nextjs/server")) as {
+    clerkClient?: () => Promise<{
+      organizations: {
+        createOrganization: (input: {
+          name: string;
+          createdBy: string;
+        }) => Promise<{ id: string }>;
+      };
+    }>;
+    default?: {
+      clerkClient?: () => Promise<{
+        organizations: {
+          createOrganization: (input: {
+            name: string;
+            createdBy: string;
+          }) => Promise<{ id: string }>;
+        };
+      }>;
+    };
+  };
+
+  const clientFactory =
+    clerkModule.clerkClient ?? clerkModule.default?.clerkClient;
+
+  if (!clientFactory) {
+    throw new Error("Failed to load Clerk server client");
+  }
+
+  return clientFactory();
+}
+
+function queryRef<Args extends object, Return>(name: string) {
+  return makeFunctionReference<"query", any, Return>(name);
+}
+
+function mutationRef<Args extends object, Return>(name: string) {
+  return makeFunctionReference<"mutation", any, Return>(name);
+}
+
+const refs = {
+  getVisibleLeagueContext: queryRef<
+    { orgIds: string[]; userId: string },
+    { visibleLeagueIds: string[]; subscribedLeagueIds: string[] }
+  >("sports:getVisibleLeagueContext"),
+  listPublicLeagues: queryRef<Record<string, never>, LeagueDto[]>(
+    "sports:listPublicLeagues",
+  ),
+  getLeagueByInviteToken: queryRef<
+    { token: string },
+    { leagueId: string; orgId: string | null; name: string } | null
+  >("sports:getLeagueByInviteToken"),
+  getLeagueForOrg: queryRef<
+    { orgId: string },
+    { id: string; token: string | null } | null
+  >("sports:getLeagueForOrg"),
+  getLeagueOrgId: queryRef<{ leagueId: string }, string | null>(
+    "sports:getLeagueOrgId",
+  ),
+  getLeagueByName: queryRef<{ name: string }, LeagueDto | null>(
+    "sports:getLeagueByName",
+  ),
+  listLeagues: queryRef<{ leagueIds: string[] }, LeagueDto[]>("sports:listLeagues"),
+  getLeague: queryRef<{ leagueId: string }, LeagueDto | null>("sports:getLeague"),
+  listDivisions: queryRef<{ leagueIds: string[] }, DivisionDto[]>(
+    "sports:listDivisions",
+  ),
+  getDivision: queryRef<{ divisionId: string }, DivisionDto | null>(
+    "sports:getDivision",
+  ),
+  listTeams: queryRef<{ leagueIds: string[] }, TeamDto[]>("sports:listTeams"),
+  listTeamsByLeague: queryRef<{ leagueId: string }, TeamDto[]>(
+    "sports:listTeamsByLeague",
+  ),
+  getTeam: queryRef<{ teamId: string }, TeamDto | null>("sports:getTeam"),
+  getTeamLeagueId: queryRef<{ teamId: string }, string | null>(
+    "sports:getTeamLeagueId",
+  ),
+  listPlayers: queryRef<{ leagueIds: string[] }, PlayerDto[]>("sports:listPlayers"),
+  listPlayersByTeam: queryRef<{ teamId: string }, PlayerDto[]>(
+    "sports:listPlayersByTeam",
+  ),
+  getPlayer: queryRef<{ playerId: string }, PlayerDto | null>("sports:getPlayer"),
+  listSeasons: queryRef<{ leagueIds: string[] }, SeasonDto[]>("sports:listSeasons"),
+  getSeason: queryRef<{ seasonId: string }, SeasonDto | null>("sports:getSeason"),
+  getSyncConfig: queryRef<
+    Record<string, never>,
+    { syncEnabled: boolean; lastSyncReportJson: string | null }
+  >("sports:getSyncConfig"),
+  healthSummary: queryRef<
+    Record<string, never>,
+    {
+      leagues: number;
+      divisions: number;
+      teams: number;
+      players: number;
+      seasons: number;
+    }
+  >("sports:healthSummary"),
+  upsertLeague: mutationRef<
+    { name: string; orgId: string | null },
+    { dto: LeagueDto; created: boolean }
+  >("sports:upsertLeague"),
+  upsertDivision: mutationRef<
+    { name: string; leagueId: string },
+    { dto: DivisionDto; created: boolean }
+  >("sports:upsertDivision"),
+  upsertTeam: mutationRef<
+    {
+      name: string;
+      city: string;
+      stadium: string;
+      leagueId: string;
+      divisionId: string | null;
+      logoUrl: string | null;
+    },
+    { dto: TeamDto; created: boolean }
+  >("sports:upsertTeam"),
+  upsertPlayer: mutationRef<
+    {
+      name: string;
+      leagueId: string;
+      teamId: string;
+      position: string;
+      jerseyNumber: number | null;
+      dateOfBirth: string | null;
+      status: string;
+      headshotUrl: string | null;
+    },
+    { dto: PlayerDto; created: boolean }
+  >("sports:upsertPlayer"),
+  upsertSeason: mutationRef<
+    {
+      name: string;
+      leagueId: string;
+      startDate: string | null;
+      endDate: string | null;
+      status: string;
+    },
+    { dto: SeasonDto; created: boolean }
+  >("sports:upsertSeason"),
+  setLeagueInviteToken: mutationRef<
+    { leagueId: string; token: string | null },
+    null
+  >("sports:setLeagueInviteToken"),
+  subscribeToLeague: mutationRef<{ userId: string; leagueId: string }, null>(
+    "sports:subscribeToLeague",
+  ),
+  unsubscribeFromLeague: mutationRef<{ userId: string; leagueId: string }, null>(
+    "sports:unsubscribeFromLeague",
+  ),
+  createTeam: mutationRef<CreateTeamInput, TeamDto>("sports:createTeam"),
+  updateTeam: mutationRef<
+    { teamId: string } & UpdateTeamInput,
+    TeamDto | null
+  >("sports:updateTeam"),
+  createPlayer: mutationRef<CreatePlayerInput, PlayerDto>("sports:createPlayer"),
+  updatePlayer: mutationRef<
+    { playerId: string } & UpdatePlayerInput,
+    PlayerDto | null
+  >("sports:updatePlayer"),
+  deletePlayer: mutationRef<{ playerId: string }, null>("sports:deletePlayer"),
+  setSyncEnabled: mutationRef<{ enabled: boolean }, null>("sports:setSyncEnabled"),
+  writeSyncReport: mutationRef<{ reportJson: string }, null>(
+    "sports:writeSyncReport",
+  ),
+};
+
+function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
+  if (!orgContext.visibleLeagueIds.includes(leagueId)) {
+    throw new Error("You do not have access to this league");
+  }
+}
+
+async function queryConvex<Args extends object, Return>(
+  ref: ReturnType<typeof queryRef<Args, Return>>,
+  args: Args,
+): Promise<Return> {
+  const client = getConvexClient();
+  return (client as unknown as {
+    query: (reference: unknown, payload: unknown) => Promise<Return>;
+  }).query(ref, args);
+}
+
+async function mutateConvex<Args extends object, Return>(
+  ref: ReturnType<typeof mutationRef<Args, Return>>,
+  args: Args,
+): Promise<Return> {
+  const client = getConvexClient();
+  return (client as unknown as {
+    mutation: (reference: unknown, payload: unknown) => Promise<Return>;
+  }).mutation(ref, args);
+}
+
+export async function getVisibleLeagueContext(userId: string, orgIds: string[]) {
+  return queryConvex(refs.getVisibleLeagueContext, { userId, orgIds });
+}
+
+export async function getPublicLeagues(): Promise<LeagueDto[]> {
+  return queryConvex(refs.listPublicLeagues, {});
+}
+
+export async function getLeagueByInviteToken(
+  token: string,
+): Promise<{ leagueId: string; orgId: string | null; name: string } | null> {
+  return queryConvex(refs.getLeagueByInviteToken, { token });
+}
+
+export async function getLeagueForOrg(
+  orgId: string,
+): Promise<{ id: string; token: string | null } | null> {
+  return queryConvex(refs.getLeagueForOrg, { orgId });
+}
+
+export async function setLeagueInviteToken(
+  leagueId: string,
+  token: string | null,
+): Promise<void> {
+  await mutateConvex(refs.setLeagueInviteToken, { leagueId, token });
+}
+
+export async function getLeagueOrgId(leagueId: string): Promise<string | null> {
+  return queryConvex(refs.getLeagueOrgId, { leagueId });
+}
+
+export async function getLeagues(visibleLeagueIds: string[]): Promise<LeagueDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  return queryConvex(refs.listLeagues, { leagueIds: visibleLeagueIds });
+}
+
+export async function getLeague(
+  id: string,
+  orgContext: OrgContext,
+): Promise<LeagueDto> {
+  requireLeagueAccessLocal(id, orgContext);
+  const league = await queryConvex(refs.getLeague, { leagueId: id });
+  if (!league) throw new Error("League not found");
+  return league;
+}
+
+export async function getLeagueByName(name: string): Promise<LeagueDto | null> {
+  return queryConvex(refs.getLeagueByName, { name });
+}
+
+export async function getDivisions(
+  visibleLeagueIds: string[],
+): Promise<DivisionDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  return queryConvex(refs.listDivisions, { leagueIds: visibleLeagueIds });
+}
+
+export async function getDivision(
+  id: string,
+  orgContext: OrgContext,
+): Promise<DivisionDto> {
+  const division = await queryConvex(refs.getDivision, { divisionId: id });
+  if (!division) throw new Error("Division not found");
+  requireLeagueAccessLocal(division.leagueId, orgContext);
+  return division;
+}
+
+export async function getTeams(visibleLeagueIds: string[]): Promise<TeamDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  return queryConvex(refs.listTeams, { leagueIds: visibleLeagueIds });
+}
+
+export async function getTeamsByLeague(
+  leagueId: string,
+  orgContext: OrgContext,
+): Promise<TeamDto[]> {
+  requireLeagueAccessLocal(leagueId, orgContext);
+  return queryConvex(refs.listTeamsByLeague, { leagueId });
+}
+
+export async function getTeam(
+  id: string,
+  orgContext: OrgContext,
+): Promise<TeamDto> {
+  const team = await queryConvex(refs.getTeam, { teamId: id });
+  if (!team) throw new Error("Team not found");
+  requireLeagueAccessLocal(team.leagueId, orgContext);
+  return team;
+}
+
+export async function getTeamLeagueId(teamId: string): Promise<string> {
+  const leagueId = await queryConvex(refs.getTeamLeagueId, { teamId });
+  if (!leagueId) throw new Error("Team not found");
+  return leagueId;
+}
+
+export async function getPlayers(
+  visibleLeagueIds: string[],
+): Promise<PlayerDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  return queryConvex(refs.listPlayers, { leagueIds: visibleLeagueIds });
+}
+
+export async function getPlayer(
+  id: string,
+  orgContext: OrgContext,
+): Promise<PlayerDto> {
+  const player = await queryConvex(refs.getPlayer, { playerId: id });
+  if (!player) throw new Error("Player not found");
+
+  const teamLeagueId = await getTeamLeagueId(player.teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  return player;
+}
+
+export async function getPlayersByTeam(
+  teamId: string,
+  orgContext: OrgContext,
+): Promise<PlayerDto[]> {
+  const teamLeagueId = await getTeamLeagueId(teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  return queryConvex(refs.listPlayersByTeam, { teamId });
+}
+
+export async function getSeasons(
+  visibleLeagueIds: string[],
+): Promise<SeasonDto[]> {
+  if (visibleLeagueIds.length === 0) return [];
+  return queryConvex(refs.listSeasons, { leagueIds: visibleLeagueIds });
+}
+
+export async function getSeason(
+  id: string,
+  orgContext: OrgContext,
+): Promise<SeasonDto> {
+  const season = await queryConvex(refs.getSeason, { seasonId: id });
+  if (!season) throw new Error("Season not found");
+  requireLeagueAccessLocal(season.leagueId, orgContext);
+  return season;
+}
+
+export async function createPlayer(input: CreatePlayerInput): Promise<PlayerDto> {
+  return mutateConvex(refs.createPlayer, input);
+}
+
+export async function updatePlayer(
+  id: string,
+  input: UpdatePlayerInput,
+): Promise<PlayerDto> {
+  const player = await mutateConvex(refs.updatePlayer, {
+    playerId: id,
+    ...input,
+  });
+  if (!player) throw new Error("Player not found");
+  return player;
+}
+
+export async function deletePlayer(id: string): Promise<null> {
+  return mutateConvex(refs.deletePlayer, { playerId: id });
+}
+
+export async function createTeam(input: CreateTeamInput): Promise<TeamDto> {
+  return mutateConvex(refs.createTeam, input);
+}
+
+export async function updateTeam(
+  id: string,
+  input: UpdateTeamInput,
+): Promise<TeamDto> {
+  const team = await mutateConvex(refs.updateTeam, {
+    teamId: id,
+    ...input,
+  });
+  if (!team) throw new Error("Team not found");
+  return team;
+}
+
+export async function upsertSeason(input: {
+  name: string;
+  leagueId: string;
+  startDate: string | null;
+  endDate: string | null;
+  status: string;
+}): Promise<{ dto: SeasonDto; created: boolean }> {
+  return mutateConvex(refs.upsertSeason, input);
+}
+
+export async function subscribeToLeague(
+  userId: string,
+  leagueId: string,
+): Promise<void> {
+  await mutateConvex(refs.subscribeToLeague, { userId, leagueId });
+}
+
+export async function unsubscribeFromLeague(
+  userId: string,
+  leagueId: string,
+): Promise<void> {
+  await mutateConvex(refs.unsubscribeFromLeague, { userId, leagueId });
+}
+
+export async function readSyncConfig(): Promise<SyncConfig> {
+  const config = await queryConvex(refs.getSyncConfig, {});
+  let lastSyncReport: SyncReport | null = null;
+  if (config.lastSyncReportJson) {
+    try {
+      lastSyncReport = JSON.parse(config.lastSyncReportJson) as SyncReport;
+    } catch {
+      lastSyncReport = null;
+    }
+  }
+
+  return {
+    syncEnabled: config.syncEnabled,
+    lastSyncReport,
+  };
+}
+
+export async function updateSyncEnabled(enabled: boolean): Promise<void> {
+  await mutateConvex(refs.setSyncEnabled, { enabled });
+}
+
+export async function writeSyncReport(report: SyncReport): Promise<void> {
+  await mutateConvex(refs.writeSyncReport, {
+    reportJson: JSON.stringify(report),
+  });
+}
+
+export async function getHealthSummary(): Promise<{
+  leagues: number;
+  divisions: number;
+  teams: number;
+  players: number;
+  seasons: number;
+}> {
+  return queryConvex(refs.healthSummary, {});
+}
+
+export async function bulkImportLeague(
+  payload: LeagueImportPayload,
+  createdByUserId?: string,
+  orgIdOverride?: string | null,
+): Promise<ImportResult> {
+  const errors: ImportError[] = [];
+  const created = { leagues: 0, divisions: 0, teams: 0, players: 0 };
+  const updated = { leagues: 0, divisions: 0, teams: 0, players: 0 };
+
+  let orgId: string | null = orgIdOverride ?? null;
+  const existingLeague = await getLeagueByName(payload.league.name);
+  const existingLeagueOrgId = existingLeague
+    ? await getLeagueOrgId(existingLeague.id)
+    : null;
+
+  if (existingLeagueOrgId && createdByUserId) {
+    const { requireOrgAdmin } = await import("./org-context");
+    await requireOrgAdmin(existingLeagueOrgId, createdByUserId);
+  }
+
+  if (orgIdOverride !== undefined) {
+    orgId = orgIdOverride;
+  } else if (!existingLeague && createdByUserId) {
+    const client = await getClerkServerClient();
+    const org = await client.organizations.createOrganization({
+      name: payload.league.name,
+      createdBy: createdByUserId,
+    });
+    orgId = org.id;
+  } else {
+    orgId = existingLeagueOrgId ?? null;
+  }
+
+  let leagueId: string;
+  try {
+    const leagueResult = await mutateConvex(refs.upsertLeague, {
+      name: payload.league.name,
+      orgId,
+    });
+    leagueId = leagueResult.dto.id;
+    if (leagueResult.created) created.leagues++;
+    else updated.leagues++;
+  } catch (err) {
+    throw new Error(
+      `Failed to upsert league "${payload.league.name}": ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  for (const div of payload.divisions) {
+    let divisionId: string;
+    try {
+      const divResult = await mutateConvex(refs.upsertDivision, {
+        name: div.name,
+        leagueId,
+      });
+      divisionId = divResult.dto.id;
+      if (divResult.created) created.divisions++;
+      else updated.divisions++;
+    } catch (err) {
+      errors.push({
+        entity: "division",
+        name: div.name,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    for (const team of div.teams) {
+      let teamId: string;
+      try {
+        const teamResult = await mutateConvex(refs.upsertTeam, {
+          name: team.name,
+          city: team.city,
+          stadium: team.stadium,
+          leagueId,
+          divisionId,
+          logoUrl: team.logoUrl ?? null,
+        });
+        teamId = teamResult.dto.id;
+        if (teamResult.created) created.teams++;
+        else updated.teams++;
+      } catch (err) {
+        errors.push({
+          entity: "team",
+          name: team.name,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+
+      for (const player of team.players) {
+        try {
+          const playerResult = await mutateConvex(refs.upsertPlayer, {
+            name: player.name,
+            leagueId,
+            teamId,
+            position: player.position,
+            jerseyNumber: player.jerseyNumber ?? null,
+            dateOfBirth: player.dateOfBirth ?? null,
+            status: player.status ?? "Active",
+            headshotUrl: player.headshotUrl ?? null,
+          });
+          if (playerResult.created) created.players++;
+          else updated.players++;
+        } catch (err) {
+          errors.push({
+            entity: "player",
+            name: player.name,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+  }
+
+  return { leagueId, created, updated, errors };
+}

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -1,0 +1,33 @@
+import { flag } from "flags/next";
+import { notFound } from "next/navigation";
+
+const defaultOn = process.env.NODE_ENV !== "production";
+
+export const depthChartV1 = flag<boolean>({
+  key: "depth_chart_v1",
+  description:
+    "Phase 0 roster management: depth-chart drag-reorder + per-season edit lock",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => defaultOn,
+});
+
+export type FeatureFlag = () => Promise<boolean>;
+
+export async function pageGuard(flagFn: FeatureFlag): Promise<void> {
+  const enabled = await flagFn();
+  if (!enabled) {
+    notFound();
+  }
+}
+
+export async function apiGuard(flagFn: FeatureFlag): Promise<Response | null> {
+  const enabled = await flagFn();
+  if (!enabled) {
+    return Response.json({ error: "flag_disabled" }, { status: 403 });
+  }
+  return null;
+}

--- a/apps/web/src/lib/salesforce-bulk-import.ts
+++ b/apps/web/src/lib/salesforce-bulk-import.ts
@@ -1,0 +1,1 @@
+export { bulkImportLeague, upsertSeason } from "./data-api";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      convex:
+        specifier: ^1.19.0
+        version: 1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       jsforce:
         specifier: ^3.6.0
         version: 3.10.14(@types/node@22.19.15)
@@ -1077,16 +1080,34 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -1095,16 +1116,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -1113,10 +1152,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -1125,10 +1176,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -1137,10 +1200,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -1149,10 +1224,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -1161,10 +1248,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -1173,16 +1272,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -1191,10 +1308,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1203,11 +1332,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -1215,16 +1356,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -3377,6 +3536,25 @@ packages:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  convex@1.35.1:
+    resolution: {integrity: sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==}
+    engines: {node: '>=18.0.0', npm: '>=7.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@auth0/auth0-react': ^2.0.1
+      '@clerk/clerk-react': ^4.12.8 || ^5.0.0
+      '@clerk/react': ^6.0.0
+      react: ^18.0.0 || ^19.0.0-0 || ^19.0.0
+    peerDependenciesMeta:
+      '@auth0/auth0-react':
+        optional: true
+      '@clerk/clerk-react':
+        optional: true
+      '@clerk/react':
+        optional: true
+      react:
+        optional: true
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
@@ -3667,6 +3845,11 @@ packages:
 
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -5696,6 +5879,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6863,6 +7051,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -8080,79 +8280,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -10437,6 +10715,18 @@ snapshots:
 
   convert-to-spaces@2.0.1: {}
 
+  convex@1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      esbuild: 0.27.0
+      prettier: 3.8.3
+      ws: 8.18.0
+    optionalDependencies:
+      '@clerk/clerk-react': 5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.1
@@ -10756,6 +11046,35 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.45.1: {}
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -13125,6 +13444,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  prettier@3.8.3: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -14396,6 +14717,8 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@7.5.10: {}
+
+  ws@8.18.0: {}
 
   ws@8.20.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       convex:
         specifier: ^1.19.0
         version: 1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      flags:
+        specifier: ^4.0.6
+        version: 4.0.6(next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       jsforce:
         specifier: ^3.6.0
         version: 3.10.14(@types/node@22.19.15)
@@ -1070,6 +1073,10 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -4187,6 +4194,26 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
+  flags@4.0.6:
+    resolution: {integrity: sha512-8Rz/5L8Gkl2+LmlV2gOXx3iJNTYDooa8eGvshFev9nrXtrcvsXa5z/DXdtElHvN15psnSHg+r51lYHge2rCASw==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      '@sveltejs/kit': '*'
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4957,6 +4984,9 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -8263,6 +8293,8 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
+
+  '@edge-runtime/cookies@5.0.2': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -11609,6 +11641,15 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
+  flags@4.0.6(next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      next: 15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.4.1
@@ -12632,6 +12673,8 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  jose@5.10.0: {}
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
## Summary
- Add `flags` (v4) + `flags/next` adapter with `depthChartV1` boolean flag.
- `pageGuard` (404 on disabled) + `apiGuard` (403 Response) helpers.
- Unit tests for both guard branches (`__tests__/flags.test.ts`).
- `.well-known/vercel/flags` discovery endpoint via `createFlagsDiscoveryEndpoint` + `getProviderData({ depthChartV1 })`.
- Includes pre-Phase-0 chore commit committing the Convex data-layer baseline.

Part of Phase 0 roster management. Flag defaults ON in dev / OFF in production. Safe to merge — no user-facing surfaces use the flag yet.

## Test plan
- [x] `pnpm --filter @sports-management/web test:unit` — flag guard suite passes
- [x] `pnpm --filter @sports-management/web type-check`
- [x] `pnpm --filter @sports-management/web lint`
- [ ] Preview deploy: `GET /.well-known/vercel/flags` returns flag metadata