### PR TITLE
feat(web): install 8bit form primitives — Input, Label, Textarea (WSM-000029)

### DIFF
--- a/apps/web/src/components/ui/8bit/input.tsx
+++ b/apps/web/src/components/ui/8bit/input.tsx
@@ -1,0 +1,54 @@
+import { type VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import { Input as ShadcnInput } from "@/components/ui/input";
+
+import "@/components/ui/8bit/retro.css";
+
+export const inputVariants = cva("", {
+  variants: {
+    font: {
+      normal: "",
+      retro: "retro",
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+  },
+});
+
+export interface BitInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {
+  asChild?: boolean;
+}
+
+function Input({ ...props }: BitInputProps) {
+  const { className, font } = props;
+
+  return (
+    <div
+      className={cn(
+        "relative border-y-6 border-foreground dark:border-ring !p-0 flex items-center",
+        className
+      )}
+    >
+      <ShadcnInput
+        {...props}
+        className={cn(
+          "rounded-none ring-0 !w-full",
+          font !== "normal" && "retro",
+          className
+        )}
+      />
+
+      <div
+        className="absolute inset-0 border-x-6 -mx-1.5 border-foreground dark:border-ring pointer-events-none"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+export { Input };

--- a/apps/web/src/components/ui/8bit/label.tsx
+++ b/apps/web/src/components/ui/8bit/label.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type * as React from "react";
+
+import type * as LabelPrimitive from "@radix-ui/react-label";
+import { type VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import { Label as ShadcnLabel } from "@/components/ui/label";
+
+import "@/components/ui/8bit/retro.css";
+
+export const inputVariants = cva("", {
+  variants: {
+    font: {
+      normal: "",
+      retro: "retro",
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+  },
+});
+
+interface BitLabelProps
+  extends React.ComponentProps<typeof LabelPrimitive.Root>,
+    VariantProps<typeof inputVariants> {
+  asChild?: boolean;
+}
+
+function Label({ className, font, ...props }: BitLabelProps) {
+  return (
+    <ShadcnLabel
+      className={cn(className, font !== "normal" && "retro")}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/apps/web/src/components/ui/8bit/textarea.tsx
+++ b/apps/web/src/components/ui/8bit/textarea.tsx
@@ -1,0 +1,54 @@
+import { type VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import { Textarea as ShadcnTextarea } from "@/components/ui/8bit/textarea";
+
+import "@/components/ui/8bit/retro.css";
+
+export const inputVariants = cva("", {
+  variants: {
+    font: {
+      normal: "",
+      retro: "retro",
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+  },
+});
+
+export interface BitTextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    VariantProps<typeof inputVariants> {
+  asChild?: boolean;
+}
+
+function Textarea({ ...props }: BitTextareaProps) {
+  const { className, font } = props;
+
+  return (
+    <div className={cn("relative w-full", className)}>
+      <ShadcnTextarea
+        {...props}
+        className={cn(
+          "rounded-none transition-transform ring-0 border-0",
+          font !== "normal" && "retro",
+          className
+        )}
+      />
+
+      <div
+        className="absolute inset-0 border-y-6 -my-1.5 border-foreground dark:border-ring pointer-events-none"
+        aria-hidden="true"
+      />
+
+      <div
+        className="absolute inset-0 border-x-6 -mx-1.5 border-foreground dark:border-ring pointer-events-none"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+export { Textarea };


### PR DESCRIPTION
## Summary

Sprint 3 story 4/11. Installs the 8bit variants of **Input**, **Label**, and **Textarea** via the \`@8bitcn\` registry. Lands at \`src/components/ui/8bit/{input,label,textarea}.tsx\` alongside the existing shadcn primitives. Button was already installed in WSM-000026.

Per the WSM-000026 architectural finding: **8bit components wrap the existing shadcn ones**, so both layers stay forever. Consumer imports get swapped from \`@/components/ui/<x>\` to \`@/components/ui/8bit/<x>\` during the feature-level re-skin in WSM-000033 / WSM-000034.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] No consumers wired yet — visual verification in WSM-000033+

🤖 Generated with [Claude Code](https://claude.com/claude-code)