### PR TITLE
feat(web): swap dashboard chrome + marketing imports to 8bit primitives (WSM-000032)

### DIFF
--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Menu } from "lucide-react";
 import { UserButton } from "@clerk/nextjs";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import Sidebar from "./sidebar";
 

--- a/apps/web/src/components/marketing/features.tsx
+++ b/apps/web/src/components/marketing/features.tsx
@@ -1,5 +1,10 @@
 import { ClipboardList, Calendar, Heart, TrendingUp } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/8bit/card";
 
 const features = [
   {

--- a/apps/web/src/components/marketing/header.tsx
+++ b/apps/web/src/components/marketing/header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { Monogram } from "./monogram";
 
 interface HeaderProps {

--- a/apps/web/src/components/marketing/hero.tsx
+++ b/apps/web/src/components/marketing/hero.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 
 interface HeroProps {
   isSignedIn: boolean;


### PR DESCRIPTION
## Summary

Sprint 3 story 7/11. **First story to swap consumer imports** — the 8-bit aesthetic actually becomes visible in the running app after this PR.

### Files updated
| File | Swap |
|---|---|
| \`dashboard/_components/mobile-header.tsx\` | Button → \`8bit/button\`. Sheet stays on slim shadcn (no 8bit Sheet variant in registry yet). |
| \`marketing/header.tsx\` | Button → \`8bit/button\` (public-page CTA). |
| \`marketing/hero.tsx\` | Button → \`8bit/button\` (above-the-fold CTAs). |
| \`marketing/features.tsx\` | Card / CardContent / CardHeader / CardTitle → \`8bit/card\`. |

Sidebar + nav-link don't currently import shadcn primitives — they use semantic HTML + lucide icons + the new design tokens (palette + radii from WSM-000027) carry the aesthetic via the global token system. No swap needed there.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] Visual verification: confirm Vercel preview deploy shows pixel-style buttons + cards on landing page and dashboard mobile header

🤖 Generated with [Claude Code](https://claude.com/claude-code)