### PR TITLE
feat(web): attribute source adapters — PFF + Madden + admin JSON (WSM-000056)

### DIFF
--- a/apps/web/src/lib/attributes/position-groups.ts
+++ b/apps/web/src/lib/attributes/position-groups.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical position-group taxonomy for player attributes (Phase 2 /
+ * `player_attributes_v1`). Mirrors the broader player-position util
+ * in `apps/web/convex/lib/positionGroup.ts` but is scoped to the
+ * attribute domain — every `playerAttributes` row carries a
+ * positionGroup matching one of these literals.
+ */
+export const POSITION_GROUPS = [
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OL",
+  "DL",
+  "LB",
+  "DB",
+  "K",
+  "P",
+] as const;
+
+export type PositionGroup = (typeof POSITION_GROUPS)[number];
+
+export function isValidPositionGroup(s: unknown): s is PositionGroup {
+  return typeof s === "string" && (POSITION_GROUPS as readonly string[]).includes(s);
+}

--- a/apps/web/src/lib/attributes/sources/__tests__/admin-json.test.ts
+++ b/apps/web/src/lib/attributes/sources/__tests__/admin-json.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAdminJson } from "../admin-json";
+
+describe("normalizeAdminJson", () => {
+  it("passes a valid canonical payload through", () => {
+    expect(
+      normalizeAdminJson({
+        playerId: "p_1",
+        positionGroup: "WR",
+        attributes: { speed: 95, separation: 88 },
+      }),
+    ).toEqual({
+      positionGroup: "WR",
+      attributes: { speed: 95, separation: 88 },
+    });
+  });
+
+  it("drops non-numeric attribute values", () => {
+    const result = normalizeAdminJson({
+      positionGroup: "QB",
+      attributes: { armStrength: 90, comment: "great", clutch: 80 },
+    });
+    expect(result?.attributes).toEqual({ armStrength: 90, clutch: 80 });
+  });
+
+  it("returns null when positionGroup is invalid", () => {
+    expect(
+      normalizeAdminJson({
+        positionGroup: "QUARTERBACK",
+        attributes: { speed: 90 },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when attributes object is missing or empty", () => {
+    expect(normalizeAdminJson({ positionGroup: "QB" })).toBeNull();
+    expect(
+      normalizeAdminJson({ positionGroup: "QB", attributes: {} }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/attributes/sources/__tests__/madden.test.ts
+++ b/apps/web/src/lib/attributes/sources/__tests__/madden.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { normalizeMadden } from "../madden";
+
+describe("normalizeMadden", () => {
+  it("flattens uppercase attribute fields into the canonical map", () => {
+    const result = normalizeMadden({
+      id: "m_1",
+      POS: "QB",
+      OVR: 92,
+      SPD: 88,
+      STR: 75,
+      AWR: 91,
+    });
+    expect(result).toEqual({
+      positionGroup: "QB",
+      attributes: { OVR: 92, SPD: 88, STR: 75, AWR: 91 },
+    });
+  });
+
+  it("excludes the id / name / TEAM metadata fields", () => {
+    const result = normalizeMadden({
+      id: "m_1",
+      name: "Player",
+      TEAM: "DAL",
+      POS: "RB",
+      OVR: 90,
+    });
+    expect(result?.attributes).toEqual({ OVR: 90 });
+  });
+
+  it("returns null for unknown POS", () => {
+    expect(normalizeMadden({ POS: "??", OVR: 80 })).toBeNull();
+  });
+
+  it("returns null when no numeric attributes remain", () => {
+    expect(
+      normalizeMadden({ id: "m_1", POS: "WR", name: "X" }),
+    ).toBeNull();
+  });
+
+  it("returns null for non-object input", () => {
+    expect(normalizeMadden(null)).toBeNull();
+    expect(normalizeMadden(42)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/attributes/sources/__tests__/pff.test.ts
+++ b/apps/web/src/lib/attributes/sources/__tests__/pff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { normalizePff } from "../pff";
+
+describe("normalizePff", () => {
+  it("returns canonical shape for a valid payload", () => {
+    expect(
+      normalizePff({
+        playerId: "p_1",
+        positionGroup: "QB",
+        attributes: { armStrength: 92, accuracy: 88 },
+      }),
+    ).toEqual({
+      positionGroup: "QB",
+      attributes: { armStrength: 92, accuracy: 88 },
+    });
+  });
+
+  it("drops non-numeric attribute values", () => {
+    const result = normalizePff({
+      positionGroup: "QB",
+      attributes: { armStrength: 92, raw: "n/a", weirdNan: NaN, ok: 70 },
+    });
+    expect(result?.attributes).toEqual({ armStrength: 92, ok: 70 });
+  });
+
+  it("returns null when positionGroup is missing", () => {
+    expect(
+      normalizePff({ attributes: { armStrength: 92 } }),
+    ).toBeNull();
+  });
+
+  it("returns null when positionGroup is unknown", () => {
+    expect(
+      normalizePff({
+        positionGroup: "WIZARD",
+        attributes: { armStrength: 92 },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when attributes object is missing", () => {
+    expect(normalizePff({ positionGroup: "QB" })).toBeNull();
+  });
+
+  it("returns null when attributes object yields no numeric entries", () => {
+    expect(
+      normalizePff({ positionGroup: "QB", attributes: { x: "y" } }),
+    ).toBeNull();
+  });
+
+  it("returns null for non-object input", () => {
+    expect(normalizePff(null)).toBeNull();
+    expect(normalizePff("string")).toBeNull();
+    expect(normalizePff(42)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/attributes/sources/admin-json.ts
+++ b/apps/web/src/lib/attributes/sources/admin-json.ts
@@ -1,0 +1,42 @@
+/**
+ * Admin-uploaded JSON source adapter.
+ *
+ * The "canonical" shape — same as the PFF format but explicitly
+ * labelled as the admin's own data. Used when the admin pastes JSON
+ * directly via the upload modal (WSM-000063) rather than uploading
+ * a vendor format.
+ *
+ *   {
+ *     "playerId": "p_123",
+ *     "positionGroup": "QB",
+ *     "attributes": {
+ *       "armStrength": 92,
+ *       "accuracy": 88
+ *     }
+ *   }
+ *
+ * Returns null when invalid.
+ */
+import { isValidPositionGroup } from "../position-groups";
+import type { NormalizedSource } from "./types";
+
+export function normalizeAdminJson(
+  payload: unknown,
+): NormalizedSource | null {
+  if (!payload || typeof payload !== "object") return null;
+  const row = payload as Record<string, unknown>;
+
+  if (!isValidPositionGroup(row.positionGroup)) return null;
+
+  const raw = row.attributes;
+  if (!raw || typeof raw !== "object") return null;
+
+  const attributes: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    attributes[key] = value;
+  }
+  if (Object.keys(attributes).length === 0) return null;
+
+  return { positionGroup: row.positionGroup, attributes };
+}

--- a/apps/web/src/lib/attributes/sources/madden.ts
+++ b/apps/web/src/lib/attributes/sources/madden.ts
@@ -1,0 +1,49 @@
+/**
+ * Madden source adapter.
+ *
+ * Assumed payload shape (one row, mirrors EA's roster export):
+ *
+ *   {
+ *     "id": "m_123",
+ *     "POS": "QB",
+ *     "OVR": 92,
+ *     "SPD": 88,
+ *     "STR": 75,
+ *     "AWR": 91,
+ *     "...": ...
+ *   }
+ *
+ * The shape is flat — every uppercase numeric field is treated as an
+ * attribute. `POS` is the position-group code (must map to our
+ * canonical taxonomy). Returns null when invalid.
+ */
+import { isValidPositionGroup } from "../position-groups";
+import type { NormalizedSource } from "./types";
+
+const NON_ATTRIBUTE_KEYS = new Set([
+  "id",
+  "POS",
+  "playerId",
+  "name",
+  "team",
+  "TEAM",
+]);
+
+export function normalizeMadden(
+  payload: unknown,
+): NormalizedSource | null {
+  if (!payload || typeof payload !== "object") return null;
+  const row = payload as Record<string, unknown>;
+
+  if (!isValidPositionGroup(row.POS)) return null;
+
+  const attributes: Record<string, number> = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (NON_ATTRIBUTE_KEYS.has(key)) continue;
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    attributes[key] = value;
+  }
+  if (Object.keys(attributes).length === 0) return null;
+
+  return { positionGroup: row.POS, attributes };
+}

--- a/apps/web/src/lib/attributes/sources/pff.ts
+++ b/apps/web/src/lib/attributes/sources/pff.ts
@@ -1,0 +1,40 @@
+/**
+ * PFF source adapter.
+ *
+ * Assumed payload shape (one row, what an admin uploads + what the
+ * future paid-feed integration will normalize to):
+ *
+ *   {
+ *     "playerId": "p_123",
+ *     "positionGroup": "QB",
+ *     "attributes": {
+ *       "armStrength": 92,
+ *       "accuracy": 88,
+ *       "decisionMaking": 85
+ *     }
+ *   }
+ *
+ * Returns null when the shape doesn't match — caller treats null as
+ * "this row was not a valid PFF row" (skip + log; no throw).
+ */
+import { isValidPositionGroup } from "../position-groups";
+import type { NormalizedSource } from "./types";
+
+export function normalizePff(payload: unknown): NormalizedSource | null {
+  if (!payload || typeof payload !== "object") return null;
+  const row = payload as Record<string, unknown>;
+
+  if (!isValidPositionGroup(row.positionGroup)) return null;
+
+  const raw = row.attributes;
+  if (!raw || typeof raw !== "object") return null;
+
+  const attributes: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    attributes[key] = value;
+  }
+  if (Object.keys(attributes).length === 0) return null;
+
+  return { positionGroup: row.positionGroup, attributes };
+}

--- a/apps/web/src/lib/attributes/sources/types.ts
+++ b/apps/web/src/lib/attributes/sources/types.ts
@@ -1,0 +1,11 @@
+import type { PositionGroup } from "../position-groups";
+
+/**
+ * Canonical normalizer output. Every source adapter
+ * (PFF / Madden / admin JSON) returns this shape on success, null on
+ * malformed input.
+ */
+export interface NormalizedSource {
+  positionGroup: PositionGroup;
+  attributes: Record<string, number>;
+}


### PR DESCRIPTION
## Summary
Sprint 6B story 3. Three source-format normalizers + canonical position-group taxonomy.

| File | Role |
|---|---|
| \`attributes/position-groups.ts\` | \`POSITION_GROUPS\` const tuple + \`PositionGroup\` type + \`isValidPositionGroup\` guard |
| \`attributes/sources/types.ts\` | shared \`NormalizedSource\` shape \`{ positionGroup, attributes }\` |
| \`attributes/sources/pff.ts\` | PFF: \`{ positionGroup, attributes: { ... } }\` → canonical |
| \`attributes/sources/madden.ts\` | Madden: flat \`{ POS, OVR, SPD, ... }\` → canonical |
| \`attributes/sources/admin-json.ts\` | Admin canonical-shape passthrough |

Each adapter returns \`null\` on malformed input (not throws) — caller treats null as "skip this row".

## Test plan
- [x] 247/247 unit tests passing (3 new test files, ~17 cases covering happy paths + null returns for missing/invalid fields)
- [x] Type-check + lint clean

## Next
WSM-000057 wires these into a single Convex \`ingestPlayerAttributes\` mutation that combines the three source paths and computes \`weightedOverall\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)