### PR TITLE
feat(web): roster audit log timeline (WSM-000018)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx
@@ -1,0 +1,93 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { rosterSnapshotsV1 } from "@/lib/flags";
+import {
+  getTeam,
+  getPlayersByTeam,
+  getSeasons,
+  getRosterAssignmentHistory,
+} from "@/lib/data-api";
+import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import RosterAuditTimeline from "@/components/roster/RosterAuditTimeline";
+
+export default async function RosterAuditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await rosterSnapshotsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: teamId } = await params;
+
+  const team = await getTeam(teamId, {
+    userId,
+    orgIds: [],
+    visibleLeagueIds: [],
+    subscribedLeagueIds: [],
+  }).catch(() => null);
+  if (!team) notFound();
+
+  const orgId = await getLeagueOrgId(team.leagueId);
+  if (!orgId) notFound();
+
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (!role) notFound();
+
+  const seasons = await getSeasons([team.leagueId]);
+  const activeSeason =
+    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  if (!activeSeason) {
+    return (
+      <div>
+        <Link
+          href={`/dashboard/teams/${teamId}/roster`}
+          className="mb-4 inline-block text-sm text-primary hover:underline"
+        >
+          &larr; Back to Roster
+        </Link>
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No season exists for this league.
+        </div>
+      </div>
+    );
+  }
+
+  const [players, entries] = await Promise.all([
+    getPlayersByTeam(teamId, {
+      userId,
+      orgIds: [orgId],
+      visibleLeagueIds: [team.leagueId],
+      subscribedLeagueIds: [],
+    }),
+    getRosterAssignmentHistory({
+      teamId,
+      seasonId: activeSeason.id,
+      limit: 200,
+    }),
+  ]);
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/teams/${teamId}/roster`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Roster
+      </Link>
+      <header className="mb-4">
+        <h2 className="text-2xl font-bold text-foreground">
+          {team.name} — Roster Audit Log
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Season: {activeSeason.name}
+        </p>
+      </header>
+      <RosterAuditTimeline entries={entries} players={players} />
+    </div>
+  );
+}

--- a/apps/web/src/components/roster/RosterAuditTimeline.tsx
+++ b/apps/web/src/components/roster/RosterAuditTimeline.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type {
+  PlayerDto,
+  RosterAuditAction,
+  RosterAuditLogDto,
+} from "@sports-management/shared-types";
+
+interface RosterAuditTimelineProps {
+  entries: RosterAuditLogDto[];
+  players: PlayerDto[];
+}
+
+const ACTION_FILTERS: Array<{
+  value: "all" | RosterAuditAction;
+  label: string;
+}> = [
+  { value: "all", label: "All" },
+  { value: "assign", label: "Assigned" },
+  { value: "remove", label: "Removed" },
+  { value: "status_change", label: "Status change" },
+  { value: "depth_reorder", label: "Reorder" },
+];
+
+const ACTION_COLORS: Record<RosterAuditAction, string> = {
+  assign: "bg-green-100 text-green-800 border-green-200",
+  remove: "bg-red-100 text-red-800 border-red-200",
+  status_change: "bg-amber-100 text-amber-800 border-amber-200",
+  depth_reorder: "bg-blue-100 text-blue-800 border-blue-200",
+};
+
+type AuditSnapshot = {
+  playerId?: string;
+  positionSlot?: string;
+  status?: string;
+  depthRank?: number;
+};
+
+function safeParse(json: string | null): AuditSnapshot | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as AuditSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+function extractPlayerId(entry: RosterAuditLogDto): string | null {
+  const before = safeParse(entry.beforeJson);
+  const after = safeParse(entry.afterJson);
+  return after?.playerId ?? before?.playerId ?? null;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export default function RosterAuditTimeline({
+  entries,
+  players,
+}: RosterAuditTimelineProps) {
+  const [actionFilter, setActionFilter] =
+    useState<"all" | RosterAuditAction>("all");
+  const [playerFilter, setPlayerFilter] = useState<string>("all");
+
+  const playersById = useMemo(() => {
+    const map = new Map<string, PlayerDto>();
+    for (const p of players) map.set(p.id, p);
+    return map;
+  }, [players]);
+
+  const playerOptions = useMemo(() => {
+    const ids = new Set<string>();
+    for (const entry of entries) {
+      const id = extractPlayerId(entry);
+      if (id) ids.add(id);
+    }
+    return Array.from(ids)
+      .map((id) => ({
+        id,
+        name: playersById.get(id)?.name ?? "Unknown player",
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [entries, playersById]);
+
+  const filtered = useMemo(() => {
+    return entries.filter((entry) => {
+      if (actionFilter !== "all" && entry.action !== actionFilter) return false;
+      if (playerFilter !== "all") {
+        const playerId = extractPlayerId(entry);
+        if (playerId !== playerFilter) return false;
+      }
+      return true;
+    });
+  }, [entries, actionFilter, playerFilter]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+        No roster activity yet for this season.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap rounded-md border p-0.5">
+          {ACTION_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setActionFilter(f.value)}
+              className={`rounded px-3 py-1 text-xs font-medium transition ${
+                actionFilter === f.value
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        {playerOptions.length > 0 ? (
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Player:</span>
+            <select
+              value={playerFilter}
+              onChange={(e) => setPlayerFilter(e.target.value)}
+              className="h-8 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="all">All players</option>
+              {playerOptions.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+          No entries match the current filters.
+        </div>
+      ) : (
+        <ol className="divide-y rounded-md border">
+          {filtered.map((entry) => (
+            <AuditRow
+              key={entry.id}
+              entry={entry}
+              playersById={playersById}
+            />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function AuditRow({
+  entry,
+  playersById,
+}: {
+  entry: RosterAuditLogDto;
+  playersById: Map<string, PlayerDto>;
+}) {
+  const before = safeParse(entry.beforeJson);
+  const after = safeParse(entry.afterJson);
+  const playerId = after?.playerId ?? before?.playerId ?? null;
+  const playerName = playerId
+    ? (playersById.get(playerId)?.name ?? "Unknown player")
+    : null;
+
+  const delta = describeDelta(entry.action, before, after);
+
+  return (
+    <li className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-3 py-2 text-sm">
+      <span
+        className={`rounded-md border px-2 py-0.5 text-xs font-semibold capitalize ${ACTION_COLORS[entry.action]}`}
+      >
+        {entry.action.replace("_", " ")}
+      </span>
+      <div className="min-w-0">
+        <p className="truncate text-foreground">
+          {playerName ? <strong>{playerName}</strong> : <em>—</em>}
+          {delta ? <span className="text-muted-foreground"> · {delta}</span> : null}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          by {entry.actorUserId}
+        </p>
+      </div>
+      <time
+        dateTime={entry.createdAt}
+        className="font-mono text-xs text-muted-foreground"
+      >
+        {formatTimestamp(entry.createdAt)}
+      </time>
+    </li>
+  );
+}
+
+function describeDelta(
+  action: RosterAuditAction,
+  before: AuditSnapshot | null,
+  after: AuditSnapshot | null,
+): string | null {
+  if (action === "assign" && after) {
+    return `${after.positionSlot ?? "—"} #${after.depthRank ?? "?"}`;
+  }
+  if (action === "remove" && before) {
+    return `${before.positionSlot ?? "—"} #${before.depthRank ?? "?"}`;
+  }
+  if (action === "status_change" && before && after) {
+    const from = before.status ?? "?";
+    const to = after.status ?? "?";
+    return `${from} → ${to}`;
+  }
+  if (action === "depth_reorder" && after) {
+    return after.positionSlot ?? null;
+  }
+  return null;
+}

--- a/apps/web/src/components/roster/RosterBoard.tsx
+++ b/apps/web/src/components/roster/RosterBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type {
   PlayerDto,
@@ -107,6 +108,12 @@ export default function RosterBoard({
             activeCount={limitStatus.activeCount}
             rosterLimit={limitStatus.rosterLimit}
           />
+          <Link
+            href={`/dashboard/teams/${team.id}/roster/audit`}
+            className="text-sm text-primary hover:underline"
+          >
+            Audit log
+          </Link>
           <AssignPlayerDialog
             teamId={team.id}
             seasonId={season.id}


### PR DESCRIPTION
## Summary

- New page at `/dashboard/teams/[id]/roster/audit`, flag-gated behind `roster_snapshots_v1`
- Timeline renders `rosterAuditLog` entries for the active season with player name + human-readable delta per action
- Action chip filter (**assign / remove / status_change / depth_reorder**) plus per-player dropdown
- RosterBoard header links to the new audit log page

## Test plan

- [x] `pnpm --filter @sports-management/web type-check` — passes
- [x] `pnpm --filter @sports-management/web test:unit` — 252 passed
- [ ] Preview-deploy manual QA: trigger assign → IR → reactivate → remove; confirm timeline entries + filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)