### PR TITLE
feat(web): add depth chart reorder + roster lock mutations (WSM-000005)

### DIFF
--- a/apps/web/convex/__tests__/depthChart.test.ts
+++ b/apps/web/convex/__tests__/depthChart.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedBaseline(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Test League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "Alpha",
+      leagueId,
+      divisionId: null,
+      city: "A",
+      stadium: "A",
+      foundedYear: null,
+      location: "A",
+      logoUrl: null,
+    });
+    const teamB = await ctx.db.insert("teams", {
+      name: "Beta",
+      leagueId,
+      divisionId: null,
+      city: "B",
+      stadium: "B",
+      foundedYear: null,
+      location: "B",
+      logoUrl: null,
+    });
+    const season = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const p1 = await ctx.db.insert("players", {
+      name: "QB1",
+      leagueId,
+      teamId: teamA,
+      position: "QB",
+      jerseyNumber: 1,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    const p2 = await ctx.db.insert("players", {
+      name: "QB2",
+      leagueId,
+      teamId: teamA,
+      position: "QB",
+      jerseyNumber: 2,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    const p3 = await ctx.db.insert("players", {
+      name: "QB3",
+      leagueId,
+      teamId: teamA,
+      position: "QB",
+      jerseyNumber: 3,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    const pB = await ctx.db.insert("players", {
+      name: "QB-B",
+      leagueId,
+      teamId: teamB,
+      position: "QB",
+      jerseyNumber: 9,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    return { leagueId, teamA, teamB, season, p1, p2, p3, pB };
+  });
+}
+
+describe("reorderDepthChart", () => {
+  it("assigns dense zero-indexed sortOrder in the given playerIds order", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedBaseline(t);
+
+    const result = await t.mutation(api.sports.reorderDepthChart, {
+      teamId: seed.teamA,
+      seasonId: seed.season,
+      positionSlot: "QB",
+      playerIds: [seed.p3, seed.p1, seed.p2],
+    });
+
+    expect(result.map((r) => r.playerId)).toEqual([seed.p3, seed.p1, seed.p2]);
+    expect(result.map((r) => r.sortOrder)).toEqual([0, 1, 2]);
+  });
+
+  it("replaces existing entries on re-order (no duplicates)", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedBaseline(t);
+
+    await t.mutation(api.sports.reorderDepthChart, {
+      teamId: seed.teamA,
+      seasonId: seed.season,
+      positionSlot: "QB",
+      playerIds: [seed.p1, seed.p2, seed.p3],
+    });
+    await t.mutation(api.sports.reorderDepthChart, {
+      teamId: seed.teamA,
+      seasonId: seed.season,
+      positionSlot: "QB",
+      playerIds: [seed.p3, seed.p1],
+    });
+
+    const rows = await t.query(api.sports.getDepthChartByTeamSeason, {
+      teamId: seed.teamA,
+      seasonId: seed.season,
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.playerId)).toEqual([seed.p3, seed.p1]);
+    expect(rows.map((r) => r.sortOrder)).toEqual([0, 1]);
+  });
+
+  it("rejects when the season is locked", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedBaseline(t);
+
+    await t.mutation(api.sports.setRosterLocked, {
+      seasonId: seed.season,
+      locked: true,
+    });
+
+    await expect(
+      t.mutation(api.sports.reorderDepthChart, {
+        teamId: seed.teamA,
+        seasonId: seed.season,
+        positionSlot: "QB",
+        playerIds: [seed.p1],
+      }),
+    ).rejects.toThrow(/season_locked/);
+  });
+
+  it("rejects a player that belongs to a different team", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedBaseline(t);
+
+    await expect(
+      t.mutation(api.sports.reorderDepthChart, {
+        teamId: seed.teamA,
+        seasonId: seed.season,
+        positionSlot: "QB",
+        playerIds: [seed.p1, seed.pB],
+      }),
+    ).rejects.toThrow(/player_not_on_team/);
+  });
+});
+
+describe("setRosterLocked", () => {
+  it("toggles rosterLocked on the season", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedBaseline(t);
+
+    const locked = await t.mutation(api.sports.setRosterLocked, {
+      seasonId: seed.season,
+      locked: true,
+    });
+    expect(locked.rosterLocked).toBe(true);
+
+    const unlocked = await t.mutation(api.sports.setRosterLocked, {
+      seasonId: seed.season,
+      locked: false,
+    });
+    expect(unlocked.rosterLocked).toBe(false);
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,5 +1,6 @@
 import { mutationGeneric, queryGeneric } from "convex/server";
 import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -1146,5 +1147,132 @@ export const writeSyncReport = mutationGeneric({
       });
     }
     return null;
+  },
+});
+
+const depthChartEntryDto = v.object({
+  id: v.string(),
+  teamId: v.string(),
+  seasonId: v.string(),
+  playerId: v.string(),
+  positionSlot: v.string(),
+  sortOrder: v.number(),
+  updatedAt: v.string(),
+});
+
+export const getDepthChartByTeamSeason = query({
+  args: {
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+  },
+  returns: v.array(depthChartEntryDto),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("depthChartEntries")
+      .withIndex("by_team_season", (q) =>
+        q.eq("teamId", args.teamId).eq("seasonId", args.seasonId),
+      )
+      .collect();
+    return rows
+      .sort((a, b) => {
+        if (a.positionSlot !== b.positionSlot) {
+          return a.positionSlot.localeCompare(b.positionSlot);
+        }
+        return a.sortOrder - b.sortOrder;
+      })
+      .map((row) => ({
+        id: row._id,
+        teamId: row.teamId,
+        seasonId: row.seasonId,
+        playerId: row.playerId,
+        positionSlot: row.positionSlot,
+        sortOrder: row.sortOrder,
+        updatedAt: row.updatedAt,
+      }));
+  },
+});
+
+export const reorderDepthChart = mutation({
+  args: {
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    positionSlot: v.string(),
+    playerIds: v.array(v.id("players")),
+  },
+  returns: v.array(depthChartEntryDto),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) {
+      throw new Error("season_not_found");
+    }
+    if (season.rosterLocked === true) {
+      throw new Error("season_locked");
+    }
+
+    const players = await Promise.all(
+      args.playerIds.map((id) => ctx.db.get(id)),
+    );
+    for (const [index, player] of players.entries()) {
+      if (!player) {
+        throw new Error(`invalid_player:${args.playerIds[index]}`);
+      }
+      if (player.teamId !== args.teamId) {
+        throw new Error(`player_not_on_team:${args.playerIds[index]}`);
+      }
+    }
+
+    const existing = await ctx.db
+      .query("depthChartEntries")
+      .withIndex("by_team_season_position", (q) =>
+        q
+          .eq("teamId", args.teamId)
+          .eq("seasonId", args.seasonId)
+          .eq("positionSlot", args.positionSlot),
+      )
+      .collect();
+    await Promise.all(existing.map((row) => ctx.db.delete(row._id)));
+
+    const updatedAt = new Date().toISOString();
+    const insertedIds = await Promise.all(
+      args.playerIds.map((playerId, index) =>
+        ctx.db.insert("depthChartEntries", {
+          teamId: args.teamId,
+          seasonId: args.seasonId,
+          playerId,
+          positionSlot: args.positionSlot,
+          sortOrder: index,
+          updatedAt,
+        }),
+      ),
+    );
+
+    return insertedIds.map((id, index) => ({
+      id,
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      playerId: args.playerIds[index],
+      positionSlot: args.positionSlot,
+      sortOrder: index,
+      updatedAt,
+    }));
+  },
+});
+
+export const setRosterLocked = mutation({
+  args: {
+    seasonId: v.id("seasons"),
+    locked: v.boolean(),
+  },
+  returns: v.object({
+    seasonId: v.string(),
+    rosterLocked: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) {
+      throw new Error("season_not_found");
+    }
+    await ctx.db.patch(args.seasonId, { rosterLocked: args.locked });
+    return { seasonId: args.seasonId, rosterLocked: args.locked };
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "eslint-config-next": "^15.3.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "convex-test": "^0.0.49"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,8 +4,13 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "convex/**/*.test.ts"],
     exclude: ["e2e/**"],
+    server: {
+      deps: {
+        inline: ["convex-test"],
+      },
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.0
         version: 19.2.3(@types/react@19.2.14)
+      convex-test:
+        specifier: ^0.0.49
+        version: 0.0.49(convex@1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -3542,6 +3545,11 @@ packages:
   convert-to-spaces@2.0.1:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  convex-test@0.0.49:
+    resolution: {integrity: sha512-mBDhwvxUZYtRuEx4a9opk7LI6IghcPOHd99QVPAzMugeYeAukLjkFkkkAU9J53edxxwGWfx1IsoKLzC+DK6ugg==}
+    peerDependencies:
+      convex: ^1.32.0
 
   convex@1.35.1:
     resolution: {integrity: sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==}
@@ -10746,6 +10754,10 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
+
+  convex-test@0.0.49(convex@1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      convex: 1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
 
   convex@1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- `reorderDepthChart({ teamId, seasonId, positionSlot, playerIds })` — rejects `season_locked`, rejects `player_not_on_team`, writes dense zero-indexed `sortOrder` per `(team, season, positionSlot)`.
- `setRosterLocked({ seasonId, locked })` — admin-only toggle; does not self-lock-check.
- Convex integration tests (convex-test) cover happy path, locked-season reject, cross-team player reject, dense-reorder, replace-on-reorder.

Stacked on #100.

## Test plan
- [x] `pnpm --filter @sports-management/web test:unit` — depth-chart mutation suite passes
- [x] All pre-existing suites unchanged