### PR TITLE
refactor(web): rewrite hardcoded Tailwind colors to semantic tokens (WSM-000037)

### DIFF
--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -11,7 +11,7 @@ export default function MobileHeader() {
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="flex items-center justify-between border-b border-gray-200 px-4 py-3 lg:hidden">
+    <header className="flex items-center justify-between border-b border-border px-4 py-3 lg:hidden">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="Open navigation menu">
@@ -22,7 +22,7 @@ export default function MobileHeader() {
           <Sidebar onNavigate={() => setOpen(false)} />
         </SheetContent>
       </Sheet>
-      <h1 className="text-lg font-semibold text-gray-900">Dashboard</h1>
+      <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
       <UserButton />
     </header>
   );

--- a/apps/web/src/app/dashboard/_components/nav-link.tsx
+++ b/apps/web/src/app/dashboard/_components/nav-link.tsx
@@ -30,7 +30,7 @@ export default function NavLink({
         "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
         isActive
           ? "bg-primary text-primary-foreground"
-          : "text-gray-700 hover:bg-gray-100",
+          : "text-foreground hover:bg-card",
       )}
     >
       {Icon && <Icon className="h-4 w-4" />}

--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -126,7 +126,7 @@ export default function PlayerForm({
         </DialogHeader>
 
         {error && (
-          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
             {error}
           </div>
         )}

--- a/apps/web/src/app/dashboard/_components/sidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/sidebar.tsx
@@ -33,7 +33,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   return (
     <div className="flex h-full flex-col">
       <div className="px-4 py-5">
-        <h2 className="text-lg font-semibold text-gray-900">Sports League</h2>
+        <h2 className="text-lg font-semibold text-foreground">Sports League</h2>
       </div>
       <nav className="flex-1 space-y-1 px-2" role="navigation" aria-label="Main navigation">
         {navItems.map((item) => (

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -91,7 +91,7 @@ export default function TeamEditForm({
         </DialogHeader>
 
         {error && (
-          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
             {error}
           </div>
         )}

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -43,13 +43,13 @@ export default async function BillingPage({
     <div className="space-y-6 p-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Billing</h1>
-        <p className="text-sm text-zinc-600">Manage your subscription and usage</p>
+        <p className="text-sm text-muted-foreground">Manage your subscription and usage</p>
       </div>
 
       {params.success && (
-        <Card className="border-green-200 bg-green-50">
+        <Card className="border-accent/30 bg-green-50">
           <CardContent className="py-4">
-            <p className="text-sm text-green-900">
+            <p className="text-sm text-accent">
               ✓ Subscription activated. Welcome to {config.name}!
             </p>
           </CardContent>
@@ -84,16 +84,16 @@ export default async function BillingPage({
         <CardContent className="space-y-4">
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
             <div>
-              <p className="text-xs uppercase tracking-wide text-zinc-500">Teams</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Teams</p>
               <p className="text-2xl font-semibold">
                 {teamCount}
-                <span className="text-sm font-normal text-zinc-500"> / {teamLimitDisplay}</span>
+                <span className="text-sm font-normal text-muted-foreground"> / {teamLimitDisplay}</span>
               </p>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-zinc-500">Players</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Players</p>
               <p className="text-2xl font-semibold">
-                <span className="text-sm font-normal text-zinc-500">unlimited</span>
+                <span className="text-sm font-normal text-muted-foreground">unlimited</span>
               </p>
             </div>
           </div>

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -49,7 +49,7 @@ export default function DiscoverLeagues({
 
   if (leagues.length === 0) {
     return (
-      <p className="text-sm text-gray-500">No public leagues available.</p>
+      <p className="text-sm text-muted-foreground">No public leagues available.</p>
     );
   }
 

--- a/apps/web/src/app/dashboard/discover/page.tsx
+++ b/apps/web/src/app/dashboard/discover/page.tsx
@@ -16,10 +16,10 @@ export default async function DiscoverPage() {
 
   return (
     <div>
-      <h2 className="mb-2 text-lg font-semibold text-gray-900">
+      <h2 className="mb-2 text-lg font-semibold text-foreground">
         Discover Leagues
       </h2>
-      <p className="mb-6 text-sm text-gray-500">
+      <p className="mb-6 text-sm text-muted-foreground">
         Browse public leagues and add them to your dashboard.
       </p>
       <DiscoverLeagues

--- a/apps/web/src/app/dashboard/divisions/error.tsx
+++ b/apps/web/src/app/dashboard/divisions/error.tsx
@@ -11,12 +11,12 @@ export default function DivisionsError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Failed to load divisions
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/divisions/loading.tsx
+++ b/apps/web/src/app/dashboard/divisions/loading.tsx
@@ -3,7 +3,7 @@ import { TableSkeleton } from "@/components/skeletons/table-skeleton";
 export default function DivisionsLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <TableSkeleton rows={5} columns={2} />
     </div>
   );

--- a/apps/web/src/app/dashboard/divisions/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/page.tsx
@@ -25,7 +25,7 @@ export default async function DivisionsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Divisions</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Divisions</h2>
       <DivisionsTable divisions={divisionsWithLeague} />
     </div>
   );

--- a/apps/web/src/app/dashboard/error.tsx
+++ b/apps/web/src/app/dashboard/error.tsx
@@ -11,12 +11,12 @@ export default function DashboardError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Something went wrong
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred while loading this page."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/import/_components/import-form.tsx
+++ b/apps/web/src/app/dashboard/import/_components/import-form.tsx
@@ -163,7 +163,7 @@ export function ImportForm() {
             onDrop={handleDrop}
             onDragOver={(e) => e.preventDefault()}
             onClick={() => fileInputRef.current?.click()}
-            className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-8 transition-colors hover:border-primary hover:bg-gray-50"
+            className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-border p-8 transition-colors hover:border-primary hover:bg-card"
             role="button"
             tabIndex={0}
             onKeyDown={(e) => {
@@ -171,8 +171,8 @@ export function ImportForm() {
             }}
             aria-label="Upload JSON file"
           >
-            <Upload className="mb-3 h-8 w-8 text-gray-400" />
-            <p className="text-sm text-gray-600">
+            <Upload className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
               Drop a <code>.json</code> file here or click to browse
             </p>
             <input
@@ -189,9 +189,9 @@ export function ImportForm() {
 
       {/* Validation Errors */}
       {state.step === "invalid" && (
-        <Card className="border-red-200">
+        <Card className="border-destructive/30">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-red-700">
+            <CardTitle className="flex items-center gap-2 text-destructive">
               <AlertCircle className="h-5 w-5" />
               Validation Failed
             </CardTitle>
@@ -203,14 +203,14 @@ export function ImportForm() {
           <CardContent>
             <div role="alert" className="space-y-2">
               {state.errors.formErrors.map((err, i) => (
-                <p key={i} className="text-sm text-red-600">
+                <p key={i} className="text-sm text-destructive">
                   {err}
                 </p>
               ))}
               {Object.entries(state.errors.fieldErrors).map(([field, errs]) =>
                 errs.map((err, i) => (
-                  <p key={`${field}-${i}`} className="text-sm text-red-600">
-                    <code className="mr-1 rounded bg-red-50 px-1 text-xs">
+                  <p key={`${field}-${i}`} className="text-sm text-destructive">
+                    <code className="mr-1 rounded bg-destructive/10 px-1 text-xs">
                       {field}
                     </code>
                     {err}
@@ -237,21 +237,21 @@ export function ImportForm() {
           </CardHeader>
           <CardContent>
             <div className="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
-              <div className="rounded-md bg-gray-50 p-3 text-center">
+              <div className="rounded-md bg-card p-3 text-center">
                 <p className="text-2xl font-bold">{state.preview.leagueName}</p>
-                <p className="text-xs text-gray-500">League</p>
+                <p className="text-xs text-muted-foreground">League</p>
               </div>
-              <div className="rounded-md bg-gray-50 p-3 text-center">
+              <div className="rounded-md bg-card p-3 text-center">
                 <p className="text-2xl font-bold">{state.preview.divisionCount}</p>
-                <p className="text-xs text-gray-500">Divisions</p>
+                <p className="text-xs text-muted-foreground">Divisions</p>
               </div>
-              <div className="rounded-md bg-gray-50 p-3 text-center">
+              <div className="rounded-md bg-card p-3 text-center">
                 <p className="text-2xl font-bold">{state.preview.teamCount}</p>
-                <p className="text-xs text-gray-500">Teams</p>
+                <p className="text-xs text-muted-foreground">Teams</p>
               </div>
-              <div className="rounded-md bg-gray-50 p-3 text-center">
+              <div className="rounded-md bg-card p-3 text-center">
                 <p className="text-2xl font-bold">{state.preview.playerCount}</p>
-                <p className="text-xs text-gray-500">Players</p>
+                <p className="text-xs text-muted-foreground">Players</p>
               </div>
             </div>
             <div className="flex gap-2">
@@ -269,7 +269,7 @@ export function ImportForm() {
         <Card>
           <CardContent className="flex items-center gap-3 py-8">
             <Loader2 className="h-5 w-5 animate-spin text-primary" />
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-muted-foreground">
               Importing data from {state.fileName}...
             </p>
           </CardContent>
@@ -278,9 +278,9 @@ export function ImportForm() {
 
       {/* Result */}
       {state.step === "done" && (
-        <Card className="border-green-200">
+        <Card className="border-accent/30">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-green-700">
+            <CardTitle className="flex items-center gap-2 text-accent">
               <CheckCircle2 className="h-5 w-5" />
               Import Complete
             </CardTitle>
@@ -289,16 +289,16 @@ export function ImportForm() {
             <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
               {(["leagues", "divisions", "teams", "players"] as const).map(
                 (entity) => (
-                  <div key={entity} className="rounded-md bg-gray-50 p-3">
-                    <p className="text-xs font-medium capitalize text-gray-500">
+                  <div key={entity} className="rounded-md bg-card p-3">
+                    <p className="text-xs font-medium capitalize text-muted-foreground">
                       {entity}
                     </p>
                     <p className="text-sm">
-                      <span className="font-semibold text-green-700">
+                      <span className="font-semibold text-accent">
                         {state.result.created[entity]} created
                       </span>
                       {", "}
-                      <span className="text-gray-600">
+                      <span className="text-muted-foreground">
                         {state.result.updated[entity]} updated
                       </span>
                     </p>
@@ -308,12 +308,12 @@ export function ImportForm() {
             </div>
 
             {state.result.errors.length > 0 && (
-              <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3">
-                <p className="mb-2 text-sm font-medium text-red-700">
+              <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/10 p-3">
+                <p className="mb-2 text-sm font-medium text-destructive">
                   {state.result.errors.length} error(s) during import:
                 </p>
                 {state.result.errors.map((err, i) => (
-                  <p key={i} className="text-sm text-red-600">
+                  <p key={i} className="text-sm text-destructive">
                     {err.entity} &quot;{err.name}&quot;: {err.message}
                   </p>
                 ))}

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -45,10 +45,10 @@ function SyncReportDisplay({ report }: { report: SyncReport }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2 text-sm text-gray-500">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Clock className="h-4 w-4" />
         <span>{formatDate(report.completedAt)}</span>
-        <span className="text-gray-300">|</span>
+        <span className="text-muted-foreground">|</span>
         <span>{formatDuration(report.durationMs)}</span>
       </div>
 
@@ -56,20 +56,20 @@ function SyncReportDisplay({ report }: { report: SyncReport }) {
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           {(["leagues", "divisions", "teams", "players"] as const).map(
             (entity) => (
-              <div key={entity} className="rounded-md bg-gray-50 p-2 text-center">
-                <p className="text-xs font-medium capitalize text-gray-500">
+              <div key={entity} className="rounded-md bg-card p-2 text-center">
+                <p className="text-xs font-medium capitalize text-muted-foreground">
                   {entity}
                 </p>
                 <p className="text-sm">
-                  <span className="font-semibold text-green-700">
+                  <span className="font-semibold text-accent">
                     {report.importResult!.created[entity]}
                   </span>
                   {" / "}
-                  <span className="text-gray-600">
+                  <span className="text-muted-foreground">
                     {report.importResult!.updated[entity]}
                   </span>
                 </p>
-                <p className="text-[10px] text-gray-400">created / updated</p>
+                <p className="text-[10px] text-muted-foreground">created / updated</p>
               </div>
             ),
           )}
@@ -77,8 +77,8 @@ function SyncReportDisplay({ report }: { report: SyncReport }) {
       )}
 
       {hasErrors && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-2">
-          <p className="text-xs font-medium text-red-700">
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-2">
+          <p className="text-xs font-medium text-destructive">
             {report.adapterErrors.length > 0 &&
               report.adapterErrors.map((e, i) => (
                 <span key={i} className="block">
@@ -95,7 +95,7 @@ function SyncReportDisplay({ report }: { report: SyncReport }) {
       )}
 
       {!hasImportResult && report.adapterErrors.length === 0 && (
-        <p className="text-sm text-gray-500">No data returned from sync.</p>
+        <p className="text-sm text-muted-foreground">No data returned from sync.</p>
       )}
     </div>
   );
@@ -188,7 +188,7 @@ export function NflSyncCard() {
       <Card>
         <CardContent className="flex items-center gap-3 py-8">
           <Loader2 className="h-5 w-5 animate-spin text-primary" />
-          <p className="text-sm text-gray-600">Loading sync config...</p>
+          <p className="text-sm text-muted-foreground">Loading sync config...</p>
         </CardContent>
       </Card>
     );
@@ -196,15 +196,15 @@ export function NflSyncCard() {
 
   if (state.phase === "error") {
     return (
-      <Card className="border-red-200">
+      <Card className="border-destructive/30">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-red-700">
+          <CardTitle className="flex items-center gap-2 text-destructive">
             <AlertCircle className="h-5 w-5" />
             NFL Live Data
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-red-600">{state.message}</p>
+          <p className="text-sm text-destructive">{state.message}</p>
           <Button variant="outline" className="mt-3" onClick={loadConfig}>
             Retry
           </Button>
@@ -234,7 +234,7 @@ export function NflSyncCard() {
             onClick={handleToggle}
             disabled={syncing}
             className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
-              config.syncEnabled ? "bg-primary" : "bg-gray-200"
+              config.syncEnabled ? "bg-primary" : "bg-muted"
             }`}
           >
             <span
@@ -257,7 +257,7 @@ export function NflSyncCard() {
               "Sync Now"
             )}
           </Button>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-muted-foreground">
             {config.syncEnabled
               ? "Nightly sync enabled (4 AM UTC)"
               : "Nightly sync disabled"}
@@ -266,14 +266,14 @@ export function NflSyncCard() {
 
         {config.lastSyncReport ? (
           <div>
-            <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
-              <CheckCircle2 className="h-4 w-4 text-green-600" />
+            <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-foreground">
+              <CheckCircle2 className="h-4 w-4 text-accent" />
               Last Sync
             </h4>
             <SyncReportDisplay report={config.lastSyncReport} />
           </div>
         ) : (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             No sync has been run yet. Click &quot;Sync Now&quot; to import NFL data.
           </p>
         )}

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -4,7 +4,7 @@ import { NflSyncCard } from "./_components/nfl-sync-card";
 export default function ImportPage() {
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+      <h2 className="mb-6 text-lg font-semibold text-foreground">
         Import Data
       </h2>
       <div className="space-y-8">

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -14,7 +14,7 @@ export default function DashboardLayout({
       </a>
 
       {/* Desktop sidebar */}
-      <aside className="hidden w-56 border-r border-gray-200 bg-gray-50 lg:block">
+      <aside className="hidden w-56 border-r border-border bg-card lg:block">
         <Sidebar />
       </aside>
 
@@ -23,8 +23,8 @@ export default function DashboardLayout({
         <MobileHeader />
 
         {/* Desktop header */}
-        <header className="hidden items-center justify-between border-b border-gray-200 px-8 py-4 lg:flex">
-          <h1 className="text-xl font-bold text-gray-900">Dashboard</h1>
+        <header className="hidden items-center justify-between border-b border-border px-8 py-4 lg:flex">
+          <h1 className="text-xl font-bold text-foreground">Dashboard</h1>
           <UserButton />
         </header>
 

--- a/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
@@ -29,24 +29,24 @@ export default function InvitationList({ orgId }: { orgId: string }) {
     load();
   }, [orgId]);
 
-  if (loading) return <p className="text-sm text-gray-500">Loading invitations...</p>;
+  if (loading) return <p className="text-sm text-muted-foreground">Loading invitations...</p>;
   if (invitations.length === 0) return null;
 
   return (
     <div>
-      <h3 className="mb-3 text-sm font-semibold text-gray-900">Pending Invitations</h3>
+      <h3 className="mb-3 text-sm font-semibold text-foreground">Pending Invitations</h3>
       <ul className="space-y-2">
         {invitations.map((inv) => (
           <li
             key={inv.id}
-            className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm"
+            className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm"
           >
-            <span className="text-gray-700">{inv.emailAddress}</span>
+            <span className="text-foreground">{inv.emailAddress}</span>
             <div className="flex items-center gap-2">
               <Badge variant={inv.status === "pending" ? "secondary" : "outline"}>
                 {inv.status}
               </Badge>
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-muted-foreground">
                 {new Date(inv.createdAt).toLocaleDateString()}
               </span>
             </div>

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
@@ -40,7 +40,7 @@ export default function InviteForm({ orgId }: { orgId: string }) {
 
   return (
     <div>
-      <h3 className="mb-3 text-sm font-semibold text-gray-900">Invite Member</h3>
+      <h3 className="mb-3 text-sm font-semibold text-foreground">Invite Member</h3>
       <form onSubmit={handleSubmit} className="flex items-end gap-3">
         <div className="flex-1">
           <Label htmlFor="invite-email">Email address</Label>
@@ -57,9 +57,9 @@ export default function InviteForm({ orgId }: { orgId: string }) {
           {submitting ? "Sending..." : "Send Invite"}
         </Button>
       </form>
-      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       {success && (
-        <p className="mt-2 text-sm text-green-600">Invitation sent successfully!</p>
+        <p className="mt-2 text-sm text-accent">Invitation sent successfully!</p>
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
@@ -57,14 +57,14 @@ export default function InviteLinkSection({ orgId }: { orgId: string }) {
     setTimeout(() => setCopied(false), 2000);
   }
 
-  if (loading) return <p className="text-sm text-gray-500">Loading invite link...</p>;
+  if (loading) return <p className="text-sm text-muted-foreground">Loading invite link...</p>;
 
   return (
     <div>
-      <h3 className="mb-3 text-sm font-semibold text-gray-900">Invite Link</h3>
+      <h3 className="mb-3 text-sm font-semibold text-foreground">Invite Link</h3>
       {linkUrl ? (
         <div className="flex items-center gap-2">
-          <code className="flex-1 rounded bg-gray-100 px-3 py-2 text-sm text-gray-700">
+          <code className="flex-1 rounded bg-card px-3 py-2 text-sm text-foreground">
             {linkUrl}
           </code>
           <Button size="sm" variant="outline" onClick={handleCopy}>

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -79,9 +79,9 @@ export default function MemberList({ orgId }: { orgId: string }) {
   }
 
   if (loading)
-    return <p className="text-sm text-gray-500">Loading members...</p>;
+    return <p className="text-sm text-muted-foreground">Loading members...</p>;
   if (members.length === 0)
-    return <p className="text-sm text-gray-500">No members found.</p>;
+    return <p className="text-sm text-muted-foreground">No members found.</p>;
 
   return (
     <div className="space-y-3">
@@ -94,7 +94,7 @@ export default function MemberList({ orgId }: { orgId: string }) {
         return (
           <div
             key={member.userId}
-            className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3"
+            className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
           >
             <div className="flex items-center gap-3">
               {member.imageUrl && (
@@ -105,10 +105,10 @@ export default function MemberList({ orgId }: { orgId: string }) {
                 />
               )}
               <div>
-                <p className="text-sm font-medium text-gray-900">
+                <p className="text-sm font-medium text-foreground">
                   {displayName}
                 </p>
-                <p className="text-xs text-gray-500">{member.email}</p>
+                <p className="text-xs text-muted-foreground">{member.email}</p>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -137,7 +137,7 @@ export default function MemberList({ orgId }: { orgId: string }) {
                 variant="outline"
                 disabled={isLoading}
                 onClick={() => handleRemove(member.userId)}
-                className="text-red-600 hover:text-red-700"
+                className="text-destructive hover:text-destructive"
               >
                 Remove
               </Button>

--- a/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
@@ -37,7 +37,7 @@ export default async function MembersPage({
         &larr; Back to {league.name}
       </Link>
 
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+      <h2 className="mb-6 text-lg font-semibold text-foreground">
         Members — {league.name}
       </h2>
 

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -77,7 +77,7 @@ export default async function LeagueDetailPage({
             </div>
           )}
           {!isAdmin && (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               You have read-only access to this league.
             </p>
           )}

--- a/apps/web/src/app/dashboard/leagues/[id]/requests/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/requests/page.tsx
@@ -36,7 +36,7 @@ export default async function RequestsPage({
         &larr; Back to {league.name}
       </Link>
 
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">
+      <h2 className="mb-6 text-lg font-semibold text-foreground">
         Join Requests — {league.name}
       </h2>
 

--- a/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/requests/requests-table.tsx
@@ -61,10 +61,10 @@ export default function RequestsTable({ orgId }: { orgId: string }) {
     }
   }
 
-  if (loading) return <p className="text-sm text-gray-500">Loading requests...</p>;
+  if (loading) return <p className="text-sm text-muted-foreground">Loading requests...</p>;
 
   if (requests.length === 0) {
-    return <p className="text-sm text-gray-500">No pending requests.</p>;
+    return <p className="text-sm text-muted-foreground">No pending requests.</p>;
   }
 
   return (
@@ -74,11 +74,11 @@ export default function RequestsTable({ orgId }: { orgId: string }) {
         return (
           <div
             key={req.userId}
-            className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3"
+            className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
           >
             <div>
-              <p className="text-sm font-medium text-gray-900">{req.email}</p>
-              <p className="text-xs text-gray-500">
+              <p className="text-sm font-medium text-foreground">{req.email}</p>
+              <p className="text-xs text-muted-foreground">
                 Requested {new Date(req.requestedAt).toLocaleDateString()}
               </p>
             </div>

--- a/apps/web/src/app/dashboard/leagues/error.tsx
+++ b/apps/web/src/app/dashboard/leagues/error.tsx
@@ -11,12 +11,12 @@ export default function LeaguesError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Failed to load leagues
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/leagues/loading.tsx
+++ b/apps/web/src/app/dashboard/leagues/loading.tsx
@@ -3,12 +3,12 @@ import { Skeleton } from "@/components/ui/8bit/skeleton";
 export default function LeaguesLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <div className="space-y-4">
         {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-lg border border-gray-200 bg-white p-6"
+            className="rounded-lg border border-border bg-white p-6"
           >
             <Skeleton className="h-6 w-40" />
             <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -37,7 +37,7 @@ export default async function LeaguesPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Leagues</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Leagues</h2>
 
       {leagues.length === 0 ? (
         <EmptyState
@@ -68,7 +68,7 @@ export default async function LeaguesPage() {
                 </CardHeader>
                 <CardContent>
                   {leagueDivisions.length === 0 ? (
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-muted-foreground">
                       No divisions in this league.
                     </p>
                   ) : (
@@ -80,8 +80,8 @@ export default async function LeaguesPage() {
                         return (
                           <div key={division.id}>
                             <div className="mb-2 flex items-center gap-2">
-                              <Layers className="h-4 w-4 text-gray-500" />
-                              <span className="text-sm font-medium text-gray-700">
+                              <Layers className="h-4 w-4 text-muted-foreground" />
+                              <span className="text-sm font-medium text-foreground">
                                 {division.name}
                               </span>
                               <Badge variant="outline" className="text-xs">
@@ -95,14 +95,14 @@ export default async function LeaguesPage() {
                                   <Link
                                     key={team.id}
                                     href={`/dashboard/teams/${team.id}`}
-                                    className="flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm transition-colors hover:bg-gray-100"
+                                    className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-card"
                                   >
-                                    <Users className="h-3.5 w-3.5 text-gray-400" />
-                                    <span className="font-medium text-gray-700">
+                                    <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                                    <span className="font-medium text-foreground">
                                       {team.name}
                                     </span>
                                     {team.city && (
-                                      <span className="text-gray-400">
+                                      <span className="text-muted-foreground">
                                         &mdash; {team.city}
                                       </span>
                                     )}
@@ -110,7 +110,7 @@ export default async function LeaguesPage() {
                                 ))}
                               </div>
                             ) : (
-                              <p className="ml-6 text-sm text-gray-400">
+                              <p className="ml-6 text-sm text-muted-foreground">
                                 No teams in this division.
                               </p>
                             )}

--- a/apps/web/src/app/dashboard/loading.tsx
+++ b/apps/web/src/app/dashboard/loading.tsx
@@ -3,7 +3,7 @@ import { CardSkeleton } from "@/components/skeletons/card-skeleton";
 export default function DashboardLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <CardSkeleton count={4} />
     </div>
   );

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Overview</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Overview</h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         {statCards.map((card) => {
           const Icon = card.icon;
@@ -63,10 +63,10 @@ export default async function DashboardPage() {
                     <Icon className="h-5 w-5 text-primary" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-gray-500">
+                    <p className="text-sm font-medium text-muted-foreground">
                       {card.label}
                     </p>
-                    <p className="text-2xl font-bold text-gray-900">
+                    <p className="text-2xl font-bold text-foreground">
                       {counts[card.key]}
                     </p>
                   </div>

--- a/apps/web/src/app/dashboard/players/error.tsx
+++ b/apps/web/src/app/dashboard/players/error.tsx
@@ -11,12 +11,12 @@ export default function PlayersError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Failed to load players
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/players/loading.tsx
+++ b/apps/web/src/app/dashboard/players/loading.tsx
@@ -3,7 +3,7 @@ import { TableSkeleton } from "@/components/skeletons/table-skeleton";
 export default function PlayersLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <TableSkeleton rows={8} columns={4} />
     </div>
   );

--- a/apps/web/src/app/dashboard/players/page.tsx
+++ b/apps/web/src/app/dashboard/players/page.tsx
@@ -13,7 +13,7 @@ export default async function PlayersPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Players</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Players</h2>
       <PlayersTable players={players} />
     </div>
   );

--- a/apps/web/src/app/dashboard/seasons/error.tsx
+++ b/apps/web/src/app/dashboard/seasons/error.tsx
@@ -11,12 +11,12 @@ export default function SeasonsError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Failed to load seasons
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/seasons/loading.tsx
+++ b/apps/web/src/app/dashboard/seasons/loading.tsx
@@ -3,7 +3,7 @@ import { TableSkeleton } from "@/components/skeletons/table-skeleton";
 export default function SeasonsLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <TableSkeleton rows={5} columns={4} />
     </div>
   );

--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -13,7 +13,7 @@ export default async function SeasonsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Seasons</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Seasons</h2>
       <SeasonsTable seasons={seasons} />
     </div>
   );

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -51,7 +51,7 @@ export default async function DepthChartPage({
         >
           &larr; Back to Team
         </Link>
-        <div className="rounded-md border border-dashed p-8 text-center text-sm text-gray-500">
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
           No season exists for this league. Create a season before editing the
           depth chart.
         </div>

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -83,7 +83,7 @@ export default function TeamManagement({
       <Card className="mb-8">
         <CardContent className="pt-6">
           <div className="flex items-start justify-between">
-            <h2 className="text-2xl font-bold text-gray-900">{team.name}</h2>
+            <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
             {canManage && (
               <Button
                 variant="outline"
@@ -98,26 +98,26 @@ export default function TeamManagement({
           <dl className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
             {team.city && (
               <div>
-                <dt className="font-medium text-gray-500">City</dt>
-                <dd className="mt-1 text-gray-900">{team.city}</dd>
+                <dt className="font-medium text-muted-foreground">City</dt>
+                <dd className="mt-1 text-foreground">{team.city}</dd>
               </div>
             )}
             {team.stadium && (
               <div>
-                <dt className="font-medium text-gray-500">Stadium</dt>
-                <dd className="mt-1 text-gray-900">{team.stadium}</dd>
+                <dt className="font-medium text-muted-foreground">Stadium</dt>
+                <dd className="mt-1 text-foreground">{team.stadium}</dd>
               </div>
             )}
             {team.foundedYear && (
               <div>
-                <dt className="font-medium text-gray-500">Founded</dt>
-                <dd className="mt-1 text-gray-900">{team.foundedYear}</dd>
+                <dt className="font-medium text-muted-foreground">Founded</dt>
+                <dd className="mt-1 text-foreground">{team.foundedYear}</dd>
               </div>
             )}
             {team.location && (
               <div>
-                <dt className="font-medium text-gray-500">Location</dt>
-                <dd className="mt-1 text-gray-900">{team.location}</dd>
+                <dt className="font-medium text-muted-foreground">Location</dt>
+                <dd className="mt-1 text-foreground">{team.location}</dd>
               </div>
             )}
           </dl>
@@ -125,7 +125,7 @@ export default function TeamManagement({
       </Card>
 
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900">
+        <h3 className="text-lg font-semibold text-foreground">
           Player Roster ({players.length})
         </h3>
         {canManage && (
@@ -160,7 +160,7 @@ export default function TeamManagement({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-red-600 hover:text-red-700"
+                      className="text-destructive hover:text-destructive"
                       onClick={() =>
                         setModal({
                           type: "deletePlayer",

--- a/apps/web/src/app/dashboard/teams/error.tsx
+++ b/apps/web/src/app/dashboard/teams/error.tsx
@@ -11,12 +11,12 @@ export default function TeamsError({
   reset: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-16 text-center">
       <AlertTriangle className="mb-3 h-10 w-10 text-yellow-500" />
-      <h2 className="text-lg font-semibold text-gray-900">
+      <h2 className="text-lg font-semibold text-foreground">
         Failed to load teams
       </h2>
-      <p className="mt-1 text-sm text-gray-500">
+      <p className="mt-1 text-sm text-muted-foreground">
         {error.message || "An unexpected error occurred."}
       </p>
       <Button className="mt-4" onClick={reset}>

--- a/apps/web/src/app/dashboard/teams/loading.tsx
+++ b/apps/web/src/app/dashboard/teams/loading.tsx
@@ -3,12 +3,12 @@ import { Skeleton } from "@/components/ui/8bit/skeleton";
 export default function TeamsLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-gray-200" />
+      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-lg border border-gray-200 bg-white p-6"
+            className="rounded-lg border border-border bg-white p-6"
           >
             <Skeleton className="h-5 w-32" />
             <div className="mt-3 space-y-2">

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -13,16 +13,16 @@ export default async function TeamsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-gray-900">Teams</h2>
+      <h2 className="mb-6 text-lg font-semibold text-foreground">Teams</h2>
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {teams.map((team) => (
           <Link
             key={team.id}
             href={`/dashboard/teams/${team.id}`}
-            className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
+            className="rounded-lg border border-border bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
           >
-            <h3 className="text-lg font-semibold text-gray-900">{team.name}</h3>
-            <dl className="mt-3 space-y-1 text-sm text-gray-600">
+            <h3 className="text-lg font-semibold text-foreground">{team.name}</h3>
+            <dl className="mt-3 space-y-1 text-sm text-muted-foreground">
               {team.city && (
                 <div>
                   <dt className="inline font-medium">City: </dt>
@@ -45,7 +45,7 @@ export default async function TeamsPage() {
           </Link>
         ))}
         {teams.length === 0 && (
-          <p className="text-gray-500">No teams found.</p>
+          <p className="text-muted-foreground">No teams found.</p>
         )}
       </div>
     </div>

--- a/apps/web/src/app/join/[token]/join-form.tsx
+++ b/apps/web/src/app/join/[token]/join-form.tsx
@@ -48,8 +48,8 @@ export default function JoinForm({
     return (
       <Card className="w-full max-w-md">
         <CardContent className="pt-6 text-center">
-          <h2 className="text-lg font-semibold text-gray-900">Request Submitted</h2>
-          <p className="mt-2 text-sm text-gray-500">
+          <h2 className="text-lg font-semibold text-foreground">Request Submitted</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
             Your request to join {leagueName} has been submitted.
             An admin will review your request.
           </p>
@@ -70,10 +70,10 @@ export default function JoinForm({
         </div>
       </CardHeader>
       <CardContent>
-        <p className="mb-4 text-sm text-gray-500">
+        <p className="mb-4 text-sm text-muted-foreground">
           You&apos;ve been invited to join this league. Click below to request access.
         </p>
-        {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+        {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
         <Button
           className="w-full"
           onClick={handleJoin}

--- a/apps/web/src/app/join/[token]/page.tsx
+++ b/apps/web/src/app/join/[token]/page.tsx
@@ -15,8 +15,8 @@ export default async function JoinPage({
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">Invalid Invite Link</h1>
-          <p className="mt-2 text-gray-500">
+          <h1 className="text-2xl font-bold text-foreground">Invalid Invite Link</h1>
+          <p className="mt-2 text-muted-foreground">
             This invitation link is invalid or has been revoked.
           </p>
         </div>

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -96,7 +96,7 @@ export function DataTable<T extends Record<string, unknown>>({
   return (
     <div className="space-y-4">
       <div className="relative max-w-sm">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           placeholder={searchPlaceholder}
           value={search}
@@ -108,17 +108,17 @@ export function DataTable<T extends Record<string, unknown>>({
         />
       </div>
 
-      <div className="rounded-lg border border-gray-200">
+      <div className="rounded-lg border border-border">
         <Table>
           <TableHeader>
-            <TableRow className="bg-gray-50 hover:bg-gray-50">
+            <TableRow className="bg-card hover:bg-card">
               {columns.map((col) => (
                 <TableHead key={col.key}>
                   {col.sortable ? (
                     <button
                       type="button"
                       onClick={() => toggleSort(col.key)}
-                      className="inline-flex items-center gap-1 hover:text-gray-900"
+                      className="inline-flex items-center gap-1 hover:text-foreground"
                     >
                       {col.header}
                       <ArrowUpDown className="h-3 w-3" />
@@ -155,7 +155,7 @@ export function DataTable<T extends Record<string, unknown>>({
               <TableRow>
                 <TableCell
                   colSpan={columns.length + (actions ? 1 : 0)}
-                  className="h-24 text-center text-gray-500"
+                  className="h-24 text-center text-muted-foreground"
                 >
                   {emptyMessage}
                 </TableCell>
@@ -166,7 +166,7 @@ export function DataTable<T extends Record<string, unknown>>({
       </div>
 
       {totalPages > 1 && (
-        <div className="flex items-center justify-between text-sm text-gray-500">
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
             Showing {safeCurrentPage * pageSize + 1}\u2013
             {Math.min((safeCurrentPage + 1) * pageSize, sorted.length)} of{" "}

--- a/apps/web/src/components/depth-chart/DepthChartBoard.tsx
+++ b/apps/web/src/components/depth-chart/DepthChartBoard.tsx
@@ -74,10 +74,10 @@ export default function DepthChartBoard({
   return (
     <div>
       <header className="mb-4">
-        <h2 className="text-2xl font-bold text-gray-900">
+        <h2 className="text-2xl font-bold text-foreground">
           {teamName} — Depth Chart
         </h2>
-        <p className="text-sm text-gray-500">Season: {season.name}</p>
+        <p className="text-sm text-muted-foreground">Season: {season.name}</p>
       </header>
 
       <LockBanner
@@ -89,7 +89,7 @@ export default function DepthChartBoard({
       />
 
       {columns.length === 0 ? (
-        <div className="rounded-md border border-dashed p-8 text-center text-sm text-gray-500">
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
           No players on this team. Add players before editing the depth chart.
         </div>
       ) : (

--- a/apps/web/src/components/depth-chart/LockBanner.tsx
+++ b/apps/web/src/components/depth-chart/LockBanner.tsx
@@ -54,16 +54,16 @@ export default function LockBanner({
       className={`mb-4 flex items-center justify-between rounded-md border p-3 ${
         optimisticLocked
           ? "border-amber-300 bg-amber-50"
-          : "border-gray-200 bg-gray-50"
+          : "border-border bg-card"
       }`}
     >
       <div className="flex items-center gap-2 text-sm">
         {optimisticLocked ? (
           <Lock className="h-4 w-4 text-amber-600" aria-hidden />
         ) : (
-          <Unlock className="h-4 w-4 text-gray-500" aria-hidden />
+          <Unlock className="h-4 w-4 text-muted-foreground" aria-hidden />
         )}
-        <span className={optimisticLocked ? "text-amber-800" : "text-gray-700"}>
+        <span className={optimisticLocked ? "text-amber-800" : "text-foreground"}>
           {optimisticLocked
             ? "Roster locked — drag handles are disabled"
             : "Roster is unlocked"}

--- a/apps/web/src/components/depth-chart/PositionColumn.tsx
+++ b/apps/web/src/components/depth-chart/PositionColumn.tsx
@@ -86,13 +86,13 @@ export default function PositionColumn({
       aria-label={`${positionSlot} depth chart`}
     >
       <header className="flex items-center justify-between border-b px-3 py-2">
-        <h3 className="font-mono text-sm font-semibold text-gray-700">
+        <h3 className="font-mono text-sm font-semibold text-foreground">
           {positionSlot}
         </h3>
-        <span className="text-xs text-gray-500">{items.length}</span>
+        <span className="text-xs text-muted-foreground">{items.length}</span>
       </header>
       {items.length === 0 ? (
-        <div className="px-3 py-6 text-center text-xs text-gray-500">
+        <div className="px-3 py-6 text-center text-xs text-muted-foreground">
           No players at this position.
         </div>
       ) : (
@@ -148,7 +148,7 @@ function SortableRow({
     >
       <button
         type="button"
-        className={`text-gray-400 ${disabled ? "cursor-not-allowed opacity-40" : "cursor-grab active:cursor-grabbing hover:text-gray-600"}`}
+        className={`text-muted-foreground ${disabled ? "cursor-not-allowed opacity-40" : "cursor-grab active:cursor-grabbing hover:text-muted-foreground"}`}
         aria-label={`Drag ${player.name}`}
         disabled={disabled}
         {...attributes}
@@ -156,10 +156,10 @@ function SortableRow({
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <span className="w-6 font-mono text-xs text-gray-500">{rank}</span>
-      <span className="flex-1 text-sm text-gray-900">{player.name}</span>
+      <span className="w-6 font-mono text-xs text-muted-foreground">{rank}</span>
+      <span className="flex-1 text-sm text-foreground">{player.name}</span>
       {player.jerseyNumber !== null && (
-        <span className="font-mono text-xs text-gray-500">
+        <span className="font-mono text-xs text-muted-foreground">
           #{player.jerseyNumber}
         </span>
       )}

--- a/apps/web/src/components/empty-state.tsx
+++ b/apps/web/src/components/empty-state.tsx
@@ -14,11 +14,11 @@ export function EmptyState({
   action,
 }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
-      {Icon && <Icon className="mb-3 h-10 w-10 text-gray-400" />}
-      <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-12 text-center">
+      {Icon && <Icon className="mb-3 h-10 w-10 text-muted-foreground" />}
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
       {description && (
-        <p className="mt-1 text-sm text-gray-500">{description}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       )}
       {action && <div className="mt-4">{action}</div>}
     </div>

--- a/apps/web/src/components/marketing/features.tsx
+++ b/apps/web/src/components/marketing/features.tsx
@@ -37,17 +37,17 @@ export function Features() {
   return (
     <section
       id="features"
-      className="border-t border-zinc-100 bg-zinc-50/50 py-20 sm:py-24"
+      className="border-t border-border bg-card/50 py-20 sm:py-24"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
             Features
           </p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Everything you need. Nothing you don&apos;t.
           </h2>
-          <p className="mt-4 text-lg text-zinc-600">
+          <p className="mt-4 text-lg text-muted-foreground">
             Built specifically for volunteer and rec-league coaches.
           </p>
         </div>
@@ -56,15 +56,15 @@ export function Features() {
           {features.map((feature) => {
             const Icon = feature.icon;
             return (
-              <Card key={feature.title} className="border-zinc-200/80">
+              <Card key={feature.title} className="border-border/80">
                 <CardHeader>
-                  <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-primary">
                     <Icon className="h-5 w-5" aria-hidden="true" />
                   </div>
                   <CardTitle className="mt-4 text-xl">{feature.title}</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-base leading-7 text-zinc-600">
+                  <p className="text-base leading-7 text-muted-foreground">
                     {feature.description}
                   </p>
                 </CardContent>

--- a/apps/web/src/components/marketing/footer.tsx
+++ b/apps/web/src/components/marketing/footer.tsx
@@ -25,31 +25,31 @@ export function MarketingFooter({ isSignedIn }: FooterProps) {
       ];
 
   return (
-    <footer className="border-t border-zinc-200 bg-white">
+    <footer className="border-t border-border bg-white">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
         <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
           <div className="col-span-2 sm:col-span-1">
             <Link
               href="/"
-              className="flex items-center gap-2 text-zinc-900"
+              className="flex items-center gap-2 text-foreground"
               aria-label="sprtsmng home"
             >
               <Monogram size={28} />
               <span className="text-base font-bold tracking-tight">sprtsmng</span>
             </Link>
-            <p className="mt-3 max-w-xs text-sm text-zinc-600">
+            <p className="mt-3 max-w-xs text-sm text-muted-foreground">
               The simplest way to run your youth sports team.
             </p>
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold text-zinc-900">Product</h3>
+            <h3 className="text-sm font-semibold text-foreground">Product</h3>
             <ul className="mt-3 space-y-2">
               {productLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-zinc-600 hover:text-zinc-900"
+                    className="text-sm text-muted-foreground hover:text-foreground"
                   >
                     {link.label}
                   </Link>
@@ -59,13 +59,13 @@ export function MarketingFooter({ isSignedIn }: FooterProps) {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold text-zinc-900">Legal</h3>
+            <h3 className="text-sm font-semibold text-foreground">Legal</h3>
             <ul className="mt-3 space-y-2">
               {legalLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-zinc-600 hover:text-zinc-900"
+                    className="text-sm text-muted-foreground hover:text-foreground"
                   >
                     {link.label}
                   </Link>
@@ -75,13 +75,13 @@ export function MarketingFooter({ isSignedIn }: FooterProps) {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold text-zinc-900">Account</h3>
+            <h3 className="text-sm font-semibold text-foreground">Account</h3>
             <ul className="mt-3 space-y-2">
               {accountLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-zinc-600 hover:text-zinc-900"
+                    className="text-sm text-muted-foreground hover:text-foreground"
                   >
                     {link.label}
                   </Link>
@@ -91,8 +91,8 @@ export function MarketingFooter({ isSignedIn }: FooterProps) {
           </div>
         </div>
 
-        <div className="mt-12 border-t border-zinc-200 pt-8">
-          <p className="text-sm text-zinc-500">
+        <div className="mt-12 border-t border-border pt-8">
+          <p className="text-sm text-muted-foreground">
             © {new Date().getFullYear()} Arcnology · Built with Next.js, Clerk,
             Stripe, and Salesforce
           </p>

--- a/apps/web/src/components/marketing/header.tsx
+++ b/apps/web/src/components/marketing/header.tsx
@@ -8,11 +8,11 @@ interface HeaderProps {
 
 export function MarketingHeader({ isSignedIn }: HeaderProps) {
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-zinc-200/60 bg-white/80 backdrop-blur-md">
+    <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-white/80 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link
           href="/"
-          className="flex items-center gap-2 text-zinc-900"
+          className="flex items-center gap-2 text-foreground"
           aria-label="sprtsmng home"
         >
           <Monogram size={32} />
@@ -20,16 +20,16 @@ export function MarketingHeader({ isSignedIn }: HeaderProps) {
         </Link>
 
         <nav
-          className="hidden items-center gap-6 text-sm font-medium text-zinc-600 sm:flex"
+          className="hidden items-center gap-6 text-sm font-medium text-muted-foreground sm:flex"
           aria-label="Primary"
         >
-          <Link href="#features" className="hover:text-zinc-900">
+          <Link href="#features" className="hover:text-foreground">
             Features
           </Link>
-          <Link href="#how-it-works" className="hover:text-zinc-900">
+          <Link href="#how-it-works" className="hover:text-foreground">
             How it works
           </Link>
-          <Link href="#pricing" className="hover:text-zinc-900">
+          <Link href="#pricing" className="hover:text-foreground">
             Pricing
           </Link>
         </nav>
@@ -43,7 +43,7 @@ export function MarketingHeader({ isSignedIn }: HeaderProps) {
             <>
               <Link
                 href="/sign-in"
-                className="hidden text-sm font-medium text-zinc-700 hover:text-zinc-900 sm:inline"
+                className="hidden text-sm font-medium text-foreground hover:text-foreground sm:inline"
               >
                 Sign in
               </Link>

--- a/apps/web/src/components/marketing/hero.tsx
+++ b/apps/web/src/components/marketing/hero.tsx
@@ -17,16 +17,16 @@ export function MarketingHero({ isSignedIn }: HeroProps) {
 
       <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-28 lg:px-8 lg:py-32">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
-            <span className="h-1.5 w-1.5 rounded-full bg-blue-600" />
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-primary">
+            <span className="h-1.5 w-1.5 rounded-full bg-primary" />
             Free for one team, forever
           </p>
 
-          <h1 className="text-balance text-4xl font-bold tracking-tight text-zinc-900 sm:text-5xl lg:text-6xl">
+          <h1 className="text-balance text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Manage your team without the spreadsheets.
           </h1>
 
-          <p className="mx-auto mt-6 max-w-2xl text-balance text-lg leading-8 text-zinc-600 sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-balance text-lg leading-8 text-muted-foreground sm:text-xl">
             sprtsmng is the simplest way to run your youth sports team. Roster,
             schedule, notifications — all in one place.
           </p>
@@ -52,7 +52,7 @@ export function MarketingHero({ isSignedIn }: HeroProps) {
             </Button>
           </div>
 
-          <p className="mt-6 text-sm text-zinc-500">
+          <p className="mt-6 text-sm text-muted-foreground">
             No credit card required · Sign in with Google
           </p>
         </div>

--- a/apps/web/src/components/marketing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/how-it-works.tsx
@@ -28,17 +28,17 @@ export function HowItWorks() {
   return (
     <section
       id="how-it-works"
-      className="border-t border-zinc-100 bg-white py-20 sm:py-24"
+      className="border-t border-border bg-white py-20 sm:py-24"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
             How it works
           </p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             From signup to first practice in 5 minutes
           </h2>
-          <p className="mt-4 text-lg text-zinc-600">
+          <p className="mt-4 text-lg text-muted-foreground">
             No setup calls. No onboarding fees. Just start managing your team.
           </p>
         </div>
@@ -50,17 +50,17 @@ export function HowItWorks() {
               <li key={step.number} className="relative">
                 <div className="flex flex-col items-start">
                   <div className="flex items-center gap-3">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-primary">
                       <Icon className="h-6 w-6" aria-hidden="true" />
                     </div>
-                    <span className="text-sm font-semibold tracking-wide text-zinc-400">
+                    <span className="text-sm font-semibold tracking-wide text-muted-foreground">
                       {step.number}
                     </span>
                   </div>
-                  <h3 className="mt-4 text-xl font-semibold text-zinc-900">
+                  <h3 className="mt-4 text-xl font-semibold text-foreground">
                     {step.title}
                   </h3>
-                  <p className="mt-2 text-base text-zinc-600">
+                  <p className="mt-2 text-base text-muted-foreground">
                     {step.description}
                   </p>
                 </div>

--- a/apps/web/src/components/marketing/legal-layout.tsx
+++ b/apps/web/src/components/marketing/legal-layout.tsx
@@ -32,16 +32,16 @@ export async function LegalLayout({
             </p>
           </div>
 
-          <header className="mb-10 border-b border-zinc-200 pb-8">
-            <h1 className="text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+          <header className="mb-10 border-b border-border pb-8">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               {title}
             </h1>
-            <p className="mt-3 text-sm text-zinc-500">
+            <p className="mt-3 text-sm text-muted-foreground">
               Last updated: {lastUpdated}
             </p>
           </header>
 
-          <article className="prose prose-zinc max-w-none [&_h2]:mt-10 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-zinc-900 [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-zinc-900 [&_p]:mt-3 [&_p]:text-base [&_p]:leading-7 [&_p]:text-zinc-700 [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-base [&_ul]:text-zinc-700 [&_li]:mt-1 [&_a]:text-blue-600 [&_a]:underline hover:[&_a]:text-blue-700">
+          <article className="prose prose-zinc max-w-none [&_h2]:mt-10 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-foreground [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-foreground [&_p]:mt-3 [&_p]:text-base [&_p]:leading-7 [&_p]:text-foreground [&_ul]:mt-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-base [&_ul]:text-foreground [&_li]:mt-1 [&_a]:text-primary [&_a]:underline hover:[&_a]:text-primary">
             {children}
           </article>
         </div>

--- a/apps/web/src/components/marketing/pricing-section.tsx
+++ b/apps/web/src/components/marketing/pricing-section.tsx
@@ -4,17 +4,17 @@ export function PricingSection() {
   return (
     <section
       id="pricing"
-      className="border-t border-zinc-100 bg-zinc-50/50 py-20 sm:py-24"
+      className="border-t border-border bg-card/50 py-20 sm:py-24"
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
             Pricing
           </p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Simple pricing. No surprises.
           </h2>
-          <p className="mt-4 text-lg text-zinc-600">
+          <p className="mt-4 text-lg text-muted-foreground">
             Start free. Upgrade if and when you need more.
           </p>
         </div>

--- a/apps/web/src/components/marketing/screenshots.tsx
+++ b/apps/web/src/components/marketing/screenshots.tsx
@@ -29,16 +29,16 @@ const screenshots = [
 
 export function Screenshots() {
   return (
-    <section className="border-t border-zinc-100 bg-white py-20 sm:py-24">
+    <section className="border-t border-border bg-white py-20 sm:py-24">
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
             See it in action
           </p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Built for the way you actually coach
           </h2>
-          <p className="mt-4 text-lg text-zinc-600">
+          <p className="mt-4 text-lg text-muted-foreground">
             Three clicks from sign-in to the player you&apos;re looking for.
           </p>
         </div>
@@ -46,7 +46,7 @@ export function Screenshots() {
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-8 sm:grid-cols-3">
           {screenshots.map((shot) => (
             <figure key={shot.src} className="flex flex-col">
-              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 shadow-sm">
+              <div className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
                 <Image
                   src={shot.src}
                   alt={shot.alt}
@@ -56,7 +56,7 @@ export function Screenshots() {
                   sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 />
               </div>
-              <figcaption className="mt-3 text-center text-sm text-zinc-600">
+              <figcaption className="mt-3 text-center text-sm text-muted-foreground">
                 {shot.caption}
               </figcaption>
             </figure>

--- a/apps/web/src/components/pricing-table.tsx
+++ b/apps/web/src/components/pricing-table.tsx
@@ -58,7 +58,7 @@ export function PricingTable({
             "rounded-md px-4 py-2 text-sm font-medium transition-colors",
             interval === "monthly"
               ? "bg-zinc-900 text-white"
-              : "text-zinc-600 hover:text-zinc-900",
+              : "text-muted-foreground hover:text-foreground",
           )}
         >
           Monthly
@@ -70,7 +70,7 @@ export function PricingTable({
             "rounded-md px-4 py-2 text-sm font-medium transition-colors",
             interval === "yearly"
               ? "bg-zinc-900 text-white"
-              : "text-zinc-600 hover:text-zinc-900",
+              : "text-muted-foreground hover:text-foreground",
           )}
         >
           Yearly
@@ -110,19 +110,19 @@ export function PricingTable({
                 <div className="mb-4">
                   <span className="text-3xl font-bold">{formatPrice(price)}</span>
                   {!isFree && (
-                    <span className="text-sm text-zinc-500">
+                    <span className="text-sm text-muted-foreground">
                       /{interval === "monthly" ? "mo" : "yr"}
                     </span>
                   )}
                   {!isFree && interval === "yearly" && savings > 0 && (
-                    <p className="mt-1 text-xs text-green-600">Save {savings}% vs monthly</p>
+                    <p className="mt-1 text-xs text-accent">Save {savings}% vs monthly</p>
                   )}
                 </div>
 
                 <ul className="mb-6 space-y-2 text-sm">
                   {config.highlights.map((feature) => (
                     <li key={feature} className="flex items-start gap-2">
-                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-600" />
+                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent" />
                       <span>{feature}</span>
                     </li>
                   ))}

--- a/apps/web/src/components/roster/RosterAuditTimeline.tsx
+++ b/apps/web/src/components/roster/RosterAuditTimeline.tsx
@@ -24,10 +24,10 @@ const ACTION_FILTERS: Array<{
 ];
 
 const ACTION_COLORS: Record<RosterAuditAction, string> = {
-  assign: "bg-green-100 text-green-800 border-green-200",
-  remove: "bg-red-100 text-red-800 border-red-200",
+  assign: "bg-green-100 text-accent border-accent/30",
+  remove: "bg-destructive/15 text-destructive border-destructive/30",
   status_change: "bg-amber-100 text-amber-800 border-amber-200",
-  depth_reorder: "bg-blue-100 text-blue-800 border-blue-200",
+  depth_reorder: "bg-blue-100 text-primary border-blue-200",
 };
 
 type AuditSnapshot = {

--- a/apps/web/src/components/roster/RosterSlotGroup.tsx
+++ b/apps/web/src/components/roster/RosterSlotGroup.tsx
@@ -168,7 +168,7 @@ function RosterRow({
           <DropdownMenuItem
             onSelect={runRemove}
             disabled={pending}
-            className="text-red-600"
+            className="text-destructive"
           >
             Remove from roster
           </DropdownMenuItem>

--- a/apps/web/src/components/skeletons/card-skeleton.tsx
+++ b/apps/web/src/components/skeletons/card-skeleton.tsx
@@ -10,7 +10,7 @@ export function CardSkeleton({ count = 4 }: CardSkeletonProps) {
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}
-          className="rounded-lg border border-gray-200 bg-white p-6"
+          className="rounded-lg border border-border bg-white p-6"
         >
           <Skeleton className="h-4 w-20" />
           <Skeleton className="mt-2 h-8 w-12" />

--- a/apps/web/src/components/skeletons/table-skeleton.tsx
+++ b/apps/web/src/components/skeletons/table-skeleton.tsx
@@ -9,8 +9,8 @@ export function TableSkeleton({ rows = 5, columns = 4 }: TableSkeletonProps) {
   return (
     <div className="space-y-4">
       <Skeleton className="h-9 w-72" />
-      <div className="rounded-lg border border-gray-200">
-        <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
+      <div className="rounded-lg border border-border">
+        <div className="border-b border-border bg-card px-4 py-3">
           <div className="flex gap-8">
             {Array.from({ length: columns }).map((_, i) => (
               <Skeleton key={i} className="h-4 w-24" />
@@ -20,7 +20,7 @@ export function TableSkeleton({ rows = 5, columns = 4 }: TableSkeletonProps) {
         {Array.from({ length: rows }).map((_, i) => (
           <div
             key={i}
-            className="flex gap-8 border-b border-gray-200 px-4 py-3 last:border-0"
+            className="flex gap-8 border-b border-border px-4 py-3 last:border-0"
           >
             {Array.from({ length: columns }).map((_, j) => (
               <Skeleton key={j} className="h-4 w-24" />

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -33,7 +33,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-gray-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
@@ -80,7 +80,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-gray-500", className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -8,10 +8,10 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "border-transparent bg-primary text-primary-foreground",
-        secondary: "border-transparent bg-gray-100 text-gray-900",
-        destructive: "border-transparent bg-red-100 text-red-800",
-        outline: "text-gray-700",
-        success: "border-transparent bg-green-100 text-green-800",
+        secondary: "border-transparent bg-card text-foreground",
+        destructive: "border-transparent bg-destructive/15 text-destructive",
+        outline: "text-foreground",
+        success: "border-transparent bg-green-100 text-accent",
         warning: "border-transparent bg-yellow-100 text-yellow-800",
       },
     },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,11 +9,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-red-600 text-white hover:bg-red-700",
+        destructive: "bg-destructive text-white hover:bg-destructive",
         outline:
-          "border border-gray-300 bg-white text-gray-700 hover:bg-gray-50",
-        secondary: "bg-gray-100 text-gray-900 hover:bg-gray-200",
-        ghost: "text-gray-700 hover:bg-gray-100",
+          "border border-border bg-white text-foreground hover:bg-card",
+        secondary: "bg-card text-foreground hover:bg-muted",
+        ghost: "text-foreground hover:bg-card",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-border bg-white px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -17,7 +17,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-gray-200",
+        "shrink-0 bg-muted",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
         className,
       )}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-gray-200", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Why this PR exists

Sprint 3 set up the new 8-bit indie pixel-art palette + 8bit/* component primitives. But user-visible production verification revealed the new aesthetic wasn't actually showing up — because **most consumer code uses hardcoded Tailwind colors** (\`bg-blue-600\`, \`text-gray-500\`, \`border-gray-200\`) directly, not the semantic tokens (\`bg-primary\`, \`text-muted-foreground\`, \`border-border\`) that my palette swap drives.

WSM-000027's commit message called this out as a "coupled assumption" but the sprint never circled back to fix it. This PR closes the gap.

## What changed

Mass mechanical swap via \`perl -pi\` across **67 files** (~289 → 12 instances), mapping every well-known hardcoded color class to its semantic token:

| Before | After |
|---|---|
| \`text-gray-{700-950}\` / \`text-zinc-{700-950}\` | \`text-foreground\` |
| \`text-gray-{300-600}\` / \`text-zinc-{300-600}\` | \`text-muted-foreground\` |
| \`bg-gray-{50,100}\` / \`bg-zinc-{50,100}\` | \`bg-card\` |
| \`bg-gray-{200,300}\` / \`bg-zinc-{200,300}\` | \`bg-muted\` |
| \`border-gray-*\` / \`border-zinc-*\` | \`border-border\` |
| \`text-blue-*\` | \`text-primary\` |
| \`bg-blue-*\` (+ hover variants) | \`bg-primary\` (\`hover:bg-primary/90\`) |
| \`focus[-visible]:ring-blue-*\` | \`focus[-visible]:ring-ring\` |
| \`text-red-*\` | \`text-destructive\` |
| \`bg-red-{50,100}\` | \`bg-destructive/{10,15}\` |
| \`text-green-*\` | \`text-accent\` |

## Residue (12 instances kept as-is)
Light blue / light green backgrounds and dark-mode zinc accents — they'd need an explicit \`info\`/\`warning\`/\`success\` palette extension to map cleanly. Acceptable for now; can address as a follow-up if needed.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean across 67 files
- [x] \`pnpm --filter @sports-management/web lint\` clean (one pre-existing warning, unrelated)
- [ ] Visual verification on Vercel preview

## Next: domain-alias promotion
Once this merges, \`sprtsmng.andrewsolomon.dev\` is still pointing at a 14-day-old deploy from before Sprint 2. Promotion to the latest production deploy is a one-shot \`vercel\` CLI command — separate from this PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)