### PR TITLE
feat(web): drop SF getLeagueOrgId + authorize teams via Convex (WSM-000047)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
@@ -5,8 +5,9 @@ import { depthChartV1 } from "@/lib/flags";
 import {
   reorderDepthChart as reorderDepthChartMutation,
   setRosterLocked as setRosterLockedMutation,
+  getLeagueOrgId,
 } from "@/lib/data-api";
-import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import { getUserRoleInOrg } from "@/lib/org-context";
 import {
   trackDepthChartReorder,
   trackSeasonLockToggle,

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -7,8 +7,9 @@ import {
   getPlayersByTeam,
   getSeasons,
   getDepthChartByTeamSeason,
+  getLeagueOrgId,
 } from "@/lib/data-api";
-import { getLeagueOrgId, getUserRoleInOrg } from "@/lib/org-context";
+import { getUserRoleInOrg } from "@/lib/org-context";
 import DepthChartBoard from "@/components/depth-chart/DepthChartBoard";
 
 export default async function DepthChartPage({

--- a/apps/web/src/lib/__tests__/authorization.test.ts
+++ b/apps/web/src/lib/__tests__/authorization.test.ts
@@ -1,22 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const {
-  mockQuery,
+  mockGetTeamLeagueId,
   mockGetLeagueOrgId,
   mockGetOrganizationMembershipList,
 } = vi.hoisted(() => ({
-  mockQuery: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
   mockGetOrganizationMembershipList: vi.fn(),
 }));
 
-vi.mock("../salesforce", () => ({
-  getSalesforceConnection: vi.fn().mockResolvedValue({
-    query: mockQuery,
-  }),
-}));
-
-vi.mock("../org-context", () => ({
+vi.mock("../data-api", () => ({
+  getTeamLeagueId: mockGetTeamLeagueId,
   getLeagueOrgId: mockGetLeagueOrgId,
 }));
 
@@ -39,7 +34,7 @@ describe("authorizeTeamMutation", () => {
   });
 
   it("returns not authorized when team is not found", async () => {
-    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    mockGetTeamLeagueId.mockRejectedValue(new Error("Team not found"));
 
     const result = await authorizeTeamMutation("team_missing", "user_1");
 
@@ -47,10 +42,7 @@ describe("authorizeTeamMutation", () => {
   });
 
   it("returns not authorized for public league (null orgId)", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ League__c: "league_1" }],
-    });
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue(null);
 
     const result = await authorizeTeamMutation("team_1", "user_1");
@@ -59,10 +51,7 @@ describe("authorizeTeamMutation", () => {
   });
 
   it("returns authorized for org admin", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ League__c: "league_1" }],
-    });
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue("org_1");
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [{ organization: { id: "org_1" }, role: "org:admin" }],
@@ -74,10 +63,7 @@ describe("authorizeTeamMutation", () => {
   });
 
   it("returns not authorized for org member (non-admin)", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ League__c: "league_1" }],
-    });
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue("org_1");
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [{ organization: { id: "org_1" }, role: "org:member" }],
@@ -89,10 +75,7 @@ describe("authorizeTeamMutation", () => {
   });
 
   it("returns not authorized for non-member of org", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ League__c: "league_1" }],
-    });
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue("org_1");
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [{ organization: { id: "org_other" }, role: "org:admin" }],
@@ -110,10 +93,7 @@ describe("canManageTeam", () => {
   });
 
   it("returns true when user is authorized", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ League__c: "league_1" }],
-    });
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue("org_1");
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [{ organization: { id: "org_1" }, role: "org:admin" }],
@@ -125,7 +105,7 @@ describe("canManageTeam", () => {
   });
 
   it("returns false when user is not authorized", async () => {
-    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
+    mockGetTeamLeagueId.mockRejectedValue(new Error("Team not found"));
 
     const result = await canManageTeam("team_missing", "user_1");
 

--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -2,11 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const {
   mockGetOrganizationMembershipList,
-  mockQuery,
   mockGetVisibleLeagueContext,
 } = vi.hoisted(() => ({
   mockGetOrganizationMembershipList: vi.fn(),
-  mockQuery: vi.fn(),
   mockGetVisibleLeagueContext: vi.fn(),
 }));
 
@@ -15,13 +13,6 @@ vi.mock("@clerk/nextjs/server", () => ({
     users: {
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
     },
-  }),
-}));
-
-// `getLeagueOrgId` (still SF-backed) keeps the salesforce mock alive.
-vi.mock("../salesforce", () => ({
-  getSalesforceConnection: vi.fn().mockResolvedValue({
-    query: mockQuery,
   }),
 }));
 
@@ -37,7 +28,6 @@ import {
   resolveOrgContext,
   requireLeagueAccess,
   requireOrgAdmin,
-  getLeagueOrgId,
 } from "../org-context";
 
 describe("resolveOrgContext", () => {
@@ -189,34 +179,3 @@ describe("requireOrgAdmin", () => {
   });
 });
 
-describe("getLeagueOrgId", () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it("returns org ID for a league with an org", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ Clerk_Org_Id__c: "org_abc" }],
-    });
-
-    const orgId = await getLeagueOrgId("league_1");
-    expect(orgId).toBe("org_abc");
-  });
-
-  it("returns null for a public league", async () => {
-    mockQuery.mockResolvedValue({
-      totalSize: 1,
-      records: [{ Clerk_Org_Id__c: null }],
-    });
-
-    const orgId = await getLeagueOrgId("league_public");
-    expect(orgId).toBeNull();
-  });
-
-  it("throws when league not found", async () => {
-    mockQuery.mockResolvedValue({ totalSize: 0, records: [] });
-
-    await expect(getLeagueOrgId("nonexistent")).rejects.toThrow(
-      "League not found",
-    );
-  });
-});

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -1,7 +1,6 @@
 import { auth, currentUser, clerkClient } from "@clerk/nextjs/server";
 import type { Tier } from "./tiers";
-import { getLeagueOrgId } from "./org-context";
-import { getSalesforceConnection } from "./salesforce";
+import { getTeamLeagueId, getLeagueOrgId } from "./data-api";
 
 export interface AuthorizationResult {
   userId: string;
@@ -10,7 +9,7 @@ export interface AuthorizationResult {
 
 /**
  * Authorize a mutation on a team. The chain is:
- * teamId -> Team__c.League__c -> League__c.Clerk_Org_Id__c -> requireOrgAdmin
+ * teamId -> team.leagueId (Convex) -> league.orgId (Convex) -> requireOrgAdmin
  *
  * Public leagues (null orgId) -> mutations denied (read-only).
  * Org leagues -> only org:admin can mutate.
@@ -20,16 +19,7 @@ export async function authorizeTeamMutation(
   userId: string,
 ): Promise<AuthorizationResult> {
   try {
-    // Get team's league
-    const conn = await getSalesforceConnection();
-    const result = await conn.query<{ League__c: string }>(
-      `SELECT League__c FROM Team__c WHERE Id = '${teamId}' LIMIT 1`,
-    );
-    if (result.totalSize === 0) {
-      return { userId, isAuthorized: false };
-    }
-
-    const leagueId = result.records[0].League__c;
+    const leagueId = await getTeamLeagueId(teamId);
     const orgId = await getLeagueOrgId(leagueId);
 
     // Public leagues are read-only

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -1,6 +1,5 @@
 import { cache } from "react";
 import { clerkClient } from "@clerk/nextjs/server";
-import { getSalesforceConnection } from "./salesforce";
 import { getVisibleLeagueContext as getVisibleLeagueContextFromConvex } from "./data-api";
 
 export interface OrgContext {
@@ -109,19 +108,3 @@ export async function getUserRoleInOrg(
   return membership.role as "org:admin" | "org:member";
 }
 
-/**
- * Find the Clerk Org ID that owns a given league.
- * Returns null for public leagues.
- */
-export async function getLeagueOrgId(
-  leagueId: string,
-): Promise<string | null> {
-  const conn = await getSalesforceConnection();
-  const result = await conn.query<{ Clerk_Org_Id__c: string | null }>(
-    `SELECT Clerk_Org_Id__c FROM League__c WHERE Id = '${leagueId}' LIMIT 1`,
-  );
-  if (result.totalSize === 0) {
-    throw new Error("League not found");
-  }
-  return result.records[0].Clerk_Org_Id__c ?? null;
-}


### PR DESCRIPTION
## Summary

Sprint 5 story 7. Cleans up the last Salesforce-coupled paths in the auth layer.

### Three swaps + a delete
1. **Depth-chart page + server actions**: split the org-context import so \`getLeagueOrgId\` comes from \`data-api\` (Convex) while \`getUserRoleInOrg\` stays on \`org-context\`. Same pattern roster pages used in WSM-000022.
2. **\`authorization.ts\`**: rewritten to drop Salesforce entirely. Was: SOQL \`SELECT League__c FROM Team__c WHERE Id = ...\` + SF \`getLeagueOrgId\`. Now: \`getTeamLeagueId(teamId)\` + \`getLeagueOrgId(leagueId)\` both from \`data-api\`. AuthorizationResult contract unchanged.
3. **\`org-context.ts\`**: drops the SF \`getLeagueOrgId\` function (15 lines) and the \`getSalesforceConnection\` import. Module is now Salesforce-free.
4. **Test fixups**: \`org-context.test.ts\` (drop describe block + SF mock), \`authorization.test.ts\` (rewrite to mock data-api functions). 252/252 tests still pass (3 SF-only assertions removed by design).

### Salesforce surface remaining after this PR
- Inline \`getLeagueForOrg\` helper in \`/api/orgs/[orgId]/invite-link\` route — sweep in WSM-000050.
- CLI bulk-import routes under \`/api/cli/*\` — Sprint 5 close-out decides whether to drop or port.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web test:unit\` — 252/252 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)