### PR TITLE
feat(web): playerAttributes query API — development + per-position (WSM-000058)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1818,3 +1818,143 @@ export const ingestPlayerAttributes = mutationGeneric({
     return { id, created: true };
   },
 });
+
+/*
+ * Phase 2 — Read API (Sprint 6B / WSM-000058).
+ */
+
+function safeParseAttributes(json: string): Record<string, number> {
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object") {
+      const out: Record<string, number> = {};
+      for (const [k, v2] of Object.entries(parsed)) {
+        if (typeof v2 === "number" && Number.isFinite(v2)) out[k] = v2;
+      }
+      return out;
+    }
+  } catch {
+    // fallthrough
+  }
+  return {};
+}
+
+const playerDevelopmentRowValidator = v.object({
+  id: v.string(),
+  seasonId: v.string(),
+  seasonName: v.string(),
+  seasonStartDate: v.union(v.string(), v.null()),
+  positionGroup: v.string(),
+  attributes: v.record(v.string(), v.number()),
+  weightedOverall: v.union(v.number(), v.null()),
+  delta: v.union(v.number(), v.null()),
+  ingestedAt: v.string(),
+});
+
+export const getPlayerDevelopment = queryGeneric({
+  args: { playerId: v.id("players") },
+  returns: v.array(playerDevelopmentRowValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", args.playerId),
+      )
+      .collect();
+
+    // Hydrate season info for sort + axis labels.
+    const hydrated = await Promise.all(
+      rows.map(async (row) => {
+        const season = await ctx.db.get(row.seasonId);
+        return {
+          row,
+          seasonName: season?.name ?? "(unknown)",
+          seasonStartDate: season?.startDate ?? null,
+        };
+      }),
+    );
+
+    // Sort: startDate ASC (nulls last so a missing date doesn't skew
+    // the chart). Compute delta vs the immediately-preceding row.
+    hydrated.sort((a, b) => {
+      const aKey = a.seasonStartDate ?? "9999";
+      const bKey = b.seasonStartDate ?? "9999";
+      return aKey.localeCompare(bKey);
+    });
+
+    let prevOverall: number | null = null;
+    return hydrated.map(({ row, seasonName, seasonStartDate }) => {
+      const overall = row.weightedOverall;
+      const delta =
+        overall !== null && prevOverall !== null
+          ? overall - prevOverall
+          : null;
+      if (overall !== null) prevOverall = overall;
+      return {
+        id: row._id,
+        seasonId: row.seasonId,
+        seasonName,
+        seasonStartDate,
+        positionGroup: row.positionGroup,
+        attributes: safeParseAttributes(row.attributesJson),
+        weightedOverall: overall,
+        delta,
+        ingestedAt: row.ingestedAt,
+      };
+    });
+  },
+});
+
+const seasonAttributesRowValidator = v.object({
+  playerId: v.string(),
+  playerName: v.string(),
+  positionGroup: v.string(),
+  attributes: v.record(v.string(), v.number()),
+  weightedOverall: v.union(v.number(), v.null()),
+  ingestedAt: v.string(),
+});
+
+export const getSeasonAttributesByPosition = queryGeneric({
+  args: {
+    seasonId: v.id("seasons"),
+    positionGroup: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(seasonAttributesRowValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_seasonId_positionGroup", (q) =>
+        q.eq("seasonId", args.seasonId),
+      )
+      .collect();
+
+    const filtered = rows.filter(
+      (row) => row.positionGroup === args.positionGroup,
+    );
+
+    // Sort by weightedOverall DESC (nulls last).
+    filtered.sort((a, b) => {
+      const aOverall = a.weightedOverall ?? -Infinity;
+      const bOverall = b.weightedOverall ?? -Infinity;
+      return bOverall - aOverall;
+    });
+
+    const limit = args.limit ?? 25;
+    const limited = filtered.slice(0, limit);
+
+    return Promise.all(
+      limited.map(async (row) => {
+        const player = await ctx.db.get(row.playerId);
+        return {
+          playerId: row.playerId,
+          playerName: player?.name ?? "(unknown)",
+          positionGroup: row.positionGroup,
+          attributes: safeParseAttributes(row.attributesJson),
+          weightedOverall: row.weightedOverall,
+          ingestedAt: row.ingestedAt,
+        };
+      }),
+    );
+  },
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -201,6 +201,31 @@ const refs = {
     },
     { id: string; created: boolean }
   >("sports:ingestPlayerAttributes"),
+  getPlayerDevelopment: queryRef<
+    { playerId: string },
+    Array<{
+      id: string;
+      seasonId: string;
+      seasonName: string;
+      seasonStartDate: string | null;
+      positionGroup: string;
+      attributes: Record<string, number>;
+      weightedOverall: number | null;
+      delta: number | null;
+      ingestedAt: string;
+    }>
+  >("sports:getPlayerDevelopment"),
+  getSeasonAttributesByPosition: queryRef<
+    { seasonId: string; positionGroup: string; limit?: number },
+    Array<{
+      playerId: string;
+      playerName: string;
+      positionGroup: string;
+      attributes: Record<string, number>;
+      weightedOverall: number | null;
+      ingestedAt: string;
+    }>
+  >("sports:getSeasonAttributesByPosition"),
   getDepthChartByTeamSeason: queryRef<
     { teamId: string; seasonId: string },
     DepthChartEntryDto[]
@@ -858,5 +883,21 @@ export async function ingestPlayerAttributes(
     pffWeight: input.pffWeight ?? 0.5,
     maddenWeight: input.maddenWeight ?? 0.5,
     weightedOverall,
+  });
+}
+
+export async function getPlayerDevelopment(playerId: string) {
+  return queryConvex(refs.getPlayerDevelopment, { playerId });
+}
+
+export async function getSeasonAttributesByPosition(
+  seasonId: string,
+  positionGroup: string,
+  limit?: number,
+) {
+  return queryConvex(refs.getSeasonAttributesByPosition, {
+    seasonId,
+    positionGroup,
+    limit,
   });
 }


### PR DESCRIPTION
## Summary
Sprint 6B story 5. Two read queries on \`playerAttributes\`.

| Query | Purpose |
|---|---|
| \`getPlayerDevelopment(playerId)\` | All rows for the player, ordered by \`season.startDate\` ASC, with per-row \`delta\` vs the previous season's \`weightedOverall\`. Powers the \`/dashboard/players/[id]/development\` chart in WSM-000060. |
| \`getSeasonAttributesByPosition(seasonId, positionGroup, limit?)\` | Top-N rows for a position group within a season, ordered by \`weightedOverall\` DESC. Powers the per-position table in WSM-000062. |

Both queries hydrate joined fields (\`season.name + startDate\`, \`player.name\`) so consumers don't need follow-up fetches. \`safeParseAttributes\` isolates the read path from future schema drift in \`attributesJson\`.

## Test plan
- [x] Type-check + lint clean
- [x] Unit tests 252/252
- [ ] Convex-test for the queries lands in WSM-000064 alongside e2e (pure read-side joins → best exercised end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)