### PR TITLE
feat(web): install 8bit display primitives — Card, Table, Skeleton, Separator (WSM-000031)

### DIFF
--- a/apps/web/src/components/ui/8bit/card.tsx
+++ b/apps/web/src/components/ui/8bit/card.tsx
@@ -1,0 +1,135 @@
+import { type VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import {
+  Card as ShadcnCard,
+  CardAction as ShadcnCardAction,
+  CardContent as ShadcnCardContent,
+  CardDescription as ShadcnCardDescription,
+  CardFooter as ShadcnCardFooter,
+  CardHeader as ShadcnCardHeader,
+  CardTitle as ShadcnCardTitle,
+} from "@/components/ui/card";
+
+import "@/components/ui/8bit/retro.css";
+
+export const cardVariants = cva("", {
+  variants: {
+    font: {
+      normal: "",
+      retro: "retro",
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+  },
+});
+
+export interface BitCardProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof cardVariants> {
+  asChild?: boolean;
+}
+
+function Card({ className, font, ...props }: BitCardProps) {
+  return (
+    <div
+      className={cn(
+        "relative bg-card text-card-foreground border-y-6 border-foreground dark:border-ring p-0!",
+        className
+      )}
+    >
+      <ShadcnCard
+        {...props}
+        className={cn(
+          "rounded-none border-0 w-full! h-full flex flex-col bg-card text-card-foreground shadow-none",
+          font !== "normal" && "retro",
+          className
+        )}
+      />
+
+      <div
+        className={cn("absolute inset-0 border-x-6 -mx-1.5 border-inherit pointer-events-none")}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+function CardHeader({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardHeader
+      className={cn(font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardTitle
+      className={cn(font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardDescription
+      className={cn(font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardAction
+      className={cn(font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardContent
+      className={cn("flex-1", font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ ...props }: BitCardProps) {
+  const { className, font } = props;
+
+  return (
+    <ShadcnCardFooter
+      data-slot="card-footer"
+      className={cn(font !== "normal" && "retro", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/apps/web/src/components/ui/8bit/separator.tsx
+++ b/apps/web/src/components/ui/8bit/separator.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type * as React from "react";
+
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator-root"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "data-[orientation=horizontal]:bg-[length:16px_8px] data-[orientation=horizontal]:bg-[linear-gradient(90deg,var(--foreground)_75%,transparent_75%)] dark:data-[orientation=horizontal]:bg-[linear-gradient(90deg,var(--ring)_75%,transparent_75%)] shrink-0 data-[orientation=horizontal]:h-0.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:bg-[length:2px_16px] data-[orientation=vertical]:bg-[linear-gradient(0deg,var(--foreground)_75%,transparent_75%)] dark:data-[orientation=vertical]:bg-[linear-gradient(0deg,var(--ring)_75%,transparent_75%)]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/apps/web/src/components/ui/8bit/skeleton.tsx
+++ b/apps/web/src/components/ui/8bit/skeleton.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+
+import { Skeleton as ShadcnSkeleton } from "@/components/ui/skeleton";
+
+import "@/components/ui/8bit/retro.css";
+
+export interface BitSkeletonProp extends React.ComponentProps<"div"> {
+  asChild?: boolean;
+}
+
+function Skeleton({ children, ...props }: BitSkeletonProp) {
+  const { className } = props;
+
+  return (
+    <div className={cn("relative animate-pulse", className)}>
+      <ShadcnSkeleton
+        {...props}
+        className={cn("rounded-none border-none bg-accent", "retro", className)}
+      >
+        {children}
+      </ShadcnSkeleton>
+
+      <div className="opacity-60">
+        <div className="absolute -top-1.5 w-1/2 left-1.5 h-1.5 bg-foreground dark:bg-ring" />
+        <div className="absolute -top-1.5 w-1/2 right-1.5 h-1.5 bg-foreground dark:bg-ring" />
+      </div>
+      <div className="opacity-60">
+        <div className="absolute -bottom-1.5 w-1/2 left-1.5 h-1.5 bg-foreground dark:bg-ring" />
+        <div className="absolute -bottom-1.5 w-1/2 right-1.5 h-1.5 bg-foreground dark:bg-ring" />
+      </div>
+      <div className="absolute top-0 left-0 size-1.5 bg-foreground/60 dark:bg-ring/60" />
+      <div className="absolute top-0 right-0 size-1.5 bg-foreground/60 dark:bg-ring/60" />
+      <div className="absolute bottom-0 left-0 size-1.5 bg-foreground/60 dark:bg-ring/60" />
+      <div className="absolute bottom-0 right-0 size-1.5 bg-foreground/60 dark:bg-ring/60" />
+      <div className="opacity-60">
+        <div className="absolute top-1 -left-1.5 h-1/2 w-1.5 bg-foreground dark:bg-ring" />
+        <div className="absolute bottom-1 -left-1.5 h-1/2 w-1.5 bg-foreground dark:bg-ring" />
+      </div>
+      <div className="opacity-60">
+        <div className="absolute top-1 -right-1.5 h-1/2 w-1.5 bg-foreground dark:bg-ring" />
+        <div className="absolute bottom-1 -right-1.5 h-1/2 w-1.5 bg-foreground dark:bg-ring" />
+      </div>
+    </div>
+  );
+}
+
+export { Skeleton };

--- a/apps/web/src/components/ui/8bit/table.tsx
+++ b/apps/web/src/components/ui/8bit/table.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type * as React from "react";
+
+import { type VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import {
+  Table as ShadcnTable,
+  TableBody as ShadcnTableBody,
+  TableCaption as ShadcnTableCaption,
+  TableCell as ShadcnTableCell,
+  TableFooter as ShadcnTableFooter,
+  TableHead as ShadcnTableHead,
+  TableHeader as ShadcnTableHeader,
+  TableRow as ShadcnTableRow,
+} from "@/components/ui/table";
+
+import "@/components/ui/8bit/retro.css";
+
+export const tableVariants = cva("", {
+  variants: {
+    variant: {
+      default: "p-4 py-2.5 border-y-6 border-foreground dark:border-ring",
+      borderless: "",
+    },
+    font: {
+      normal: "",
+      retro: "retro",
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+    variant: "default",
+  },
+});
+
+function Table({
+  className,
+  font,
+  variant,
+  ...props
+}: React.ComponentProps<"table"> & {
+  font?: VariantProps<typeof tableVariants>["font"];
+  variant?: VariantProps<typeof tableVariants>["variant"];
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex justify-center w-fit",
+        tableVariants({ font, variant })
+      )}
+    >
+      <ShadcnTable className={className} {...props} />
+
+      {variant !== "borderless" && (
+        <div
+          className="absolute inset-0 border-x-6 -mx-1.5 border-foreground dark:border-ring pointer-events-none"
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <ShadcnTableHeader
+      className={cn(className, "border-b-4 border-foreground dark:border-ring")}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return <ShadcnTableBody className={cn(className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return <ShadcnTableFooter className={cn(className)} {...props} />;
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <ShadcnTableRow
+      className={cn(
+        className,
+        "border-dashed border-b-4 border-foreground dark:border-ring"
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return <ShadcnTableHead className={cn(className)} {...props} />;
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return <ShadcnTableCell className={cn(className)} {...props} />;
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return <ShadcnTableCaption className={cn(className)} {...props} />;
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,63 +1,92 @@
-import * as React from "react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border border-gray-200 bg-white shadow-sm",
-      className,
-    )}
-    {...props}
-  />
-));
-Card.displayName = "Card";
+import { cn } from "@/lib/utils"
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-));
-CardHeader.displayName = "CardHeader";
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-));
-CardTitle.displayName = "CardTitle";
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-gray-500", className)}
-    {...props}
-  />
-));
-CardDescription.displayName = "CardDescription";
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-));
-CardContent.displayName = "CardContent";
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
 
-export { Card, CardHeader, CardTitle, CardDescription, CardContent };
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,83 +1,116 @@
-import * as React from "react";
-import { cn } from "@/lib/utils";
+"use client"
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
       {...props}
     />
-  </div>
-));
-Table.displayName = "Table";
+  )
+}
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-));
-TableHeader.displayName = "TableHeader";
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-));
-TableBody.displayName = "TableBody";
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b border-gray-200 transition-colors hover:bg-gray-50",
-      className,
-    )}
-    {...props}
-  />
-));
-TableRow.displayName = "TableRow";
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      "h-10 px-4 text-left align-middle text-xs font-medium uppercase tracking-wider text-gray-500 [&:has([role=checkbox])]:pr-0",
-      className,
-    )}
-    {...props}
-  />
-));
-TableHead.displayName = "TableHead";
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn(
-      "px-4 py-3 align-middle [&:has([role=checkbox])]:pr-0",
-      className,
-    )}
-    {...props}
-  />
-));
-TableCell.displayName = "TableCell";
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary

Sprint 3 story 6/11. Adds 8bit variants of **Card**, **Table**, **Skeleton**, **Separator** at \`src/components/ui/8bit/\`. Re-installed canonical shadcn card + table to bring API surface to current (CardAction, CardFooter, TableCaption, TableFooter exports the 8bit wrappers expect).

### Skipped (deferred to follow-up)

| Component | Reason |
|---|---|
| **Badge (8bit)** | Re-installing canonical shadcn badge would drop the custom \`success\` and \`warning\` variants that \`status-badge.tsx\` depends on. Keeping the local slim badge this PR; will reconcile by either porting status-badge to the canonical variant set, or extending the canonical badge with custom variants. |
| **Tabs (8bit)** | Same upstream 8bitcn TS bug as 8bit Tooltip in WSM-000030 — \`BitTabsContentProps\` recursively references itself. Shadcn primitive is in place; 8bit variant deferred. |

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] No consumers wired yet — visual verification in WSM-000033+

🤖 Generated with [Claude Code](https://claude.com/claude-code)