### PR TITLE
feat(web): add writeAuditLog helper for transactional roster audit rows (WSM-000013)

### DIFF
--- a/apps/web/convex/__tests__/auditLog.test.ts
+++ b/apps/web/convex/__tests__/auditLog.test.ts
@@ -1,0 +1,124 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { writeAuditLog } from "../lib/auditLog";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Audit League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamId = await ctx.db.insert("teams", {
+      name: "Audit Team",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "City",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    return { leagueId, teamId, seasonId };
+  });
+}
+
+describe("writeAuditLog", () => {
+  it("inserts an audit row with stringified before/after JSON", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, teamId, seasonId } = await seed(t);
+
+    const insertedId = await t.run(async (ctx) => {
+      return writeAuditLog(ctx, {
+        leagueId,
+        teamId,
+        seasonId,
+        actorUserId: "user_123",
+        action: "assign",
+        before: null,
+        after: { playerId: "p1", depthRank: 1 },
+      });
+    });
+
+    const row = await t.run(async (ctx) => ctx.db.get(insertedId));
+    expect(row).toMatchObject({
+      leagueId,
+      teamId,
+      seasonId,
+      actorUserId: "user_123",
+      action: "assign",
+      beforeJson: null,
+      afterJson: JSON.stringify({ playerId: "p1", depthRank: 1 }),
+    });
+    expect(row?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("round-trips both before and after", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, teamId, seasonId } = await seed(t);
+
+    const before = { status: "active", depthRank: 2 };
+    const after = { status: "ir", depthRank: null };
+
+    const id = await t.run(async (ctx) =>
+      writeAuditLog(ctx, {
+        leagueId,
+        teamId,
+        seasonId,
+        actorUserId: "user_xyz",
+        action: "status_change",
+        before,
+        after,
+      }),
+    );
+
+    const row = await t.run(async (ctx) => ctx.db.get(id));
+    expect(row?.beforeJson).toBe(JSON.stringify(before));
+    expect(row?.afterJson).toBe(JSON.stringify(after));
+  });
+
+  it("throws when leagueId does not resolve", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId } = await seed(t);
+
+    // Create a fake league id by inserting then deleting.
+    const orphanLeagueId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert("leagues", {
+        name: "Doomed",
+        orgId: null,
+        isPublic: false,
+        inviteToken: null,
+      });
+      await ctx.db.delete(id);
+      return id;
+    });
+
+    await expect(
+      t.run((ctx) =>
+        writeAuditLog(ctx, {
+          leagueId: orphanLeagueId,
+          teamId,
+          seasonId,
+          actorUserId: "u",
+          action: "assign",
+          before: null,
+          after: { x: 1 },
+        }),
+      ),
+    ).rejects.toThrow(/audit_log_invalid_leagueId/);
+  });
+});

--- a/apps/web/convex/lib/auditLog.ts
+++ b/apps/web/convex/lib/auditLog.ts
@@ -1,0 +1,43 @@
+import type { MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+
+export type RosterAuditAction =
+  | "assign"
+  | "remove"
+  | "status_change"
+  | "depth_reorder";
+
+export interface WriteAuditLogInput {
+  leagueId: Id<"leagues">;
+  teamId: Id<"teams">;
+  seasonId: Id<"seasons">;
+  actorUserId: string;
+  action: RosterAuditAction;
+  before: unknown | null;
+  after: unknown | null;
+}
+
+export async function writeAuditLog(
+  ctx: MutationCtx,
+  input: WriteAuditLogInput,
+): Promise<Id<"rosterAuditLog">> {
+  const [league, team, season] = await Promise.all([
+    ctx.db.get(input.leagueId),
+    ctx.db.get(input.teamId),
+    ctx.db.get(input.seasonId),
+  ]);
+  if (!league) throw new Error("audit_log_invalid_leagueId");
+  if (!team) throw new Error("audit_log_invalid_teamId");
+  if (!season) throw new Error("audit_log_invalid_seasonId");
+
+  return ctx.db.insert("rosterAuditLog", {
+    leagueId: input.leagueId,
+    teamId: input.teamId,
+    seasonId: input.seasonId,
+    actorUserId: input.actorUserId,
+    action: input.action,
+    beforeJson: input.before === null ? null : JSON.stringify(input.before),
+    afterJson: input.after === null ? null : JSON.stringify(input.after),
+    createdAt: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- New helper `apps/web/convex/lib/auditLog.ts` → `writeAuditLog(ctx, input)` that inserts a `rosterAuditLog` row inside the caller's mutation transaction.
- Validates leagueId/teamId/seasonId resolve (defensive — catches typos).
- Accepts plain JS objects for `before` / `after` and handles JSON serialization.
- Emits `createdAt` via `new Date().toISOString()` for index-friendly sorting.

## Why this matters
Phase 1 roster mutations (WSM-000014) and the migrated `reorderDepthChart` (WSM-000016) must write an audit row atomically with every state change. Centralising the logic avoids drift between call sites.

## Base branch
Stacked on `feat/WSM-000010-schema-roster-assignments` (needs `rosterAuditLog` table). Retarget to `main` once WSM-000010 merges.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`
- [x] `pnpm --filter @sports-management/web test:unit` — 194 tests passing (3 new `writeAuditLog` tests via convex-test)
- Covers: happy path insert, before+after JSON round-trip, rejection on unresolved leagueId

🤖 Generated with [Claude Code](https://claude.com/claude-code)