### PR TITLE
fix(ci): tighten release-workflow skip guard to startsWith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,8 +13,11 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    # Skip release on commits made by semantic-release itself (version bumps)
-    if: "!contains(github.event.head_commit.message, 'chore(release):')"
+    # Skip when the triggering commit IS a release bump (matches first line only).
+    # Using startsWith avoids false matches from commit bodies that mention the
+    # phrase as context. workflow_dispatch has no head_commit, so the guard
+    # short-circuits to true (no skip) for manual runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
The loop guard in `.github/workflows/release.yml` used `contains('chore(release):')` which false-matches any commit whose body mentions the phrase as context. PR #112's squash-merge commit body mentioned `chore(release):` several times while explaining the issue being fixed, so the Release workflow skipped the run that should have cut **v0.4.0**.

Use `startsWith()` — the guard now fires only when the commit message **begins** with `chore(release):`. Since PR #112 removed `@semantic-release/git`, no release commits will ever land on main via this flow anyway, so the guard is defensive.

Also add `workflow_dispatch:` so Release can be invoked manually to backfill the skipped v0.4.0 release.

## Test plan
- [ ] After merge, manually dispatch the Release workflow via `gh workflow run Release`
- [ ] v0.4.0 tag + GitHub Release created with WSM-000003..000009 in the notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)