### PR TITLE
feat(web): add roster_snapshots_v1 feature flag (WSM-000011)

### DIFF
--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -20,7 +20,7 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-import { depthChartV1, pageGuard, apiGuard } from "../flags";
+import { depthChartV1, rosterSnapshotsV1, pageGuard, apiGuard } from "../flags";
 
 describe("depthChartV1 flag declaration", () => {
   it("uses the canonical key", () => {
@@ -29,6 +29,16 @@ describe("depthChartV1 flag declaration", () => {
 
   it("has a description for the Vercel Toolbar", () => {
     expect(depthChartV1.description).toMatch(/depth.chart/i);
+  });
+});
+
+describe("rosterSnapshotsV1 flag declaration", () => {
+  it("uses the canonical key", () => {
+    expect(rosterSnapshotsV1.key).toBe("roster_snapshots_v1");
+  });
+
+  it("has a Phase 1 description for the Vercel Toolbar", () => {
+    expect(rosterSnapshotsV1.description).toMatch(/roster|snapshot/i);
   });
 });
 

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -19,6 +19,21 @@ export const depthChartV1 = flag<boolean>({
   },
 });
 
+export const rosterSnapshotsV1 = flag<boolean>({
+  key: "roster_snapshots_v1",
+  description:
+    "Phase 1 roster management: season rosters, assignment audit log, depth chart v2",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    void trackFlagExposure("roster_snapshots_v1", defaultOn);
+    return defaultOn;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
## Summary
- Declares `rosterSnapshotsV1` — the Phase 1 rollout gate for season rosters, audit log, and depth chart v2.
- Mirrors `depthChartV1`: default on in dev/preview, off in production.
- Emits `trackFlagExposure("roster_snapshots_v1", ...)` on every evaluation for telemetry parity with Phase 0.

## Why this matters
Adds the single kill switch that the rest of Sprint 2 / Phase 1 stories (mutations, UI, audit log UI) will gate on. Merging early lets the remaining work branch off a stable flag export.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`
- [x] `pnpm --filter @sports-management/web exec vitest run src/lib/__tests__/flags.test.ts` — 8/8 passing
- [ ] After deploy: verify the new flag appears in Vercel Flags Explorer (Toolbar) on preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)