### PR TITLE
feat(web): add position-group util + players.positionGroup backfill (WSM-000012)

### DIFF
--- a/apps/web/convex/migrations/20260428_playersPositionGroup.ts
+++ b/apps/web/convex/migrations/20260428_playersPositionGroup.ts
@@ -1,0 +1,30 @@
+import { mutationGeneric } from "convex/server";
+import { v } from "convex/values";
+import { derivePositionGroup } from "../../src/lib/position-group";
+
+export const backfillPlayersPositionGroup = mutationGeneric({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    patched: v.number(),
+    unresolved: v.number(),
+  }),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("players").collect();
+    let patched = 0;
+    let unresolved = 0;
+    for (const row of rows) {
+      const existing = (row as { positionGroup?: string | null })
+        .positionGroup;
+      if (existing) continue;
+      const group = derivePositionGroup(row.position);
+      if (group === null) {
+        unresolved += 1;
+        continue;
+      }
+      await ctx.db.patch(row._id, { positionGroup: group });
+      patched += 1;
+    }
+    return { scanned: rows.length, patched, unresolved };
+  },
+});

--- a/apps/web/src/lib/__tests__/position-group.test.ts
+++ b/apps/web/src/lib/__tests__/position-group.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { derivePositionGroup } from "../position-group";
+
+describe("derivePositionGroup", () => {
+  const cases: Array<[string, ReturnType<typeof derivePositionGroup>]> = [
+    ["QB", "QB"],
+    ["HB", "RB"],
+    ["FB", "RB"],
+    ["WR", "WR"],
+    ["TE", "TE"],
+    ["LT", "OL"],
+    ["LG", "OL"],
+    ["C", "OL"],
+    ["RG", "OL"],
+    ["RT", "OL"],
+    ["DE", "DL"],
+    ["DT", "DL"],
+    ["NT", "DL"],
+    ["OLB", "LB"],
+    ["MLB", "LB"],
+    ["ILB", "LB"],
+    ["CB", "DB"],
+    ["S", "DB"],
+    ["FS", "DB"],
+    ["SS", "DB"],
+    ["NB", "DB"],
+    ["K", "K/P"],
+    ["P", "K/P"],
+    ["LS", "K/P"],
+  ];
+
+  it.each(cases)("maps %s → %s", (position, expected) => {
+    expect(derivePositionGroup(position)).toBe(expected);
+  });
+
+  it("returns null for an unknown position", () => {
+    expect(derivePositionGroup("XYZ")).toBeNull();
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(derivePositionGroup("  qb  ")).toBe("QB");
+    expect(derivePositionGroup("olb")).toBe("LB");
+  });
+
+  it("returns null for an empty string", () => {
+    expect(derivePositionGroup("")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/position-group.ts
+++ b/apps/web/src/lib/position-group.ts
@@ -1,0 +1,42 @@
+export type PositionGroup =
+  | "QB"
+  | "RB"
+  | "WR"
+  | "TE"
+  | "OL"
+  | "DL"
+  | "LB"
+  | "DB"
+  | "K/P";
+
+const POSITION_TO_GROUP: Readonly<Record<string, PositionGroup>> = {
+  QB: "QB",
+  HB: "RB",
+  FB: "RB",
+  WR: "WR",
+  TE: "TE",
+  LT: "OL",
+  LG: "OL",
+  C: "OL",
+  RG: "OL",
+  RT: "OL",
+  DE: "DL",
+  DT: "DL",
+  NT: "DL",
+  OLB: "LB",
+  MLB: "LB",
+  ILB: "LB",
+  CB: "DB",
+  S: "DB",
+  FS: "DB",
+  SS: "DB",
+  NB: "DB",
+  K: "K/P",
+  P: "K/P",
+  LS: "K/P",
+};
+
+export function derivePositionGroup(position: string): PositionGroup | null {
+  const normalized = position.trim().toUpperCase();
+  return POSITION_TO_GROUP[normalized] ?? null;
+}


### PR DESCRIPTION
## Summary
- New pure helper `derivePositionGroup(position)` implementing the §4.5 American-football taxonomy (QB/RB/WR/TE/OL/DL/LB/DB/K-P). Trims + uppercases input; returns `null` for unknowns.
- One-shot Convex backfill migration `backfillPlayersPositionGroup` that patches existing `players` rows and reports `scanned / patched / unresolved` counts.
- Vitest covers every taxonomy row plus unknown / whitespace / empty-string paths (24 taxonomy + 3 edge-case tests).

## Base branch
Branched off `feat/WSM-000010-schema-roster-assignments` because the migration references `players.positionGroup`, which doesn't exist on main yet. Rebase/retarget onto `main` once WSM-000010 lands.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`
- [x] `pnpm --filter @sports-management/web test:unit` — 218 tests passing (27 new in position-group suite)
- [ ] Run `pnpm convex run migrations/20260428_playersPositionGroup:backfillPlayersPositionGroup` in preview after WSM-000010 deploys; spot-check a handful of player rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)