### PR TITLE
feat(web): public-read primitives — leagues.isPublic guard + getPlayerDevelopmentPublic (WSM-000059)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1958,3 +1958,81 @@ export const getSeasonAttributesByPosition = queryGeneric({
     );
   },
 });
+
+/*
+ * Phase 2 — Public read primitives (Sprint 6B / WSM-000059).
+ *
+ * The public viewer in WSM-000061 hits these without a Clerk session.
+ * Both queries gate on `league.isPublic === true`. No org-membership
+ * check; visibility is the league's own opt-in.
+ */
+
+export const getLeagueVisibility = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.union(v.object({ isPublic: v.boolean() }), v.null()),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) return null;
+    return { isPublic: league.isPublic };
+  },
+});
+
+export const getPlayerDevelopmentPublic = queryGeneric({
+  args: {
+    leagueId: v.id("leagues"),
+    playerId: v.id("players"),
+  },
+  returns: v.union(v.array(playerDevelopmentRowValidator), v.null()),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league || !league.isPublic) return null;
+
+    const player = await ctx.db.get(args.playerId);
+    if (!player || player.leagueId !== args.leagueId) return null;
+
+    const rows = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", args.playerId),
+      )
+      .collect();
+
+    const hydrated = await Promise.all(
+      rows.map(async (row) => {
+        const season = await ctx.db.get(row.seasonId);
+        return {
+          row,
+          seasonName: season?.name ?? "(unknown)",
+          seasonStartDate: season?.startDate ?? null,
+        };
+      }),
+    );
+
+    hydrated.sort((a, b) => {
+      const aKey = a.seasonStartDate ?? "9999";
+      const bKey = b.seasonStartDate ?? "9999";
+      return aKey.localeCompare(bKey);
+    });
+
+    let prevOverall: number | null = null;
+    return hydrated.map(({ row, seasonName, seasonStartDate }) => {
+      const overall = row.weightedOverall;
+      const delta =
+        overall !== null && prevOverall !== null
+          ? overall - prevOverall
+          : null;
+      if (overall !== null) prevOverall = overall;
+      return {
+        id: row._id,
+        seasonId: row.seasonId,
+        seasonName,
+        seasonStartDate,
+        positionGroup: row.positionGroup,
+        attributes: safeParseAttributes(row.attributesJson),
+        weightedOverall: overall,
+        delta,
+        ingestedAt: row.ingestedAt,
+      };
+    });
+  },
+});

--- a/apps/web/src/lib/__tests__/public-league-guard.test.ts
+++ b/apps/web/src/lib/__tests__/public-league-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetLeagueVisibility } = vi.hoisted(() => ({
+  mockGetLeagueVisibility: vi.fn(),
+}));
+
+vi.mock("../data-api", () => ({
+  getLeagueVisibility: mockGetLeagueVisibility,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    const err = new Error("NEXT_NOT_FOUND");
+    (err as Error & { digest?: string }).digest = "NEXT_NOT_FOUND";
+    throw err;
+  }),
+}));
+
+import { publicLeagueGuard } from "../public-league-guard";
+
+describe("publicLeagueGuard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("resolves silently when the league is public", async () => {
+    mockGetLeagueVisibility.mockResolvedValue({ isPublic: true });
+    await expect(publicLeagueGuard("lg_pub")).resolves.toBeUndefined();
+  });
+
+  it("throws notFound() when the league is not public", async () => {
+    mockGetLeagueVisibility.mockResolvedValue({ isPublic: false });
+    await expect(publicLeagueGuard("lg_priv")).rejects.toThrow(
+      "NEXT_NOT_FOUND",
+    );
+  });
+
+  it("throws notFound() when the league is missing", async () => {
+    mockGetLeagueVisibility.mockResolvedValue(null);
+    await expect(publicLeagueGuard("lg_missing")).rejects.toThrow(
+      "NEXT_NOT_FOUND",
+    );
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -226,6 +226,24 @@ const refs = {
       ingestedAt: string;
     }>
   >("sports:getSeasonAttributesByPosition"),
+  getLeagueVisibility: queryRef<
+    { leagueId: string },
+    { isPublic: boolean } | null
+  >("sports:getLeagueVisibility"),
+  getPlayerDevelopmentPublic: queryRef<
+    { leagueId: string; playerId: string },
+    Array<{
+      id: string;
+      seasonId: string;
+      seasonName: string;
+      seasonStartDate: string | null;
+      positionGroup: string;
+      attributes: Record<string, number>;
+      weightedOverall: number | null;
+      delta: number | null;
+      ingestedAt: string;
+    }> | null
+  >("sports:getPlayerDevelopmentPublic"),
   getDepthChartByTeamSeason: queryRef<
     { teamId: string; seasonId: string },
     DepthChartEntryDto[]
@@ -900,4 +918,15 @@ export async function getSeasonAttributesByPosition(
     positionGroup,
     limit,
   });
+}
+
+export async function getLeagueVisibility(leagueId: string) {
+  return queryConvex(refs.getLeagueVisibility, { leagueId });
+}
+
+export async function getPlayerDevelopmentPublic(
+  leagueId: string,
+  playerId: string,
+) {
+  return queryConvex(refs.getPlayerDevelopmentPublic, { leagueId, playerId });
 }

--- a/apps/web/src/lib/public-league-guard.ts
+++ b/apps/web/src/lib/public-league-guard.ts
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+import { getLeagueVisibility } from "./data-api";
+
+/**
+ * Page-level guard for public viewer routes (Phase 2 / WSM-000059).
+ *
+ * Throws notFound() (Next App Router pattern) when the league is
+ * missing or not opted into public visibility. Use at the top of
+ * any server component under `/leagues/[id]/...` that should be
+ * reachable without authentication.
+ *
+ * No org-membership check — visibility here is the league's own
+ * opt-in via `leagues.isPublic`.
+ */
+export async function publicLeagueGuard(leagueId: string): Promise<void> {
+  const visibility = await getLeagueVisibility(leagueId);
+  if (!visibility || !visibility.isPublic) {
+    notFound();
+  }
+}


### PR DESCRIPTION
## Summary
Sprint 6B story 6. Auth/visibility primitives for the public viewer route landing in WSM-000061.

| Layer | Addition |
|---|---|
| Convex | \`getLeagueVisibility(leagueId)\` returns \`{isPublic}\` or null |
| Convex | \`getPlayerDevelopmentPublic(leagueId, playerId)\` — same shape as \`getPlayerDevelopment\` but gates on \`league.isPublic\` + \`player.leagueId === leagueId\`. Returns null on either guard failure. |
| data-api | wrappers for both |
| Page guard | \`publicLeagueGuard(leagueId)\` calls visibility + throws \`notFound()\` if missing or not public |
| Tests | 3 cases: public → resolves, private → 404, missing → 404 |

## Test plan
- [x] Type-check + lint clean
- [x] Unit tests 255/255

🤖 Generated with [Claude Code](https://claude.com/claude-code)