### PR TITLE
fix(web): degrade dashboard overview gracefully when Salesforce read fails (WSM-000038)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -30,28 +30,61 @@ export default async function DashboardPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const orgContext = await resolveOrgContext(userId);
-  const ids = orgContext.visibleLeagueIds;
-
-  const [leagues, teams, players, seasons, divisions] = await Promise.all([
-    getLeagues(ids),
-    getTeams(ids),
-    getPlayers(ids),
-    getSeasons(ids),
-    getDivisions(ids),
-  ]);
-
-  const counts: Record<string, number> = {
-    leagues: leagues.length,
-    teams: teams.length,
-    players: players.length,
-    seasons: seasons.length,
-    divisions: divisions.length,
+  // Salesforce read path can fail in production (e.g., rotated Connected
+  // App credentials, JWT_AUTH_FAILED). Degrade to zeros + surface a
+  // non-fatal banner so the dashboard still renders and the rest of the
+  // app stays navigable. Sprint 5 (Salesforce decoupling) makes this
+  // graceful path the steady state.
+  let counts: Record<string, number> = {
+    leagues: 0,
+    teams: 0,
+    players: 0,
+    seasons: 0,
+    divisions: 0,
   };
+  let degraded = false;
+
+  try {
+    const orgContext = await resolveOrgContext(userId);
+    const ids = orgContext.visibleLeagueIds;
+    const [leagues, teams, players, seasons, divisions] = await Promise.all([
+      getLeagues(ids),
+      getTeams(ids),
+      getPlayers(ids),
+      getSeasons(ids),
+      getDivisions(ids),
+    ]);
+    counts = {
+      leagues: leagues.length,
+      teams: teams.length,
+      players: players.length,
+      seasons: seasons.length,
+      divisions: divisions.length,
+    };
+  } catch (err) {
+    degraded = true;
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "dashboard_overview_degraded",
+        route: "/dashboard",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
 
   return (
     <div>
       <h2 className="mb-6 text-lg font-semibold text-foreground">Overview</h2>
+      {degraded ? (
+        <div
+          role="status"
+          className="mb-4 border-2 border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-foreground"
+        >
+          Live data is temporarily unavailable. Showing placeholders while we
+          reconnect.
+        </div>
+      ) : null}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         {statCards.map((card) => {
           const Icon = card.icon;


### PR DESCRIPTION
## Summary

Containment patch for the production-error screen the user hit on \`sprtsmng.andrewsolomon.dev/dashboard\` after the Sprint 3 alias promotion. **Not caused by the re-skin** — the underlying Salesforce JWT bearer flow has been broken in prod for some time, just hidden because the custom domain was previously frozen on a 14-day-old deploy that nobody hit.

## Root cause from runtime logs
\`\`\`
[SF Auth] JWT auth failed: 400 {"error":"invalid_client_id","error_description":"client identifier invalid"}
\`\`\`

\`SF_CLIENT_ID\` / connected-app credentials in Vercel envs are stale. The dashboard read path (\`resolveOrgContext\` + \`getLeagues/Teams/Players/Seasons/Divisions\` from \`salesforce-api.ts\`) can't authenticate, so every server render throws.

## What this PR does
Wraps the entire SF read block in a single try/catch in \`apps/web/src/app/dashboard/page.tsx\`:

- **On success:** real counts, page renders as before.
- **On failure:** structured-log the SF error as \`dashboard_overview_degraded\`, render with all counts at 0, and surface a soft destructive-styled banner: *"Live data is temporarily unavailable. Showing placeholders while we reconnect."*

## What this PR does NOT do
- **Doesn't fix Salesforce auth.** Per-entity pages (\`/dashboard/leagues\`, \`/dashboard/teams\`, etc.) still route through the same broken path independently and will keep erroring until either (a) SF credentials are rotated in Vercel envs, or (b) Sprint 5 lands the Convex decoupling per the prior "full-throttle Convex" direction.
- **Doesn't address the strategic decoupling.** This is containment, not the answer.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] Visual verification on prod after merge + alias promotion: dashboard renders with banner + zero stats instead of 500

## Next
Sprint 5 — Salesforce decoupling — moves from "scheduled" to "next up."

🤖 Generated with [Claude Code](https://claude.com/claude-code)