### PR TITLE
feat(web): swap roster + depth chart imports to 8bit primitives (WSM-000033)

### DIFF
--- a/apps/web/src/components/depth-chart/LockBanner.tsx
+++ b/apps/web/src/components/depth-chart/LockBanner.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { Lock, Unlock } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { setRosterLockedAction } from "@/app/dashboard/teams/[id]/depth-chart/actions";
 
 interface LockBannerProps {

--- a/apps/web/src/components/roster/AssignPlayerDialog.tsx
+++ b/apps/web/src/components/roster/AssignPlayerDialog.tsx
@@ -10,16 +10,16 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Label } from "@/components/ui/8bit/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "@/components/ui/8bit/select";
 import { assignPlayerToRosterAction } from "@/app/dashboard/teams/[id]/roster/actions";
 
 export interface AssignPlayerDialogProps {

--- a/apps/web/src/components/roster/RosterSlotGroup.tsx
+++ b/apps/web/src/components/roster/RosterSlotGroup.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+} from "@/components/ui/8bit/dropdown-menu";
 import {
   removePlayerFromRosterAction,
   updateRosterStatusAction,

--- a/apps/web/src/components/roster/RosterStatusList.tsx
+++ b/apps/web/src/components/roster/RosterStatusList.tsx
@@ -6,7 +6,7 @@ import type {
   PlayerDto,
   RosterAssignmentDto,
 } from "@sports-management/shared-types";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { updateRosterStatusAction } from "@/app/dashboard/teams/[id]/roster/actions";
 
 export interface RosterStatusListProps {


### PR DESCRIPTION
## Summary

Sprint 3 story 8/11. Swaps shadcn ui imports to their 8bit equivalents in roster + depth-chart feature components.

| File | Swap |
|---|---|
| \`roster/AssignPlayerDialog.tsx\` | Dialog + Button + Label + Select |
| \`roster/RosterStatusList.tsx\` | Button (Reactivate / Release row actions) |
| \`roster/RosterSlotGroup.tsx\` | DropdownMenu (per-row actions menu) |
| \`depth-chart/LockBanner.tsx\` | Button (admin lock toggle) |

Components without explicit ui imports (RosterBoard, RosterAuditTimeline, RosterLimitBadge, DepthChartBoard, PositionColumn) inherit the aesthetic via the global token system (palette + radii + typography from WSM-000027/28). The local Badge stays slim until status-badge reconciliation lands as a follow-up (per WSM-000031 deferral).

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] e2e suite re-run lands in WSM-000035 (semantic selectors should survive the swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)