### PR TITLE
feat(web): final SF eviction — CLI + invite-link + nfl-sync (WSM-000051)

### DIFF
--- a/apps/web/src/app/api/cli/divisions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/divisions/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
-vi.mock("@/lib/salesforce-api", () => ({ getDivisions: vi.fn() }));
+vi.mock("@/lib/data-api", () => ({ getDivisions: vi.fn() }));
 vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
@@ -11,7 +11,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { getDivisions } from "@/lib/salesforce-api";
+import { getDivisions } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 

--- a/apps/web/src/app/api/cli/divisions/route.ts
+++ b/apps/web/src/app/api/cli/divisions/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getDivisions } from "@/lib/salesforce-api";
+import { getDivisions } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/cli/import/route.ts
+++ b/apps/web/src/app/api/cli/import/route.ts
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
 import { LeagueImportSchema } from "@sports-management/api-contracts";
-import { bulkImportLeague } from "@/lib/salesforce-api";
+import { bulkImportLeague } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";

--- a/apps/web/src/app/api/cli/leagues/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/leagues/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),
 }));
-vi.mock("@/lib/salesforce-api", () => ({
+vi.mock("@/lib/data-api", () => ({
   getLeagues: vi.fn(),
 }));
 vi.mock("@/lib/org-context", () => ({
@@ -17,7 +17,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { getLeagues } from "@/lib/salesforce-api";
+import { getLeagues } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 

--- a/apps/web/src/app/api/cli/leagues/route.ts
+++ b/apps/web/src/app/api/cli/leagues/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getLeagues } from "@/lib/salesforce-api";
+import { getLeagues } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/cli/players/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/players/[id]/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
-vi.mock("@/lib/salesforce-api", () => ({ updatePlayer: vi.fn() }));
+vi.mock("@/lib/data-api", () => ({ updatePlayer: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
     const { NextResponse } = require("next/server");
@@ -11,7 +11,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { updatePlayer } from "@/lib/salesforce-api";
+import { updatePlayer } from "@/lib/data-api";
 import { PUT } from "../route";
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;

--- a/apps/web/src/app/api/cli/players/[id]/route.ts
+++ b/apps/web/src/app/api/cli/players/[id]/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
-import { updatePlayer } from "@/lib/salesforce-api";
+import { updatePlayer } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";

--- a/apps/web/src/app/api/cli/players/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/players/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
-vi.mock("@/lib/salesforce-api", () => ({ getPlayersByTeam: vi.fn() }));
+vi.mock("@/lib/data-api", () => ({ getPlayersByTeam: vi.fn() }));
 vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
@@ -12,7 +12,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { getPlayersByTeam } from "@/lib/salesforce-api";
+import { getPlayersByTeam } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 

--- a/apps/web/src/app/api/cli/players/route.ts
+++ b/apps/web/src/app/api/cli/players/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
-import { getPlayersByTeam } from "@/lib/salesforce-api";
+import { getPlayersByTeam } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/cli/seasons/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/seasons/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: vi.fn() }));
-vi.mock("@/lib/salesforce-api", () => ({ getSeasons: vi.fn() }));
+vi.mock("@/lib/data-api", () => ({ getSeasons: vi.fn() }));
 vi.mock("@/lib/org-context", () => ({ resolveOrgContext: vi.fn() }));
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn(() => {
@@ -11,7 +11,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { getSeasons } from "@/lib/salesforce-api";
+import { getSeasons } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { GET } from "../route";
 

--- a/apps/web/src/app/api/cli/seasons/route.ts
+++ b/apps/web/src/app/api/cli/seasons/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getSeasons } from "@/lib/salesforce-api";
+import { getSeasons } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/cli/teams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cli/teams/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { NextRequest } from "next/server";
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),
 }));
-vi.mock("@/lib/salesforce-api", () => ({
+vi.mock("@/lib/data-api", () => ({
   getTeams: vi.fn(),
   getTeamsByLeague: vi.fn(),
   createTeam: vi.fn(),
@@ -20,7 +20,7 @@ vi.mock("@/lib/api-error", () => ({
 }));
 
 import { auth } from "@clerk/nextjs/server";
-import { getTeams, getTeamsByLeague, createTeam } from "@/lib/salesforce-api";
+import { getTeams, getTeamsByLeague, createTeam } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { GET, POST } from "../route";
 

--- a/apps/web/src/app/api/cli/teams/route.ts
+++ b/apps/web/src/app/api/cli/teams/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse, type NextRequest } from "next/server";
-import { getTeams, getTeamsByLeague, createTeam } from "@/lib/salesforce-api";
+import { getTeams, getTeamsByLeague, createTeam } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { handleApiError } from "@/lib/api-error";
 

--- a/apps/web/src/app/api/orgs/[orgId]/invite-link/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/invite-link/__tests__/route.test.ts
@@ -1,25 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mocks = vi.hoisted(() => {
-  const mockQuery = vi.fn();
-  const mockUpdate = vi.fn();
-  return {
-    mockAuth: vi.fn(),
-    mockRequireOrgAdmin: vi.fn(),
-    mockGetSalesforceConnection: vi.fn(() => ({
-      query: mockQuery,
-      sobject: vi.fn(() => ({ update: mockUpdate })),
-    })),
-    mockHandleApiError: vi.fn((_err: unknown, _route?: string) => {
-      const { NextResponse } = require("next/server");
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-    }),
-    mockSetLeagueInviteToken: vi.fn(),
-    mockQuery,
-    mockUpdate,
-    mockRandomUUID: vi.fn(() => "test-uuid-1234"),
-  };
-});
+const mocks = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockRequireOrgAdmin: vi.fn(),
+  mockGetLeagueForOrg: vi.fn(),
+  mockSetLeagueInviteToken: vi.fn(),
+  mockHandleApiError: vi.fn((_err: unknown, _route?: string) => {
+    const { NextResponse } = require("next/server");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }),
+  mockRandomUUID: vi.fn(() => "test-uuid-1234"),
+}));
 
 vi.mock("@clerk/nextjs/server", () => ({
   auth: mocks.mockAuth,
@@ -29,11 +20,8 @@ vi.mock("@/lib/org-context", () => ({
   requireOrgAdmin: mocks.mockRequireOrgAdmin,
 }));
 
-vi.mock("@/lib/salesforce", () => ({
-  getSalesforceConnection: mocks.mockGetSalesforceConnection,
-}));
-
 vi.mock("@/lib/data-api", () => ({
+  getLeagueForOrg: mocks.mockGetLeagueForOrg,
   setLeagueInviteToken: mocks.mockSetLeagueInviteToken,
 }));
 
@@ -83,10 +71,7 @@ describe("invite-link API", () => {
     it("returns null when no invite link exists", async () => {
       mocks.mockAuth.mockResolvedValue({ userId: "user_1" });
       mocks.mockRequireOrgAdmin.mockResolvedValue(undefined);
-      mocks.mockQuery.mockResolvedValue({
-        totalSize: 1,
-        records: [{ Id: "league_1", Invite_Token__c: null }],
-      });
+      mocks.mockGetLeagueForOrg.mockResolvedValue({ id: "league_1", token: null });
 
       const res = await GET(makeRequest("GET"), { params });
       expect(res.status).toBe(200);
@@ -98,10 +83,7 @@ describe("invite-link API", () => {
     it("returns invite link URL when token exists", async () => {
       mocks.mockAuth.mockResolvedValue({ userId: "user_1" });
       mocks.mockRequireOrgAdmin.mockResolvedValue(undefined);
-      mocks.mockQuery.mockResolvedValue({
-        totalSize: 1,
-        records: [{ Id: "league_1", Invite_Token__c: "abc-123" }],
-      });
+      mocks.mockGetLeagueForOrg.mockResolvedValue({ id: "league_1", token: "abc-123" });
 
       const res = await GET(makeRequest("GET"), { params });
       expect(res.status).toBe(200);
@@ -115,10 +97,7 @@ describe("invite-link API", () => {
     it("generates a new token and returns 201", async () => {
       mocks.mockAuth.mockResolvedValue({ userId: "user_1" });
       mocks.mockRequireOrgAdmin.mockResolvedValue(undefined);
-      mocks.mockQuery.mockResolvedValue({
-        totalSize: 1,
-        records: [{ Id: "league_1", Invite_Token__c: null }],
-      });
+      mocks.mockGetLeagueForOrg.mockResolvedValue({ id: "league_1", token: null });
       mocks.mockSetLeagueInviteToken.mockResolvedValue(undefined);
 
       const res = await POST(makeRequest("POST"), { params });
@@ -134,10 +113,7 @@ describe("invite-link API", () => {
     it("revokes the token", async () => {
       mocks.mockAuth.mockResolvedValue({ userId: "user_1" });
       mocks.mockRequireOrgAdmin.mockResolvedValue(undefined);
-      mocks.mockQuery.mockResolvedValue({
-        totalSize: 1,
-        records: [{ Id: "league_1", Invite_Token__c: "abc-123" }],
-      });
+      mocks.mockGetLeagueForOrg.mockResolvedValue({ id: "league_1", token: "abc-123" });
       mocks.mockSetLeagueInviteToken.mockResolvedValue(undefined);
 
       const res = await DELETE(makeRequest("DELETE"), { params });

--- a/apps/web/src/app/api/orgs/[orgId]/invite-link/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/invite-link/route.ts
@@ -1,19 +1,21 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { requireOrgAdmin } from "@/lib/org-context";
-import { setLeagueInviteToken } from "@/lib/data-api";
-import { getSalesforceConnection } from "@/lib/salesforce";
+import {
+  setLeagueInviteToken,
+  getLeagueForOrg as getLeagueForOrgFromConvex,
+} from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 import crypto from "crypto";
 
-// Find the league that belongs to this org
-async function getLeagueForOrg(orgId: string): Promise<{ id: string; token: string | null }> {
-  const conn = await getSalesforceConnection();
-  const result = await conn.query<{ Id: string; Invite_Token__c: string | null }>(
-    `SELECT Id, Invite_Token__c FROM League__c WHERE Clerk_Org_Id__c = '${orgId}' LIMIT 1`,
-  );
-  if (result.totalSize === 0) throw new Error("League not found for this organization");
-  return { id: result.records[0].Id, token: result.records[0].Invite_Token__c ?? null };
+async function getLeagueForOrg(
+  orgId: string,
+): Promise<{ id: string; token: string | null }> {
+  const league = await getLeagueForOrgFromConvex(orgId);
+  if (!league) {
+    throw new Error("League not found for this organization");
+  }
+  return league;
 }
 
 export async function GET(

--- a/apps/web/src/app/join/[token]/page.tsx
+++ b/apps/web/src/app/join/[token]/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getLeagueByInviteToken } from "@/lib/salesforce-api";
+import { getLeagueByInviteToken } from "@/lib/data-api";
 import JoinForm from "./join-form";
 
 export default async function JoinPage({

--- a/apps/web/src/lib/sync/__tests__/nfl-sync.test.ts
+++ b/apps/web/src/lib/sync/__tests__/nfl-sync.test.ts
@@ -28,7 +28,7 @@ const mockImportResult: ImportResult = {
   errors: [],
 };
 
-vi.mock("../../salesforce-api", () => ({
+vi.mock("../../data-api", () => ({
   bulkImportLeague: vi.fn(() => Promise.resolve(mockImportResult)),
 }));
 
@@ -41,7 +41,7 @@ vi.mock("../../adapters/espn-nfl", () => ({
 }));
 
 import { syncNfl, readSyncConfig, updateSyncEnabled } from "../nfl-sync";
-import { bulkImportLeague } from "../../salesforce-api";
+import { bulkImportLeague } from "../../data-api";
 
 describe("NFL Sync Service", () => {
   beforeEach(() => {

--- a/apps/web/src/lib/sync/nfl-sync.ts
+++ b/apps/web/src/lib/sync/nfl-sync.ts
@@ -1,6 +1,6 @@
 import type { SyncReport, SyncConfig } from "@sports-management/shared-types";
 import { getSalesforceConnection } from "../salesforce";
-import { bulkImportLeague } from "../salesforce-api";
+import { bulkImportLeague } from "../data-api";
 import { EspnNflAdapter } from "../adapters/espn-nfl";
 
 interface SyncConfigRecord {


### PR DESCRIPTION
## Summary

Sprint 6A story 1. Swaps every remaining \`@/lib/salesforce-api\` importer to \`@/lib/data-api\` so the SF module can be deleted in WSM-000052.

### 16 files swapped
- \`/app/join/[token]/page.tsx\`
- \`/app/api/cli/{leagues, teams, players, players/[id], divisions, seasons, import}\` (7 routes)
- 7 corresponding \`__tests__\`
- \`/lib/sync/nfl-sync.ts\` + its test

### Inline SF helper rewritten
\`/api/orgs/[orgId]/invite-link/route.ts\` previously did raw SOQL:
\`\`\`
SELECT Id, Invite_Token__c FROM League__c WHERE Clerk_Org_Id__c = '...'
\`\`\`
Now uses \`getLeagueForOrg\` from data-api — the Convex query already returns \`{ id, token }\` with the exact shape the route helper expected. Pure drop-in adapter. Drops the \`getSalesforceConnection\` import.

### Test mock fixups (8 specs)
- Mass swap \`vi.mock("@/lib/salesforce-api", ...)\` → \`vi.mock("@/lib/data-api", ...)\` across CLI + nfl-sync tests.
- invite-link test: rewrote to mock \`getLeagueForOrg\` instead of the raw SF query/sobject pair. 4 SOQL stubs (\`{totalSize, records: [{Id, ...}]}\`) swapped for the \`{id, token}\` shape.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web lint\` clean (one pre-existing warning)
- [x] \`pnpm --filter @sports-management/web test:unit\` — 252/252 passing

## Next
WSM-000052 deletes \`salesforce-api.ts\`, \`salesforce.ts\`, the re-export shim, the self-test, and removes \`SF_*\` env vars from \`.env.local.example\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)