### PR TITLE
feat(ops): add depth chart analytics events + flag exposure (WSM-000008)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
@@ -7,6 +7,10 @@ import {
   setRosterLocked as setRosterLockedMutation,
 } from "@/lib/data-api";
 import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import {
+  trackDepthChartReorder,
+  trackSeasonLockToggle,
+} from "@/lib/analytics";
 import type { DepthChartEntryDto } from "@sports-management/shared-types";
 
 async function requireFlag() {
@@ -39,12 +43,19 @@ export async function reorderDepthChartAction(input: {
   if (!orgId) throw new Error("not_authorized");
   await requireOrgMembership(orgId, userId);
 
-  return reorderDepthChartMutation({
+  const result = await reorderDepthChartMutation({
     teamId: input.teamId,
     seasonId: input.seasonId,
     positionSlot: input.positionSlot,
     playerIds: input.playerIds,
   });
+  void trackDepthChartReorder({
+    teamId: input.teamId,
+    seasonId: input.seasonId,
+    positionSlot: input.positionSlot,
+    playerCount: input.playerIds.length,
+  });
+  return result;
 }
 
 export async function setRosterLockedAction(input: {
@@ -61,5 +72,10 @@ export async function setRosterLockedAction(input: {
   const role = await requireOrgMembership(orgId, userId);
   if (role !== "org:admin") throw new Error("not_authorized");
 
-  return setRosterLockedMutation(input.seasonId, input.locked);
+  const result = await setRosterLockedMutation(input.seasonId, input.locked);
+  void trackSeasonLockToggle({
+    seasonId: input.seasonId,
+    locked: result.rosterLocked,
+  });
+  return result;
 }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,45 @@
+import { track } from "@vercel/analytics/server";
+
+type Props = Record<string, string | number | boolean | null>;
+
+async function safeTrack(event: string, props: Props): Promise<void> {
+  try {
+    await track(event, props);
+  } catch {
+    // Analytics must never block user-facing flows.
+  }
+}
+
+export function trackFlagExposure(
+  flagKey: string,
+  value: boolean | string,
+): Promise<void> {
+  return safeTrack("flag_exposure", {
+    flag: flagKey,
+    value: String(value),
+  });
+}
+
+export function trackDepthChartReorder(props: {
+  teamId: string;
+  seasonId: string;
+  positionSlot: string;
+  playerCount: number;
+}): Promise<void> {
+  return safeTrack("depth_chart_reorder", {
+    teamId: props.teamId,
+    seasonId: props.seasonId,
+    positionSlot: props.positionSlot,
+    playerCount: props.playerCount,
+  });
+}
+
+export function trackSeasonLockToggle(props: {
+  seasonId: string;
+  locked: boolean;
+}): Promise<void> {
+  return safeTrack("season_lock_toggle", {
+    seasonId: props.seasonId,
+    locked: props.locked,
+  });
+}

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -1,5 +1,6 @@
 import { flag } from "flags/next";
 import { notFound } from "next/navigation";
+import { trackFlagExposure } from "./analytics";
 
 const defaultOn = process.env.NODE_ENV !== "production";
 
@@ -12,7 +13,10 @@ export const depthChartV1 = flag<boolean>({
     { label: "Off", value: false },
     { label: "On", value: true },
   ],
-  decide: () => defaultOn,
+  decide: () => {
+    void trackFlagExposure("depth_chart_v1", defaultOn);
+    return defaultOn;
+  },
 });
 
 export type FeatureFlag = () => Promise<boolean>;


### PR DESCRIPTION
## Summary
- `apps/web/src/lib/analytics.ts` — `safeTrack` wrapper around `@vercel/analytics/server` (never blocks user flows on analytics failure).
- Three events: `flag_exposure`, `depth_chart_reorder`, `season_lock_toggle` — property shapes fixed to the Gherkin AC (no PII).
- `flag_exposure` emitted inside `depthChartV1.decide()` so every guard call is tracked.
- Reorder + lock events fired from server actions after successful mutations.

Stacked on #103.

## Test plan
- [x] Build + lint + type-check clean
- [ ] Preview deploy: Vercel Analytics Explorer shows all three events from preview URL