### PR TITLE
feat(web): fixture mutations + read queries (WSM-000068)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2050,3 +2050,207 @@ export const getPlayerDevelopmentPublic = queryGeneric({
     });
   },
 });
+
+/*
+ * Phase 3 — Fixture CRUD (Sprint 7 / WSM-000068).
+ *
+ * `fixtures` rows model scheduled games. The `recordGameResult`
+ * mutation in WSM-000069 will flip `status` → "final"; deletion
+ * cascades to the matching `gameResults` row to keep standings
+ * computation honest.
+ */
+
+const fixtureDtoValidator = v.object({
+  id: v.string(),
+  seasonId: v.string(),
+  homeTeamId: v.string(),
+  awayTeamId: v.string(),
+  homeTeamName: v.string(),
+  awayTeamName: v.string(),
+  scheduledAt: v.union(v.string(), v.null()),
+  week: v.union(v.number(), v.null()),
+  venue: v.union(v.string(), v.null()),
+  status: v.string(),
+  createdAt: v.string(),
+  createdBy: v.string(),
+});
+
+export const createFixture = mutationGeneric({
+  args: {
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+    scheduledAt: v.union(v.string(), v.null()),
+    week: v.union(v.number(), v.null()),
+    venue: v.union(v.string(), v.null()),
+    actorUserId: v.string(),
+  },
+  returns: fixtureDtoValidator,
+  handler: async (ctx, args) => {
+    if (args.homeTeamId === args.awayTeamId) {
+      throw new Error("home_and_away_must_differ");
+    }
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+
+    const home = await ctx.db.get(args.homeTeamId);
+    const away = await ctx.db.get(args.awayTeamId);
+    if (!home || !away) throw new Error("team_not_found");
+    if (
+      home.leagueId !== season.leagueId ||
+      away.leagueId !== season.leagueId
+    ) {
+      throw new Error("teams_outside_league");
+    }
+
+    const createdAt = new Date().toISOString();
+    const id = await ctx.db.insert("fixtures", {
+      seasonId: args.seasonId,
+      homeTeamId: args.homeTeamId,
+      awayTeamId: args.awayTeamId,
+      scheduledAt: args.scheduledAt,
+      week: args.week,
+      venue: args.venue,
+      status: "scheduled",
+      createdAt,
+      createdBy: args.actorUserId,
+    });
+
+    return {
+      id,
+      seasonId: args.seasonId,
+      homeTeamId: args.homeTeamId,
+      awayTeamId: args.awayTeamId,
+      homeTeamName: home.name,
+      awayTeamName: away.name,
+      scheduledAt: args.scheduledAt,
+      week: args.week,
+      venue: args.venue,
+      status: "scheduled",
+      createdAt,
+      createdBy: args.actorUserId,
+    };
+  },
+});
+
+export const updateFixture = mutationGeneric({
+  args: {
+    fixtureId: v.id("fixtures"),
+    scheduledAt: v.optional(v.union(v.string(), v.null())),
+    week: v.optional(v.union(v.number(), v.null())),
+    venue: v.optional(v.union(v.string(), v.null())),
+    status: v.optional(v.string()),
+  },
+  returns: v.union(fixtureDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.fixtureId);
+    if (!existing) return null;
+
+    const patch: Record<string, unknown> = {};
+    if (args.scheduledAt !== undefined) patch.scheduledAt = args.scheduledAt;
+    if (args.week !== undefined) patch.week = args.week;
+    if (args.venue !== undefined) patch.venue = args.venue;
+    if (args.status !== undefined) patch.status = args.status;
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch(args.fixtureId, patch);
+    }
+
+    const merged = { ...existing, ...patch } as typeof existing;
+    const home = await ctx.db.get(merged.homeTeamId);
+    const away = await ctx.db.get(merged.awayTeamId);
+    return {
+      id: merged._id,
+      seasonId: merged.seasonId,
+      homeTeamId: merged.homeTeamId,
+      awayTeamId: merged.awayTeamId,
+      homeTeamName: home?.name ?? "(unknown)",
+      awayTeamName: away?.name ?? "(unknown)",
+      scheduledAt: merged.scheduledAt,
+      week: merged.week,
+      venue: merged.venue,
+      status: merged.status,
+      createdAt: merged.createdAt,
+      createdBy: merged.createdBy,
+    };
+  },
+});
+
+export const deleteFixture = mutationGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.fixtureId);
+    if (!existing) return null;
+
+    // Cascade: drop any gameResults row attached to this fixture so
+    // standings computation doesn't keep counting an orphaned result.
+    const results = await ctx.db
+      .query("gameResults")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    for (const r of results) {
+      await ctx.db.delete(r._id);
+    }
+
+    await ctx.db.delete(args.fixtureId);
+    return null;
+  },
+});
+
+export const listFixturesBySeason = queryGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(fixtureDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("fixtures")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    return Promise.all(
+      rows.map(async (row) => {
+        const home = await ctx.db.get(row.homeTeamId);
+        const away = await ctx.db.get(row.awayTeamId);
+        return {
+          id: row._id,
+          seasonId: row.seasonId,
+          homeTeamId: row.homeTeamId,
+          awayTeamId: row.awayTeamId,
+          homeTeamName: home?.name ?? "(unknown)",
+          awayTeamName: away?.name ?? "(unknown)",
+          scheduledAt: row.scheduledAt,
+          week: row.week,
+          venue: row.venue,
+          status: row.status,
+          createdAt: row.createdAt,
+          createdBy: row.createdBy,
+        };
+      }),
+    );
+  },
+});
+
+export const getFixture = queryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.union(fixtureDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.fixtureId);
+    if (!row) return null;
+    const home = await ctx.db.get(row.homeTeamId);
+    const away = await ctx.db.get(row.awayTeamId);
+    return {
+      id: row._id,
+      seasonId: row.seasonId,
+      homeTeamId: row.homeTeamId,
+      awayTeamId: row.awayTeamId,
+      homeTeamName: home?.name ?? "(unknown)",
+      awayTeamName: away?.name ?? "(unknown)",
+      scheduledAt: row.scheduledAt,
+      week: row.week,
+      venue: row.venue,
+      status: row.status,
+      createdAt: row.createdAt,
+      createdBy: row.createdBy,
+    };
+  },
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -4,6 +4,7 @@ import type {
   CreateTeamInput,
   DepthChartEntryDto,
   DivisionDto,
+  FixtureDto,
   ImportError,
   ImportResult,
   LeagueDto,
@@ -308,6 +309,37 @@ const refs = {
     },
     RosterAssignmentDto
   >("sports:updateRosterStatus"),
+  createFixture: mutationRef<
+    {
+      seasonId: string;
+      homeTeamId: string;
+      awayTeamId: string;
+      scheduledAt: string | null;
+      week: number | null;
+      venue: string | null;
+      actorUserId: string;
+    },
+    FixtureDto
+  >("sports:createFixture"),
+  updateFixture: mutationRef<
+    {
+      fixtureId: string;
+      scheduledAt?: string | null;
+      week?: number | null;
+      venue?: string | null;
+      status?: string;
+    },
+    FixtureDto | null
+  >("sports:updateFixture"),
+  deleteFixture: mutationRef<{ fixtureId: string }, null>(
+    "sports:deleteFixture",
+  ),
+  listFixturesBySeason: queryRef<{ seasonId: string }, FixtureDto[]>(
+    "sports:listFixturesBySeason",
+  ),
+  getFixture: queryRef<{ fixtureId: string }, FixtureDto | null>(
+    "sports:getFixture",
+  ),
 };
 
 function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
@@ -940,4 +972,48 @@ export async function getPlayerDevelopmentPublic(
   playerId: string,
 ) {
   return queryConvex(refs.getPlayerDevelopmentPublic, { leagueId, playerId });
+}
+
+// --- Phase 3 (schedules_standings_v1) — fixture CRUD wrappers ---
+
+export interface CreateFixtureInput {
+  seasonId: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  scheduledAt: string | null;
+  week: number | null;
+  venue: string | null;
+  actorUserId: string;
+}
+
+export async function createFixture(
+  input: CreateFixtureInput,
+): Promise<FixtureDto> {
+  return mutateConvex(refs.createFixture, input);
+}
+
+export async function updateFixture(input: {
+  fixtureId: string;
+  scheduledAt?: string | null;
+  week?: number | null;
+  venue?: string | null;
+  status?: string;
+}): Promise<FixtureDto | null> {
+  return mutateConvex(refs.updateFixture, input);
+}
+
+export async function deleteFixture(fixtureId: string): Promise<void> {
+  await mutateConvex(refs.deleteFixture, { fixtureId });
+}
+
+export async function listFixturesBySeason(
+  seasonId: string,
+): Promise<FixtureDto[]> {
+  return queryConvex(refs.listFixturesBySeason, { seasonId });
+}
+
+export async function getFixture(
+  fixtureId: string,
+): Promise<FixtureDto | null> {
+  return queryConvex(refs.getFixture, { fixtureId });
 }


### PR DESCRIPTION
## Summary

Sprint 7 Story 3 — adds the five Convex functions backing the schedule UI. No UI yet; that comes in WSM-000071.

- \`createFixture\` — same-team + cross-league guards before insert; status defaults to \"scheduled\".
- \`updateFixture\` — partial patch for date/week/venue/status.
- \`deleteFixture\` — cascades to matching \`gameResults\` row so standings can't double-count an orphan.
- \`listFixturesBySeason\` — uses \`by_seasonId\` with team-name hydration.
- \`getFixture\` — single-row read with team-name hydration.

\`data-api.ts\` wrappers exported alongside a \`CreateFixtureInput\` type for the form submission in WSM-000071.

## Test plan
- [x] \`pnpm exec convex dev --once\` — functions deployed
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 257 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)