### PR TITLE
docs(roster): Phase 0 cutover + sprint 1 verification (WSM-000009)

### DIFF
--- a/docs/roster-management.md
+++ b/docs/roster-management.md
@@ -15,6 +15,22 @@ We are adding **roster management** on top of the existing League / Division / T
 
 ## 1. Overview
 
+### Phase 0 — LIVE (2026-04-22)
+
+Phase 0 (per-team, per-season depth chart + season-level edit lock) is merged to `main` behind the `depth_chart_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 1 across eight PRs, one per story:
+
+| Story | PR | What shipped |
+|-------|----|--------------|
+| WSM-000003 | `feat/WSM-000003-depth-chart-flag` | `apps/web/src/lib/flags.ts` + `.well-known/vercel/flags` discovery endpoint; `pageGuard` + `apiGuard` |
+| WSM-000004 | `feat/WSM-000004-depth-chart-schema` | `seasons.rosterLocked: v.boolean()` + `depthChartEntries` table with two indexes; one-shot backfill migration |
+| WSM-000005 | `feat/WSM-000005-depth-chart-mutations` | `reorderDepthChart` + `setRosterLocked` Convex mutations with lock enforcement + cross-team rejection + convex-test suite |
+| WSM-000006 | `feat/WSM-000006-depth-chart-ui` | `/dashboard/teams/[id]/depth-chart` page + `DepthChartBoard`/`PositionColumn`/`LockBanner` components + server actions |
+| WSM-000007 | `feat/WSM-000007-depth-chart-e2e` | Playwright flag-gate smoke; three seed-dependent scenarios parked as `test.fixme` until a Convex seeding harness lands |
+| WSM-000008 | `feat/WSM-000008-depth-chart-analytics` | `apps/web/src/lib/analytics.ts` wrapper; emits `flag_exposure`, `depth_chart_reorder`, `season_lock_toggle` |
+| WSM-000009 | `feat/WSM-000009-phase-0-docs` | This update + §11.1 close-out rows |
+
+**Flag flip pending:** prod flip to `on` is gated on a preview-deploy manual QA pass. Until flipped, end users cannot reach `/dashboard/teams/[id]/depth-chart` in production.
+
 ### Problem
 Players in the current schema (`apps/web/convex/schema.ts:37`) attach directly to a single `teamId` with no season context. There is no concept of a depth chart, no player attributes/ratings, no schedule, no standings, and no audit trail for roster changes. This blocks real-world usage by NFL-style leagues where rosters evolve week-to-week and historical season data matters.
 
@@ -488,6 +504,11 @@ Append a row any time a §2.1 working assumption or §11 default is overridden. 
 | initial | Open Q5 Per-team Coach | Deferred to v2 | (unassigned) |
 | 2026-04-16 | Sprint plan | Sprint plan created in Linear team ARC, project "Sprtsmng Roster Management": WSM-000001–WSM-000046 (ARC-102 through ARC-147). 4 parent epics, 42 child stories, 41 Blocked-by relations. | Andrew Solomon |
 | 2026-04-17 | Sprint 0 (pre-roster) | Platform-foundation sprint added in new Linear project "Sprtsmng Infrastructure": WSM-000047–WSM-000056 (ARC-148–ARC-157). 1 epic + 9 children. Closes release automation + commit enforcement + branching gaps BEFORE WSM-000002 (Phase 0) execution begins. | Andrew Solomon |
+| 2026-04-22 | Vercel Flags package (WSM-000003) | Used `flags` v4 (renamed from `@vercel/flags`) with the `flags/next` subpath. Static `decide()` driven by `NODE_ENV` so runtime flips via the Vercel Toolbar work without a provider adapter for now. Adapter will land when production `FLAGS` env var is provisioned. | Andrew Solomon |
+| 2026-04-22 | Dnd-kit spike close-out (WSM-000002) | Chose `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities`. Vertical sortable list per `positionSlot`; pointer + keyboard sensors; optimistic update shape is `{ items, mutation, onMutate, onError }` — on drop we arrayMove locally, then call the server action inside a `useTransition`; on rejection we snap back and surface the error via `sonner`. No scratch page was created — the decisions fed straight into WSM-000006. | Andrew Solomon |
+| 2026-04-22 | Forward-compat invariant (Phase 0 → Phase 1) | `depthChartEntries.sortOrder` is dense, zero-indexed within `(teamId, seasonId, positionSlot)`. Phase 1's WSM-000019 can rename to `rosterAssignments.depthRank` as a pure column rename — no data reshape. | Andrew Solomon |
+| 2026-04-22 | E2E scope narrowed | `coach-depth-chart.spec.ts` ships with one active smoke (flag-gated route reachable) and three `test.fixme` scenarios. A Convex seeding harness + a second Clerk test user are prerequisites and are not in Phase 0 scope. | Andrew Solomon |
+| 2026-04-22 | Analytics surface | Three events — `flag_exposure`, `depth_chart_reorder`, `season_lock_toggle` — fired via `@vercel/analytics/server` through `apps/web/src/lib/analytics.ts`. No PII. Errors swallowed so telemetry never blocks user flows. | Andrew Solomon |
 
 ---
 

--- a/docs/sprints/SPRINT_1_VERIFICATION.md
+++ b/docs/sprints/SPRINT_1_VERIFICATION.md
@@ -1,0 +1,68 @@
+# Sprint 1 — Phase 0 Roster Management — Verification Report
+
+> **Status:** Code merged to `main` behind `depth_chart_v1` flag. Awaiting production flag flip (preview-deploy manual QA).
+> **Closed (code):** 2026-04-22
+> **Source plan:** `/Users/andrewsolomon/.claude/plans/lets-begin-dev-work-mighty-leaf.md`
+> **Linear project:** Sprtsmng Roster Management (WSM-000002..WSM-000009)
+> **Design spec:** [`docs/roster-management.md`](../roster-management.md) §1 (Phase 0 — LIVE), §11.1
+
+Phase 0 delivers the minimum differentiator from the design doc Q7 working
+assumption: **per-team, per-season depth-chart drag-reorder + season-level
+edit lock.** Eight stories shipped as eight PRs, each cutting its own
+semantic-release bump (all `feat:` or `docs:`).
+
+## Criteria Matrix
+
+| # | Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| 1 | `depth_chart_v1` flag declared with `pageGuard` / `apiGuard` | `apps/web/src/lib/flags.ts` + unit suite `apps/web/src/lib/__tests__/flags.test.ts` | ✓ |
+| 2 | `.well-known/vercel/flags` discovery endpoint returns flag metadata | `apps/web/src/app/.well-known/vercel/flags/route.ts` uses `createFlagsDiscoveryEndpoint` + `getProviderData` | ✓ |
+| 3 | `seasons.rosterLocked` persisted; `depthChartEntries` table indexed on `(team,season)` and `(team,season,position)` | `apps/web/convex/schema.ts` | ✓ |
+| 4 | One-shot backfill for pre-existing seasons | `apps/web/convex/migrations/20260422_seasonsRosterLocked.ts` | ✓ |
+| 5 | `reorderDepthChart` rejects locked seasons with `season_locked` | `apps/web/convex/__tests__/depthChart.test.ts` — "rejects when the season is locked" | ✓ |
+| 6 | `reorderDepthChart` rejects players that don't belong to the team with `player_not_on_team` | `apps/web/convex/__tests__/depthChart.test.ts` — "rejects a player that belongs to a different team" | ✓ |
+| 7 | `reorderDepthChart` writes dense, zero-indexed `sortOrder` per `(team,season,positionSlot)` | `apps/web/convex/__tests__/depthChart.test.ts` — "assigns dense zero-indexed sortOrder" + "replaces existing entries on re-order" | ✓ |
+| 8 | `setRosterLocked` toggle mutation shipped | `apps/web/convex/sports.ts` + test "toggles rosterLocked on the season" | ✓ |
+| 9 | Depth-chart route renders behind `pageGuard(depthChartV1)`; 404 when flag off | `apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx` line 21 | ✓ |
+| 10 | Server actions enforce flag + Clerk org membership; admin-only for lock toggle | `apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts` | ✓ |
+| 11 | Drag-reorder UI with optimistic update + snap-back on error | `apps/web/src/components/depth-chart/PositionColumn.tsx` (arrayMove + useTransition + sonner toast) | ✓ |
+| 12 | Three analytics events emitted with documented property shape | `apps/web/src/lib/analytics.ts` — `flag_exposure`, `depth_chart_reorder`, `season_lock_toggle` | ✓ |
+| 13 | E2E smoke verifies flag-gated route is reachable | `apps/web/e2e/tests/coach-depth-chart.spec.ts` — "flag-gated route is reachable in dev" | ✓ |
+| 14 | Seed-dependent E2E scenarios parked as `test.fixme` with TODOs | Same spec — 3× `test.fixme` blocks | ✓ |
+| 15 | All pre-existing Vitest suites still pass (191/191) | `pnpm --filter @sports-management/web test:unit` | ✓ |
+| 16 | Type-check + lint clean after every story | `pnpm --filter @sports-management/web type-check`, `pnpm --filter @sports-management/web lint` | ✓ |
+| 17 | Production build succeeds with depth-chart route registered | `pnpm --filter @sports-management/web build` shows `/dashboard/teams/[id]/depth-chart   18.8 kB` | ✓ |
+| 18 | Production flag flip completed | Vercel Flags UI — `depth_chart_v1` = `on` in production for ≥48h, analytics monitored | ☐ pending preview QA |
+
+## PR / Release Evidence
+
+| Story | Branch | Expected bump |
+| --- | --- | --- |
+| WSM-000003 | `feat/WSM-000003-depth-chart-flag` | minor |
+| WSM-000004 | `feat/WSM-000004-depth-chart-schema` | minor |
+| WSM-000005 | `feat/WSM-000005-depth-chart-mutations` | minor |
+| WSM-000006 | `feat/WSM-000006-depth-chart-ui` | minor |
+| WSM-000007 | `feat/WSM-000007-depth-chart-e2e` | minor |
+| WSM-000008 | `feat/WSM-000008-depth-chart-analytics` | minor |
+| WSM-000009 | `feat/WSM-000009-phase-0-docs` | no bump (`docs:`) |
+
+WSM-000002 (spike) was folded into WSM-000006 — no scratch page was ever merged; the spike decisions (package choice, optimistic update shape) are recorded in `docs/roster-management.md` §11.1.
+
+## Deferred / Follow-ups (not Phase 0 scope)
+
+1. **Full E2E coverage** — drag-reorder and lock-enforcement specs are parked behind a Convex seeding harness + second Clerk test user.
+2. **Vercel Flags provider adapter** — currently `decide()` is static (`NODE_ENV !== "production"`). Adapter lands once `FLAGS` env var is provisioned.
+3. **Salesforce mirror** — `DepthChartEntry__c` / `RosterAssignment__c` Salesforce objects are Phase 2 per `docs/roster-management.md` §4.3.
+4. **Phase 1 migration path** — `depthChartEntries.sortOrder` is deliberately kept semantically identical to what `rosterAssignments.depthRank` will become in WSM-000019; that story is a column rename, not a data reshape.
+
+## Flag-flip checklist
+
+Do **not** flip `depth_chart_v1` to `on` in production until all of the following are checked:
+
+- [ ] Preview-deploy manual QA: sign in as coach, reorder QB depth chart, refresh → order persists
+- [ ] Preview-deploy manual QA: sign in as admin, lock roster, switch back to coach account → banner visible, drag handles disabled
+- [ ] Preview-deploy manual QA: admin unlocks → coach can drag again
+- [ ] Vercel Analytics Explorer shows `depth_chart_reorder`, `season_lock_toggle`, `flag_exposure` events from the preview deploy
+- [ ] Convex migrations dashboard confirms `backfillSeasonsRosterLocked` has run against production data
+
+After flip, keep the flag on for ≥48h with analytics monitored before declaring Phase 0 shipped.


### PR DESCRIPTION
## Summary
- `docs/roster-management.md` §1: new "Phase 0 — LIVE (2026-04-22)" subsection listing the 7 merged PRs.
- `docs/roster-management.md` §11.1 decision log: Vercel Flags package choice, dnd-kit spike roll-up (replaces WSM-000002 deliverable), sortOrder↔depthRank forward-compat invariant, narrowed E2E scope, analytics surface.
- `docs/sprints/SPRINT_1_VERIFICATION.md`: 18-row criteria matrix, PR/release evidence, deferred follow-ups, flag-flip checklist.

Docs-only. Conventional prefix `docs:` — no semantic-release version bump expected.

Stacked on #104.

## Test plan
- [x] N/A — docs-only