### PR TITLE
feat(web): fixtures + gameResults schema + DTOs (WSM-000066)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -142,4 +142,40 @@ export default defineSchema({
   })
     .index("by_playerId_seasonId", ["playerId", "seasonId"])
     .index("by_seasonId_positionGroup", ["seasonId", "positionGroup"]),
+
+  /*
+   * Phase 3 — `schedules_standings_v1` (Sprint 7).
+   *
+   * One row per scheduled game. `status` transitions
+   * "scheduled" → "final" when a `gameResults` row is recorded.
+   * `scheduledAt` + `week` are nullable for TBD entries.
+   */
+  fixtures: defineTable({
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+    scheduledAt: v.union(v.string(), v.null()),
+    week: v.union(v.number(), v.null()),
+    venue: v.union(v.string(), v.null()),
+    status: v.string(),
+    createdAt: v.string(),
+    createdBy: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_seasonId_week", ["seasonId", "week"])
+    .index("by_homeTeamId", ["homeTeamId"])
+    .index("by_awayTeamId", ["awayTeamId"]),
+
+  /*
+   * One row per played fixture. `playerStatsJson` is reserved for
+   * Phase 4 per-player rollups feeding `playerAttributes`; null in v1.
+   */
+  gameResults: defineTable({
+    fixtureId: v.id("fixtures"),
+    homeScore: v.number(),
+    awayScore: v.number(),
+    playerStatsJson: v.union(v.string(), v.null()),
+    recordedAt: v.string(),
+    recordedBy: v.string(),
+  }).index("by_fixtureId", ["fixtureId"]),
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -194,6 +194,49 @@ export interface PlayerAttributeDto {
   ingestedAt: string;
 }
 
+// --- Schedules & standings (Phase 3, schedules_standings_v1) ---
+
+export type FixtureStatus = "scheduled" | "final" | "cancelled";
+
+export interface FixtureDto {
+  id: string;
+  seasonId: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  scheduledAt: string | null;
+  week: number | null;
+  venue: string | null;
+  status: FixtureStatus;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface GameResultDto {
+  id: string;
+  fixtureId: string;
+  homeScore: number;
+  awayScore: number;
+  playerStatsJson: string | null;
+  recordedAt: string;
+  recordedBy: string;
+}
+
+export interface Standing {
+  teamId: string;
+  teamName: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  pointsFor: number;
+  pointsAgainst: number;
+  divisionRank: number;
+  leagueRank: number;
+  /** Phase 4 per-player stat-rollup hook. */
+  extended?: Record<string, number>;
+}
+
 // --- Subscription tier types ---
 
 export type Tier = "free" | "plus" | "club" | "league";


### PR DESCRIPTION
## Summary

Sprint 7 (Phase 3 — Schedules & Standings) kickoff PR. Schema + DTOs only — every subsequent Phase 3 story depends on these tables compiling cleanly.

- Adds `fixtures` table (per-game) with indexes `by_seasonId`, `by_seasonId_week`, `by_homeTeamId`, `by_awayTeamId`.
- Adds `gameResults` table (per-fixture) with `by_fixtureId` index.
- Adds `FixtureDto`, `GameResultDto`, `Standing` to `packages/shared-types` mirroring `docs/roster-management.md` §5.4.

No functions, no UI. The next PR (WSM-000067) wires the `schedules_standings_v1` flag, then WSM-000068 brings the fixture CRUD mutations.

## Test plan
- [x] `pnpm exec convex dev --once` — schema applied + indexes created
- [x] `pnpm --filter @sports-management/web type-check` — clean
- [x] `pnpm --filter @sports-management/web lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)