### PR TITLE
feat(web): record game result + per-fixture read (WSM-000069)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2254,3 +2254,93 @@ export const getFixture = queryGeneric({
     };
   },
 });
+
+/*
+ * Phase 3 — Game result CRUD (Sprint 7 / WSM-000069).
+ *
+ * Recording a result transitions the parent fixture's status to
+ * "final" in the same transaction. Idempotent on `fixtureId`:
+ * a re-record replaces the existing result row in place.
+ */
+
+const gameResultDtoValidator = v.object({
+  id: v.string(),
+  fixtureId: v.string(),
+  homeScore: v.number(),
+  awayScore: v.number(),
+  playerStatsJson: v.union(v.string(), v.null()),
+  recordedAt: v.string(),
+  recordedBy: v.string(),
+});
+
+export const recordGameResult = mutationGeneric({
+  args: {
+    fixtureId: v.id("fixtures"),
+    homeScore: v.number(),
+    awayScore: v.number(),
+    actorUserId: v.string(),
+  },
+  returns: gameResultDtoValidator,
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+
+    const recordedAt = new Date().toISOString();
+    const payload = {
+      fixtureId: args.fixtureId,
+      homeScore: args.homeScore,
+      awayScore: args.awayScore,
+      playerStatsJson: null,
+      recordedAt,
+      recordedBy: args.actorUserId,
+    };
+
+    const existing = await ctx.db
+      .query("gameResults")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+
+    let resultId: string;
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+      resultId = existing._id;
+    } else {
+      resultId = await ctx.db.insert("gameResults", payload);
+    }
+
+    if (fixture.status !== "final") {
+      await ctx.db.patch(args.fixtureId, { status: "final" });
+    }
+
+    return {
+      id: resultId,
+      fixtureId: args.fixtureId,
+      homeScore: args.homeScore,
+      awayScore: args.awayScore,
+      playerStatsJson: null,
+      recordedAt,
+      recordedBy: args.actorUserId,
+    };
+  },
+});
+
+export const getResultByFixture = queryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.union(gameResultDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameResults")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    if (!row) return null;
+    return {
+      id: row._id,
+      fixtureId: row.fixtureId,
+      homeScore: row.homeScore,
+      awayScore: row.awayScore,
+      playerStatsJson: row.playerStatsJson,
+      recordedAt: row.recordedAt,
+      recordedBy: row.recordedBy,
+    };
+  },
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -5,6 +5,7 @@ import type {
   DepthChartEntryDto,
   DivisionDto,
   FixtureDto,
+  GameResultDto,
   ImportError,
   ImportResult,
   LeagueDto,
@@ -339,6 +340,18 @@ const refs = {
   ),
   getFixture: queryRef<{ fixtureId: string }, FixtureDto | null>(
     "sports:getFixture",
+  ),
+  recordGameResult: mutationRef<
+    {
+      fixtureId: string;
+      homeScore: number;
+      awayScore: number;
+      actorUserId: string;
+    },
+    GameResultDto
+  >("sports:recordGameResult"),
+  getResultByFixture: queryRef<{ fixtureId: string }, GameResultDto | null>(
+    "sports:getResultByFixture",
   ),
 };
 
@@ -1016,4 +1029,25 @@ export async function getFixture(
   fixtureId: string,
 ): Promise<FixtureDto | null> {
   return queryConvex(refs.getFixture, { fixtureId });
+}
+
+// --- Phase 3 — game result wrappers ---
+
+export interface RecordGameResultInput {
+  fixtureId: string;
+  homeScore: number;
+  awayScore: number;
+  actorUserId: string;
+}
+
+export async function recordGameResult(
+  input: RecordGameResultInput,
+): Promise<GameResultDto> {
+  return mutateConvex(refs.recordGameResult, input);
+}
+
+export async function getResultByFixture(
+  fixtureId: string,
+): Promise<GameResultDto | null> {
+  return queryConvex(refs.getResultByFixture, { fixtureId });
 }


### PR DESCRIPTION
## Summary

Sprint 7 Story 4 — completes the schedule write loop with the two Convex functions that record results and let the dialog pre-fill existing scores.

- \`recordGameResult\` — idempotent on \`fixtureId\` (re-record replaces in place). Patches parent fixture status → \`final\` in the same transaction so standings (WSM-000070) pick it up immediately.
- \`getResultByFixture\` — \`by_fixtureId\` index lookup for the Record-result dialog to pre-fill.

\`playerStatsJson\` is reserved for Phase 4 — null in v1.

## Test plan
- [x] \`pnpm exec convex dev --once\` — functions deployed
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 257 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)