### PR TITLE
feat(web): swap dashboard API route reads to Convex (WSM-000042 + 043 + 044)

### DIFF
--- a/apps/web/src/app/api/divisions/route.ts
+++ b/apps/web/src/app/api/divisions/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getDivisions } from "@/lib/salesforce-api";
+import { getDivisions } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/leagues/public/route.ts
+++ b/apps/web/src/app/api/leagues/public/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getPublicLeagues } from "@/lib/salesforce-api";
+import { getPublicLeagues } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET() {

--- a/apps/web/src/app/api/leagues/route.ts
+++ b/apps/web/src/app/api/leagues/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getLeagues } from "@/lib/salesforce-api";
+import { getLeagues } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/orgs/[orgId]/invite-link/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/invite-link/route.ts
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { requireOrgAdmin } from "@/lib/org-context";
-import { setLeagueInviteToken } from "@/lib/salesforce-api";
+import { setLeagueInviteToken } from "@/lib/data-api";
 import { getSalesforceConnection } from "@/lib/salesforce";
 import { handleApiError } from "@/lib/api-error";
 import crypto from "crypto";

--- a/apps/web/src/app/api/players/[id]/route.ts
+++ b/apps/web/src/app/api/players/[id]/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getPlayer, updatePlayer, deletePlayer } from "@/lib/salesforce-api";
+import { getPlayer, updatePlayer, deletePlayer } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { UpdatePlayerInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";

--- a/apps/web/src/app/api/players/route.ts
+++ b/apps/web/src/app/api/players/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { getPlayers, getPlayersByTeam, createPlayer } from "@/lib/salesforce-api";
+import { getPlayers, getPlayersByTeam, createPlayer } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { CreatePlayerInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";

--- a/apps/web/src/app/api/seasons/route.ts
+++ b/apps/web/src/app/api/seasons/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getSeasons } from "@/lib/salesforce-api";
+import { getSeasons } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getTeam, getPlayersByTeam, updateTeam } from "@/lib/salesforce-api";
+import { getTeam, getPlayersByTeam, updateTeam } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";

--- a/apps/web/src/app/api/teams/route.ts
+++ b/apps/web/src/app/api/teams/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getTeams } from "@/lib/salesforce-api";
+import { getTeams } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 


### PR DESCRIPTION
## Summary

Sprint 5 stories 2–4, combined since each is a one-line import swap.

| Route | From | To |
|---|---|---|
| \`/api/leagues\` | salesforce-api | data-api |
| \`/api/leagues/public\` | salesforce-api | data-api |
| \`/api/teams\` + \`/api/teams/[id]\` | salesforce-api | data-api |
| \`/api/players\` + \`/api/players/[id]\` | salesforce-api | data-api |
| \`/api/seasons\` | salesforce-api | data-api |
| \`/api/divisions\` | salesforce-api | data-api |
| \`/api/orgs/[orgId]/invite-link\` | salesforce-api | data-api |

Function signatures match across both modules — Convex equivalents already exist in \`data-api.ts\` (Sprint 2 work).

### What this PR does NOT do
- **CLI bulk-import routes** under \`/api/cli/*\` keep their \`salesforce-api\` imports — \`data-api\` doesn't yet expose \`bulkImportLeague\` / \`upsertLeague\` / \`upsertDivision\` / \`upsertPlayer\` / \`upsertTeam\`. **WSM-000050** decides whether to drop those if unused or port as a follow-up.
- **Server actions** (roster, depth-chart mutations) already used data-api per Sprint 2.

### Where Sprint 5 stands after this PR
Combined with WSM-000041 (resolveOrgContext via Convex), the dashboard read path is **end-to-end Convex** for every list page and entity API. Salesforce remains only for the still-pending \`getLeagueOrgId\` callers (depth-chart, authorization.ts) — that's WSM-000047.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean (9-file swap + signature verification)
- [x] \`pnpm --filter @sports-management/web test:unit\` — 255/255 passing
- [ ] After merge + alias: visit \`/dashboard/leagues\`, \`/teams\`, etc. on iPhone Safari — should show real data instead of empty state if Convex has data

🤖 Generated with [Claude Code](https://claude.com/claude-code)