### PR TITLE
feat(web): add seasons.rosterLocked + depthChartEntries schema (WSM-000004)

### DIFF
--- a/apps/web/convex/migrations/20260422_seasonsRosterLocked.ts
+++ b/apps/web/convex/migrations/20260422_seasonsRosterLocked.ts
@@ -1,0 +1,21 @@
+import { mutationGeneric } from "convex/server";
+import { v } from "convex/values";
+
+export const backfillSeasonsRosterLocked = mutationGeneric({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    patched: v.number(),
+  }),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("seasons").collect();
+    let patched = 0;
+    for (const row of rows) {
+      if ((row as { rosterLocked?: boolean }).rosterLocked === undefined) {
+        await ctx.db.patch(row._id, { rosterLocked: false });
+        patched += 1;
+      }
+    }
+    return { scanned: rows.length, patched };
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -54,9 +54,21 @@ export default defineSchema({
     startDate: v.union(v.string(), v.null()),
     endDate: v.union(v.string(), v.null()),
     status: v.string(),
+    rosterLocked: v.boolean(),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_leagueId_name", ["leagueId", "name"]),
+
+  depthChartEntries: defineTable({
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    playerId: v.id("players"),
+    positionSlot: v.string(),
+    sortOrder: v.number(),
+    updatedAt: v.string(),
+  })
+    .index("by_team_season", ["teamId", "seasonId"])
+    .index("by_team_season_position", ["teamId", "seasonId", "positionSlot"]),
 
   leagueSubscriptions: defineTable({
     userId: v.string(),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1018,7 +1018,10 @@ export const upsertSeason = mutationGeneric({
       };
     }
 
-    const seasonId = await ctx.db.insert("seasons", args);
+    const seasonId = await ctx.db.insert("seasons", {
+      ...args,
+      rosterLocked: false,
+    });
     return {
       dto: {
         id: seasonId,


### PR DESCRIPTION
## Summary
- Add `seasons.rosterLocked: boolean`; persist per-season edit lock.
- Add `depthChartEntries` table with `(teamId, seasonId)` and `(teamId, seasonId, positionSlot)` indexes.
- One-shot `backfillSeasonsRosterLocked` migration patches pre-existing `seasons` rows to `rosterLocked: false`.
- Phase 0 roster management depth-chart aggregate — `sortOrder` kept semantically identical to Phase 1 `depthRank` to keep WSM-000019 a rename, not a reshape.

Re-opened after #100 was closed due to a stacked-PR cascade. Targets main directly.

## Test plan
- [x] Pre-existing Vitest suites still pass (191/191)
- [x] `pnpm --filter @sports-management/web type-check`
- [ ] Run `pnpm convex run backfillSeasonsRosterLocked` against production data