### PR TITLE
fix(web): degrade resolveOrgContext gracefully on Salesforce auth failure (WSM-000039)

### DIFF
--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -64,31 +64,46 @@ export const resolveOrgContext = cache(
       return { userId, orgIds, visibleLeagueIds: [], subscribedLeagueIds };
     }
 
-    let conn;
+    // Salesforce read path. If SF auth or the SOQL query fails (e.g.
+    // rotated Connected App credentials, transient Salesforce outage),
+    // degrade to an empty visibleLeagueIds set rather than throwing.
+    // Every downstream list query in salesforce-api.ts already
+    // short-circuits to [] when visibleLeagueIds.length === 0, so this
+    // single chokepoint propagates graceful empty state to every
+    // dashboard list page without per-page try/catch. Sprint 5
+    // (Salesforce decoupling) replaces this path with Convex entirely.
     try {
-      conn = await getSalesforceConnection();
-    } catch (e) {
-      console.error("[OrgContext] SF connection failed:", e);
-      throw e;
+      const conn = await getSalesforceConnection();
+      let soql: string;
+
+      if (hasOrgs && hasSubs) {
+        const orgIdStr = idList(orgIds);
+        const subIdStr = idList(subscribedLeagueIds);
+        soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr}) OR Id IN (${subIdStr})`;
+      } else if (hasOrgs) {
+        const orgIdStr = idList(orgIds);
+        soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr})`;
+      } else {
+        const subIdStr = idList(subscribedLeagueIds);
+        soql = `SELECT Id FROM League__c WHERE Id IN (${subIdStr})`;
+      }
+
+      const result = await conn.query<{ Id: string }>(soql);
+      const visibleLeagueIds = result.records.map((r) => r.Id);
+      return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          msg: "org_context_sf_degraded",
+          userId,
+          orgIdCount: orgIds.length,
+          subscribedCount: subscribedLeagueIds.length,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return { userId, orgIds, visibleLeagueIds: [], subscribedLeagueIds };
     }
-    let soql: string;
-
-    if (hasOrgs && hasSubs) {
-      const orgIdStr = idList(orgIds);
-      const subIdStr = idList(subscribedLeagueIds);
-      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr}) OR Id IN (${subIdStr})`;
-    } else if (hasOrgs) {
-      const orgIdStr = idList(orgIds);
-      soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr})`;
-    } else {
-      const subIdStr = idList(subscribedLeagueIds);
-      soql = `SELECT Id FROM League__c WHERE Id IN (${subIdStr})`;
-    }
-
-    const result = await conn.query<{ Id: string }>(soql);
-    const visibleLeagueIds = result.records.map((r) => r.Id);
-
-    return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
   },
 );
 


### PR DESCRIPTION
## Summary

Generalizes the WSM-000038 dashboard containment patch to the entire list-page tree via a single chokepoint.

### How
Every downstream list function in \`salesforce-api.ts\` (\`getLeagues\`, \`getTeams\`, \`getPlayers\`, \`getSeasons\`, \`getDivisions\`) already short-circuits to \`[]\` when \`visibleLeagueIds.length === 0\`. Previously a failure inside \`resolveOrgContext\` threw, propagating to every list page as a 500. This PR catches that throw and returns \`visibleLeagueIds: []\` instead, so every list page renders its existing empty state.

### What's affected (15+ pages, no per-page changes needed)
- \`/dashboard\` — already had its own try/catch from #142, this is now redundant but harmless
- \`/dashboard/leagues\` + \`[id]\` + members + requests
- \`/dashboard/teams\` + \`[id]\`
- \`/dashboard/players\`
- \`/dashboard/seasons\`
- \`/dashboard/divisions\`
- \`/dashboard/billing\`
- \`/dashboard/discover\`
- Roster + depth-chart per-team detail pages (already used Convex \`getLeagueOrgId\` per WSM-000022)

### What this PR does NOT do
- **Doesn't touch \`getLeagueOrgId\`** (the SF version in \`org-context.ts\` line 157). A small number of callers still use it; Sprint 5 replaces both with Convex.
- **Doesn't surface a banner outside dashboard root.** The existing empty states ("No leagues yet", "No teams yet", etc.) take over visually. If silent empty state confuses users, add per-page banners as a follow-up.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (pre-existing warning, unrelated)
- [ ] After merge + alias promotion: navigate \`/dashboard/leagues\` → \`/dashboard/teams\` → \`/dashboard/players\` etc. on the iPhone, confirm each renders its empty state instead of "Something went wrong"

## Strategic next
Sprint 5 — Salesforce decoupling — is now urgent (real numbers won't return until then or until SF creds rotate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)