### PR TITLE
docs(sprints): Phase 2 analytics + cutover docs + Sprint 6B closeout (WSM-000065)

### DIFF
--- a/apps/web/src/app/dashboard/players/[id]/development/actions.ts
+++ b/apps/web/src/app/dashboard/players/[id]/development/actions.ts
@@ -10,6 +10,7 @@ import {
   getPlayer,
 } from "@/lib/data-api";
 import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+import { trackPlayerAttributesIngest } from "@/lib/analytics";
 
 export type AttributeSource = "pff" | "madden" | "admin";
 
@@ -83,6 +84,12 @@ export async function ingestPlayerAttributesAction(
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };
   }
+
+  void trackPlayerAttributesIngest({
+    playerId: input.playerId,
+    seasonId: input.seasonId,
+    source: input.source,
+  });
 
   revalidatePath(`/dashboard/players/${input.playerId}/development`);
   return { ok: true };

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -13,6 +13,7 @@ import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
 import AttributesUploadDialog from "@/components/attributes/AttributesUploadDialog";
+import { trackPlayerAttributesView } from "@/lib/analytics";
 
 export default async function PlayerDevelopmentPage({
   params,
@@ -34,6 +35,7 @@ export default async function PlayerDevelopmentPage({
   if (!player) notFound();
 
   const development = await getPlayerDevelopment(playerId);
+  void trackPlayerAttributesView({ playerId, route: "dashboard" });
 
   // Admin gate for the upload dialog: player → team → league → org admin.
   const playerLeagueId = await getTeamLeagueId(player.teamId).catch(

--- a/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
+++ b/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
@@ -5,6 +5,7 @@ import { getPlayerDevelopmentPublic } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
+import { trackPlayerAttributesView } from "@/lib/analytics";
 
 /*
  * Public viewer route (Phase 2 / WSM-000061).
@@ -31,6 +32,7 @@ export default async function PublicPlayerDevelopmentPage({
 
   const development = await getPlayerDevelopmentPublic(leagueId, playerId);
   if (development === null) notFound();
+  void trackPlayerAttributesView({ playerId, route: "public" });
 
   const points = development.map((row) => ({
     x: row.seasonName,

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -91,3 +91,28 @@ export function trackRosterLimitBlocked(props: {
     teamId: props.teamId,
   });
 }
+
+// --- Phase 2 (player_attributes_v1) ------------------------------
+
+export function trackPlayerAttributesView(props: {
+  playerId: string;
+  /** "dashboard" or "public" — distinguishes the two viewer routes. */
+  route: "dashboard" | "public";
+}): Promise<void> {
+  return safeTrack("player_attributes_view", {
+    playerId: props.playerId,
+    route: props.route,
+  });
+}
+
+export function trackPlayerAttributesIngest(props: {
+  playerId: string;
+  seasonId: string;
+  source: "pff" | "madden" | "admin";
+}): Promise<void> {
+  return safeTrack("player_attributes_ingest", {
+    playerId: props.playerId,
+    seasonId: props.seasonId,
+    source: props.source,
+  });
+}

--- a/docs/roster-management.md
+++ b/docs/roster-management.md
@@ -15,6 +15,34 @@ We are adding **roster management** on top of the existing League / Division / T
 
 ## 1. Overview
 
+### Phase 2 — LIVE (2026-04-29)
+
+Phase 2 (player attributes & development + public viewer) is merged to `main` behind the `player_attributes_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 6B across twelve PRs, one per story:
+
+| Story | PR | What shipped |
+|-------|----|--------------|
+| WSM-000054 | #154 | `playerAttributes` table + DTO (per-player per-season, with PFF/Madden/admin source payloads + weighted overall) |
+| WSM-000055 | #155 | `player_attributes_v1` feature flag |
+| WSM-000056 | #156 | Source adapters: PFF + Madden + admin-JSON normalizers + canonical position-group taxonomy |
+| WSM-000057 | #157 | `ingestPlayerAttributes` mutation (Convex) + wrapper that runs adapters + computes weighted overall |
+| WSM-000058 | #158 | `getPlayerDevelopment` + `getSeasonAttributesByPosition` queries (Convex) + wrappers |
+| WSM-000059 | #159 | Public-read primitives: `leagues.isPublic` guard + `getPlayerDevelopmentPublic` |
+| WSM-000060 | #160 | UI: `/dashboard/players/[id]/development` (org-gated) + `PixelLineChart` 8-bit SVG component |
+| WSM-000061 | #161 | UI: `/leagues/[id]/players/[playerId]/development` (public viewer) + middleware whitelist |
+| WSM-000062 | #162 | UI: `/dashboard/seasons/[id]/attributes/[positionGroup]` (top-N table per position group) |
+| WSM-000063 | #163 | UI: `AttributesUploadDialog` (admin paste-JSON modal) + `LeaguePublicToggle` |
+| WSM-000064 | #164 | Playwright e2e: ingest happy path + public-toggle gating |
+| WSM-000065 | this PR | Analytics events + `docs/roster-management.md` cutover + Sprint 6B verification + closeout |
+
+**Flag flip pending:** prod flip to `on` is gated on a preview-deploy manual QA pass + analytics verification.
+
+**Routes added:**
+- `/dashboard/players/[id]/development` — org-gated development chart
+- `/leagues/[id]/players/[playerId]/development` — public viewer (gated by `leagues.isPublic`)
+- `/dashboard/seasons/[id]/attributes/[positionGroup]` — top-N per position group
+
+**Analytics events:** `player_attributes_view`, `player_attributes_ingest`, `flag_exposure(player_attributes_v1)`.
+
 ### Phase 1 — LIVE (2026-04-22)
 
 Phase 1 (season rosters + depth-chart migration + audit log) is merged to `main` behind the `roster_snapshots_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 2 across eleven PRs, one per story:

--- a/docs/sprints/SPRINT_6B_CLOSEOUT.md
+++ b/docs/sprints/SPRINT_6B_CLOSEOUT.md
@@ -1,0 +1,210 @@
+# Sprint 6B — Phase 2 (Player Attributes & Development) Close-Out
+
+> **Sprint:** 2026-04-29 (single-day burst, immediately after Sprint 6A)
+> **Companion docs:** [SPRINT_6B_VERIFICATION.md](./SPRINT_6B_VERIFICATION.md) — criteria matrix + locked decisions
+> **Stories shipped:** WSM-000054..WSM-000065 (12 PRs)
+> **Feature flag:** `player_attributes_v1` (production default: off)
+
+Phase 2 delivers per-player per-season attribute snapshots, a development chart UI (org-gated + public mirror), a per-position top-N table, an admin upload flow, the `Make-public` toggle that gates the public viewer, e2e coverage, and analytics. All twelve stories landed as separate PRs.
+
+Per-story implementation notes below.
+
+---
+
+## WSM-000054 — Schema: `playerAttributes` table
+
+**PR:** #154
+
+### Files touched
+- `apps/web/convex/schema.ts` — new `playerAttributes` table with `by_playerId_seasonId` + `by_seasonId_positionGroup` indexes
+- `packages/shared-types/src/index.ts` — `PlayerAttributeDto`
+
+### Key decisions
+- `attributesJson` stored as a string for forward-compat with arbitrary attribute keys; the read queries parse it server-side and return `Record<string, number>` so consumers don't repeat the work.
+- `pffSourceJson` + `maddenSourceJson` (raw payloads) kept alongside the canonical `attributesJson` for future re-normalization without re-fetching from sources.
+- `weightedOverall` nullable when no source carried an OVR-like attribute.
+
+---
+
+## WSM-000055 — Flag: `player_attributes_v1`
+
+**PR:** #155
+
+### Files touched
+- `apps/web/src/lib/flags.ts` — new `playerAttributesV1` flag
+- `apps/web/src/lib/__tests__/flags.test.ts` — added on/off + key + description cases
+
+### Key decisions
+- Same shape as `depth_chart_v1` and `roster_snapshots_v1` from prior phases. Same `pageGuard` / `apiGuard` helpers work unchanged.
+
+---
+
+## WSM-000056 — Source adapters
+
+**PR:** #156
+
+### Files touched
+- `apps/web/src/lib/attributes/position-groups.ts` — canonical `POSITION_GROUPS` tuple + `isValidPositionGroup` type guard
+- `apps/web/src/lib/attributes/sources/types.ts` — shared `NormalizedSource` shape
+- `apps/web/src/lib/attributes/sources/{pff,madden,admin-json}.ts` — three normalizers
+- `apps/web/src/lib/attributes/sources/__tests__/{pff,madden,admin-json}.test.ts` — happy-path + null-input + invalid-shape coverage
+
+### Key decisions
+- All three adapters return `null` (not throw) on malformed input — caller treats null as "skip this row".
+- PFF + admin-JSON share the canonical shape `{ positionGroup, attributes: { ... } }`. Madden adapter handles the flat `{ POS, OVR, SPD, ... }` format and excludes id/name/team metadata fields.
+
+---
+
+## WSM-000057 — `ingestPlayerAttributes` mutation + wrapper
+
+**PR:** #157
+
+### Files touched
+- `apps/web/convex/sports.ts` — `ingestPlayerAttributes` mutation
+- `apps/web/src/lib/data-api.ts` — wrapper that runs the adapters + computes weighted overall + persists
+- `apps/web/src/lib/__tests__/ingest-player-attributes.test.ts` — 5 unit-test cases
+
+### Key decisions
+- Normalization happens in the wrapper (client-side relative to Convex), not the mutation. Convex receives canonical pre-blended pieces. Keeps Convex code free of any source-format awareness.
+- Idempotent upsert by `(playerId, seasonId)`. Looks up via leading-field-only index form to sidestep an `IndexRange` typing quirk under `mutationGeneric`.
+- Weighted average is per-attribute across all surviving sources. Admin uploads use weight 1.0; PFF + Madden default 0.5/0.5.
+
+---
+
+## WSM-000058 — Read queries
+
+**PR:** #158
+
+### Files touched
+- `apps/web/convex/sports.ts` — `getPlayerDevelopment` + `getSeasonAttributesByPosition`
+- `apps/web/src/lib/data-api.ts` — wrappers
+
+### Key decisions
+- `getPlayerDevelopment` hydrates season info via `ctx.db.get` per row + sorts by `season.startDate` ASC. Per-row `delta` computed at query layer.
+- `getSeasonAttributesByPosition` uses leading-field index lookup + filter, sorts by `weightedOverall` DESC, slices to limit (default 25). Hydrates `player.name`.
+- `safeParseAttributes` helper drops non-finite numeric values, isolating the read path from future `attributesJson` schema drift.
+
+---
+
+## WSM-000059 — Public-read primitives
+
+**PR:** #159
+
+### Files touched
+- `apps/web/convex/sports.ts` — `getLeagueVisibility` + `getPlayerDevelopmentPublic`
+- `apps/web/src/lib/data-api.ts` — wrappers
+- `apps/web/src/lib/public-league-guard.ts` — page-level guard
+- `apps/web/src/lib/__tests__/public-league-guard.test.ts` — 3 cases
+
+### Key decisions
+- `getPlayerDevelopmentPublic` enforces both `league.isPublic === true` AND `player.leagueId === leagueId`. Returns `null` on either guard failure. Layered defense alongside the page-level guard.
+
+---
+
+## WSM-000060 — Org-gated dev chart UI + `PixelLineChart`
+
+**PR:** #160
+
+### Files touched
+- `apps/web/src/components/attributes/PixelLineChart.tsx` — hand-rolled SVG chart
+- `apps/web/src/app/dashboard/players/[id]/development/page.tsx`
+
+### Key decisions
+- No recharts. Hand-rolled SVG with `image-rendering: pixelated`, chunky 4px stroke, 10×10 filled-square vertices, palette tokens (`--color-primary`, `--color-card`, etc.). Inherits dark/light mode automatically.
+- Skips null y values cleanly so a missing season doesn't break the line.
+- Page layout: header (player name + position) → chart card with delta call-out → per-season table card.
+
+---
+
+## WSM-000061 — Public viewer route
+
+**PR:** #161
+
+### Files touched
+- `apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx`
+- `apps/web/src/middleware.ts` — added `/leagues/(.*)` to `isPublicRoute`
+
+### Key decisions
+- Reuses `PixelLineChart` + the same headline/table layout as the dashboard variant. Stripped to `max-w-3xl` with no sidebar (route lives outside `/dashboard/`).
+- Visibility enforced inside the page via `publicLeagueGuard`; middleware just doesn't gate on Clerk auth.
+- Note: `middleware.ts` → `proxy.ts` migration (Next 16) flagged by post-tool validator. Out of scope; separate dedicated migration with runtime + response-shape changes.
+
+---
+
+## WSM-000062 — Per-position attributes table
+
+**PR:** #162
+
+### Files touched
+- `apps/web/src/app/dashboard/seasons/[id]/attributes/[positionGroup]/page.tsx`
+
+### Key decisions
+- Validates the `[positionGroup]` URL slug against `POSITION_GROUPS` — unknown slug → 404.
+- Position-group nav row at top: 10 chip-style links, active group highlighted via the chunky-border + `bg-primary` styling from Sprint 3.
+- Player name links to the player's `/development` page (cross-link between the two views).
+
+---
+
+## WSM-000063 — Admin upload + Make-public toggle
+
+**PR:** #163
+
+### Files touched
+- `apps/web/src/components/attributes/AttributesUploadDialog.tsx` — single textarea + source select + season select
+- `apps/web/src/app/dashboard/players/[id]/development/actions.ts` — `ingestPlayerAttributesAction` (org:admin gated)
+- `apps/web/convex/sports.ts` — `setLeaguePublic` mutation
+- `apps/web/src/lib/data-api.ts` — `setLeaguePublic` wrapper
+- `apps/web/src/app/dashboard/leagues/[id]/actions.ts` — `setLeaguePublicAction` (org:admin gated)
+- `apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx` — admin-only toggle component
+- `apps/web/src/app/dashboard/leagues/[id]/page.tsx` — wires the toggle into the existing admin sidebar block
+
+### Key decisions
+- `ingestPlayerAttributesAction` returns `{ ok, error? }` rather than throwing — the dialog maps known error codes to friendly toast messages.
+- Upload modal uses the 8bit Dialog/Select/Textarea/Button primitives + sonner for feedback.
+
+---
+
+## WSM-000064 — E2E coverage
+
+**PR:** #164
+
+### Files touched
+- `apps/web/e2e/tests/player-attributes.spec.ts`
+
+### Key decisions
+- Two scenarios in a single `describe.serial` block: (1) admin uploads canonical JSON → chart + table render the row; (2) league public toggle gates the public viewer route (private → 404; flip to public → renders).
+- Reuses `withRosterFixture` + `signInTestUser` from WSM-000022+. Same env prerequisites — no new setup.
+- Spec exercises the new playwright surface; runs against running Convex + dev server (same workflow as the WSM-000023+ specs). CI pipeline doesn't currently run Playwright; local + preview verification.
+
+---
+
+## WSM-000065 — Analytics + docs + closeout
+
+**PR:** this PR
+
+### Files touched
+- `apps/web/src/lib/analytics.ts` — `trackPlayerAttributesView` + `trackPlayerAttributesIngest`
+- `apps/web/src/app/dashboard/players/[id]/development/page.tsx` + `/leagues/[id]/players/[playerId]/development/page.tsx` — fire-and-forget view event
+- `apps/web/src/app/dashboard/players/[id]/development/actions.ts` — fire-and-forget ingest event after success
+- `docs/roster-management.md` — Phase 2 — LIVE row appended to §1
+- `docs/sprints/SPRINT_6B_VERIFICATION.md` (new)
+- `docs/sprints/SPRINT_6B_CLOSEOUT.md` (this file)
+
+---
+
+## Running baseline at sprint close
+
+- `pnpm --filter @sports-management/web type-check` — clean
+- `pnpm --filter @sports-management/web lint` — one pre-existing warning, no new
+- `pnpm --filter @sports-management/web test:unit` — **255 passed** (no regression vs. Sprint 6A close)
+- `pnpm exec playwright test --grep WSM-000064` — runs against local Convex + dev server (same flow as the prior roster e2e specs)
+
+## Where Sprint 7 picks up
+
+The product roadmap from `docs/roster-management.md` §5 has one phase remaining:
+
+**Sprint 7 — Phase 3: Schedules & Standings** (`schedules_standings_v1` flag). Per design doc §5.4: admin creates `fixtures` manually + via CSV upload, enters results into `gameResults`, standings computed on read with configurable tiebreakers. ~10-12 stories.
+
+Alternatives to consider before committing:
+- **Soak-and-cleanup sprint** — `middleware.ts` → `proxy.ts` migration, visual regression coverage for the chart, public viewer landing page polish, address any prod issues that surface from the Phase 2 flag flip.
+- **Live PFF/Madden integration** — wire actual feeds into the adapters from WSM-000056. Smaller scope (~3 stories) but requires business decisions on credentials/licensing.

--- a/docs/sprints/SPRINT_6B_VERIFICATION.md
+++ b/docs/sprints/SPRINT_6B_VERIFICATION.md
@@ -1,0 +1,86 @@
+# Sprint 6B — Phase 2 (Player Attributes & Development) — Verification Report
+
+> **Status:** Code merged to `main` behind `player_attributes_v1` flag. Awaiting preview-deploy manual QA + analytics verification before prod flag flip.
+> **Closed (code):** 2026-04-29
+> **Source plan:** SPRINT_3_CLOSEOUT.md outline (12 stories WSM-000054..065). Originally scoped as Sprint 4; deferred behind the 8-bit re-skin (Sprint 3) and the Salesforce decoupling (Sprint 5 + 6A). Now ships into a Convex-native, 8-bit-styled stack.
+> **Anchor:** `playerAttributes` table on Convex with the existing `players` + `seasons` join surface. Three source adapters (PFF / Madden / admin-uploaded JSON) feed a single ingest mutation that computes weighted overall.
+
+## Locked decisions
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | Source data — admin-only or feed-ready? | Both. Three adapters: PFF / Madden / admin canonical JSON. v1 runs on admin pastes; live feeds are a future op. |
+| 2 | Read access — org-gated or public? | Both. Org-gated `/dashboard/players/[id]/development` for the back-office, public `/leagues/[id]/players/[playerId]/development` for parents/fans. Public is opt-in per league via `leagues.isPublic`. |
+| 3 | Position-group taxonomy — football-only? | Football-first. `POSITION_GROUPS = QB / RB / WR / TE / OL / DL / LB / DB / K / P` shared between adapters + the per-position UI. |
+| 4 | Chart library — recharts or hand-rolled SVG? | Hand-rolled `PixelLineChart` SVG with `image-rendering: pixelated`. The polished anti-aliased look of recharts fights the 8-bit aesthetic from Sprint 3. |
+| 5 | Public route URL shape | `/leagues/[id]/players/[playerId]/development` (id-based, no slug column). Matches the rest of the dashboard tree's id-first pattern. |
+| 6 | Admin upload UX | Single textarea + source select (Admin / PFF / Madden). Same code path as the three adapters; smallest UI surface. |
+| 7 | Weighted-overall formula on dual-source ingest | Per-attribute weighted average across surviving sources. Admin uploads use weight 1.0 (canonical); PFF + Madden default 0.5/0.5 (configurable per ingest). `weightedOverall` picks the canonical OVR-like key from the blended map. |
+
+## Criteria Matrix
+
+| # | Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| 1 | `playerAttributes` table + indexes | `apps/web/convex/schema.ts` — `by_playerId_seasonId`, `by_seasonId_positionGroup` | ✓ |
+| 2 | `player_attributes_v1` flag declared with `pageGuard` / `apiGuard` parity | `apps/web/src/lib/flags.ts` + flags.test.ts cases | ✓ |
+| 3 | Three normalizers expose canonical `{ positionGroup, attributes }` | `apps/web/src/lib/attributes/sources/{pff,madden,admin-json}.ts` + per-adapter unit tests | ✓ |
+| 4 | `ingestPlayerAttributes` mutation idempotent on `(playerId, seasonId)` | `convex/sports.ts` + `lib/__tests__/ingest-player-attributes.test.ts` | ✓ |
+| 5 | Wrapper computes weighted overall from blended sources | `lib/data-api.ts ingestPlayerAttributes` + 5 unit-test cases | ✓ |
+| 6 | `getPlayerDevelopment` returns season-ordered rows with deltas | `convex/sports.ts` + data-api wrapper | ✓ |
+| 7 | `getSeasonAttributesByPosition` returns top-N for a position group | same | ✓ |
+| 8 | `publicLeagueGuard` + `getPlayerDevelopmentPublic` gate the public viewer | `lib/public-league-guard.ts` + `__tests__/public-league-guard.test.ts` (3 cases) | ✓ |
+| 9 | `/dashboard/players/[id]/development` renders chart + per-season table + admin upload (admin-only) | `apps/web/src/app/dashboard/players/[id]/development/page.tsx` | ✓ |
+| 10 | `/leagues/[id]/players/[playerId]/development` renders for the public when isPublic, 404s when private | `apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx` | ✓ |
+| 11 | `/dashboard/seasons/[id]/attributes/[positionGroup]` renders ranked table + position-group nav | `apps/web/src/app/dashboard/seasons/[id]/attributes/[positionGroup]/page.tsx` | ✓ |
+| 12 | League detail page exposes `Make public` toggle for org admins | `apps/web/src/app/dashboard/leagues/[id]/page.tsx` + `league-public-toggle.tsx` | ✓ |
+| 13 | `setLeaguePublic` Convex mutation + server action | `convex/sports.ts` + `dashboard/leagues/[id]/actions.ts` | ✓ |
+| 14 | E2E spec exercises ingest happy path + public-toggle gating | `e2e/tests/player-attributes.spec.ts` | ✓ |
+| 15 | Analytics events emitted: `player_attributes_view`, `player_attributes_ingest`, `flag_exposure` | `lib/analytics.ts` + dev-page + ingest-action wiring | ✓ |
+| 16 | Type-check + lint clean after every story | each PR's CI | ✓ |
+| 17 | Unit tests still pass | 255/255 | ✓ |
+| 18 | `docs/roster-management.md` Phase 2 — LIVE row appended | this PR | ✓ |
+| 19 | Production flag flip completed | Vercel Flags UI — `player_attributes_v1` = `on` ≥48h, analytics monitored | ☐ pending preview QA |
+
+## PR / Release Evidence
+
+| Story | Branch | PR | Expected bump |
+| --- | --- | --- | --- |
+| WSM-000054 | `feat/WSM-000054-player-attributes-schema` | #154 | minor |
+| WSM-000055 | `feat/WSM-000055-player-attributes-flag` | #155 | minor |
+| WSM-000056 | `feat/WSM-000056-attribute-source-adapters` | #156 | minor |
+| WSM-000057 | `feat/WSM-000057-ingest-player-attributes` | #157 | minor |
+| WSM-000058 | `feat/WSM-000058-player-attributes-queries` | #158 | minor |
+| WSM-000059 | `feat/WSM-000059-public-read-primitives` | #159 | minor |
+| WSM-000060 | `feat/WSM-000060-development-chart-org` | #160 | minor |
+| WSM-000061 | `feat/WSM-000061-development-chart-public` | #161 | minor |
+| WSM-000062 | `feat/WSM-000062-position-attributes-table` | #162 | minor |
+| WSM-000063 | `feat/WSM-000063-admin-upload-public-toggle` | #163 | minor |
+| WSM-000064 | `feat/WSM-000064-attributes-e2e` | #164 | no bump (`test:`) |
+| WSM-000065 | `feat/WSM-000065-sprint6b-closeout` | this PR | no bump (`docs:`) |
+
+## Deferred / Sprint 7+ candidates
+
+1. **Live PFF / Madden feed integrations** — adapters exist, but actual feed access (API keys, scraping rights, paid licenses) is a separate business decision. Today the system runs on admin pastes.
+2. **Public viewer landing page** — the `/leagues/[id]/...` tree currently only exposes `/players/[playerId]/development` directly. A `/leagues/[id]` index page summarizing the league + linking to player charts would polish the public surface.
+3. **Per-attribute weights** — current implementation has scalar `pffWeight + maddenWeight` shared across all attributes. Per-attribute weights (e.g. trust PFF more for QB accuracy, Madden more for OL strength) would need a richer mutation arg.
+4. **Audit log for attribute ingest** — Phase 1 has `rosterAuditLog`. Phase 2 doesn't audit attribute writes; if compliance becomes a concern we'd add an `attributeIngestLog` table.
+5. **Visual regression for `PixelLineChart`** — no Playwright screenshot tests yet. Consider during Sprint 7 if visual drift becomes a concern.
+6. **Phase 3 — Schedules & Standings** per design doc §5.4 (`schedules_standings_v1` flag). Natural next sprint for product roadmap.
+
+## Flag-flip checklist
+
+Do **not** flip `player_attributes_v1` to `on` in production until all of the following are checked:
+
+- [ ] Preview-deploy manual QA: sign in as admin → open a player's `/development` → click "Add attributes" → paste canonical JSON → confirm chart updates + table row appears
+- [ ] Preview-deploy manual QA: open the league detail page → click "Make public" → confirm toggle flips + toast appears
+- [ ] Preview-deploy manual QA: hit `/leagues/[id]/players/[id]/development` in an incognito window (no Clerk session) → confirm public chart renders
+- [ ] Preview-deploy manual QA: flip the same league back to private → confirm public route 404s
+- [ ] Vercel Analytics Explorer shows `player_attributes_view`, `player_attributes_ingest`, `flag_exposure(player_attributes_v1)` events from the preview deploy
+- [ ] Soak the flag at on for ≥48h with analytics monitored before declaring Phase 2 shipped
+
+## Risks closed
+
+- **Aesthetic divergence** — the new chart was built native to the 8-bit aesthetic (hand-rolled `PixelLineChart`), avoiding the alternative cycle of "ship recharts, restyle later".
+- **Salesforce coupling** — Sprint 6A removed every SF read path; Phase 2 ships into a clean Convex-only stack, so no SF dependency for ingest, queries, or public viewer.
+- **Public-leak risk** — `leagues.isPublic` is the single chokepoint that gates the public viewer. Both `publicLeagueGuard` (page-level) and `getPlayerDevelopmentPublic` (query-level) enforce it; layered defense.
+- **Mock divergence** — the ingest wrapper has 5 unit-test cases covering the source-blending + weighted-overall math, so future ingest changes can't silently regress the formula.


### PR DESCRIPTION
## Summary
**Final story of Sprint 6B.** Three deliverables:

### 1. Analytics
- \`trackPlayerAttributesView({ playerId, route })\` — wired into both dashboard + public dev pages
- \`trackPlayerAttributesIngest({ playerId, seasonId, source })\` — wired into the ingest server action
- \`flag_exposure(player_attributes_v1)\` — already emitted by the flag's \`decide()\`, no extra wiring needed

### 2. Cutover doc
\`docs/roster-management.md\` §1 — Phase 2 — LIVE row added with the 12-PR table, route inventory, analytics event names.

### 3. Sprint 6B closeout docs
- \`SPRINT_6B_VERIFICATION.md\` — criteria matrix (19 rows), locked decisions (7), PR/release evidence (#154-165), deferred follow-ups, **prod flag-flip checklist**, risks closed.
- \`SPRINT_6B_CLOSEOUT.md\` — per-story implementation notes for WSM-000054..065. Sprint 7 candidates: Phase 3 (Schedules & Standings) / soak-and-cleanup / live feed integration.

## Test plan
- [x] Type-check + lint clean
- [x] Unit tests 255/255

## Sprint 6B final state
After this merge: Phase 2 ships behind \`player_attributes_v1\` (production default off). Prod flip awaits the documented preview-deploy QA + analytics verification checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)