### PR TITLE
feat(web): /dashboard/players/[id]/development chart UI (WSM-000060)

### DIFF
--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -1,0 +1,151 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { playerAttributesV1 } from "@/lib/flags";
+import {
+  getPlayer,
+  getPlayerDevelopment,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { Card, CardContent } from "@/components/ui/8bit/card";
+import PixelLineChart from "@/components/attributes/PixelLineChart";
+
+export default async function PlayerDevelopmentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await playerAttributesV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: playerId } = await params;
+
+  // Resolve the user's visible leagues, then fetch the player through
+  // the access check. Anything outside the user's org tree → 404.
+  const orgContext = await resolveOrgContext(userId);
+  const player = await getPlayer(playerId, orgContext).catch(() => null);
+  if (!player) notFound();
+
+  const development = await getPlayerDevelopment(playerId);
+
+  const points = development.map((row) => ({
+    x: row.seasonName,
+    y: row.weightedOverall,
+  }));
+
+  // Latest two rows for the headline delta call-out.
+  const last = development[development.length - 1] ?? null;
+  const headlineDelta = last?.delta ?? null;
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/players`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Players
+      </Link>
+
+      <header className="mb-6 flex flex-col gap-1">
+        <h2 className="text-2xl font-bold text-foreground">
+          {player.name}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Position: {player.position}
+          {player.positionGroup ? ` · ${player.positionGroup}` : ""}
+        </p>
+      </header>
+
+      <Card className="mb-6">
+        <CardContent className="p-6">
+          <div className="mb-4 flex items-baseline gap-3">
+            <h3 className="text-lg font-semibold text-foreground">
+              Weighted overall by season
+            </h3>
+            {headlineDelta !== null ? (
+              <span
+                className={`font-mono text-sm ${
+                  headlineDelta >= 0 ? "text-accent" : "text-destructive"
+                }`}
+              >
+                {headlineDelta >= 0 ? "+" : ""}
+                {headlineDelta.toFixed(1)} vs last season
+              </span>
+            ) : null}
+          </div>
+          <PixelLineChart
+            points={points}
+            ariaLabel={`${player.name} weighted overall by season`}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b-2 border-border bg-muted text-left text-foreground">
+                <th className="px-4 py-2 font-mono text-xs uppercase">
+                  Season
+                </th>
+                <th className="px-4 py-2 font-mono text-xs uppercase">
+                  Position group
+                </th>
+                <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+                  Overall
+                </th>
+                <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+                  Δ
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {development.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-center text-muted-foreground"
+                  >
+                    No attribute data ingested yet for this player.
+                  </td>
+                </tr>
+              ) : (
+                development.map((row) => (
+                  <tr key={row.id} className="border-b border-border">
+                    <td className="px-4 py-2 text-foreground">
+                      {row.seasonName}
+                    </td>
+                    <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                      {row.positionGroup}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-foreground">
+                      {row.weightedOverall === null
+                        ? "—"
+                        : row.weightedOverall.toFixed(1)}
+                    </td>
+                    <td
+                      className={`px-4 py-2 text-right font-mono ${
+                        row.delta === null
+                          ? "text-muted-foreground"
+                          : row.delta >= 0
+                            ? "text-accent"
+                            : "text-destructive"
+                      }`}
+                    >
+                      {row.delta === null
+                        ? "—"
+                        : `${row.delta >= 0 ? "+" : ""}${row.delta.toFixed(1)}`}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/attributes/PixelLineChart.tsx
+++ b/apps/web/src/components/attributes/PixelLineChart.tsx
@@ -1,0 +1,184 @@
+/**
+ * Hand-rolled pixel-art line chart (Phase 2 / WSM-000060).
+ *
+ * No recharts — the antialiased polish fights the 8-bit aesthetic.
+ * Renders a chunky-stroke polyline with filled-square vertices and
+ * `image-rendering: pixelated` for the crispest possible look.
+ *
+ * Skips null y values: a missing season's segment is omitted, and
+ * the line picks up at the next non-null point.
+ */
+import { POSITION_GROUPS } from "@/lib/attributes/position-groups";
+
+export interface PixelLineChartPoint {
+  /** Display label for the x-axis tick (e.g. season name). */
+  x: string;
+  /** Numeric y value, null to omit the point + segment. */
+  y: number | null;
+}
+
+export interface PixelLineChartProps {
+  points: PixelLineChartPoint[];
+  /** Inclusive y-range. Defaults to 0..100 (attribute scale). */
+  yMin?: number;
+  yMax?: number;
+  /** SVG dimensions. */
+  width?: number;
+  height?: number;
+  /** Aria label for screen readers. */
+  ariaLabel?: string;
+}
+
+const PADDING = { top: 16, right: 16, bottom: 36, left: 36 };
+
+export default function PixelLineChart({
+  points,
+  yMin = 0,
+  yMax = 100,
+  width = 480,
+  height = 240,
+  ariaLabel = "Line chart",
+}: PixelLineChartProps) {
+  const innerW = width - PADDING.left - PADDING.right;
+  const innerH = height - PADDING.top - PADDING.bottom;
+
+  // Empty state — render an empty axis frame.
+  if (points.length === 0) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        role="img"
+        aria-label={ariaLabel}
+        style={{ imageRendering: "pixelated" }}
+      >
+        <rect
+          x={PADDING.left}
+          y={PADDING.top}
+          width={innerW}
+          height={innerH}
+          fill="var(--color-card)"
+          stroke="var(--color-border)"
+          strokeWidth={2}
+        />
+        <text
+          x={width / 2}
+          y={height / 2}
+          textAnchor="middle"
+          fill="var(--color-muted-foreground)"
+          fontSize={12}
+        >
+          No data
+        </text>
+      </svg>
+    );
+  }
+
+  const xStep = points.length > 1 ? innerW / (points.length - 1) : 0;
+  const yScale = (y: number) => {
+    const clamped = Math.max(yMin, Math.min(yMax, y));
+    const t = (clamped - yMin) / (yMax - yMin);
+    return PADDING.top + innerH - t * innerH;
+  };
+  const xPos = (i: number) =>
+    points.length === 1 ? PADDING.left + innerW / 2 : PADDING.left + i * xStep;
+
+  // Build line segments, skipping over null y values.
+  const segments: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (a.y === null || b.y === null) continue;
+    segments.push({
+      x1: xPos(i),
+      y1: yScale(a.y),
+      x2: xPos(i + 1),
+      y2: yScale(b.y),
+    });
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      role="img"
+      aria-label={ariaLabel}
+      style={{ imageRendering: "pixelated" }}
+    >
+      {/* Plot area background */}
+      <rect
+        x={PADDING.left}
+        y={PADDING.top}
+        width={innerW}
+        height={innerH}
+        fill="var(--color-card)"
+        stroke="var(--color-border)"
+        strokeWidth={2}
+      />
+
+      {/* Y-axis labels: min, mid, max */}
+      {[yMin, Math.round((yMin + yMax) / 2), yMax].map((tick) => (
+        <text
+          key={tick}
+          x={PADDING.left - 6}
+          y={yScale(tick) + 4}
+          textAnchor="end"
+          fill="var(--color-muted-foreground)"
+          fontSize={11}
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          {tick}
+        </text>
+      ))}
+
+      {/* X-axis labels under each point */}
+      {points.map((p, i) => (
+        <text
+          key={`x-${i}`}
+          x={xPos(i)}
+          y={height - PADDING.bottom + 16}
+          textAnchor="middle"
+          fill="var(--color-muted-foreground)"
+          fontSize={10}
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          {p.x}
+        </text>
+      ))}
+
+      {/* Chunky line segments */}
+      {segments.map((s, i) => (
+        <line
+          key={`seg-${i}`}
+          x1={s.x1}
+          y1={s.y1}
+          x2={s.x2}
+          y2={s.y2}
+          stroke="var(--color-primary)"
+          strokeWidth={4}
+          strokeLinecap="square"
+        />
+      ))}
+
+      {/* Square vertices for each non-null point */}
+      {points.map((p, i) =>
+        p.y === null ? null : (
+          <rect
+            key={`v-${i}`}
+            x={xPos(i) - 5}
+            y={yScale(p.y) - 5}
+            width={10}
+            height={10}
+            fill="var(--color-primary)"
+            stroke="var(--color-foreground)"
+            strokeWidth={2}
+          />
+        ),
+      )}
+    </svg>
+  );
+}
+
+// Re-export here so the chart module is the single source of attribute-page
+// imports for the position-group taxonomy.
+export { POSITION_GROUPS };


### PR DESCRIPTION
## Summary
Sprint 6B story 7. **First user-visible Phase 2 surface.**

### \`PixelLineChart.tsx\` (new)
Hand-rolled SVG line chart — no recharts (antialiased polish fights the 8-bit aesthetic).
- \`image-rendering: pixelated\`, chunky 4px stroke, 10×10 filled-square vertices with 2px border
- Inherits palette tokens (\`--color-card\`, \`--color-border\`, \`--color-primary\`, etc.)
- Y-axis min/mid/max ticks with Geist Mono labels
- Skips null y values cleanly
- Empty state: axis frame + "No data" caption

### \`/dashboard/players/[id]/development/page.tsx\` (new)
- Gated on \`playerAttributesV1\` + Clerk auth + \`resolveOrgContext\` (player must be in a visible league)
- Header: name + position + position group
- Card 1: \`PixelLineChart\` of weightedOverall by season + headline delta call-out (\`+3.5 vs last season\`, green/red)
- Card 2: per-season table (season / position group / overall / delta) with empty state

## Test plan
- [x] Type-check + lint clean
- [x] Unit tests 255/255

## Next
WSM-000061 mirrors this as a public viewer route (\`/leagues/[id]/players/[id]/development\`) reusing the same \`PixelLineChart\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)