### PR TITLE
feat(web): roster management UI (WSM-000017)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/roster/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/actions.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { rosterSnapshotsV1 } from "@/lib/flags";
+import {
+  assignPlayerToRoster as assignPlayerToRosterMutation,
+  removePlayerFromRoster as removePlayerFromRosterMutation,
+  updateRosterStatus as updateRosterStatusMutation,
+} from "@/lib/data-api";
+import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import {
+  trackRosterAssign,
+  trackRosterLimitBlocked,
+  trackRosterRemove,
+  trackRosterStatusChange,
+} from "@/lib/analytics";
+import type { RosterAssignmentDto } from "@sports-management/shared-types";
+
+async function requireFlag() {
+  const enabled = await rosterSnapshotsV1();
+  if (!enabled) throw new Error("flag_disabled");
+}
+
+async function requireOrgMembership(orgId: string, userId: string) {
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (!role) throw new Error("not_authorized");
+  return role;
+}
+
+export async function assignPlayerToRosterAction(input: {
+  seasonId: string;
+  teamId: string;
+  leagueId: string;
+  playerId: string;
+  positionSlot: string;
+}): Promise<RosterAssignmentDto> {
+  await requireFlag();
+  const { userId } = await auth();
+  if (!userId) throw new Error("not_authenticated");
+
+  const orgId = await getLeagueOrgId(input.leagueId);
+  if (!orgId) throw new Error("not_authorized");
+  await requireOrgMembership(orgId, userId);
+
+  try {
+    const result = await assignPlayerToRosterMutation({
+      seasonId: input.seasonId,
+      teamId: input.teamId,
+      playerId: input.playerId,
+      positionSlot: input.positionSlot,
+      actorUserId: userId,
+    });
+    void trackRosterAssign({
+      seasonId: input.seasonId,
+      teamId: input.teamId,
+      positionSlot: input.positionSlot,
+    });
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.startsWith("roster_limit_exceeded")) {
+      void trackRosterLimitBlocked({
+        seasonId: input.seasonId,
+        teamId: input.teamId,
+      });
+    }
+    throw err;
+  }
+}
+
+export async function removePlayerFromRosterAction(input: {
+  assignmentId: string;
+  seasonId: string;
+  teamId: string;
+  leagueId: string;
+  positionSlot: string;
+}): Promise<void> {
+  await requireFlag();
+  const { userId } = await auth();
+  if (!userId) throw new Error("not_authenticated");
+
+  const orgId = await getLeagueOrgId(input.leagueId);
+  if (!orgId) throw new Error("not_authorized");
+  await requireOrgMembership(orgId, userId);
+
+  await removePlayerFromRosterMutation({
+    assignmentId: input.assignmentId,
+    actorUserId: userId,
+  });
+  void trackRosterRemove({
+    seasonId: input.seasonId,
+    teamId: input.teamId,
+    positionSlot: input.positionSlot,
+  });
+}
+
+export async function updateRosterStatusAction(input: {
+  assignmentId: string;
+  seasonId: string;
+  teamId: string;
+  leagueId: string;
+  fromStatus: string;
+  newStatus: string;
+}): Promise<RosterAssignmentDto> {
+  await requireFlag();
+  const { userId } = await auth();
+  if (!userId) throw new Error("not_authenticated");
+
+  const orgId = await getLeagueOrgId(input.leagueId);
+  if (!orgId) throw new Error("not_authorized");
+  await requireOrgMembership(orgId, userId);
+
+  const result = await updateRosterStatusMutation({
+    assignmentId: input.assignmentId,
+    newStatus: input.newStatus,
+    actorUserId: userId,
+  });
+  void trackRosterStatusChange({
+    seasonId: input.seasonId,
+    teamId: input.teamId,
+    fromStatus: input.fromStatus,
+    toStatus: input.newStatus,
+  });
+  return result;
+}

--- a/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
@@ -1,0 +1,90 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { rosterSnapshotsV1 } from "@/lib/flags";
+import {
+  getTeam,
+  getPlayersByTeam,
+  getSeasons,
+  getRosterBySeasonTeam,
+  getTeamRosterLimitStatus,
+} from "@/lib/data-api";
+import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import RosterBoard from "@/components/roster/RosterBoard";
+
+export default async function RosterPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await rosterSnapshotsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: teamId } = await params;
+
+  const team = await getTeam(teamId, {
+    userId,
+    orgIds: [],
+    visibleLeagueIds: [],
+    subscribedLeagueIds: [],
+  }).catch(() => null);
+  if (!team) notFound();
+
+  const orgId = await getLeagueOrgId(team.leagueId);
+  if (!orgId) notFound();
+
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (!role) notFound();
+
+  const seasons = await getSeasons([team.leagueId]);
+  const activeSeason =
+    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  if (!activeSeason) {
+    return (
+      <div>
+        <Link
+          href={`/dashboard/teams/${teamId}`}
+          className="mb-4 inline-block text-sm text-primary hover:underline"
+        >
+          &larr; Back to Team
+        </Link>
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No season exists for this league. Create a season before managing the
+          roster.
+        </div>
+      </div>
+    );
+  }
+
+  const [players, assignments, limitStatus] = await Promise.all([
+    getPlayersByTeam(teamId, {
+      userId,
+      orgIds: [orgId],
+      visibleLeagueIds: [team.leagueId],
+      subscribedLeagueIds: [],
+    }),
+    getRosterBySeasonTeam(activeSeason.id, teamId),
+    getTeamRosterLimitStatus(activeSeason.id, teamId),
+  ]);
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/teams/${teamId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Team
+      </Link>
+      <RosterBoard
+        team={team}
+        season={activeSeason}
+        players={players}
+        assignments={assignments}
+        limitStatus={limitStatus}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/AssignPlayerDialog.tsx
+++ b/apps/web/src/components/roster/AssignPlayerDialog.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import type { PlayerDto } from "@sports-management/shared-types";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { assignPlayerToRosterAction } from "@/app/dashboard/teams/[id]/roster/actions";
+
+export interface AssignPlayerDialogProps {
+  teamId: string;
+  seasonId: string;
+  leagueId: string;
+  eligiblePlayers: PlayerDto[];
+  onAssigned: () => void;
+  disabled?: boolean;
+}
+
+export default function AssignPlayerDialog({
+  teamId,
+  seasonId,
+  leagueId,
+  eligiblePlayers,
+  onAssigned,
+  disabled,
+}: AssignPlayerDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [playerId, setPlayerId] = useState<string>("");
+  const [positionSlot, setPositionSlot] = useState<string>("");
+  const [pending, startTransition] = useTransition();
+
+  const selectedPlayer = eligiblePlayers.find((p) => p.id === playerId) ?? null;
+  const effectiveSlot = positionSlot || selectedPlayer?.position || "";
+
+  function handleSubmit() {
+    if (!playerId || !effectiveSlot) {
+      toast.error("Pick a player and a position slot.");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await assignPlayerToRosterAction({
+          seasonId,
+          teamId,
+          leagueId,
+          playerId,
+          positionSlot: effectiveSlot,
+        });
+        toast.success("Player added to roster");
+        setOpen(false);
+        setPlayerId("");
+        setPositionSlot("");
+        onAssigned();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(mapAssignError(message));
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button disabled={disabled}>Add to Roster</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add player to roster</DialogTitle>
+          <DialogDescription>
+            Pick a player on this team and the depth-chart slot they belong to.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="roster-player">Player</Label>
+            <Select
+              value={playerId}
+              onValueChange={(value) => {
+                setPlayerId(value);
+                const player = eligiblePlayers.find((p) => p.id === value);
+                if (player) setPositionSlot(player.position);
+              }}
+            >
+              <SelectTrigger id="roster-player">
+                <SelectValue placeholder="Select a player" />
+              </SelectTrigger>
+              <SelectContent>
+                {eligiblePlayers.length === 0 ? (
+                  <div className="px-2 py-1 text-sm text-muted-foreground">
+                    No eligible players.
+                  </div>
+                ) : (
+                  eligiblePlayers.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.name}
+                      {p.jerseyNumber !== null ? ` (#${p.jerseyNumber})` : ""}
+                      {" — "}
+                      {p.position}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="roster-slot">Position slot</Label>
+            <input
+              id="roster-slot"
+              value={effectiveSlot}
+              onChange={(e) => setPositionSlot(e.target.value.toUpperCase())}
+              className="h-10 rounded-md border bg-background px-3 text-sm font-mono"
+              placeholder="e.g. QB, WR1"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={pending || !playerId}>
+            {pending ? "Adding…" : "Add to roster"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function mapAssignError(message: string): string {
+  if (message.startsWith("roster_limit_exceeded"))
+    return "Roster is full. Move a player to IR or Released before adding another.";
+  if (message === "season_locked")
+    return "Season is locked. Ask an admin to unlock it.";
+  if (message === "player_already_on_roster")
+    return "Player is already on the roster.";
+  if (message === "player_not_on_team")
+    return "Pick a player that belongs to this team.";
+  return message;
+}

--- a/apps/web/src/components/roster/RosterBoard.tsx
+++ b/apps/web/src/components/roster/RosterBoard.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  PlayerDto,
+  RosterAssignmentDto,
+  SeasonDto,
+  TeamDto,
+} from "@sports-management/shared-types";
+import AssignPlayerDialog from "./AssignPlayerDialog";
+import RosterLimitBadge from "./RosterLimitBadge";
+import RosterSlotGroup from "./RosterSlotGroup";
+import RosterStatusList from "./RosterStatusList";
+
+export interface RosterBoardProps {
+  team: TeamDto;
+  season: SeasonDto;
+  players: PlayerDto[];
+  assignments: RosterAssignmentDto[];
+  limitStatus: {
+    activeCount: number;
+    rosterLimit: number | null;
+    remaining: number | null;
+  };
+}
+
+const NON_ACTIVE_STATUSES = ["ir", "suspended", "released"] as const;
+
+export default function RosterBoard({
+  team,
+  season,
+  players,
+  assignments,
+  limitStatus,
+}: RosterBoardProps) {
+  const router = useRouter();
+  const [statusFilter, setStatusFilter] =
+    useState<"active" | "ir" | "suspended" | "released">("active");
+
+  const playersById = useMemo(() => {
+    const map = new Map<string, PlayerDto>();
+    for (const p of players) map.set(p.id, p);
+    return map;
+  }, [players]);
+
+  const activeAssignments = useMemo(
+    () => assignments.filter((a) => a.status === "active"),
+    [assignments],
+  );
+
+  const assignedPlayerIds = useMemo(
+    () => new Set(activeAssignments.map((a) => a.playerId)),
+    [activeAssignments],
+  );
+
+  const eligiblePlayers = useMemo(
+    () =>
+      players.filter(
+        (p) => p.teamId === team.id && !assignedPlayerIds.has(p.id),
+      ),
+    [players, team.id, assignedPlayerIds],
+  );
+
+  const slotGroups = useMemo(() => {
+    const grouped = new Map<string, RosterAssignmentDto[]>();
+    for (const a of activeAssignments) {
+      const list = grouped.get(a.positionSlot) ?? [];
+      list.push(a);
+      grouped.set(a.positionSlot, list);
+    }
+    for (const [slot, list] of grouped) {
+      list.sort((a, b) => a.depthRank - b.depthRank);
+      grouped.set(slot, list);
+    }
+    return Array.from(grouped.entries()).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+  }, [activeAssignments]);
+
+  const filteredNonActive = useMemo(
+    () => assignments.filter((a) => a.status === statusFilter),
+    [assignments, statusFilter],
+  );
+
+  const atLimit =
+    limitStatus.rosterLimit !== null &&
+    limitStatus.activeCount >= limitStatus.rosterLimit;
+
+  function handleMutated() {
+    router.refresh();
+  }
+
+  return (
+    <div>
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">
+            {team.name} — Roster
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Season: {season.name}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <RosterLimitBadge
+            activeCount={limitStatus.activeCount}
+            rosterLimit={limitStatus.rosterLimit}
+          />
+          <AssignPlayerDialog
+            teamId={team.id}
+            seasonId={season.id}
+            leagueId={team.leagueId}
+            eligiblePlayers={eligiblePlayers}
+            onAssigned={handleMutated}
+            disabled={atLimit || season.rosterLocked}
+          />
+        </div>
+      </header>
+
+      {season.rosterLocked ? (
+        <div
+          role="status"
+          className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900"
+        >
+          This season is locked. Roster changes are disabled until an admin
+          unlocks it.
+        </div>
+      ) : null}
+
+      <section aria-label="Active roster" className="mb-8">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Active ({activeAssignments.length})
+        </h3>
+        {slotGroups.length === 0 ? (
+          <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No players on the active roster yet. Use{" "}
+            <strong>Add to Roster</strong> to get started.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {slotGroups.map(([positionSlot, rows]) => (
+              <RosterSlotGroup
+                key={positionSlot}
+                positionSlot={positionSlot}
+                assignments={rows}
+                playersById={playersById}
+                teamId={team.id}
+                seasonId={season.id}
+                leagueId={team.leagueId}
+                disabled={season.rosterLocked}
+                onChanged={handleMutated}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section aria-label="Non-active roster">
+        <div className="mb-3 flex items-center gap-2">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Non-active
+          </h3>
+          <div className="flex rounded-md border p-0.5">
+            {NON_ACTIVE_STATUSES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setStatusFilter(s)}
+                className={`rounded px-3 py-1 text-xs font-medium capitalize transition ${
+                  statusFilter === s
+                    ? "bg-foreground text-background"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {s === "ir" ? "IR" : s} (
+                {assignments.filter((a) => a.status === s).length})
+              </button>
+            ))}
+          </div>
+        </div>
+        <RosterStatusList
+          assignments={filteredNonActive}
+          playersById={playersById}
+          teamId={team.id}
+          seasonId={season.id}
+          leagueId={team.leagueId}
+          disabled={season.rosterLocked || atLimit}
+          onChanged={handleMutated}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/RosterLimitBadge.tsx
+++ b/apps/web/src/components/roster/RosterLimitBadge.tsx
@@ -1,0 +1,30 @@
+import { Badge } from "@/components/ui/badge";
+
+export interface RosterLimitBadgeProps {
+  activeCount: number;
+  rosterLimit: number | null;
+}
+
+export default function RosterLimitBadge({
+  activeCount,
+  rosterLimit,
+}: RosterLimitBadgeProps) {
+  if (rosterLimit === null) {
+    return (
+      <Badge variant="secondary" className="font-mono">
+        {activeCount} active
+      </Badge>
+    );
+  }
+
+  const atLimit = activeCount >= rosterLimit;
+  return (
+    <Badge
+      variant={atLimit ? "destructive" : "secondary"}
+      className="font-mono"
+      aria-label={`${activeCount} of ${rosterLimit} roster slots used`}
+    >
+      {activeCount} / {rosterLimit}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/roster/RosterSlotGroup.tsx
+++ b/apps/web/src/components/roster/RosterSlotGroup.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useTransition } from "react";
+import { MoreVertical } from "lucide-react";
+import { toast } from "sonner";
+import type {
+  PlayerDto,
+  RosterAssignmentDto,
+} from "@sports-management/shared-types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  removePlayerFromRosterAction,
+  updateRosterStatusAction,
+} from "@/app/dashboard/teams/[id]/roster/actions";
+
+export interface RosterSlotGroupProps {
+  positionSlot: string;
+  assignments: RosterAssignmentDto[];
+  playersById: Map<string, PlayerDto>;
+  teamId: string;
+  seasonId: string;
+  leagueId: string;
+  disabled: boolean;
+  onChanged: () => void;
+}
+
+const STATUS_OPTIONS: Array<{ value: "ir" | "suspended" | "released"; label: string }> = [
+  { value: "ir", label: "Move to IR" },
+  { value: "suspended", label: "Suspend" },
+  { value: "released", label: "Release" },
+];
+
+export default function RosterSlotGroup({
+  positionSlot,
+  assignments,
+  playersById,
+  teamId,
+  seasonId,
+  leagueId,
+  disabled,
+  onChanged,
+}: RosterSlotGroupProps) {
+  return (
+    <section
+      className="rounded-md border bg-background"
+      aria-label={`${positionSlot} roster`}
+    >
+      <header className="flex items-center justify-between border-b px-3 py-2">
+        <h4 className="font-mono text-sm font-semibold text-foreground">
+          {positionSlot}
+        </h4>
+        <span className="text-xs text-muted-foreground">
+          {assignments.length}
+        </span>
+      </header>
+      <ol className="divide-y">
+        {assignments.map((assignment) => (
+          <RosterRow
+            key={assignment.id}
+            assignment={assignment}
+            player={playersById.get(assignment.playerId) ?? null}
+            teamId={teamId}
+            seasonId={seasonId}
+            leagueId={leagueId}
+            disabled={disabled}
+            onChanged={onChanged}
+          />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function RosterRow({
+  assignment,
+  player,
+  teamId,
+  seasonId,
+  leagueId,
+  disabled,
+  onChanged,
+}: {
+  assignment: RosterAssignmentDto;
+  player: PlayerDto | null;
+  teamId: string;
+  seasonId: string;
+  leagueId: string;
+  disabled: boolean;
+  onChanged: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function runStatus(newStatus: "ir" | "suspended" | "released") {
+    startTransition(async () => {
+      try {
+        await updateRosterStatusAction({
+          assignmentId: assignment.id,
+          seasonId,
+          teamId,
+          leagueId,
+          fromStatus: assignment.status,
+          newStatus,
+        });
+        toast.success(`Moved to ${newStatus === "ir" ? "IR" : newStatus}`);
+        onChanged();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }
+
+  function runRemove() {
+    startTransition(async () => {
+      try {
+        await removePlayerFromRosterAction({
+          assignmentId: assignment.id,
+          seasonId,
+          teamId,
+          leagueId,
+          positionSlot: assignment.positionSlot,
+        });
+        toast.success("Removed from roster");
+        onChanged();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }
+
+  return (
+    <li className="flex items-center gap-3 px-3 py-2">
+      <span className="w-6 font-mono text-xs text-muted-foreground">
+        {assignment.depthRank}
+      </span>
+      <span className="flex-1 text-sm text-foreground">
+        {player?.name ?? <em>Unknown player</em>}
+      </span>
+      {player?.jerseyNumber != null ? (
+        <span className="font-mono text-xs text-muted-foreground">
+          #{player.jerseyNumber}
+        </span>
+      ) : null}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="rounded-md p-1 text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={disabled || pending}
+          aria-label={`Actions for ${player?.name ?? "player"}`}
+        >
+          <MoreVertical className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {STATUS_OPTIONS.map((opt) => (
+            <DropdownMenuItem
+              key={opt.value}
+              onSelect={() => runStatus(opt.value)}
+              disabled={pending}
+            >
+              {opt.label}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={runRemove}
+            disabled={pending}
+            className="text-red-600"
+          >
+            Remove from roster
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </li>
+  );
+}

--- a/apps/web/src/components/roster/RosterStatusList.tsx
+++ b/apps/web/src/components/roster/RosterStatusList.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import type {
+  PlayerDto,
+  RosterAssignmentDto,
+} from "@sports-management/shared-types";
+import { Button } from "@/components/ui/button";
+import { updateRosterStatusAction } from "@/app/dashboard/teams/[id]/roster/actions";
+
+export interface RosterStatusListProps {
+  assignments: RosterAssignmentDto[];
+  playersById: Map<string, PlayerDto>;
+  teamId: string;
+  seasonId: string;
+  leagueId: string;
+  disabled: boolean;
+  onChanged: () => void;
+}
+
+export default function RosterStatusList({
+  assignments,
+  playersById,
+  teamId,
+  seasonId,
+  leagueId,
+  disabled,
+  onChanged,
+}: RosterStatusListProps) {
+  if (assignments.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+        No players in this status.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y rounded-md border">
+      {assignments.map((assignment) => (
+        <StatusRow
+          key={assignment.id}
+          assignment={assignment}
+          player={playersById.get(assignment.playerId) ?? null}
+          teamId={teamId}
+          seasonId={seasonId}
+          leagueId={leagueId}
+          disabled={disabled}
+          onChanged={onChanged}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function StatusRow({
+  assignment,
+  player,
+  teamId,
+  seasonId,
+  leagueId,
+  disabled,
+  onChanged,
+}: {
+  assignment: RosterAssignmentDto;
+  player: PlayerDto | null;
+  teamId: string;
+  seasonId: string;
+  leagueId: string;
+  disabled: boolean;
+  onChanged: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function run(newStatus: "active" | "released") {
+    startTransition(async () => {
+      try {
+        await updateRosterStatusAction({
+          assignmentId: assignment.id,
+          seasonId,
+          teamId,
+          leagueId,
+          fromStatus: assignment.status,
+          newStatus,
+        });
+        toast.success(
+          newStatus === "active"
+            ? "Reactivated on roster"
+            : "Released from roster",
+        );
+        onChanged();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(mapStatusError(message));
+      }
+    });
+  }
+
+  return (
+    <li className="flex items-center gap-3 px-3 py-2">
+      <span className="font-mono text-xs uppercase text-muted-foreground">
+        {assignment.positionSlot}
+      </span>
+      <span className="flex-1 text-sm text-foreground">
+        {player?.name ?? <em>Unknown player</em>}
+      </span>
+      {player?.jerseyNumber != null ? (
+        <span className="font-mono text-xs text-muted-foreground">
+          #{player.jerseyNumber}
+        </span>
+      ) : null}
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => run("active")}
+          disabled={disabled || pending}
+        >
+          Reactivate
+        </Button>
+        {assignment.status !== "released" ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => run("released")}
+            disabled={pending}
+          >
+            Release
+          </Button>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function mapStatusError(message: string): string {
+  if (message.startsWith("roster_limit_exceeded"))
+    return "Roster is full. Move a player to IR or Released before reactivating another.";
+  if (message === "season_locked")
+    return "Season is locked. Ask an admin to unlock it.";
+  if (message === "invalid_status_transition")
+    return "That status change is not allowed.";
+  return message;
+}

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -43,3 +43,51 @@ export function trackSeasonLockToggle(props: {
     locked: props.locked,
   });
 }
+
+export function trackRosterAssign(props: {
+  seasonId: string;
+  teamId: string;
+  positionSlot: string;
+}): Promise<void> {
+  return safeTrack("roster_assign", {
+    seasonId: props.seasonId,
+    teamId: props.teamId,
+    positionSlot: props.positionSlot,
+  });
+}
+
+export function trackRosterRemove(props: {
+  seasonId: string;
+  teamId: string;
+  positionSlot: string;
+}): Promise<void> {
+  return safeTrack("roster_remove", {
+    seasonId: props.seasonId,
+    teamId: props.teamId,
+    positionSlot: props.positionSlot,
+  });
+}
+
+export function trackRosterStatusChange(props: {
+  seasonId: string;
+  teamId: string;
+  fromStatus: string;
+  toStatus: string;
+}): Promise<void> {
+  return safeTrack("roster_status_change", {
+    seasonId: props.seasonId,
+    teamId: props.teamId,
+    fromStatus: props.fromStatus,
+    toStatus: props.toStatus,
+  });
+}
+
+export function trackRosterLimitBlocked(props: {
+  seasonId: string;
+  teamId: string;
+}): Promise<void> {
+  return safeTrack("roster_limit_blocked", {
+    seasonId: props.seasonId,
+    teamId: props.teamId,
+  });
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -8,6 +8,8 @@ import type {
   ImportResult,
   LeagueDto,
   PlayerDto,
+  RosterAssignmentDto,
+  RosterAuditLogDto,
   SeasonDto,
   SyncConfig,
   SyncReport,
@@ -202,6 +204,49 @@ const refs = {
     { seasonId: string; locked: boolean },
     { seasonId: string; rosterLocked: boolean }
   >("sports:setRosterLocked"),
+  getRosterBySeasonTeam: queryRef<
+    { seasonId: string; teamId: string },
+    RosterAssignmentDto[]
+  >("sports:getRosterBySeasonTeam"),
+  getTeamRosterLimitStatus: queryRef<
+    { seasonId: string; teamId: string },
+    {
+      activeCount: number;
+      rosterLimit: number | null;
+      remaining: number | null;
+    }
+  >("sports:getTeamRosterLimitStatus"),
+  getRosterAssignmentHistory: queryRef<
+    {
+      teamId: string;
+      seasonId: string;
+      playerId: string | null;
+      limit: number | null;
+    },
+    RosterAuditLogDto[]
+  >("sports:getRosterAssignmentHistory"),
+  assignPlayerToRoster: mutationRef<
+    {
+      seasonId: string;
+      teamId: string;
+      playerId: string;
+      positionSlot: string;
+      actorUserId: string;
+    },
+    RosterAssignmentDto
+  >("sports:assignPlayerToRoster"),
+  removePlayerFromRoster: mutationRef<
+    { assignmentId: string; actorUserId: string },
+    null
+  >("sports:removePlayerFromRoster"),
+  updateRosterStatus: mutationRef<
+    {
+      assignmentId: string;
+      newStatus: string;
+      actorUserId: string;
+    },
+    RosterAssignmentDto
+  >("sports:updateRosterStatus"),
 };
 
 function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
@@ -609,4 +654,61 @@ export async function setRosterLocked(
   locked: boolean,
 ): Promise<{ seasonId: string; rosterLocked: boolean }> {
   return mutateConvex(refs.setRosterLocked, { seasonId, locked });
+}
+
+export async function getRosterBySeasonTeam(
+  seasonId: string,
+  teamId: string,
+): Promise<RosterAssignmentDto[]> {
+  return queryConvex(refs.getRosterBySeasonTeam, { seasonId, teamId });
+}
+
+export async function getTeamRosterLimitStatus(
+  seasonId: string,
+  teamId: string,
+): Promise<{
+  activeCount: number;
+  rosterLimit: number | null;
+  remaining: number | null;
+}> {
+  return queryConvex(refs.getTeamRosterLimitStatus, { seasonId, teamId });
+}
+
+export async function getRosterAssignmentHistory(input: {
+  teamId: string;
+  seasonId: string;
+  playerId?: string | null;
+  limit?: number | null;
+}): Promise<RosterAuditLogDto[]> {
+  return queryConvex(refs.getRosterAssignmentHistory, {
+    teamId: input.teamId,
+    seasonId: input.seasonId,
+    playerId: input.playerId ?? null,
+    limit: input.limit ?? null,
+  });
+}
+
+export async function assignPlayerToRoster(input: {
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  positionSlot: string;
+  actorUserId: string;
+}): Promise<RosterAssignmentDto> {
+  return mutateConvex(refs.assignPlayerToRoster, input);
+}
+
+export async function removePlayerFromRoster(input: {
+  assignmentId: string;
+  actorUserId: string;
+}): Promise<null> {
+  return mutateConvex(refs.removePlayerFromRoster, input);
+}
+
+export async function updateRosterStatus(input: {
+  assignmentId: string;
+  newStatus: string;
+  actorUserId: string;
+}): Promise<RosterAssignmentDto> {
+  return mutateConvex(refs.updateRosterStatus, input);
 }


### PR DESCRIPTION
## Summary

- Phase 1 roster surface at `/dashboard/teams/[id]/roster` behind `roster_snapshots_v1`
- Server component parallel-loads team/season/players/assignments/limit; `RosterBoard` client orchestrator groups active rows by `positionSlot`
- Non-active tab filter cycles through IR / suspended / released with per-row **Reactivate** / **Release**
- `AssignPlayerDialog` auto-fills slot from `player.position`, disables at limit or when season locked
- Three server actions (`assignPlayerToRosterAction`, `removePlayerFromRosterAction`, `updateRosterStatusAction`) wrap Convex mutations with flag guard + Clerk auth + org-role check
- Analytics events: `roster_assign`, `roster_remove`, `roster_status_change`, `roster_limit_blocked`

## Test plan

- [x] `pnpm --filter @sports-management/web type-check` — passes
- [x] `pnpm --filter @sports-management/web lint` — no new warnings
- [x] `pnpm --filter @sports-management/web test:unit` — 252 passed
- [ ] Preview-deploy manual QA once Vercel preview is up: assign/remove/status cycle + limit-enforced toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)