### PR TITLE
feat(web): schedules_standings_v1 flag (WSM-000067)

### DIFF
--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -24,6 +24,7 @@ import {
   depthChartV1,
   rosterSnapshotsV1,
   playerAttributesV1,
+  schedulesStandingsV1,
   pageGuard,
   apiGuard,
 } from "../flags";
@@ -55,6 +56,18 @@ describe("playerAttributesV1 flag declaration", () => {
 
   it("has a Phase 2 description for the Vercel Toolbar", () => {
     expect(playerAttributesV1.description).toMatch(/attribute|development/i);
+  });
+});
+
+describe("schedulesStandingsV1 flag declaration", () => {
+  it("uses the canonical key", () => {
+    expect(schedulesStandingsV1.key).toBe("schedules_standings_v1");
+  });
+
+  it("has a Phase 3 description for the Vercel Toolbar", () => {
+    expect(schedulesStandingsV1.description).toMatch(
+      /schedule|standing|fixture/i,
+    );
   });
 });
 

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -49,6 +49,21 @@ export const playerAttributesV1 = flag<boolean>({
   },
 });
 
+export const schedulesStandingsV1 = flag<boolean>({
+  key: "schedules_standings_v1",
+  description:
+    "Phase 3 schedules & standings: fixtures, game results, computed standings, public standings viewer",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    void trackFlagExposure("schedules_standings_v1", defaultOn);
+    return defaultOn;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
## Summary

Sprint 7 Story 2 — declares the `schedules_standings_v1` Vercel flag matching the prior phase pattern. All Phase 3 routes + mutations will gate on this flag.

- `apps/web/src/lib/flags.ts` — new `schedulesStandingsV1` flag (production default off; dev/preview default on).
- `apps/web/src/lib/__tests__/flags.test.ts` — 2 new cases (canonical key, Phase 3 description).

Production flip happens at the end of Sprint 7 per the verification checklist (preview-deploy QA + 48h soak).

## Test plan
- [x] \`pnpm --filter @sports-management/web test:unit\` — 257 passed (was 255)
- [x] \`pnpm --filter @sports-management/web type-check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)