### PR TITLE
feat(web): admin upload + Make-public toggle (WSM-000063)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1977,6 +1977,20 @@ export const getLeagueVisibility = queryGeneric({
   },
 });
 
+export const setLeaguePublic = mutationGeneric({
+  args: {
+    leagueId: v.id("leagues"),
+    isPublic: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) throw new Error("league_not_found");
+    await ctx.db.patch(args.leagueId, { isPublic: args.isPublic });
+    return null;
+  },
+});
+
 export const getPlayerDevelopmentPublic = queryGeneric({
   args: {
     leagueId: v.id("leagues"),

--- a/apps/web/src/app/dashboard/leagues/[id]/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/actions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import {
+  getLeagueOrgId,
+  setLeaguePublic as setLeaguePublicMutation,
+} from "@/lib/data-api";
+import { getUserRoleInOrg } from "@/lib/org-context";
+
+/**
+ * Server action — flip the `leagues.isPublic` field that drives the
+ * public viewer route gating (WSM-000059 / WSM-000061).
+ *
+ * Auth: caller must be org:admin of the league's owning Clerk org.
+ */
+export async function setLeaguePublicAction(
+  leagueId: string,
+  isPublic: boolean,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "league_not_owned" };
+
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+
+  await setLeaguePublicMutation(leagueId, isPublic);
+  revalidatePath(`/dashboard/leagues/${leagueId}`);
+  return { ok: true };
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/8bit/button";
+import { setLeaguePublicAction } from "./actions";
+
+export interface LeaguePublicToggleProps {
+  leagueId: string;
+  /** Initial isPublic value from the server. */
+  initialIsPublic: boolean;
+}
+
+export default function LeaguePublicToggle({
+  leagueId,
+  initialIsPublic,
+}: LeaguePublicToggleProps) {
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [pending, startTransition] = useTransition();
+
+  function handleToggle() {
+    const next = !isPublic;
+    startTransition(async () => {
+      const result = await setLeaguePublicAction(leagueId, next);
+      if (result.ok) {
+        setIsPublic(next);
+        toast.success(next ? "League is now public." : "League is private.");
+      } else {
+        toast.error(`Failed to update visibility: ${result.error}`);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-2 border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-foreground">
+            Public viewer
+          </p>
+          <p className="text-xs text-muted-foreground">
+            When on, anyone can view player development charts at{" "}
+            <code className="font-mono">/leagues/{leagueId}/...</code>
+          </p>
+        </div>
+        <Button
+          variant={isPublic ? "destructive" : "default"}
+          onClick={handleToggle}
+          disabled={pending}
+        >
+          {pending ? "Saving…" : isPublic ? "Make private" : "Make public"}
+        </Button>
+      </div>
+      <p className="font-mono text-xs text-muted-foreground">
+        Currently: {isPublic ? "PUBLIC" : "PRIVATE"}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getLeague } from "@/lib/data-api";
+import { getLeague, getLeagueVisibility } from "@/lib/data-api";
 import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +9,7 @@ import { Trophy } from "lucide-react";
 import InviteForm from "./invite-form";
 import InvitationList from "./invitation-list";
 import InviteLinkSection from "./invite-link-section";
+import LeaguePublicToggle from "./league-public-toggle";
 
 export default async function LeagueDetailPage({
   params,
@@ -21,6 +22,7 @@ export default async function LeagueDetailPage({
   const { id } = await params;
   const orgContext = await resolveOrgContext(userId);
   const league = await getLeague(id, orgContext);
+  const visibility = await getLeagueVisibility(id);
 
   // Check if user is admin of this league's org
   let isAdmin = false;
@@ -60,6 +62,10 @@ export default async function LeagueDetailPage({
               <InviteForm orgId={league.orgId} />
               <InvitationList orgId={league.orgId} />
               <InviteLinkSection orgId={league.orgId} />
+              <LeaguePublicToggle
+                leagueId={id}
+                initialIsPublic={visibility?.isPublic ?? false}
+              />
               <div className="flex gap-4">
                 <Link
                   href={`/dashboard/leagues/${id}/members`}

--- a/apps/web/src/app/dashboard/players/[id]/development/actions.ts
+++ b/apps/web/src/app/dashboard/players/[id]/development/actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { playerAttributesV1 } from "@/lib/flags";
+import {
+  ingestPlayerAttributes,
+  getTeamLeagueId,
+  getLeagueOrgId,
+  getPlayer,
+} from "@/lib/data-api";
+import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+
+export type AttributeSource = "pff" | "madden" | "admin";
+
+interface IngestActionInput {
+  playerId: string;
+  seasonId: string;
+  source: AttributeSource;
+  rawJson: string;
+  pffWeight?: number;
+  maddenWeight?: number;
+}
+
+/**
+ * Server action — admin uploads a single player's attributes for a
+ * season via the AttributesUploadDialog.
+ *
+ * Auth chain:
+ *   - playerAttributesV1 must be on
+ *   - Clerk session present
+ *   - Player must be visible to the user (resolveOrgContext)
+ *   - Caller must be org:admin of the league owning the player's team
+ *
+ * Parses the raw JSON paste, dispatches to the matching adapter via
+ * the data-api ingestPlayerAttributes wrapper (which runs the
+ * normalize + weighted-overall computation client-side).
+ */
+export async function ingestPlayerAttributesAction(
+  input: IngestActionInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const enabled = await playerAttributesV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  // Resolve player + league + org for the auth chain.
+  const orgContext = await resolveOrgContext(userId);
+  const player = await getPlayer(input.playerId, orgContext).catch(
+    () => null,
+  );
+  if (!player) return { ok: false, error: "player_not_found" };
+
+  const leagueId = await getTeamLeagueId(player.teamId).catch(() => null);
+  if (!leagueId) return { ok: false, error: "league_not_found" };
+
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "league_not_owned" };
+
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+
+  // Parse raw JSON.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input.rawJson);
+  } catch {
+    return { ok: false, error: "invalid_json" };
+  }
+
+  try {
+    await ingestPlayerAttributes({
+      playerId: input.playerId,
+      seasonId: input.seasonId,
+      pffSource: input.source === "pff" ? parsed : undefined,
+      maddenSource: input.source === "madden" ? parsed : undefined,
+      adminSource: input.source === "admin" ? parsed : undefined,
+      pffWeight: input.pffWeight,
+      maddenWeight: input.maddenWeight,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+
+  revalidatePath(`/dashboard/players/${input.playerId}/development`);
+  return { ok: true };
+}

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -5,10 +5,14 @@ import { playerAttributesV1 } from "@/lib/flags";
 import {
   getPlayer,
   getPlayerDevelopment,
+  getTeamLeagueId,
+  getLeagueOrgId,
+  getSeasons,
 } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
+import AttributesUploadDialog from "@/components/attributes/AttributesUploadDialog";
 
 export default async function PlayerDevelopmentPage({
   params,
@@ -31,6 +35,19 @@ export default async function PlayerDevelopmentPage({
 
   const development = await getPlayerDevelopment(playerId);
 
+  // Admin gate for the upload dialog: player → team → league → org admin.
+  const playerLeagueId = await getTeamLeagueId(player.teamId).catch(
+    () => null,
+  );
+  const playerOrgId = playerLeagueId
+    ? await getLeagueOrgId(playerLeagueId)
+    : null;
+  const role = playerOrgId
+    ? await getUserRoleInOrg(playerOrgId, userId)
+    : null;
+  const isAdmin = role === "org:admin";
+  const seasons = playerLeagueId ? await getSeasons([playerLeagueId]) : [];
+
   const points = development.map((row) => ({
     x: row.seasonName,
     y: row.weightedOverall,
@@ -49,14 +66,22 @@ export default async function PlayerDevelopmentPage({
         &larr; Back to Players
       </Link>
 
-      <header className="mb-6 flex flex-col gap-1">
-        <h2 className="text-2xl font-bold text-foreground">
-          {player.name}
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Position: {player.position}
-          {player.positionGroup ? ` · ${player.positionGroup}` : ""}
-        </p>
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-2xl font-bold text-foreground">
+            {player.name}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Position: {player.position}
+            {player.positionGroup ? ` · ${player.positionGroup}` : ""}
+          </p>
+        </div>
+        {isAdmin ? (
+          <AttributesUploadDialog
+            playerId={playerId}
+            seasons={seasons.map((s) => ({ id: s.id, name: s.name }))}
+          />
+        ) : null}
       </header>
 
       <Card className="mb-6">

--- a/apps/web/src/components/attributes/AttributesUploadDialog.tsx
+++ b/apps/web/src/components/attributes/AttributesUploadDialog.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Label } from "@/components/ui/8bit/label";
+import { Textarea } from "@/components/ui/8bit/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/8bit/select";
+import {
+  ingestPlayerAttributesAction,
+  type AttributeSource,
+} from "@/app/dashboard/players/[id]/development/actions";
+
+export interface AttributesUploadDialogProps {
+  playerId: string;
+  /** Available seasons in the player's league. */
+  seasons: Array<{ id: string; name: string }>;
+}
+
+const SOURCE_OPTIONS: Array<{ value: AttributeSource; label: string }> = [
+  { value: "admin", label: "Admin (canonical JSON)" },
+  { value: "pff", label: "PFF" },
+  { value: "madden", label: "Madden" },
+];
+
+export default function AttributesUploadDialog({
+  playerId,
+  seasons,
+}: AttributesUploadDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [source, setSource] = useState<AttributeSource>("admin");
+  const [seasonId, setSeasonId] = useState<string>("");
+  const [rawJson, setRawJson] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit() {
+    if (!seasonId) {
+      toast.error("Pick a season.");
+      return;
+    }
+    if (!rawJson.trim()) {
+      toast.error("Paste the source JSON.");
+      return;
+    }
+    startTransition(async () => {
+      const result = await ingestPlayerAttributesAction({
+        playerId,
+        seasonId,
+        source,
+        rawJson,
+      });
+      if (result.ok) {
+        toast.success("Attributes ingested.");
+        setOpen(false);
+        setRawJson("");
+      } else {
+        toast.error(mapIngestError(result.error));
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Add attributes</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add player attributes</DialogTitle>
+          <DialogDescription>
+            Paste the source JSON for one season. The adapter normalizes
+            it into the canonical attribute map and writes a row.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="attr-source">Source</Label>
+            <Select
+              value={source}
+              onValueChange={(value) => setSource(value as AttributeSource)}
+            >
+              <SelectTrigger id="attr-source">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SOURCE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="attr-season">Season</Label>
+            <Select value={seasonId} onValueChange={setSeasonId}>
+              <SelectTrigger id="attr-season">
+                <SelectValue placeholder="Select a season" />
+              </SelectTrigger>
+              <SelectContent>
+                {seasons.length === 0 ? (
+                  <div className="px-2 py-1 text-sm text-muted-foreground">
+                    No seasons yet.
+                  </div>
+                ) : (
+                  seasons.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="attr-json">Raw JSON</Label>
+            <Textarea
+              id="attr-json"
+              rows={10}
+              value={rawJson}
+              onChange={(e) => setRawJson(e.target.value)}
+              placeholder='{ "positionGroup": "QB", "attributes": { "armStrength": 92, "accuracy": 88 } }'
+              className="font-mono text-xs"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={pending}>
+            {pending ? "Ingesting…" : "Ingest"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function mapIngestError(code: string): string {
+  switch (code) {
+    case "flag_disabled":
+      return "Player attributes feature is disabled.";
+    case "unauthorized":
+      return "Sign in required.";
+    case "player_not_found":
+      return "Player not found in your visible leagues.";
+    case "league_not_found":
+    case "league_not_owned":
+      return "League access denied.";
+    case "not_admin":
+      return "Only org admins can ingest attributes.";
+    case "invalid_json":
+      return "JSON didn't parse — check the paste.";
+    case "ingest_no_valid_source":
+      return "The pasted payload didn't match the chosen source format.";
+    default:
+      return code;
+  }
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -230,6 +230,10 @@ const refs = {
     { leagueId: string },
     { isPublic: boolean } | null
   >("sports:getLeagueVisibility"),
+  setLeaguePublic: mutationRef<
+    { leagueId: string; isPublic: boolean },
+    null
+  >("sports:setLeaguePublic"),
   getPlayerDevelopmentPublic: queryRef<
     { leagueId: string; playerId: string },
     Array<{
@@ -922,6 +926,13 @@ export async function getSeasonAttributesByPosition(
 
 export async function getLeagueVisibility(leagueId: string) {
   return queryConvex(refs.getLeagueVisibility, { leagueId });
+}
+
+export async function setLeaguePublic(
+  leagueId: string,
+  isPublic: boolean,
+): Promise<void> {
+  await mutateConvex(refs.setLeaguePublic, { leagueId, isPublic });
 }
 
 export async function getPlayerDevelopmentPublic(


### PR DESCRIPTION
## Summary
Sprint 6B story 10. **Last UI surface for Phase 2.** Two pieces:

### Admin attribute upload
- \`AttributesUploadDialog\` — single textarea + source select (Admin / PFF / Madden) + season select. Mounted on the dev chart page only when the user is org:admin.
- \`ingestPlayerAttributesAction\` — server action with auth chain: flag → Clerk → \`resolveOrgContext\` → \`getTeamLeagueId\` → \`getLeagueOrgId\` → org:admin check. Parses JSON, dispatches to the right adapter, calls the wrapper from WSM-000057.

### Make-public toggle
- New Convex mutation \`setLeaguePublic({leagueId, isPublic})\` + data-api wrapper.
- \`setLeaguePublicAction\` — org:admin gated.
- \`LeaguePublicToggle\` client component on the league detail page (admin-only block). Renders current state + a button to flip + sonner toast.

## Test plan
- [x] Type-check + lint clean
- [x] Unit tests 255/255

🤖 Generated with [Claude Code](https://claude.com/claude-code)