### PR TITLE
feat(web): roster query API for Phase 1 UI (WSM-000015)

### DIFF
--- a/apps/web/convex/__tests__/rosterQueries.test.ts
+++ b/apps/web/convex/__tests__/rosterQueries.test.ts
@@ -1,0 +1,386 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_test_actor";
+
+async function seed(
+  t: ReturnType<typeof convexTest>,
+  rosterLimit: number | null = 53,
+) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Query League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const team = await ctx.db.insert("teams", {
+      name: "Team",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Loc",
+      logoUrl: null,
+      rosterLimit,
+    });
+    const season = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const otherSeason = await ctx.db.insert("seasons", {
+      name: "2025",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const makePlayer = async (name: string, position: string) =>
+      ctx.db.insert("players", {
+        name,
+        leagueId,
+        teamId: team,
+        position,
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      });
+    const qb1 = await makePlayer("QB1", "QB");
+    const qb2 = await makePlayer("QB2", "QB");
+    const rb1 = await makePlayer("RB1", "HB");
+    return { leagueId, team, season, otherSeason, qb1, qb2, rb1 };
+  });
+}
+
+describe("getRosterBySeasonTeam", () => {
+  it("returns an empty array when no assignments exist", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("sorts by positionSlot, then active before non-active, then depthRank", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.rb1,
+      positionSlot: "HB",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.positionSlot)).toEqual(["HB", "QB", "QB"]);
+    expect(rows[0].playerId).toBe(s.rb1);
+    expect(rows[1].playerId).toBe(s.qb1);
+    expect(rows[1].depthRank).toBe(1);
+    expect(rows[2].playerId).toBe(s.qb2);
+    expect(rows[2].depthRank).toBe(2);
+  });
+
+  it("puts non-active rows after active rows within a slot", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: a1.id as Id<"rosterAssignments">,
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(rows.map((r) => r.status)).toEqual(["active", "ir"]);
+    expect(rows[0].playerId).toBe(s.qb2);
+    expect(rows[0].depthRank).toBe(1);
+    expect(rows[1].playerId).toBe(s.qb1);
+  });
+
+  it("ignores assignments from other seasons", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.otherSeason,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(rows).toEqual([]);
+  });
+});
+
+describe("getTeamRosterLimitStatus", () => {
+  it("reports zero active with the team's rosterLimit", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t, 3);
+
+    const status = await t.query(api.sports.getTeamRosterLimitStatus, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(status).toEqual({
+      activeCount: 0,
+      rosterLimit: 3,
+      remaining: 3,
+    });
+  });
+
+  it("reports remaining decrementing as assignments land", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t, 2);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const status = await t.query(api.sports.getTeamRosterLimitStatus, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(status).toEqual({
+      activeCount: 1,
+      rosterLimit: 2,
+      remaining: 1,
+    });
+  });
+
+  it("treats null rosterLimit as unlimited (remaining stays null)", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t, null);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const status = await t.query(api.sports.getTeamRosterLimitStatus, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(status).toEqual({
+      activeCount: 1,
+      rosterLimit: null,
+      remaining: null,
+    });
+  });
+
+  it("excludes non-active rows from the count", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t, 5);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: a1.id as Id<"rosterAssignments">,
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    const status = await t.query(api.sports.getTeamRosterLimitStatus, {
+      seasonId: s.season,
+      teamId: s.team,
+    });
+
+    expect(status.activeCount).toBe(0);
+    expect(status.remaining).toBe(5);
+  });
+});
+
+describe("getRosterAssignmentHistory", () => {
+  it("returns all team/season audit rows when playerId is null, newest first", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterAssignmentHistory, {
+      teamId: s.team,
+      seasonId: s.season,
+      playerId: null,
+      limit: null,
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].action).toBe("assign");
+    expect(rows[0].createdAt >= rows[1].createdAt).toBe(true);
+  });
+
+  it("filters rows by playerId via JSON snapshot match", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.updateRosterStatus, {
+      assignmentId: a1.id as Id<"rosterAssignments">,
+      newStatus: "ir",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterAssignmentHistory, {
+      teamId: s.team,
+      seasonId: s.season,
+      playerId: s.qb1,
+      limit: null,
+    });
+
+    expect(rows.map((r) => r.action).sort()).toEqual(["assign", "status_change"]);
+  });
+
+  it("honours the limit arg when provided", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.season,
+      teamId: s.team,
+      playerId: s.qb2,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterAssignmentHistory, {
+      teamId: s.team,
+      seasonId: s.season,
+      playerId: null,
+      limit: 1,
+    });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("excludes audit rows from other seasons", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(api.sports.assignPlayerToRoster, {
+      seasonId: s.otherSeason,
+      teamId: s.team,
+      playerId: s.qb1,
+      positionSlot: "QB",
+      actorUserId: ACTOR,
+    });
+
+    const rows = await t.query(api.sports.getRosterAssignmentHistory, {
+      teamId: s.team,
+      seasonId: s.season,
+      playerId: null,
+      limit: null,
+    });
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -153,6 +153,42 @@ const rosterAssignmentDtoValidator = v.object({
   assignedBy: v.string(),
 });
 
+function toRosterAuditLogDto(doc: {
+  _id: string;
+  leagueId: string;
+  teamId: string;
+  seasonId: string;
+  actorUserId: string;
+  action: string;
+  beforeJson: string | null;
+  afterJson: string | null;
+  createdAt: string;
+}) {
+  return {
+    id: doc._id,
+    leagueId: doc.leagueId,
+    teamId: doc.teamId,
+    seasonId: doc.seasonId,
+    actorUserId: doc.actorUserId,
+    action: doc.action,
+    beforeJson: doc.beforeJson ?? null,
+    afterJson: doc.afterJson ?? null,
+    createdAt: doc.createdAt,
+  };
+}
+
+const rosterAuditLogDtoValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  teamId: v.string(),
+  seasonId: v.string(),
+  actorUserId: v.string(),
+  action: v.string(),
+  beforeJson: v.union(v.string(), v.null()),
+  afterJson: v.union(v.string(), v.null()),
+  createdAt: v.string(),
+});
+
 const ROSTER_STATUSES = ["active", "ir", "suspended", "released"] as const;
 
 function assertValidRosterStatus(status: string): void {
@@ -1611,5 +1647,104 @@ export const updateRosterStatus = mutation({
     });
 
     return after;
+  },
+});
+
+export const getRosterBySeasonTeam = query({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+  },
+  returns: v.array(rosterAssignmentDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+
+    const sorted = [...rows].sort((a, b) => {
+      if (a.positionSlot !== b.positionSlot) {
+        return a.positionSlot.localeCompare(b.positionSlot);
+      }
+      const aActive = a.status === "active" ? 0 : 1;
+      const bActive = b.status === "active" ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+      if (a.status === "active" && b.status === "active") {
+        return a.depthRank - b.depthRank;
+      }
+      return a.assignedAt.localeCompare(b.assignedAt);
+    });
+
+    return sorted.map(toRosterAssignmentDto);
+  },
+});
+
+export const getTeamRosterLimitStatus = query({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+  },
+  returns: v.object({
+    activeCount: v.number(),
+    rosterLimit: v.union(v.number(), v.null()),
+    remaining: v.union(v.number(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("team_not_found");
+
+    const rows = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+
+    const activeCount = rows.filter((row) => row.status === "active").length;
+    const rosterLimit = team.rosterLimit ?? null;
+    const remaining =
+      rosterLimit === null ? null : Math.max(0, rosterLimit - activeCount);
+
+    return { activeCount, rosterLimit, remaining };
+  },
+});
+
+export const getRosterAssignmentHistory = query({
+  args: {
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    playerId: v.union(v.id("players"), v.null()),
+    limit: v.union(v.number(), v.null()),
+  },
+  returns: v.array(rosterAuditLogDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("rosterAuditLog")
+      .withIndex("by_teamId_createdAt", (q) => q.eq("teamId", args.teamId))
+      .order("desc")
+      .collect();
+
+    const matchesSeason = (row: (typeof rows)[number]) =>
+      row.seasonId === args.seasonId;
+
+    const matchesPlayer = (row: (typeof rows)[number]) => {
+      if (!args.playerId) return true;
+      const needle = `"playerId":"${args.playerId}"`;
+      return (
+        (row.beforeJson ?? "").includes(needle) ||
+        (row.afterJson ?? "").includes(needle)
+      );
+    };
+
+    const filtered = rows.filter(
+      (row) => matchesSeason(row) && matchesPlayer(row),
+    );
+
+    const limited =
+      args.limit === null ? filtered : filtered.slice(0, args.limit);
+
+    return limited.map(toRosterAuditLogDto);
   },
 });


### PR DESCRIPTION
## Summary
- Adds three Convex queries for the Phase 1 roster surface:
  - \`getRosterBySeasonTeam(seasonId, teamId)\` — all assignments for a season/team, sorted by positionSlot → active-first → depthRank → assignedAt.
  - \`getTeamRosterLimitStatus(seasonId, teamId)\` — active-count vs \`teams.rosterLimit\`; \`null\` = unlimited, \`remaining\` stays \`null\`.
  - \`getRosterAssignmentHistory(teamId, seasonId, playerId?, limit?)\` — audit-log rows scoped to the season; when \`playerId\` is provided, filtered via JSON snapshot substring match on \`beforeJson\`/\`afterJson\`.
- Introduces \`toRosterAuditLogDto\` + \`rosterAuditLogDtoValidator\` alongside the existing \`rosterAssignment\` helpers in \`sports.ts\`.

## Tracking
- Plan: Sprint 2 / Phase 1 (§5.1, §5.5 in \`docs/roster-management.md\`)
- Flag: \`roster_snapshots_v1\` (prod default off)
- Consumers: WSM-000017 roster UI, WSM-000018 audit UI

## Test plan
- [x] \`pnpm -r type-check\` passes
- [x] \`pnpm --filter @sports-management/web test:unit\` — 249/249 pass, including 12 new \`rosterQueries\` convex-test cases
- [ ] Manual verification deferred to WSM-000017 (UI) + WSM-000019 (E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)