### PR TITLE
feat(web): swap entity dashboard imports to 8bit primitives (WSM-000034)

### DIFF
--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -12,17 +12,17 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Input } from "@/components/ui/8bit/input";
+import { Label } from "@/components/ui/8bit/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "@/components/ui/8bit/select";
 import { toast } from "sonner";
 
 interface PlayerFormProps {

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -9,10 +9,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Input } from "@/components/ui/8bit/input";
+import { Label } from "@/components/ui/8bit/label";
 import { toast } from "sonner";
 
 interface TeamEditFormProps {

--- a/apps/web/src/app/dashboard/billing/_components/billing-actions.tsx
+++ b/apps/web/src/app/dashboard/billing/_components/billing-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { PricingTable } from "@/components/pricing-table";
 import type { Tier } from "@/lib/tiers";
 

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -4,7 +4,7 @@ import { getUserTier, getStripeCustomerId } from "@/lib/authorization";
 import { TIER_CONFIGS } from "@/lib/tiers";
 import { getTeams } from "@/lib/salesforce-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/8bit/card";
 import { Badge } from "@/components/ui/badge";
 import { BillingActions } from "./_components/billing-actions";
 

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
+import { Button } from "@/components/ui/8bit/button";
 import { Badge } from "@/components/ui/badge";
 import { Trophy } from "lucide-react";
 

--- a/apps/web/src/app/dashboard/divisions/error.tsx
+++ b/apps/web/src/app/dashboard/divisions/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function DivisionsError({

--- a/apps/web/src/app/dashboard/error.tsx
+++ b/apps/web/src/app/dashboard/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function DashboardError({

--- a/apps/web/src/app/dashboard/import/_components/import-form.tsx
+++ b/apps/web/src/app/dashboard/import/_components/import-form.tsx
@@ -4,14 +4,14 @@ import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LeagueImportSchema } from "@sports-management/api-contracts";
 import type { ImportResult } from "@sports-management/shared-types";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from "@/components/ui/8bit/card";
 import { Upload, FileJson, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 
 type ValidationError = {

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -3,14 +3,14 @@
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { SyncConfig, SyncReport } from "@sports-management/shared-types";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from "@/components/ui/8bit/card";
 import {
   Loader2,
   RefreshCw,

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/8bit/button";
+import { Input } from "@/components/ui/8bit/input";
+import { Label } from "@/components/ui/8bit/label";
 
 export default function InviteForm({ orgId }: { orgId: string }) {
   const [email, setEmail] = useState("");

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { Copy, Link2, Trash2 } from "lucide-react";
 
 export default function InviteLinkSection({ orgId }: { orgId: string }) {

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 
 interface Member {
   userId: string;

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getLeague } from "@/lib/salesforce-api";
 import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import { Badge } from "@/components/ui/badge";
 import { Trophy } from "lucide-react";
 import InviteForm from "./invite-form";

--- a/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 
 interface PendingRequest {
   userId: string;

--- a/apps/web/src/app/dashboard/leagues/error.tsx
+++ b/apps/web/src/app/dashboard/leagues/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function LeaguesError({

--- a/apps/web/src/app/dashboard/leagues/loading.tsx
+++ b/apps/web/src/app/dashboard/leagues/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { Skeleton } from "@/components/ui/8bit/skeleton";
 
 export default function LeaguesLoading() {
   return (

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getLeagues, getDivisions, getTeams } from "@/lib/salesforce-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
 import { Trophy, Layers, Users } from "lucide-react";

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import {
   getLeagues,
 } from "@/lib/salesforce-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/8bit/card";
 import {
   Trophy,
   Users,

--- a/apps/web/src/app/dashboard/players/error.tsx
+++ b/apps/web/src/app/dashboard/players/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function PlayersError({

--- a/apps/web/src/app/dashboard/seasons/error.tsx
+++ b/apps/web/src/app/dashboard/seasons/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function SeasonsError({

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -9,8 +9,8 @@ import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
 import { StatusBadge } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/8bit/button";
+import { Card, CardContent } from "@/components/ui/8bit/card";
 import { UserCircle, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 

--- a/apps/web/src/app/dashboard/teams/error.tsx
+++ b/apps/web/src/app/dashboard/teams/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/8bit/button";
 import { AlertTriangle } from "lucide-react";
 
 export default function TeamsError({

--- a/apps/web/src/app/dashboard/teams/loading.tsx
+++ b/apps/web/src/app/dashboard/teams/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { Skeleton } from "@/components/ui/8bit/skeleton";
 
 export default function TeamsLoading() {
   return (


### PR DESCRIPTION
## Summary

Sprint 3 story 9/11. Mass swap of remaining shadcn ui imports across the entity dashboard surfaces — completes the import-swap phase of the re-skin.

### Surface coverage (23 files)
- **Leagues:** list, detail, error, loading, requests, invite-form, invite-link-section, member-list
- **Teams:** list, detail (team-management), error, loading
- **Players + Seasons + Divisions:** error pages
- **Discover:** discover-leagues
- **Billing:** page, billing-actions
- **Import:** import-form, nfl-sync-card
- **Dashboard root:** page.tsx, error.tsx, _components (player-form, team-edit-form)

### Mechanical swap

Single \`sed\` pass over all matching files:
\`\`\`
s|from "@/components/ui/(button|input|label|textarea|dialog|dropdown-menu|select|card|table|skeleton|separator)"|from "@/components/ui/8bit/\1"|g
\`\`\`

Other primitives (badge, tabs, sheet, tooltip) stay on shadcn — no 8bit variant per prior-story deferrals.

### Where we are after this PR
Combined with WSM-000032 (chrome) + WSM-000033 (roster/depth chart), the entire app surface now consumes \`8bit/*\` primitives. Components without explicit ui imports inherit the aesthetic via the global token system.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean (after 24-file swap)
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] e2e suite re-run lands in WSM-000035

🤖 Generated with [Claude Code](https://claude.com/claude-code)