### PR TITLE
feat(web): roster assignment mutations + transactional audit log (WSM-000014)

### DIFF
--- a/apps/web/convex/__tests__/rosterAssignments.test.ts
+++ b/apps/web/convex/__tests__/rosterAssignments.test.ts
@@ -1,0 +1,462 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const asAssignmentId = (id: string) => id as Id<"rosterAssignments">;
+
+const ACTOR = "user_test_actor";
+
+async function seed(
+  t: ReturnType<typeof convexTest>,
+  rosterLimit: number | null = 53,
+) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Roster League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "A",
+      leagueId,
+      divisionId: null,
+      city: "A",
+      stadium: "A",
+      foundedYear: null,
+      location: "A",
+      logoUrl: null,
+      rosterLimit,
+    });
+    const teamB = await ctx.db.insert("teams", {
+      name: "B",
+      leagueId,
+      divisionId: null,
+      city: "B",
+      stadium: "B",
+      foundedYear: null,
+      location: "B",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const season = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const makePlayer = async (name: string, position: string, teamId: typeof teamA) =>
+      ctx.db.insert("players", {
+        name,
+        leagueId,
+        teamId,
+        position,
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      });
+    const qb1 = await makePlayer("QB1", "QB", teamA);
+    const qb2 = await makePlayer("QB2", "QB", teamA);
+    const qb3 = await makePlayer("QB3", "QB", teamA);
+    const rb1 = await makePlayer("RB1", "HB", teamA);
+    const qbB = await makePlayer("QB-B", "QB", teamB);
+    return { leagueId, teamA, teamB, season, qb1, qb2, qb3, rb1, qbB };
+  });
+}
+
+describe("assignPlayerToRoster", () => {
+  it("appends an active row with the next depthRank in the slot", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const first = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    expect(first.depthRank).toBe(1);
+    expect(first.status).toBe("active");
+
+    const second = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    expect(second.depthRank).toBe(2);
+  });
+
+  it("writes an audit row with action=assign", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const audit = await t.run((ctx) =>
+      ctx.db.query("rosterAuditLog").collect(),
+    );
+    expect(audit).toHaveLength(1);
+    expect(audit[0].action).toBe("assign");
+    expect(audit[0].beforeJson).toBeNull();
+    expect(audit[0].afterJson).not.toBeNull();
+  });
+
+  it("rejects when the season is locked", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    await t.mutation(api.sports.setRosterLocked, {
+      seasonId: seed1.season,
+      locked: true,
+    });
+
+    await expect(
+      t.mutation(api.sports.assignPlayerToRoster, {
+        seasonId: seed1.season,
+        teamId: seed1.teamA,
+        playerId: seed1.qb1,
+        positionSlot: "QB",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/season_locked/);
+  });
+
+  it("rejects when roster limit is reached", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t, 2);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await expect(
+      t.mutation(api.sports.assignPlayerToRoster, {
+        seasonId: seed1.season,
+        teamId: seed1.teamA,
+        playerId: seed1.qb3,
+        positionSlot: "QB",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/roster_limit_exceeded/);
+  });
+
+  it("allows unlimited assignments when rosterLimit is null", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t, null);
+
+    const r1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    const r2 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    expect(r1.depthRank).toBe(1);
+    expect(r2.depthRank).toBe(2);
+  });
+
+  it("rejects adding the same player twice while active", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await expect(
+      t.mutation(api.sports.assignPlayerToRoster, {
+        seasonId: seed1.season,
+        teamId: seed1.teamA,
+        playerId: seed1.qb1,
+        positionSlot: "QB",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/player_already_on_roster/);
+  });
+
+  it("rejects a player that belongs to another team", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    await expect(
+      t.mutation(api.sports.assignPlayerToRoster, {
+        seasonId: seed1.season,
+        teamId: seed1.teamA,
+        playerId: seed1.qbB,
+        positionSlot: "QB",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/player_not_on_team/);
+  });
+});
+
+describe("removePlayerFromRoster", () => {
+  it("deletes the row and compacts remaining depthRanks", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    const a2 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb3,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await t.mutation(api.sports.removePlayerFromRoster, {
+      assignmentId: asAssignmentId(a1.id),
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.run((ctx) =>
+      ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", seed1.season).eq("teamId", seed1.teamA),
+        )
+        .collect(),
+    );
+    expect(rows.map((r) => r.depthRank).sort()).toEqual([1, 2]);
+    const remaining = rows.find((r) => r._id === a2.id);
+    expect(remaining?.depthRank).toBe(1);
+  });
+
+  it("rejects removing a non-active assignment", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a.id),
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    await expect(
+      t.mutation(api.sports.removePlayerFromRoster, {
+        assignmentId: asAssignmentId(a.id),
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/cannot_remove_non_active/);
+  });
+});
+
+describe("updateRosterStatus", () => {
+  it("moves active → ir, zeroes depthRank, compacts the slot", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    const a2 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const updated = await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a1.id),
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+    expect(updated.status).toBe("ir");
+    expect(updated.depthRank).toBe(0);
+
+    const stillActive = await t.run((ctx) =>
+      ctx.db.get(asAssignmentId(a2.id)),
+    );
+    expect(stillActive?.depthRank).toBe(1);
+  });
+
+  it("rejects an invalid status value", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await expect(
+      t.mutation(api.sports.updateRosterStatus, {
+        assignmentId: asAssignmentId(a.id),
+        newStatus: "bogus",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/invalid_status/);
+  });
+
+  it("requires an open slot when reactivating; assigns next depthRank", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t, 2);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a1.id),
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    // With rosterLimit 2 and one remaining active, we can reactivate a1.
+    const back = await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a1.id),
+      newStatus: "active",
+      actorUserId: ACTOR,
+    });
+    expect(back.status).toBe("active");
+    expect(back.depthRank).toBe(2);
+  });
+
+  it("rejects reactivation when roster is already at limit", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t, 2);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a1.id),
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    // Fill the freed slot with qb3.
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb3,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    await expect(
+      t.mutation(api.sports.updateRosterStatus, {
+        assignmentId: asAssignmentId(a1.id),
+        newStatus: "active",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/roster_limit_exceeded/);
+  });
+
+  it("writes an audit row with action=status_change", async () => {
+    const t = convexTest(schema, modules);
+    const seed1 = await seed(t);
+
+    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: seed1.season,
+      teamId: seed1.teamA,
+      playerId: seed1.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: asAssignmentId(a.id),
+      newStatus: "suspended",
+      actorUserId: ACTOR,
+    });
+
+    const audit = await t.run((ctx) =>
+      ctx.db.query("rosterAuditLog").collect(),
+    );
+    const statusAudits = audit.filter((r) => r.action === "status_change");
+    expect(statusAudits).toHaveLength(1);
+    expect(statusAudits[0].beforeJson).not.toBeNull();
+    expect(statusAudits[0].afterJson).not.toBeNull();
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,6 +1,9 @@
 import { mutationGeneric, queryGeneric } from "convex/server";
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { writeAuditLog } from "./lib/auditLog";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -109,6 +112,53 @@ function toSeasonDto(doc: {
     status: doc.status,
     rosterLocked: doc.rosterLocked ?? false,
   };
+}
+
+function toRosterAssignmentDto(doc: {
+  _id: string;
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  leagueId: string;
+  depthRank: number;
+  positionSlot: string;
+  status: string;
+  assignedAt: string;
+  assignedBy: string;
+}) {
+  return {
+    id: doc._id,
+    seasonId: doc.seasonId,
+    teamId: doc.teamId,
+    playerId: doc.playerId,
+    leagueId: doc.leagueId,
+    depthRank: doc.depthRank,
+    positionSlot: doc.positionSlot,
+    status: doc.status,
+    assignedAt: doc.assignedAt,
+    assignedBy: doc.assignedBy,
+  };
+}
+
+const rosterAssignmentDtoValidator = v.object({
+  id: v.string(),
+  seasonId: v.string(),
+  teamId: v.string(),
+  playerId: v.string(),
+  leagueId: v.string(),
+  depthRank: v.number(),
+  positionSlot: v.string(),
+  status: v.string(),
+  assignedAt: v.string(),
+  assignedBy: v.string(),
+});
+
+const ROSTER_STATUSES = ["active", "ir", "suspended", "released"] as const;
+
+function assertValidRosterStatus(status: string): void {
+  if (!ROSTER_STATUSES.includes(status as (typeof ROSTER_STATUSES)[number])) {
+    throw new Error(`invalid_status:${status}`);
+  }
 }
 
 export const getVisibleLeagueContext = queryGeneric({
@@ -1306,5 +1356,260 @@ export const setRosterLocked = mutation({
     }
     await ctx.db.patch(args.seasonId, { rosterLocked: args.locked });
     return { seasonId: args.seasonId, rosterLocked: args.locked };
+  },
+});
+
+export const assignPlayerToRoster = mutation({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    playerId: v.id("players"),
+    positionSlot: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: rosterAssignmentDtoValidator,
+  handler: async (ctx, args) => {
+    const [season, team, player] = await Promise.all([
+      ctx.db.get(args.seasonId),
+      ctx.db.get(args.teamId),
+      ctx.db.get(args.playerId),
+    ]);
+    if (!season) throw new Error("season_not_found");
+    if (!team) throw new Error("team_not_found");
+    if (!player) throw new Error("player_not_found");
+    if (season.rosterLocked === true) throw new Error("season_locked");
+    if (team.leagueId !== season.leagueId) {
+      throw new Error("team_season_league_mismatch");
+    }
+    if (player.teamId !== args.teamId) {
+      throw new Error("player_not_on_team");
+    }
+
+    const teamAssignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+
+    const activeForPlayer = teamAssignments.find(
+      (row) => row.playerId === args.playerId && row.status === "active",
+    );
+    if (activeForPlayer) {
+      throw new Error("player_already_on_roster");
+    }
+
+    const activeCount = teamAssignments.filter(
+      (row) => row.status === "active",
+    ).length;
+    if (team.rosterLimit !== null && activeCount >= team.rosterLimit) {
+      throw new Error("roster_limit_exceeded");
+    }
+
+    const slotActive = teamAssignments.filter(
+      (row) =>
+        row.status === "active" && row.positionSlot === args.positionSlot,
+    );
+    const nextDepthRank =
+      slotActive.reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+
+    const assignedAt = new Date().toISOString();
+    const insertedId = await ctx.db.insert("rosterAssignments", {
+      seasonId: args.seasonId,
+      teamId: args.teamId,
+      playerId: args.playerId,
+      leagueId: team.leagueId,
+      depthRank: nextDepthRank,
+      positionSlot: args.positionSlot,
+      status: "active",
+      assignedAt,
+      assignedBy: args.actorUserId,
+    });
+
+    const after = {
+      id: insertedId,
+      seasonId: args.seasonId,
+      teamId: args.teamId,
+      playerId: args.playerId,
+      leagueId: team.leagueId,
+      depthRank: nextDepthRank,
+      positionSlot: args.positionSlot,
+      status: "active",
+      assignedAt,
+      assignedBy: args.actorUserId,
+    };
+
+    await writeAuditLog(ctx, {
+      leagueId: team.leagueId,
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      actorUserId: args.actorUserId,
+      action: "assign",
+      before: null,
+      after,
+    });
+
+    return toRosterAssignmentDto({ _id: insertedId, ...after });
+  },
+});
+
+async function compactSlotRanks(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+  teamId: Id<"teams">,
+  positionSlot: string,
+): Promise<void> {
+  const slotRows = await ctx.db
+    .query("rosterAssignments")
+    .withIndex("by_seasonId_teamId_position", (q) =>
+      q
+        .eq("seasonId", seasonId)
+        .eq("teamId", teamId)
+        .eq("positionSlot", positionSlot),
+    )
+    .collect();
+
+  const active = slotRows
+    .filter((row) => row.status === "active")
+    .sort((a, b) => a.depthRank - b.depthRank);
+
+  await Promise.all(
+    active.map((row, index) => {
+      const desired = index + 1;
+      if (row.depthRank === desired) return Promise.resolve();
+      return ctx.db.patch(row._id, { depthRank: desired });
+    }),
+  );
+}
+
+export const removePlayerFromRoster = mutation({
+  args: {
+    assignmentId: v.id("rosterAssignments"),
+    actorUserId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const assignment = await ctx.db.get(args.assignmentId);
+    if (!assignment) throw new Error("assignment_not_found");
+
+    const season = await ctx.db.get(assignment.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.rosterLocked === true) throw new Error("season_locked");
+
+    if (assignment.status !== "active") {
+      throw new Error("cannot_remove_non_active");
+    }
+
+    const before = toRosterAssignmentDto(assignment);
+
+    await ctx.db.delete(args.assignmentId);
+    await compactSlotRanks(
+      ctx,
+      assignment.seasonId,
+      assignment.teamId,
+      assignment.positionSlot,
+    );
+
+    await writeAuditLog(ctx, {
+      leagueId: assignment.leagueId,
+      teamId: assignment.teamId,
+      seasonId: assignment.seasonId,
+      actorUserId: args.actorUserId,
+      action: "remove",
+      before,
+      after: null,
+    });
+
+    return null;
+  },
+});
+
+export const updateRosterStatus = mutation({
+  args: {
+    assignmentId: v.id("rosterAssignments"),
+    newStatus: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: rosterAssignmentDtoValidator,
+  handler: async (ctx, args) => {
+    assertValidRosterStatus(args.newStatus);
+
+    const assignment = await ctx.db.get(args.assignmentId);
+    if (!assignment) throw new Error("assignment_not_found");
+
+    const season = await ctx.db.get(assignment.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.rosterLocked === true) throw new Error("season_locked");
+
+    if (assignment.status === args.newStatus) {
+      return toRosterAssignmentDto(assignment);
+    }
+
+    const before = toRosterAssignmentDto(assignment);
+
+    const wasActive = assignment.status === "active";
+    const willBeActive = args.newStatus === "active";
+
+    let nextDepthRank = assignment.depthRank;
+
+    if (!wasActive && willBeActive) {
+      const team = await ctx.db.get(assignment.teamId);
+      if (!team) throw new Error("team_not_found");
+
+      const teamAssignments = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", assignment.seasonId).eq("teamId", assignment.teamId),
+        )
+        .collect();
+
+      const activeCount = teamAssignments.filter(
+        (row) => row.status === "active" && row._id !== assignment._id,
+      ).length;
+      if (team.rosterLimit !== null && activeCount >= team.rosterLimit) {
+        throw new Error("roster_limit_exceeded");
+      }
+
+      const slotActive = teamAssignments.filter(
+        (row) =>
+          row.status === "active" &&
+          row.positionSlot === assignment.positionSlot &&
+          row._id !== assignment._id,
+      );
+      nextDepthRank =
+        slotActive.reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+    } else if (wasActive && !willBeActive) {
+      nextDepthRank = 0;
+    }
+
+    await ctx.db.patch(args.assignmentId, {
+      status: args.newStatus,
+      depthRank: nextDepthRank,
+    });
+
+    if (wasActive && !willBeActive) {
+      await compactSlotRanks(
+        ctx,
+        assignment.seasonId,
+        assignment.teamId,
+        assignment.positionSlot,
+      );
+    }
+
+    const updated = await ctx.db.get(args.assignmentId);
+    if (!updated) throw new Error("assignment_not_found");
+    const after = toRosterAssignmentDto(updated);
+
+    await writeAuditLog(ctx, {
+      leagueId: assignment.leagueId,
+      teamId: assignment.teamId,
+      seasonId: assignment.seasonId,
+      actorUserId: args.actorUserId,
+      action: "status_change",
+      before,
+      after,
+    });
+
+    return after;
   },
 });


### PR DESCRIPTION
## Summary
- Adds `assignPlayerToRoster`, `removePlayerFromRoster`, `updateRosterStatus` Convex mutations plus a `compactSlotRanks` helper (dense 1-indexed `depthRank` across `status: "active"` rows).
- Every mutation calls `writeAuditLog` (from WSM-000013) with `action`, `before`, `after` so the Phase 1 audit UI (WSM-000018) can replay history.
- Auth remains at the Next.js route layer (`authorizeTeamMutation`). Mutations accept `actorUserId` as an explicit arg and enforce data invariants only.

## Invariants enforced
- `season_locked` (season.rosterLocked === true)
- `roster_limit_exceeded` (`teams.rosterLimit`, `null` = unlimited)
- `player_already_on_roster`, `player_not_on_team`
- `cannot_remove_non_active` (only `active` rows are removable)
- `invalid_status` (active|ir|suspended|released only)

Non-active rows use `depthRank: 0` as a sentinel (schema is `v.number()`); reactivation recomputes via `max(active in slot) + 1`.

## Tracking
- Plan: Sprint 2 / Phase 1 (§5.1, §5.5 in \`docs/roster-management.md\`)
- Flag: \`roster_snapshots_v1\` (prod default off)
- Depends on: WSM-000010 schema, WSM-000013 audit-log helper

## Test plan
- [x] \`pnpm -r type-check\` passes
- [x] \`pnpm --filter @sports-management/web test:unit\` — 237/237 pass including 14 new \`rosterAssignments\` convex-test cases
- [ ] Manual verification deferred to WSM-000017 (UI) + WSM-000019 (E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)