### PR TITLE
feat(web): add convex e2e seed harness for roster fixtures (WSM-000021)

### DIFF
--- a/apps/web/convex/__tests__/e2eSeed.test.ts
+++ b/apps/web/convex/__tests__/e2eSeed.test.ts
@@ -1,0 +1,224 @@
+/// <reference types="vite/client" />
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { anyApi } from "convex/server";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const FIXTURE_KEY = "wsm-e2e-test";
+
+interface FixtureResult {
+  fixtureKey: string;
+  leagueId: Id<"leagues">;
+  seasonId: Id<"seasons">;
+  teamId: Id<"teams">;
+  playerIds: Id<"players">[];
+  activeAssignmentIds: Id<"rosterAssignments">[];
+}
+
+function asFixture(r: unknown): FixtureResult {
+  return r as FixtureResult;
+}
+
+describe("e2eSeed", () => {
+  const originalEnv = process.env.CONVEX_ENABLE_E2E_SEED;
+
+  beforeEach(() => {
+    process.env.CONVEX_ENABLE_E2E_SEED = "1";
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CONVEX_ENABLE_E2E_SEED;
+    } else {
+      process.env.CONVEX_ENABLE_E2E_SEED = originalEnv;
+    }
+  });
+
+  it("refuses to run when the env guard is off", async () => {
+    process.env.CONVEX_ENABLE_E2E_SEED = "0";
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+      }),
+    ).rejects.toThrow("e2e_seed_disabled");
+  });
+
+  it("creates league + season + team + bench players with no active assignments by default", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: "org_test_123",
+        rosterLimit: 53,
+      }),
+    );
+
+    expect(result.fixtureKey).toBe(FIXTURE_KEY);
+    expect(result.playerIds).toHaveLength(2);
+    expect(result.activeAssignmentIds).toHaveLength(0);
+
+    await t.run(async (ctx) => {
+      const league = await ctx.db.get(result.leagueId);
+      expect(league?.name).toBe(`E2E:${FIXTURE_KEY}`);
+      expect(league?.orgId).toBe("org_test_123");
+      const season = await ctx.db.get(result.seasonId);
+      expect(season?.rosterLocked).toBe(false);
+      const team = await ctx.db.get(result.teamId);
+      expect(team?.rosterLimit).toBe(53);
+    });
+  });
+
+  it("pre-seeds active roster assignments when requested", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 5,
+        seedActivePlayers: 3,
+        extraBenchPlayers: 2,
+        positionSlot: "QB",
+      }),
+    );
+
+    expect(result.playerIds).toHaveLength(5);
+    expect(result.activeAssignmentIds).toHaveLength(3);
+
+    await t.run(async (ctx) => {
+      const assignments = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", result.seasonId).eq("teamId", result.teamId),
+        )
+        .collect();
+      expect(assignments).toHaveLength(3);
+      const ranks = assignments
+        .map((row) => row.depthRank)
+        .sort((a, b) => a - b);
+      expect(ranks).toEqual([1, 2, 3]);
+      expect(assignments.every((row) => row.status === "active")).toBe(true);
+    });
+  });
+
+  it("is idempotent: re-running replaces the prior fixture", async () => {
+    const t = convexTest(schema, modules);
+    const first = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+        extraBenchPlayers: 4,
+      }),
+    );
+    const second = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 40,
+        extraBenchPlayers: 1,
+      }),
+    );
+
+    expect(second.leagueId).not.toBe(first.leagueId);
+    expect(second.playerIds).toHaveLength(1);
+
+    await t.run(async (ctx) => {
+      const leagues = await ctx.db
+        .query("leagues")
+        .withIndex("by_name", (q) =>
+          q.eq("name", `E2E:${FIXTURE_KEY}`),
+        )
+        .collect();
+      expect(leagues).toHaveLength(1);
+      expect(leagues[0]._id).toBe(second.leagueId);
+
+      const team = await ctx.db.get(second.teamId);
+      expect(team?.rosterLimit).toBe(40);
+    });
+  });
+
+  it("respects rosterLocked=true when requested", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+        rosterLocked: true,
+      }),
+    );
+
+    await t.run(async (ctx) => {
+      const season = await ctx.db.get(result.seasonId);
+      expect(season?.rosterLocked).toBe(true);
+    });
+  });
+
+  it("resetRosterFixture deletes all rows created under the fixtureKey", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+        seedActivePlayers: 2,
+        extraBenchPlayers: 2,
+      }),
+    );
+
+    const { deleted } = (await t.mutation(
+      anyApi.e2eSeed.resetRosterFixture,
+      { fixtureKey: FIXTURE_KEY },
+    )) as { deleted: number };
+    expect(deleted).toBeGreaterThan(0);
+
+    await t.run(async (ctx) => {
+      const leagues = await ctx.db
+        .query("leagues")
+        .withIndex("by_name", (q) =>
+          q.eq("name", `E2E:${FIXTURE_KEY}`),
+        )
+        .collect();
+      expect(leagues).toHaveLength(0);
+
+      const strayPlayer = await ctx.db.get(result.playerIds[0]);
+      expect(strayPlayer).toBeNull();
+      const strayAssignment = await ctx.db.get(result.activeAssignmentIds[0]);
+      expect(strayAssignment).toBeNull();
+    });
+  });
+
+  it("does not touch other leagues", async () => {
+    const t = convexTest(schema, modules);
+
+    const otherLeague = await t.run(async (ctx) =>
+      ctx.db.insert("leagues", {
+        name: "Real Production League",
+        orgId: "org_real",
+        isPublic: true,
+        inviteToken: null,
+      }),
+    );
+
+    await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: null,
+      rosterLimit: 53,
+    });
+
+    await t.mutation(anyApi.e2eSeed.resetRosterFixture, {
+      fixtureKey: FIXTURE_KEY,
+    });
+
+    await t.run(async (ctx) => {
+      const survived = await ctx.db.get(otherLeague);
+      expect(survived?.name).toBe("Real Production League");
+    });
+  });
+});

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -1,0 +1,226 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+
+const FIXTURE_LEAGUE_PREFIX = "E2E:";
+const SEED_ACTOR = "e2e_seed_harness";
+
+function assertSeedEnabled(): void {
+  if (process.env.CONVEX_ENABLE_E2E_SEED !== "1") {
+    throw new Error("e2e_seed_disabled");
+  }
+}
+
+function fixtureLeagueName(fixtureKey: string): string {
+  return `${FIXTURE_LEAGUE_PREFIX}${fixtureKey}`;
+}
+
+const fixtureResultValidator = v.object({
+  fixtureKey: v.string(),
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  playerIds: v.array(v.id("players")),
+  activeAssignmentIds: v.array(v.id("rosterAssignments")),
+});
+
+async function deleteFixtureByKey(
+  ctx: {
+    db: {
+      query: (table: string) => {
+        withIndex: (name: string, fn: (q: any) => any) => {
+          collect: () => Promise<any[]>;
+        };
+      };
+      delete: (id: any) => Promise<void>;
+    };
+  },
+  fixtureKey: string,
+): Promise<number> {
+  const leagueName = fixtureLeagueName(fixtureKey);
+  const leagues = (await ctx.db
+    .query("leagues")
+    .withIndex("by_name", (q: any) => q.eq("name", leagueName))
+    .collect()) as Array<{ _id: Id<"leagues"> }>;
+
+  let deleted = 0;
+  for (const league of leagues) {
+    const [
+      seasons,
+      teams,
+      players,
+      assignments,
+      auditRows,
+      depthEntries,
+    ] = await Promise.all([
+      ctx.db
+        .query("seasons")
+        .withIndex("by_leagueId", (q: any) => q.eq("leagueId", league._id))
+        .collect(),
+      ctx.db
+        .query("teams")
+        .withIndex("by_leagueId", (q: any) => q.eq("leagueId", league._id))
+        .collect(),
+      ctx.db
+        .query("players")
+        .withIndex("by_leagueId", (q: any) => q.eq("leagueId", league._id))
+        .collect(),
+      ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_leagueId_seasonId", (q: any) =>
+          q.eq("leagueId", league._id),
+        )
+        .collect(),
+      ctx.db
+        .query("rosterAuditLog")
+        .withIndex("by_leagueId_createdAt", (q: any) =>
+          q.eq("leagueId", league._id),
+        )
+        .collect(),
+      // depth chart rows aren't indexed on leagueId — walk via teams below
+      Promise.resolve([] as Array<{ _id: Id<"depthChartEntries"> }>),
+    ]);
+
+    for (const row of assignments) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    for (const row of auditRows) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    for (const team of teams as Array<{ _id: Id<"teams"> }>) {
+      const teamDepth = (await ctx.db
+        .query("depthChartEntries")
+        .withIndex("by_team_season", (q: any) => q.eq("teamId", team._id))
+        .collect()) as Array<{ _id: Id<"depthChartEntries"> }>;
+      for (const row of teamDepth) {
+        await ctx.db.delete(row._id);
+        deleted += 1;
+      }
+    }
+    for (const row of players) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    for (const row of teams) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    for (const row of seasons) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    void depthEntries;
+    await ctx.db.delete(league._id);
+    deleted += 1;
+  }
+  return deleted;
+}
+
+export const createRosterFixture = mutation({
+  args: {
+    fixtureKey: v.string(),
+    clerkOrgId: v.union(v.string(), v.null()),
+    teamName: v.optional(v.string()),
+    rosterLimit: v.union(v.number(), v.null()),
+    rosterLocked: v.optional(v.boolean()),
+    seedActivePlayers: v.optional(v.number()),
+    extraBenchPlayers: v.optional(v.number()),
+    positionSlot: v.optional(v.string()),
+  },
+  returns: fixtureResultValidator,
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+
+    await deleteFixtureByKey(ctx as any, args.fixtureKey);
+
+    const teamName = args.teamName ?? "E2E Test Team";
+    const positionSlot = args.positionSlot ?? "QB";
+    const seedActive = args.seedActivePlayers ?? 0;
+    const extraBench = args.extraBenchPlayers ?? 2;
+    const rosterLocked = args.rosterLocked ?? false;
+
+    const leagueId = await ctx.db.insert("leagues", {
+      name: fixtureLeagueName(args.fixtureKey),
+      orgId: args.clerkOrgId,
+      isPublic: false,
+      inviteToken: null,
+    });
+
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "E2E Season",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked,
+    });
+
+    const teamId = await ctx.db.insert("teams", {
+      name: teamName,
+      leagueId,
+      divisionId: null,
+      city: "Test City",
+      stadium: "Test Stadium",
+      foundedYear: null,
+      location: "Test City, TS",
+      logoUrl: null,
+      rosterLimit: args.rosterLimit,
+    });
+
+    const totalPlayers = seedActive + extraBench;
+    const playerIds: Id<"players">[] = [];
+    for (let i = 0; i < totalPlayers; i++) {
+      const playerId = await ctx.db.insert("players", {
+        name: `E2E Player ${i + 1}`,
+        leagueId,
+        teamId,
+        position: positionSlot,
+        positionGroup: null,
+        jerseyNumber: i + 1,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      });
+      playerIds.push(playerId);
+    }
+
+    const assignedAt = new Date().toISOString();
+    const activeAssignmentIds: Id<"rosterAssignments">[] = [];
+    for (let i = 0; i < seedActive; i++) {
+      const playerId = playerIds[i];
+      const assignmentId = await ctx.db.insert("rosterAssignments", {
+        seasonId,
+        teamId,
+        playerId,
+        leagueId,
+        depthRank: i + 1,
+        positionSlot,
+        status: "active",
+        assignedAt,
+        assignedBy: SEED_ACTOR,
+      });
+      activeAssignmentIds.push(assignmentId);
+    }
+
+    return {
+      fixtureKey: args.fixtureKey,
+      leagueId,
+      seasonId,
+      teamId,
+      playerIds,
+      activeAssignmentIds,
+    };
+  },
+});
+
+export const resetRosterFixture = mutation({
+  args: { fixtureKey: v.string() },
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const deleted = await deleteFixtureByKey(ctx as any, args.fixtureKey);
+    return { deleted };
+  },
+});

--- a/apps/web/e2e/helpers/seed-roster.ts
+++ b/apps/web/e2e/helpers/seed-roster.ts
@@ -1,0 +1,120 @@
+/**
+ * Roster seed harness — Playwright side.
+ *
+ * Wraps the Convex `e2eSeed` mutations so Playwright specs can stand up
+ * and tear down deterministic roster fixtures.
+ *
+ * Runtime prerequisites (see SPRINT_2_VERIFICATION.md follow-up):
+ *   - `CONVEX_ENABLE_E2E_SEED=1` on the target Convex deployment
+ *   - `NEXT_PUBLIC_CONVEX_URL` + (for remote deployments) `CONVEX_ADMIN_KEY`
+ *     in the Playwright runner environment
+ *   - `E2E_CLERK_ORG_ID` for tests that require the fixture league to be
+ *     owned by the current Clerk test user's org
+ */
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
+
+export interface RosterFixtureConfig {
+  fixtureKey: string;
+  clerkOrgId: string | null;
+  teamName?: string;
+  rosterLimit: number | null;
+  rosterLocked?: boolean;
+  seedActivePlayers?: number;
+  extraBenchPlayers?: number;
+  positionSlot?: string;
+}
+
+export interface RosterFixtureResult {
+  fixtureKey: string;
+  leagueId: string;
+  seasonId: string;
+  teamId: string;
+  playerIds: string[];
+  activeAssignmentIds: string[];
+}
+
+const createFixtureRef = makeFunctionReference<
+  "mutation",
+  any,
+  RosterFixtureResult
+>("e2eSeed:createRosterFixture");
+
+const resetFixtureRef = makeFunctionReference<
+  "mutation",
+  any,
+  { deleted: number }
+>("e2eSeed:resetRosterFixture");
+
+function getSeedClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+
+  if (!url) {
+    throw new Error(
+      "[seed-roster] NEXT_PUBLIC_CONVEX_URL is required to run the e2e seed harness.",
+    );
+  }
+  const isLocalDeployment =
+    url.includes("127.0.0.1") || url.includes("localhost");
+  if (!adminKey && !isLocalDeployment) {
+    throw new Error(
+      "[seed-roster] CONVEX_ADMIN_KEY is required for non-local deployments.",
+    );
+  }
+
+  const client = new ConvexHttpClient(url);
+  if (adminKey) {
+    (client as ConvexHttpClient & {
+      setAdminAuth?: (key: string) => void;
+    }).setAdminAuth?.(adminKey);
+  }
+  return client;
+}
+
+export async function createRosterFixture(
+  config: RosterFixtureConfig,
+): Promise<RosterFixtureResult> {
+  const client = getSeedClient();
+  try {
+    return await client.mutation(createFixtureRef, config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("e2e_seed_disabled")) {
+      throw new Error(
+        "[seed-roster] Convex rejected the seed mutation — set CONVEX_ENABLE_E2E_SEED=1 on the target deployment.",
+      );
+    }
+    throw err;
+  }
+}
+
+export async function resetRosterFixture(
+  fixtureKey: string,
+): Promise<{ deleted: number }> {
+  const client = getSeedClient();
+  return client.mutation(resetFixtureRef, { fixtureKey });
+}
+
+/**
+ * Convenience wrapper for `test.beforeEach` / `test.afterEach`:
+ * creates a fresh fixture and returns a teardown handle.
+ */
+export async function withRosterFixture(
+  config: RosterFixtureConfig,
+): Promise<{
+  fixture: RosterFixtureResult;
+  teardown: () => Promise<void>;
+}> {
+  const fixture = await createRosterFixture(config);
+  return {
+    fixture,
+    teardown: async () => {
+      await resetRosterFixture(config.fixtureKey);
+    },
+  };
+}
+
+export function getTestOrgId(): string | null {
+  return process.env.E2E_CLERK_ORG_ID ?? null;
+}


### PR DESCRIPTION
## Summary

- New Convex `e2eSeed` module (`createRosterFixture` + `resetRosterFixture`) env-guarded by `CONVEX_ENABLE_E2E_SEED=1`, namespaced by league-name prefix `E2E:${fixtureKey}` so teardown is safe against real data.
- New Playwright helper `e2e/helpers/seed-roster.ts` wrapping the Convex client with a `withRosterFixture` convenience for beforeEach/afterEach.
- Vitest suite covers the env guard, default fixture shape, pre-seeded active rows, idempotency, `rosterLocked=true`, teardown, and a safety check that the harness never touches non-fixture leagues.

## Why

Sprint 2 closed with 14 `test.fixme` blocks across `coach-roster.spec.ts` and `coach-depth-chart.spec.ts`, all waiting on a Convex seed harness (the #1 deferred follow-up in `docs/sprints/SPRINT_2_VERIFICATION.md`). This PR stages the harness so follow-up PRs can unfixme scenarios one by one.

## Test plan

- [x] `pnpm --filter @sports-management/web type-check` — clean
- [x] `pnpm --filter @sports-management/web lint` — only pre-existing `<img>` warning, no new issues
- [x] `pnpm --filter @sports-management/web test:unit` — **259 passed** (up from 252 at Sprint 2 close; 7 new tests in `e2eSeed.test.ts`)

## Runtime config required (for the follow-up PR that unfixmes scenarios)

- `CONVEX_ENABLE_E2E_SEED=1` on the target Convex dev deployment
- `E2E_CLERK_ORG_ID` in the Playwright runner env (so the fixture league is visible to the Clerk test user)

## Deferred

Concrete `test.fixme → test` conversions land in a follow-up PR once the runtime config above is in place. That PR will also address the cross-org 403 scenario which needs a second Clerk test user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)