### PR TITLE
feat(web): add playerAttributes table + DTO (WSM-000054)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -118,4 +118,28 @@ export default defineSchema({
     syncEnabled: v.boolean(),
     lastSyncReportJson: v.union(v.string(), v.null()),
   }).index("by_key", ["key"]),
+
+  /*
+   * Phase 2 — `player_attributes_v1` (Sprint 6B).
+   *
+   * One row per player per season. Stores raw source payloads
+   * (PFF + Madden + admin-uploaded JSON) for transparency, plus
+   * a canonical `attributesJson` that downstream code reads.
+   * `weightedOverall` is computed at ingest time per the formula in
+   * roster-management.md §5.3 — sources with null weight short-circuit.
+   */
+  playerAttributes: defineTable({
+    playerId: v.id("players"),
+    seasonId: v.id("seasons"),
+    positionGroup: v.string(),
+    attributesJson: v.string(),
+    pffSourceJson: v.union(v.string(), v.null()),
+    maddenSourceJson: v.union(v.string(), v.null()),
+    pffWeight: v.number(),
+    maddenWeight: v.number(),
+    weightedOverall: v.union(v.number(), v.null()),
+    ingestedAt: v.string(),
+  })
+    .index("by_playerId_seasonId", ["playerId", "seasonId"])
+    .index("by_seasonId_positionGroup", ["seasonId", "positionGroup"]),
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -175,6 +175,25 @@ export interface SyncConfig {
   lastSyncReport: SyncReport | null;
 }
 
+// --- Player attributes (Phase 2, player_attributes_v1) ---
+
+export interface PlayerAttributeDto {
+  id: string;
+  playerId: string;
+  seasonId: string;
+  positionGroup: string;
+  /** Canonical attribute map (already normalized + weighted). */
+  attributes: Record<string, number>;
+  /** Raw PFF payload as ingested, null if not provided. */
+  pffSource: Record<string, unknown> | null;
+  /** Raw Madden payload as ingested, null if not provided. */
+  maddenSource: Record<string, unknown> | null;
+  pffWeight: number;
+  maddenWeight: number;
+  weightedOverall: number | null;
+  ingestedAt: string;
+}
+
 // --- Subscription tier types ---
 
 export type Tier = "free" | "plus" | "club" | "league";


### PR DESCRIPTION
## Summary

Sprint 6B story 1 — schema foundation for Phase 2 (player attributes & development).

### Convex schema additions
\`playerAttributes\` table per the design doc §4.1:
- \`playerId\`, \`seasonId\`, \`positionGroup\`, \`attributesJson\`
- \`pffSourceJson\` + \`maddenSourceJson\` (raw payloads kept for transparency)
- \`pffWeight\` + \`maddenWeight\` (per-source weights, 0..1)
- \`weightedOverall\` (computed at ingest time, nullable)
- \`ingestedAt\`
- Indexes: \`by_playerId_seasonId\` + \`by_seasonId_positionGroup\`

### Shared types
\`PlayerAttributeDto\` on \`packages/shared-types/src/index.ts\`. Exposes parsed attribute objects (\`Record<string, number>\`) and source payloads (\`Record<string, unknown> | null\`) so consumers don't have to JSON.parse strings.

### Sprint 6B outline (12 stories)
```
54  Schema (this PR)
55  Flag — player_attributes_v1
56  Source adapters: PFF + Madden + admin JSON
57  Ingest mutation
58  Query API
59  Public-read primitives (leagues.isPublic guard)
60  UI — org-gated dev chart
61  UI — public viewer route
62  UI — per-position attributes table
63  UI — admin upload + Make-public toggle
64  E2E coverage
65  Analytics + closeout
```

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` clean
- [x] \`pnpm --filter @sports-management/web test:unit\` — 229/229 passing
- [ ] No consumers yet — visual + integration verification in WSM-000060+

🤖 Generated with [Claude Code](https://claude.com/claude-code)