### PR TITLE
docs(sprints): Sprint 2 Phase 1 close-out (WSM-000020)

### DIFF
--- a/docs/roster-management.md
+++ b/docs/roster-management.md
@@ -15,6 +15,26 @@ We are adding **roster management** on top of the existing League / Division / T
 
 ## 1. Overview
 
+### Phase 1 — LIVE (2026-04-22)
+
+Phase 1 (season rosters + depth-chart migration + audit log) is merged to `main` behind the `roster_snapshots_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 2 across eleven PRs, one per story:
+
+| Story | PR | What shipped |
+|-------|----|--------------|
+| WSM-000010 | #115 | `rosterAssignments` + `rosterAuditLog` tables + DTO extensions |
+| WSM-000011 | #116 | `roster_snapshots_v1` feature flag |
+| WSM-000012 | #117 | Position-group util + `players.positionGroup` backfill |
+| WSM-000013 | #118 | `writeAuditLog` transactional helper |
+| WSM-000014 | #119 | `assignPlayerToRoster` / `removePlayerFromRoster` / `updateRosterStatus` mutations with audit log |
+| WSM-000015 | #120 | `getRosterBySeasonTeam`, `getTeamRosterLimitStatus`, `getRosterAssignmentHistory` queries |
+| WSM-000016 | #121 | `depthChartEntries → rosterAssignments` migration (1-indexed `depthRank`) |
+| WSM-000017 | #122 | `/dashboard/teams/[id]/roster` UI: active + IR/suspended/released + limit badge + assign dialog |
+| WSM-000018 | #123 | `/dashboard/teams/[id]/roster/audit` timeline with action + player filters |
+| WSM-000019 | #124 | Playwright roster + audit smoke + fixme scaffolding |
+| WSM-000020 | this PR | Phase 1 close-out docs + §11.1 decision rows |
+
+**Flag flip pending:** prod flip to `on` is gated on a preview-deploy manual QA pass and on the depth-chart migration (WSM-000016) being invoked against production data.
+
 ### Phase 0 — LIVE (2026-04-22)
 
 Phase 0 (per-team, per-season depth chart + season-level edit lock) is merged to `main` behind the `depth_chart_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 1 across eight PRs, one per story:
@@ -509,6 +529,13 @@ Append a row any time a §2.1 working assumption or §11 default is overridden. 
 | 2026-04-22 | Forward-compat invariant (Phase 0 → Phase 1) | `depthChartEntries.sortOrder` is dense, zero-indexed within `(teamId, seasonId, positionSlot)`. Phase 1's WSM-000019 can rename to `rosterAssignments.depthRank` as a pure column rename — no data reshape. | Andrew Solomon |
 | 2026-04-22 | E2E scope narrowed | `coach-depth-chart.spec.ts` ships with one active smoke (flag-gated route reachable) and three `test.fixme` scenarios. A Convex seeding harness + a second Clerk test user are prerequisites and are not in Phase 0 scope. | Andrew Solomon |
 | 2026-04-22 | Analytics surface | Three events — `flag_exposure`, `depth_chart_reorder`, `season_lock_toggle` — fired via `@vercel/analytics/server` through `apps/web/src/lib/analytics.ts`. No PII. Errors swallowed so telemetry never blocks user flows. | Andrew Solomon |
+| 2026-04-22 | Phase 1 flag name (WSM-000011) | `roster_snapshots_v1` controls the full Phase 1 surface (mutations, queries, page, audit log). Separate from `depth_chart_v1` so Phase 0 can stay live in production while Phase 1 is still under flag. | Andrew Solomon |
+| 2026-04-22 | `depthRank` sentinel (WSM-000014) | Schema uses `v.number()`, not nullable. Non-active rows (`ir`, `suspended`, `released`) carry `depthRank: 0` as a sentinel meaning "not on the active chart." Active rows are 1-indexed (`depthRank >= 1`). Chose this over a nullable column so the Convex index on `(seasonId, teamId, positionSlot, depthRank)` stays totally-ordered. | Andrew Solomon |
+| 2026-04-22 | Migration mapping (WSM-000016) | `depthChartEntries.sortOrder + 1 → rosterAssignments.depthRank`. All migrated rows land as `status: "active"`. The migration is idempotent — re-running skips `(teamId, seasonId, positionSlot, playerId)` that already exist. | Andrew Solomon |
+| 2026-04-22 | Audit log for depth reorders (WSM-000014) | Bulk `reorderDepthChart` in Phase 0 emits one `depth_reorder` audit row per position-slot reorder. Individual row insert/delete during reorder do **not** emit separate `assign`/`remove` rows — that would flood the timeline. Phase 1's `assignPlayerToRoster` / `removePlayerFromRoster` are the only paths that emit `assign` / `remove`. | Andrew Solomon |
+| 2026-04-22 | Roster mutation auth (WSM-000014) | Convex mutations take `actorUserId: v.string()` as an explicit argument. Auth (Clerk `auth()` + `getUserRoleInOrg`) happens at the Next.js server-action layer, not inside Convex. This keeps the mutations reusable from scripts/migrations (e.g., WSM-000016) without a Clerk context. | Andrew Solomon |
+| 2026-04-22 | Phase 1 analytics surface (WSM-000017) | Four new events — `roster_assign`, `roster_remove`, `roster_status_change`, `roster_limit_blocked` — emitted from server actions via `@vercel/analytics/server`. `roster_limit_blocked` carries only `{seasonId, teamId}` because the thrown mutation error (`roster_limit_exceeded`) doesn't include the limit value. | Andrew Solomon |
+| 2026-04-22 | Audit log filtering via JSON substring (WSM-000015) | `getRosterAssignmentHistory` filters by `playerId` using a substring match (`"playerId":"${id}"`) against `beforeJson` / `afterJson`. Acceptable for Phase 1 since audit-log volume per team is bounded (dozens per season), and it avoids a dedicated `playerId` column on the audit table. If volume grows, revisit with a denormalized column + index. | Andrew Solomon |
 
 ---
 

--- a/docs/sprints/SPRINT_2_CLOSEOUT.md
+++ b/docs/sprints/SPRINT_2_CLOSEOUT.md
@@ -1,0 +1,194 @@
+# Sprint 2 — Phase 1 Close-Out
+
+> **Sprint:** 2026-04-22 (single-day burst)
+> **Companion docs:** [SPRINT_2_VERIFICATION.md](./SPRINT_2_VERIFICATION.md) — criteria matrix + flag-flip checklist
+> **Stories shipped:** WSM-000010..WSM-000020 (11 PRs)
+> **Feature flag:** `roster_snapshots_v1` (production default: off)
+
+Phase 1 delivers per-team season rosters with active + IR + suspended + released status slots, roster-limit enforcement, a transactional audit log, a migration from Phase 0 `depthChartEntries`, the roster + audit UI, and Phase 1 E2E smoke. All eleven stories landed as separate PRs — Sprint 0's semantic-release automation cut a minor version per `feat:` merge.
+
+Per-story implementation notes below. Paired with the verification matrix; this document captures the "what actually landed and why" for each issue.
+
+---
+
+## WSM-000010 — Schema: `rosterAssignments` + `rosterAuditLog`
+
+**PR:** #115
+
+### Files touched
+- `apps/web/convex/schema.ts` — new `rosterAssignments` + `rosterAuditLog` tables
+- `packages/shared-types/src/index.ts` — `RosterAssignmentDto`, `RosterAuditLogDto`, `RosterAuditAction`
+
+### Key decisions
+- `depthRank: v.number()` (not nullable). Non-active rows carry `depthRank: 0` as a sentinel meaning "not on the active chart." Keeps the composite index totally ordered.
+- Audit log stores `beforeJson` / `afterJson` as stringified DTO snapshots — no denormalized `playerId` column. Substring filtering in WSM-000015 is the tradeoff; revisit if audit volume grows.
+- `leagueId` denormalized onto `rosterAssignments` so authorization checks don't need a second `teams` lookup.
+
+---
+
+## WSM-000011 — Flag: `roster_snapshots_v1`
+
+**PR:** #116
+
+### Files touched
+- `apps/web/src/lib/flags.ts` — `rosterSnapshotsV1` declared alongside `depthChartV1`
+- `apps/web/src/lib/__tests__/flags.test.ts` — added on/off cases for the new guard
+
+### Key decisions
+- Kept Phase 1 behind a separate flag from Phase 0 so `depth_chart_v1` can stay live in production while `roster_snapshots_v1` is still under flag.
+- Same `pageGuard` / `apiGuard` pattern as Phase 0. No new helper shape.
+
+---
+
+## WSM-000012 — `players.positionGroup` + backfill
+
+**PR:** #117
+
+### Files touched
+- `apps/web/convex/schema.ts` — add `players.positionGroup: v.optional(v.string())`
+- `apps/web/convex/lib/positionGroup.ts` — canonical slot → group lookup (e.g. `LT` → `OL`)
+- `apps/web/convex/migrations/20260428_playersPositionGroup.ts` — one-shot backfill
+- `apps/web/convex/sports.ts` — project `positionGroup` onto `PlayerDto`
+- `packages/shared-types/src/index.ts` — extend `PlayerDto`
+
+### Key decisions
+- Optional column — nullable for unknown positions rather than forcing a catch-all group.
+- Backfill is idempotent — skips rows that already carry `positionGroup`.
+
+---
+
+## WSM-000013 — `writeAuditLog` helper
+
+**PR:** #118
+
+### Files touched
+- `apps/web/convex/lib/auditLog.ts` — `writeAuditLog(ctx, {...})` helper
+- `apps/web/convex/__tests__/auditLog.test.ts` — unit suite
+
+### Key decisions
+- Helper serializes `before` / `after` inline with `JSON.stringify`. Accepts `null` for either side so assign (`before=null`) and remove (`after=null`) are the same call shape.
+- No separate batch API — every mutation that writes to `rosterAssignments` calls `writeAuditLog` exactly once in the same transaction.
+
+---
+
+## WSM-000014 — Roster mutations + transactional audit log
+
+**PR:** #119
+
+### Files touched
+- `apps/web/convex/sports.ts` — `assignPlayerToRoster`, `removePlayerFromRoster`, `updateRosterStatus`
+- `apps/web/convex/__tests__/rosterAssignments.test.ts` — convex-test scenarios for limit, lock, status cycles, duplicate guards, audit log count
+
+### Key decisions
+- Mutations take `actorUserId: v.string()` as an explicit argument. Auth lives at the Next.js server-action layer — keeps mutations callable from scripts/migrations without a Clerk context.
+- `updateRosterStatus` re-checks `team.rosterLimit` on `* → active` transitions so reactivating from IR can be rejected with `roster_limit_exceeded`.
+- On `active → non-active`, `depthRank` is reset to 0 and the slot's remaining active rows are compacted.
+- `removePlayerFromRoster` rejects non-active rows (`cannot_remove_non_active`) so the "release" flow is explicit rather than silent.
+
+---
+
+## WSM-000015 — Roster query API
+
+**PR:** #120
+
+### Files touched
+- `apps/web/convex/sports.ts` — `getRosterBySeasonTeam`, `getTeamRosterLimitStatus`, `getRosterAssignmentHistory`, `toRosterAuditLogDto`, `rosterAuditLogDtoValidator`
+- `apps/web/convex/__tests__/rosterQueries.test.ts` — 12 scenarios (sort order, status transitions, cross-season isolation, limit passthrough, audit filtering)
+
+### Key decisions
+- Sort for `getRosterBySeasonTeam`: positionSlot (locale) → active-before-non-active → depthRank ascending → assignedAt. Makes the roster UI a simple `forEach` grouping.
+- `getRosterAssignmentHistory.playerId` uses a JSON substring match (`"playerId":"${id}"`) against `beforeJson` / `afterJson`. Tradeoff accepted — see decision row in §11.1.
+- `getTeamRosterLimitStatus.remaining` is `null` when `rosterLimit` is `null`, not `Infinity` — keeps the DTO validator simple.
+
+---
+
+## WSM-000016 — `depthChartEntries → rosterAssignments` migration
+
+**PR:** #121
+
+### Files touched
+- `apps/web/convex/migrations/20260428_depthChartToRoster.ts` — `migrateDepthChartToRoster` mutation
+- `apps/web/convex/__tests__/depthChartToRoster.test.ts` — three scenarios
+
+### Key decisions
+- Idempotent via index lookup: for every `depthChartEntries` row, check `rosterAssignments` on `(seasonId, teamId, positionSlot)` + `playerId` filter; skip if present.
+- `depthRank = sortOrder + 1` (0-indexed → 1-indexed). All migrated rows land as `status: "active"`.
+- Writes one `assign` audit row per copy. Skipped rows do not emit audit entries.
+- Uses the typed `mutation` helper (not `mutationGeneric`) so inserts into `rosterAssignments` typecheck against the schema.
+- Tests address the module via `anyApi.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster` because `_generated/api.d.ts` only typechecks `sports.ts`.
+
+---
+
+## WSM-000017 — Roster UI
+
+**PR:** #122
+
+### Files touched
+- `apps/web/src/app/dashboard/teams/[id]/roster/page.tsx` — server component
+- `apps/web/src/app/dashboard/teams/[id]/roster/actions.ts` — three server actions
+- `apps/web/src/components/roster/RosterBoard.tsx` — client orchestrator
+- `apps/web/src/components/roster/RosterSlotGroup.tsx` — active per-slot group with dropdown actions
+- `apps/web/src/components/roster/RosterStatusList.tsx` — non-active tab content
+- `apps/web/src/components/roster/AssignPlayerDialog.tsx` — shadcn Dialog + player select + slot input
+- `apps/web/src/components/roster/RosterLimitBadge.tsx` — shadcn Badge
+- `apps/web/src/lib/analytics.ts` — four new track functions
+- `apps/web/src/lib/data-api.ts` — six roster refs + wrappers
+
+### Key decisions
+- No shadcn Tabs primitive yet — non-active statuses surface via a chip filter that cycles IR / suspended / released.
+- `AssignPlayerDialog` pre-fills `positionSlot` from `player.position` but allows manual override (e.g., `QB` player listed in `QB2` slot).
+- `atLimit` disables the **Add to Roster** button before the user even opens the dialog; the limit is enforced again in `assignPlayerToRoster` mutation for server-side integrity.
+- Inlined a `<div>`-based dialog footer rather than adding a `DialogFooter` primitive — keeps the PR focused on roster UI.
+
+---
+
+## WSM-000018 — Audit log UI
+
+**PR:** #123
+
+### Files touched
+- `apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx` — server component
+- `apps/web/src/components/roster/RosterAuditTimeline.tsx` — client timeline with filters
+- `apps/web/src/components/roster/RosterBoard.tsx` — adds "Audit log" link in header
+
+### Key decisions
+- Parses `beforeJson` / `afterJson` with a `safeParse` helper so a single malformed row doesn't break the whole timeline.
+- Delta rendering is action-specific: `assign` → `QB #1`; `remove` → `QB #1`; `status_change` → `active → ir`; `depth_reorder` → `QB` (position slot only, because reorder events don't carry a single player).
+- Limits to 200 entries client-side (server-side `limit` is also 200). Pagination deferred — see follow-up in verification doc.
+
+---
+
+## WSM-000019 — Phase 1 E2E scaffolding
+
+**PR:** #124
+
+### Files touched
+- `apps/web/e2e/tests/coach-roster.spec.ts`
+
+### Key decisions
+- Two live scenarios: `/roster` and `/roster/audit` both reachable when the flag is on (dev default).
+- Seven `test.fixme` blocks cover assign / limit / IR cycle / reactivate-respecting-limit / audit trail / cross-team 403. Same convention as `coach-depth-chart.spec.ts` — wait for a Convex seed harness + second Clerk test user.
+
+---
+
+## WSM-000020 — Phase 1 ops + docs close-out
+
+**PR:** this PR
+
+### Files touched
+- `docs/roster-management.md` — new §1 "Phase 1 — LIVE" table + 7 decision rows appended to §11.1
+- `docs/sprints/SPRINT_2_VERIFICATION.md` — criteria matrix + flag-flip checklist
+- `docs/sprints/SPRINT_2_CLOSEOUT.md` — this file
+
+### Deferred to production-flip checklist
+- Preview-deploy manual QA (six scenarios)
+- Vercel Analytics verification of the four new events
+- `pnpm convex run migrations:migrateDepthChartToRoster` against production data
+
+---
+
+## Running Vitest + type-check baseline at sprint close
+
+- `pnpm --filter @sports-management/web type-check` — clean
+- `pnpm --filter @sports-management/web lint` — one pre-existing warning, no new
+- `pnpm --filter @sports-management/web test:unit` — **252 passed** (up from 191 at Sprint 1 close)

--- a/docs/sprints/SPRINT_2_VERIFICATION.md
+++ b/docs/sprints/SPRINT_2_VERIFICATION.md
@@ -1,0 +1,75 @@
+# Sprint 2 — Phase 1 Roster Management — Verification Report
+
+> **Status:** Code merged to `main` behind `roster_snapshots_v1` flag. Awaiting production flag flip (preview-deploy manual QA + prod migration run).
+> **Closed (code):** 2026-04-22
+> **Source plan:** Linear project "Sprtsmng Roster Management" (WSM-000010..WSM-000020)
+> **Design spec:** [`docs/roster-management.md`](../roster-management.md) §1 (Phase 1 — LIVE), §5.1, §5.2, §5.5, §11.1
+
+Phase 1 delivers per-team season rosters (active + IR + suspended + released) with roster-limit enforcement, a transactional audit log, and a clean migration from Phase 0's `depthChartEntries` to `rosterAssignments`. Eleven stories shipped as eleven PRs.
+
+## Criteria Matrix
+
+| # | Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| 1 | `rosterAssignments` + `rosterAuditLog` tables with indexes | `apps/web/convex/schema.ts` — `by_seasonId_teamId`, `by_seasonId_teamId_position`, `by_team_season` indexes | ✓ |
+| 2 | `roster_snapshots_v1` flag declared; page + API guards share signature with Phase 0 | `apps/web/src/lib/flags.ts` — `rosterSnapshotsV1` alongside `depthChartV1` | ✓ |
+| 3 | `players.positionGroup` backfilled from `position` | `apps/web/convex/migrations/20260428_playersPositionGroup.ts` + convex-test suite | ✓ |
+| 4 | `writeAuditLog` helper serializes `before` / `after` into `rosterAuditLog` inside the same transaction | `apps/web/convex/lib/auditLog.ts` + unit suite | ✓ |
+| 5 | `assignPlayerToRoster` respects `team.rosterLimit`, rejects locked seasons, blocks same-team duplicates | `apps/web/convex/__tests__/rosterAssignments.test.ts` | ✓ |
+| 6 | `removePlayerFromRoster` compacts `depthRank` after delete | same suite — "compacts depthRank after a remove" | ✓ |
+| 7 | `updateRosterStatus` re-applies the limit on `active → ir → active` cycles | same suite — "roster_limit_exceeded on reactivate" | ✓ |
+| 8 | Each assign / remove / status_change writes exactly one `rosterAuditLog` row | same suite — audit-row count assertions | ✓ |
+| 9 | `getRosterBySeasonTeam` sorts by positionSlot → active-first → depthRank | `apps/web/convex/__tests__/rosterQueries.test.ts` — "sorts by position, then active before non-active, then depthRank" | ✓ |
+| 10 | `getTeamRosterLimitStatus` returns `{activeCount, rosterLimit, remaining}` with `null` rosterLimit passthrough | same suite | ✓ |
+| 11 | `getRosterAssignmentHistory` supports optional `playerId` + `limit` | same suite — "filters by playerId", "honors limit" | ✓ |
+| 12 | `depthChartEntries → rosterAssignments` migration is idempotent and 1-indexes `depthRank` | `apps/web/convex/__tests__/depthChartToRoster.test.ts` — "second run skips already-migrated rows", "sortOrder N → depthRank N+1" | ✓ |
+| 13 | Migration writes one `assign` audit row per copied entry | same suite — "one audit row per migrated entry" | ✓ |
+| 14 | `/dashboard/teams/[id]/roster` renders active roster with per-slot grouping + limit badge + assign dialog | `apps/web/src/app/dashboard/teams/[id]/roster/page.tsx`, `apps/web/src/components/roster/RosterBoard.tsx` | ✓ |
+| 15 | Non-active rows surface in filter tab (IR / suspended / released) with reactivate + release actions | `apps/web/src/components/roster/RosterStatusList.tsx` | ✓ |
+| 16 | `/dashboard/teams/[id]/roster/audit` renders the timeline with action + player filters | `apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx`, `apps/web/src/components/roster/RosterAuditTimeline.tsx` | ✓ |
+| 17 | Server actions enforce flag + Clerk org membership | `apps/web/src/app/dashboard/teams/[id]/roster/actions.ts` | ✓ |
+| 18 | Four analytics events emitted: `roster_assign`, `roster_remove`, `roster_status_change`, `roster_limit_blocked` | `apps/web/src/lib/analytics.ts` | ✓ |
+| 19 | E2E smoke verifies flag-gated `/roster` and `/roster/audit` routes reachable | `apps/web/e2e/tests/coach-roster.spec.ts` — two smoke tests pass | ✓ |
+| 20 | Seed-dependent E2E scenarios parked as `test.fixme` with TODO notes | same spec — seven `test.fixme` blocks | ✓ |
+| 21 | All pre-existing Vitest suites still pass (252/252) | `pnpm --filter @sports-management/web test:unit` | ✓ |
+| 22 | Type-check + lint clean after every story | `pnpm --filter @sports-management/web type-check`, `pnpm --filter @sports-management/web lint` | ✓ |
+| 23 | Production flag flip completed | Vercel Flags UI — `roster_snapshots_v1` = `on` in production for ≥48h, analytics monitored | ☐ pending preview QA + prod migration run |
+| 24 | `depthChartEntries → rosterAssignments` migration invoked against production | `pnpm convex run migrations:migrateDepthChartToRoster` run + output captured | ☐ pending |
+
+## PR / Release Evidence
+
+| Story | Branch | PR | Expected bump |
+| --- | --- | --- | --- |
+| WSM-000010 | `feat/WSM-000010-roster-schema` | #115 | minor |
+| WSM-000011 | `feat/WSM-000011-roster-snapshots-flag` | #116 | minor |
+| WSM-000012 | `feat/WSM-000012-position-group-util` | #117 | minor |
+| WSM-000013 | `feat/WSM-000013-audit-log-helper` | #118 | minor |
+| WSM-000014 | `feat/WSM-000014-roster-mutations` | #119 | minor |
+| WSM-000015 | `feat/WSM-000015-roster-queries` | #120 | minor |
+| WSM-000016 | `feat/WSM-000016-depth-chart-migration` | #121 | minor |
+| WSM-000017 | `feat/WSM-000017-roster-ui` | #122 | minor |
+| WSM-000018 | `feat/WSM-000018-audit-log-ui` | #123 | minor |
+| WSM-000019 | `feat/WSM-000019-phase-1-e2e` | #124 | no bump (`test:`) |
+| WSM-000020 | `feat/WSM-000020-phase-1-closeout` | this PR | no bump (`docs:`) |
+
+## Deferred / Follow-ups (not Phase 1 scope)
+
+1. **Full E2E coverage** — seven roster scenarios (assign / limit-blocked / IR cycle / reactivate respecting limit / audit trail / cross-team 403) are parked behind a Convex seeding harness + second Clerk test user.
+2. **Vercel Flags provider adapter** — both `depth_chart_v1` and `roster_snapshots_v1` still use static `decide()`. Adapter lands once `FLAGS` env var is provisioned in production.
+3. **Salesforce mirror** — `RosterAssignment__c` / `RosterAuditLog__c` remain Phase 2 per `docs/roster-management.md` §4.3.
+4. **Audit-log pagination** — current UI fetches last 200 entries. If a team exceeds that in a single season, add cursor-based pagination.
+5. **Player-filtered history perf** — substring match against `beforeJson` / `afterJson` is acceptable at Phase 1 scale; revisit with a denormalized `playerId` column if audit volume grows past a few thousand rows per team.
+
+## Flag-flip checklist
+
+Do **not** flip `roster_snapshots_v1` to `on` in production until all of the following are checked:
+
+- [ ] Preview-deploy manual QA: sign in as coach, open `/roster`, assign an eligible player → active count increments, row appears in the correct positionSlot
+- [ ] Preview-deploy manual QA: move that player to IR → row disappears from active, appears under the **IR** tab with `depthRank=0`
+- [ ] Preview-deploy manual QA: reactivate from IR while roster is at the limit → `roster_limit_exceeded` toast; release a different active player; reactivate succeeds
+- [ ] Preview-deploy manual QA: visit `/roster/audit` → four rows visible (assign + status_change → ir + status_change → active + remove); filter by player narrows to just that player's rows
+- [ ] Preview-deploy manual QA: season locked by admin → Add to Roster button disabled + banner visible + toast on any mutation attempt
+- [ ] Vercel Analytics Explorer shows `roster_assign`, `roster_remove`, `roster_status_change`, `roster_limit_blocked` events from the preview deploy
+- [ ] Convex migrations dashboard confirms `migrateDepthChartToRoster` has run against production data and reports `{scanned, copied, skipped}` summary
+
+After flip, keep the flag on for ≥48h with analytics monitored before declaring Phase 1 shipped.


### PR DESCRIPTION
## Summary

- `docs/roster-management.md` §1: adds "Phase 1 — LIVE" table for WSM-000010..WSM-000020 (eleven PRs)
- `docs/roster-management.md` §11.1: appends seven decision rows (flag split, depthRank sentinel, migration mapping, audit scope for reorders, auth seam, Phase 1 analytics events, audit-log playerId filtering tradeoff)
- New `docs/sprints/SPRINT_2_VERIFICATION.md` — 24-row criteria matrix, PR/release evidence table, deferred follow-ups, flag-flip checklist
- New `docs/sprints/SPRINT_2_CLOSEOUT.md` — per-story implementation notes covering every story in Sprint 2

## Test plan

- [x] `pnpm --filter @sports-management/web type-check` — passes
- [x] `pnpm --filter @sports-management/web test:unit` — 252 passed
- [ ] Preview-deploy manual QA + production flip of `roster_snapshots_v1` tracked on the verification doc checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)