### PR TITLE
feat(web): rewrite resolveOrgContext to read leagues from Convex (WSM-000041)

### DIFF
--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -1,25 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetOrganizationMembershipList, mockQuery, mockGetUser } =
-  vi.hoisted(() => ({
-    mockGetOrganizationMembershipList: vi.fn(),
-    mockQuery: vi.fn(),
-    mockGetUser: vi.fn(),
-  }));
+const {
+  mockGetOrganizationMembershipList,
+  mockQuery,
+  mockGetVisibleLeagueContext,
+} = vi.hoisted(() => ({
+  mockGetOrganizationMembershipList: vi.fn(),
+  mockQuery: vi.fn(),
+  mockGetVisibleLeagueContext: vi.fn(),
+}));
 
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn().mockResolvedValue({
     users: {
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
-      getUser: mockGetUser,
     },
   }),
 }));
 
+// `getLeagueOrgId` (still SF-backed) keeps the salesforce mock alive.
 vi.mock("../salesforce", () => ({
   getSalesforceConnection: vi.fn().mockResolvedValue({
     query: mockQuery,
   }),
+}));
+
+vi.mock("../data-api", () => ({
+  getVisibleLeagueContext: mockGetVisibleLeagueContext,
 }));
 
 vi.mock("react", () => ({
@@ -36,40 +43,39 @@ import {
 describe("resolveOrgContext", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns visible league IDs for user with org memberships", async () => {
+  it("returns visible + subscribed league IDs from Convex", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [
         { organization: { id: "org_abc" } },
         { organization: { id: "org_def" } },
       ],
     });
-
-    mockGetUser.mockResolvedValue({
-      publicMetadata: { subscribedLeagueIds: [] },
-    });
-
-    mockQuery.mockResolvedValue({
-      records: [{ Id: "league_1" }, { Id: "league_2" }],
+    mockGetVisibleLeagueContext.mockResolvedValue({
+      visibleLeagueIds: ["league_1", "league_2", "league_pub_1"],
+      subscribedLeagueIds: ["league_pub_1"],
     });
 
     const ctx = await resolveOrgContext("user_123");
 
     expect(ctx.userId).toBe("user_123");
     expect(ctx.orgIds).toEqual(["org_abc", "org_def"]);
-    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_2"]);
-    expect(ctx.subscribedLeagueIds).toEqual([]);
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("org_abc"),
-    );
-    expect(mockQuery).not.toHaveBeenCalledWith(
-      expect.stringContaining("Clerk_Org_Id__c = null"),
-    );
+    expect(ctx.visibleLeagueIds).toEqual([
+      "league_1",
+      "league_2",
+      "league_pub_1",
+    ]);
+    expect(ctx.subscribedLeagueIds).toEqual(["league_pub_1"]);
+    expect(mockGetVisibleLeagueContext).toHaveBeenCalledWith("user_123", [
+      "org_abc",
+      "org_def",
+    ]);
   });
 
-  it("returns empty visibleLeagueIds when no orgs and no subscriptions", async () => {
+  it("passes empty orgIds to Convex when user has no orgs", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
-    mockGetUser.mockResolvedValue({
-      publicMetadata: { subscribedLeagueIds: [] },
+    mockGetVisibleLeagueContext.mockResolvedValue({
+      visibleLeagueIds: [],
+      subscribedLeagueIds: [],
     });
 
     const ctx = await resolveOrgContext("user_no_orgs");
@@ -77,17 +83,17 @@ describe("resolveOrgContext", () => {
     expect(ctx.orgIds).toEqual([]);
     expect(ctx.visibleLeagueIds).toEqual([]);
     expect(ctx.subscribedLeagueIds).toEqual([]);
-    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockGetVisibleLeagueContext).toHaveBeenCalledWith(
+      "user_no_orgs",
+      [],
+    );
   });
 
-  it("includes subscribed public league IDs in visible set", async () => {
+  it("subscriptions-only user gets visible IDs from Convex without org memberships", async () => {
     mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
-    mockGetUser.mockResolvedValue({
-      publicMetadata: { subscribedLeagueIds: ["league_pub_1", "league_pub_2"] },
-    });
-
-    mockQuery.mockResolvedValue({
-      records: [{ Id: "league_pub_1" }, { Id: "league_pub_2" }],
+    mockGetVisibleLeagueContext.mockResolvedValue({
+      visibleLeagueIds: ["league_pub_1", "league_pub_2"],
+      subscribedLeagueIds: ["league_pub_1", "league_pub_2"],
     });
 
     const ctx = await resolveOrgContext("user_with_subs");
@@ -98,34 +104,6 @@ describe("resolveOrgContext", () => {
       "league_pub_1",
       "league_pub_2",
     ]);
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("Id IN"),
-    );
-  });
-
-  it("combines org leagues and subscribed leagues", async () => {
-    mockGetOrganizationMembershipList.mockResolvedValue({
-      data: [{ organization: { id: "org_abc" } }],
-    });
-    mockGetUser.mockResolvedValue({
-      publicMetadata: { subscribedLeagueIds: ["league_pub_1"] },
-    });
-
-    mockQuery.mockResolvedValue({
-      records: [{ Id: "league_1" }, { Id: "league_pub_1" }],
-    });
-
-    const ctx = await resolveOrgContext("user_both");
-
-    expect(ctx.orgIds).toEqual(["org_abc"]);
-    expect(ctx.visibleLeagueIds).toEqual(["league_1", "league_pub_1"]);
-    expect(ctx.subscribedLeagueIds).toEqual(["league_pub_1"]);
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("Clerk_Org_Id__c IN"),
-    );
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining("Id IN"),
-    );
   });
 
   it("handles pagination of org memberships", async () => {
@@ -137,55 +115,19 @@ describe("resolveOrgContext", () => {
     mockGetOrganizationMembershipList
       .mockResolvedValueOnce({ data: firstPage })
       .mockResolvedValueOnce({ data: secondPage });
-
-    mockGetUser.mockResolvedValue({
-      publicMetadata: { subscribedLeagueIds: [] },
+    mockGetVisibleLeagueContext.mockResolvedValue({
+      visibleLeagueIds: [],
+      subscribedLeagueIds: [],
     });
-
-    mockQuery.mockResolvedValue({ records: [] });
 
     const ctx = await resolveOrgContext("user_many_orgs");
 
     expect(ctx.orgIds).toHaveLength(101);
     expect(mockGetOrganizationMembershipList).toHaveBeenCalledTimes(2);
-  });
-
-  it("handles missing publicMetadata gracefully", async () => {
-    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
-    mockGetUser.mockResolvedValue({ publicMetadata: {} });
-
-    const ctx = await resolveOrgContext("user_no_metadata");
-
-    expect(ctx.subscribedLeagueIds).toEqual([]);
-    expect(ctx.visibleLeagueIds).toEqual([]);
-  });
-
-  it("gracefully handles getUser Forbidden error", async () => {
-    mockGetOrganizationMembershipList.mockResolvedValue({
-      data: [{ organization: { id: "org_abc" } }],
-    });
-    mockGetUser.mockRejectedValue(new Error("Forbidden"));
-
-    mockQuery.mockResolvedValue({
-      records: [{ Id: "league_1" }],
-    });
-
-    const ctx = await resolveOrgContext("user_forbidden");
-
-    expect(ctx.orgIds).toEqual(["org_abc"]);
-    expect(ctx.visibleLeagueIds).toEqual(["league_1"]);
-    expect(ctx.subscribedLeagueIds).toEqual([]);
-  });
-
-  it("returns org leagues when getUser throws and no subscriptions", async () => {
-    mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
-    mockGetUser.mockRejectedValue(new Error("Forbidden"));
-
-    const ctx = await resolveOrgContext("user_no_access");
-
-    expect(ctx.visibleLeagueIds).toEqual([]);
-    expect(ctx.subscribedLeagueIds).toEqual([]);
-    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockGetVisibleLeagueContext).toHaveBeenCalledWith(
+      "user_many_orgs",
+      expect.arrayContaining(["org_0", "org_99", "org_100"]),
+    );
   });
 });
 

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getSalesforceConnection } from "./salesforce";
+import { getVisibleLeagueContext as getVisibleLeagueContextFromConvex } from "./data-api";
 
 export interface OrgContext {
   userId: string;
@@ -10,19 +11,21 @@ export interface OrgContext {
 }
 
 /**
- * Resolves the authenticated user's org memberships and the Salesforce league IDs
+ * Resolves the authenticated user's org memberships and the Convex league IDs
  * they are allowed to see. Uses React cache() to deduplicate within a single
  * request/render pass.
  *
- * Visible leagues = leagues owned by user's orgs + explicitly subscribed public leagues.
- * Public leagues (Clerk_Org_Id__c = null) are opt-in only via subscribedLeagueIds
- * stored in Clerk user publicMetadata.
+ * Visible leagues = leagues owned by user's orgs + explicitly subscribed public
+ * leagues. The org → league mapping is read from Convex via the `by_orgId`
+ * index on the `leagues` table; the subscriptions list is read from the
+ * Convex `leagueSubscriptions` table indexed by userId. Salesforce is no
+ * longer in this read path (per Sprint 5).
  */
 export const resolveOrgContext = cache(
   async (userId: string): Promise<OrgContext> => {
     const client = await clerkClient();
 
-    // Get all orgs the user belongs to (handle pagination)
+    // Get all orgs the user belongs to (handle pagination).
     const orgIds: string[] = [];
     let offset = 0;
     const limit = 100;
@@ -42,74 +45,15 @@ export const resolveOrgContext = cache(
       offset += limit;
     }
 
-    // Get subscribed public league IDs from Clerk user metadata.
-    // We already have org memberships from getOrganizationMembershipList above,
-    // so use currentUser() pattern via the membership list's user data when
-    // possible. Fall back to getUser() if needed, but handle Forbidden errors
-    // gracefully for Clerk instances where the secret key lacks users.read scope.
-    let subscribedLeagueIds: string[] = [];
-    try {
-      const user = await client.users.getUser(userId);
-      subscribedLeagueIds =
-        (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
-    } catch {
-      // If getUser fails (e.g. Forbidden), continue with empty subscriptions
-    }
+    // Single Convex query resolves both visible-league fan-out (via the
+    // `leagues.by_orgId` index for each org the user belongs to) and the
+    // subscribed-league set (via `leagueSubscriptions.by_userId`).
+    const { visibleLeagueIds, subscribedLeagueIds } =
+      await getVisibleLeagueContextFromConvex(userId, orgIds);
 
-    // Build SOQL based on what the user has access to
-    const hasOrgs = orgIds.length > 0;
-    const hasSubs = subscribedLeagueIds.length > 0;
-
-    if (!hasOrgs && !hasSubs) {
-      return { userId, orgIds, visibleLeagueIds: [], subscribedLeagueIds };
-    }
-
-    // Salesforce read path. If SF auth or the SOQL query fails (e.g.
-    // rotated Connected App credentials, transient Salesforce outage),
-    // degrade to an empty visibleLeagueIds set rather than throwing.
-    // Every downstream list query in salesforce-api.ts already
-    // short-circuits to [] when visibleLeagueIds.length === 0, so this
-    // single chokepoint propagates graceful empty state to every
-    // dashboard list page without per-page try/catch. Sprint 5
-    // (Salesforce decoupling) replaces this path with Convex entirely.
-    try {
-      const conn = await getSalesforceConnection();
-      let soql: string;
-
-      if (hasOrgs && hasSubs) {
-        const orgIdStr = idList(orgIds);
-        const subIdStr = idList(subscribedLeagueIds);
-        soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr}) OR Id IN (${subIdStr})`;
-      } else if (hasOrgs) {
-        const orgIdStr = idList(orgIds);
-        soql = `SELECT Id FROM League__c WHERE Clerk_Org_Id__c IN (${orgIdStr})`;
-      } else {
-        const subIdStr = idList(subscribedLeagueIds);
-        soql = `SELECT Id FROM League__c WHERE Id IN (${subIdStr})`;
-      }
-
-      const result = await conn.query<{ Id: string }>(soql);
-      const visibleLeagueIds = result.records.map((r) => r.Id);
-      return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
-    } catch (err) {
-      console.error(
-        JSON.stringify({
-          level: "error",
-          msg: "org_context_sf_degraded",
-          userId,
-          orgIdCount: orgIds.length,
-          subscribedCount: subscribedLeagueIds.length,
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
-      return { userId, orgIds, visibleLeagueIds: [], subscribedLeagueIds };
-    }
+    return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
   },
 );
-
-function idList(ids: string[]): string {
-  return ids.map((id) => `'${id}'`).join(",");
-}
 
 /**
  * Check that a specific league is within the user's visible set.


### PR DESCRIPTION
## Summary

Sprint 5 story 1. Replaces the Salesforce SOQL fan-out in \`resolveOrgContext\` with the existing Convex \`getVisibleLeagueContext\` query (already wired in \`data-api.ts\`).

### Why this works as a single chokepoint
\`resolveOrgContext\` is called from every dashboard server component. Switching it to Convex means **every list page that previously short-circuited to empty under WSM-000039's degradation banner now returns real data**, with no per-page changes needed. Once SF data has been backfilled to Convex (or once the page tree is exclusively reading Convex-native fixtures), the dashboard goes from "Live data is temporarily unavailable" to live numbers.

### Behavioral changes
- Visible league IDs come from Convex's \`leagues.by_orgId\` index per the user's Clerk org memberships.
- Subscribed league IDs come from Convex's \`leagueSubscriptions\` table (indexed by userId), not from Clerk \`publicMetadata\`.
- The WSM-000039 SF degradation try/catch is removed — the Convex path can't fail on JWT auth.
- Drops the unused \`idList\` SOQL helper.
- Drops the Clerk \`users.getUser\` read for \`publicMetadata\`.

### What this PR does NOT do
- \`getLeagueOrgId\` (lines 117+) still hits Salesforce. Depth-chart pages, server actions, and \`authorization.ts\` call it. **WSM-000047** swaps those callers to the Convex equivalent in \`data-api.ts\` (which roster pages already use per WSM-000022). The remaining Salesforce import is preserved here for that one function.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (one pre-existing warning, unrelated)
- [x] \`pnpm --filter @sports-management/web test:unit\` — **255/255 passing** (4 of 8 prior \`resolveOrgContext\` tests collapsed because the Convex-backed flow covers their cases at the integration boundary; remaining 4 verify shape / empty-orgs / subs-only / pagination)
- [ ] Visual: after merge, dashboard list pages should show real data instead of the SF-degradation banner (if Convex has data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)