### PR TITLE
feat(web): depth-chart → roster migration (WSM-000016)

### DIFF
--- a/apps/web/convex/__tests__/depthChartToRoster.test.ts
+++ b/apps/web/convex/__tests__/depthChartToRoster.test.ts
@@ -1,0 +1,149 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import { anyApi } from "convex/server";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "migration:WSM-000016";
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Migration League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "A",
+      leagueId,
+      divisionId: null,
+      city: "A",
+      stadium: "A",
+      foundedYear: null,
+      location: "A",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const season = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const makePlayer = async (name: string, position: string) =>
+      ctx.db.insert("players", {
+        name,
+        leagueId,
+        teamId: teamA,
+        position,
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      });
+    const qb1 = await makePlayer("QB1", "QB");
+    const qb2 = await makePlayer("QB2", "QB");
+    const qb3 = await makePlayer("QB3", "QB");
+
+    await ctx.db.insert("depthChartEntries", {
+      teamId: teamA,
+      seasonId: season,
+      playerId: qb1,
+      positionSlot: "QB",
+      sortOrder: 0,
+      updatedAt: new Date().toISOString(),
+    });
+    await ctx.db.insert("depthChartEntries", {
+      teamId: teamA,
+      seasonId: season,
+      playerId: qb2,
+      positionSlot: "QB",
+      sortOrder: 1,
+      updatedAt: new Date().toISOString(),
+    });
+    await ctx.db.insert("depthChartEntries", {
+      teamId: teamA,
+      seasonId: season,
+      playerId: qb3,
+      positionSlot: "QB",
+      sortOrder: 2,
+      updatedAt: new Date().toISOString(),
+    });
+    return { leagueId, teamA, season, qb1, qb2, qb3 };
+  });
+}
+
+describe("migrateDepthChartToRoster", () => {
+  it("copies every depth-chart entry into rosterAssignments with 1-indexed depthRank", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const result = await t.mutation(
+      anyApi.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster,
+      { actorUserId: ACTOR },
+    );
+
+    expect(result).toEqual({ scanned: 3, copied: 3, skipped: 0 });
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.teamA,
+    });
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.depthRank)).toEqual([1, 2, 3]);
+    expect(rows.map((r) => r.playerId)).toEqual([s.qb1, s.qb2, s.qb3]);
+    expect(rows.every((r) => r.status === "active")).toBe(true);
+    expect(rows.every((r) => r.assignedBy === ACTOR)).toBe(true);
+  });
+
+  it("is idempotent — a second run skips existing rows", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(
+      anyApi.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster,
+      { actorUserId: ACTOR },
+    );
+    const second = await t.mutation(
+      anyApi.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster,
+      { actorUserId: ACTOR },
+    );
+
+    expect(second).toEqual({ scanned: 3, copied: 0, skipped: 3 });
+
+    const rows = await t.query(api.sports.getRosterBySeasonTeam, {
+      seasonId: s.season,
+      teamId: s.teamA,
+    });
+    expect(rows).toHaveLength(3);
+  });
+
+  it("writes one audit row per copied assignment", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    await t.mutation(
+      anyApi.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster,
+      { actorUserId: ACTOR },
+    );
+
+    const history = await t.query(api.sports.getRosterAssignmentHistory, {
+      teamId: s.teamA,
+      seasonId: s.season,
+      playerId: null,
+      limit: null,
+    });
+
+    expect(history).toHaveLength(3);
+    expect(history.every((row) => row.action === "assign")).toBe(true);
+    expect(history.every((row) => row.actorUserId === ACTOR)).toBe(true);
+  });
+});

--- a/apps/web/convex/migrations/20260428_depthChartToRoster.ts
+++ b/apps/web/convex/migrations/20260428_depthChartToRoster.ts
@@ -1,0 +1,86 @@
+import { v } from "convex/values";
+import { mutation } from "../_generated/server";
+import { writeAuditLog } from "../lib/auditLog";
+
+export const migrateDepthChartToRoster = mutation({
+  args: { actorUserId: v.string() },
+  returns: v.object({
+    scanned: v.number(),
+    copied: v.number(),
+    skipped: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const entries = await ctx.db.query("depthChartEntries").collect();
+    let copied = 0;
+    let skipped = 0;
+
+    for (const entry of entries) {
+      const existing = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId_position", (q) =>
+          q
+            .eq("seasonId", entry.seasonId)
+            .eq("teamId", entry.teamId)
+            .eq("positionSlot", entry.positionSlot),
+        )
+        .filter((q) => q.eq(q.field("playerId"), entry.playerId))
+        .first();
+
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+
+      const team = await ctx.db.get(entry.teamId);
+      if (!team) {
+        skipped += 1;
+        continue;
+      }
+
+      const depthRank = entry.sortOrder + 1;
+      const now = new Date().toISOString();
+
+      const insertedId = await ctx.db.insert("rosterAssignments", {
+        seasonId: entry.seasonId,
+        teamId: entry.teamId,
+        playerId: entry.playerId,
+        leagueId: team.leagueId,
+        positionSlot: entry.positionSlot,
+        depthRank,
+        status: "active",
+        assignedAt: now,
+        assignedBy: args.actorUserId,
+      });
+
+      const inserted = await ctx.db.get(insertedId);
+      if (!inserted) {
+        throw new Error("migration_insert_failed");
+      }
+
+      await writeAuditLog(ctx, {
+        leagueId: team.leagueId,
+        teamId: entry.teamId,
+        seasonId: entry.seasonId,
+        actorUserId: args.actorUserId,
+        action: "assign",
+        before: null,
+        after: {
+          id: insertedId,
+          seasonId: inserted.seasonId,
+          teamId: inserted.teamId,
+          playerId: inserted.playerId,
+          leagueId: inserted.leagueId,
+          depthRank: inserted.depthRank,
+          positionSlot: inserted.positionSlot,
+          status: inserted.status,
+          assignedAt: inserted.assignedAt,
+          assignedBy: inserted.assignedBy,
+        },
+      });
+
+      copied += 1;
+    }
+
+    return { scanned: entries.length, copied, skipped };
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a one-shot Convex mutation that copies every \`depthChartEntries\` row into \`rosterAssignments\` (\`status: "active"\`) with 1-indexed \`depthRank\` (Phase 0 \`sortOrder + 1\`).
- Idempotent: a second run skips rows with an existing matching \`(seasonId, teamId, positionSlot, playerId)\` assignment.
- Writes a transactional audit row per copied assignment (action: \`assign\`) via the WSM-000013 \`writeAuditLog\` helper so the Phase 1 audit timeline reflects migrated history.

## Invocation
\`\`\`bash
pnpm convex run migrations/20260428_depthChartToRoster:migrateDepthChartToRoster '{"actorUserId":"migration:WSM-000016"}'
\`\`\`

## Scope notes
- \`depthChartEntries\` stays in the schema. Dropping the table is scheduled for a later sprint so Phase 0 code paths remain functional while \`rosterSnapshotsV1\` rolls out.

## Tracking
- Plan: Sprint 2 / Phase 1 (§5.2 in \`docs/roster-management.md\`)
- Flag: \`roster_snapshots_v1\` (prod default off)
- Depends on: WSM-000010 schema, WSM-000013 audit helper, WSM-000014 mutations, WSM-000015 queries

## Test plan
- [x] \`pnpm -r type-check\` passes
- [x] \`pnpm --filter @sports-management/web test:unit\` — 252/252 pass, 3 new \`depthChartToRoster\` convex-test cases covering copy, idempotency, and audit-row shape
- [ ] Manual preview-deploy dry-run deferred to WSM-000020

🤖 Generated with [Claude Code](https://claude.com/claude-code)