### PR TITLE
feat(web): declare player_attributes_v1 feature flag (WSM-000055)

### DIFF
--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -20,7 +20,13 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-import { depthChartV1, rosterSnapshotsV1, pageGuard, apiGuard } from "../flags";
+import {
+  depthChartV1,
+  rosterSnapshotsV1,
+  playerAttributesV1,
+  pageGuard,
+  apiGuard,
+} from "../flags";
 
 describe("depthChartV1 flag declaration", () => {
   it("uses the canonical key", () => {
@@ -39,6 +45,16 @@ describe("rosterSnapshotsV1 flag declaration", () => {
 
   it("has a Phase 1 description for the Vercel Toolbar", () => {
     expect(rosterSnapshotsV1.description).toMatch(/roster|snapshot/i);
+  });
+});
+
+describe("playerAttributesV1 flag declaration", () => {
+  it("uses the canonical key", () => {
+    expect(playerAttributesV1.key).toBe("player_attributes_v1");
+  });
+
+  it("has a Phase 2 description for the Vercel Toolbar", () => {
+    expect(playerAttributesV1.description).toMatch(/attribute|development/i);
   });
 });
 

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -34,6 +34,21 @@ export const rosterSnapshotsV1 = flag<boolean>({
   },
 });
 
+export const playerAttributesV1 = flag<boolean>({
+  key: "player_attributes_v1",
+  description:
+    "Phase 2 player attributes & development: per-season attribute snapshots, dev chart, public viewer",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    void trackFlagExposure("player_attributes_v1", defaultOn);
+    return defaultOn;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
## Summary
Sprint 6B story 2. Adds \`player_attributes_v1\` alongside existing \`depth_chart_v1\` + \`roster_snapshots_v1\`. Same shape — defaultValue based on NODE_ENV, on/off options, \`flag_exposure\` analytics emission. Default off in prod.

## Test plan
- [x] Type-check + lint clean
- [x] \`pnpm --filter @sports-management/web test:unit\` — **231/231 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)