### PR TITLE
feat(web): schedule UI + fixture/result actions (WSM-000071)

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as e2eSeed from "../e2eSeed.js";
 import type * as lib_auditLog from "../lib/auditLog.js";
+import type * as lib_standings from "../lib/standings.js";
 import type * as migrations_20260422_seasonsRosterLocked from "../migrations/20260422_seasonsRosterLocked.js";
 import type * as migrations_20260428_depthChartToRoster from "../migrations/20260428_depthChartToRoster.js";
 import type * as migrations_20260428_playersPositionGroup from "../migrations/20260428_playersPositionGroup.js";
@@ -24,6 +25,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   e2eSeed: typeof e2eSeed;
   "lib/auditLog": typeof lib_auditLog;
+  "lib/standings": typeof lib_standings;
   "migrations/20260422_seasonsRosterLocked": typeof migrations_20260422_seasonsRosterLocked;
   "migrations/20260428_depthChartToRoster": typeof migrations_20260428_depthChartToRoster;
   "migrations/20260428_playersPositionGroup": typeof migrations_20260428_playersPositionGroup;

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -79,6 +79,18 @@ export default async function LeagueDetailPage({
                 >
                   Join Requests &rarr;
                 </Link>
+                <Link
+                  href={`/dashboard/leagues/${id}/schedule`}
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  Schedule &rarr;
+                </Link>
+                <Link
+                  href={`/dashboard/leagues/${id}/standings`}
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  Standings &rarr;
+                </Link>
               </div>
             </div>
           )}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -1,0 +1,148 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import {
+  createFixture,
+  deleteFixture,
+  getLeague,
+  getLeagueOrgId,
+  recordGameResult,
+} from "@/lib/data-api";
+import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+
+interface CreateFixtureActionInput {
+  leagueId: string;
+  seasonId: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  scheduledAt: string | null;
+  week: number | null;
+  venue: string | null;
+}
+
+/*
+ * Auth chain shared by the three schedule actions:
+ *   1. flag enabled
+ *   2. Clerk session present
+ *   3. league visible to the user (resolveOrgContext)
+ *   4. caller is org:admin of the league's org
+ */
+async function authorizeAdminAction(
+  leagueId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) return { ok: false, error: "league_not_found" };
+
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "league_not_owned" };
+
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+
+  return { ok: true };
+}
+
+export async function createFixtureAction(
+  input: CreateFixtureActionInput,
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const guard = await authorizeAdminAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  if (input.homeTeamId === input.awayTeamId) {
+    return { ok: false, error: "home_and_away_must_differ" };
+  }
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  try {
+    const fixture = await createFixture({
+      seasonId: input.seasonId,
+      homeTeamId: input.homeTeamId,
+      awayTeamId: input.awayTeamId,
+      scheduledAt: input.scheduledAt,
+      week: input.week,
+      venue: input.venue,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    return { ok: true, id: fixture.id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+interface RecordResultActionInput {
+  leagueId: string;
+  fixtureId: string;
+  homeScore: number;
+  awayScore: number;
+}
+
+export async function recordGameResultAction(
+  input: RecordResultActionInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const guard = await authorizeAdminAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  if (
+    !Number.isFinite(input.homeScore) ||
+    !Number.isFinite(input.awayScore) ||
+    input.homeScore < 0 ||
+    input.awayScore < 0
+  ) {
+    return { ok: false, error: "invalid_score" };
+  }
+
+  try {
+    await recordGameResult({
+      fixtureId: input.fixtureId,
+      homeScore: input.homeScore,
+      awayScore: input.awayScore,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    revalidatePath(`/leagues/${input.leagueId}/standings`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+interface DeleteFixtureActionInput {
+  leagueId: string;
+  fixtureId: string;
+}
+
+export async function deleteFixtureAction(
+  input: DeleteFixtureActionInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const guard = await authorizeAdminAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  try {
+    await deleteFixture(input.fixtureId);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,0 +1,203 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import {
+  getLeague,
+  getLeagueOrgId,
+  getSeasons,
+  getResultByFixture,
+  getTeamsByLeague,
+  listFixturesBySeason,
+} from "@/lib/data-api";
+import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
+import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
+import RecordResultDialog from "@/components/schedule/RecordResultDialog";
+
+export default async function LeagueSchedulePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: leagueId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  // Admin gate (only admins see "New fixture" + "Record result").
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await getUserRoleInOrg(orgId, userId) : null;
+  const isAdmin = role === "org:admin";
+
+  // Pick the active season — fall back to whichever exists if none flagged active.
+  const allSeasons = await getSeasons([leagueId]);
+  const activeSeason =
+    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+
+  const teams = await getTeamsByLeague(leagueId, orgContext);
+
+  const fixtures = activeSeason
+    ? await listFixturesBySeason(activeSeason.id)
+    : [];
+
+  // Hydrate per-fixture result for "Record result" pre-fill + score display.
+  const fixturesWithResults = await Promise.all(
+    fixtures.map(async (f) => {
+      const result =
+        f.status === "final" ? await getResultByFixture(f.id) : null;
+      return { fixture: f, result };
+    }),
+  );
+
+  // Group by week (null week → "Unscheduled" bucket at the end).
+  const buckets = new Map<number | null, typeof fixturesWithResults>();
+  for (const row of fixturesWithResults) {
+    const key = row.fixture.week;
+    const arr = buckets.get(key) ?? [];
+    arr.push(row);
+    buckets.set(key, arr);
+  }
+  const weekKeys = Array.from(buckets.keys()).sort((a, b) => {
+    if (a === null) return 1;
+    if (b === null) return -1;
+    return a - b;
+  });
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">{league.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Schedule {activeSeason ? `· ${activeSeason.name}` : ""}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Link
+            href={`/dashboard/leagues/${leagueId}/standings`}
+            className="text-sm text-primary hover:underline"
+          >
+            Standings &rarr;
+          </Link>
+          {isAdmin && activeSeason ? (
+            <FixtureFormDialog
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+              teams={teams.map((t) => ({ id: t.id, name: t.name }))}
+            />
+          ) : null}
+        </div>
+      </header>
+
+      {!activeSeason ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            No seasons in this league yet. Create a season before scheduling
+            fixtures.
+          </CardContent>
+        </Card>
+      ) : weekKeys.length === 0 ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            No fixtures scheduled yet for {activeSeason.name}.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {weekKeys.map((week) => {
+            const rows = buckets.get(week)!;
+            return (
+              <Card key={week ?? "unscheduled"}>
+                <CardHeader>
+                  <CardTitle>
+                    {week === null ? "Unscheduled" : `Week ${week}`}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b-2 border-border bg-muted text-left text-foreground">
+                        <th className="px-4 py-2 font-mono text-xs uppercase">
+                          When
+                        </th>
+                        <th className="px-4 py-2 font-mono text-xs uppercase">
+                          Home
+                        </th>
+                        <th className="px-4 py-2 font-mono text-xs uppercase">
+                          Away
+                        </th>
+                        <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+                          Score
+                        </th>
+                        <th className="px-4 py-2 font-mono text-xs uppercase">
+                          Status
+                        </th>
+                        {isAdmin ? (
+                          <th className="px-4 py-2 font-mono text-xs uppercase">
+                            Actions
+                          </th>
+                        ) : null}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map(({ fixture, result }) => (
+                        <tr key={fixture.id} className="border-b border-border">
+                          <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                            {fixture.scheduledAt
+                              ? new Date(fixture.scheduledAt).toLocaleString()
+                              : "TBD"}
+                          </td>
+                          <td className="px-4 py-2 text-foreground">
+                            {fixture.homeTeamName}
+                          </td>
+                          <td className="px-4 py-2 text-foreground">
+                            {fixture.awayTeamName}
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono text-foreground">
+                            {result
+                              ? `${result.homeScore} – ${result.awayScore}`
+                              : "—"}
+                          </td>
+                          <td className="px-4 py-2 font-mono text-xs uppercase text-muted-foreground">
+                            {fixture.status}
+                          </td>
+                          {isAdmin ? (
+                            <td className="px-4 py-2">
+                              <RecordResultDialog
+                                leagueId={leagueId}
+                                fixtureId={fixture.id}
+                                homeTeamName={fixture.homeTeamName}
+                                awayTeamName={fixture.awayTeamName}
+                                initialHomeScore={result?.homeScore ?? null}
+                                initialAwayScore={result?.awayScore ?? null}
+                                triggerLabel={result ? "Edit result" : "Record result"}
+                              />
+                            </td>
+                          ) : null}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/schedule/FixtureFormDialog.tsx
+++ b/apps/web/src/components/schedule/FixtureFormDialog.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Label } from "@/components/ui/8bit/label";
+import { Input } from "@/components/ui/8bit/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/8bit/select";
+import { createFixtureAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+
+export interface FixtureFormDialogProps {
+  leagueId: string;
+  seasonId: string;
+  /** All teams in this league. */
+  teams: Array<{ id: string; name: string }>;
+}
+
+export default function FixtureFormDialog({
+  leagueId,
+  seasonId,
+  teams,
+}: FixtureFormDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [homeTeamId, setHomeTeamId] = useState<string>("");
+  const [awayTeamId, setAwayTeamId] = useState<string>("");
+  const [scheduledAt, setScheduledAt] = useState<string>("");
+  const [week, setWeek] = useState<string>("");
+  const [venue, setVenue] = useState<string>("");
+  const [pending, startTransition] = useTransition();
+
+  function reset() {
+    setHomeTeamId("");
+    setAwayTeamId("");
+    setScheduledAt("");
+    setWeek("");
+    setVenue("");
+  }
+
+  function handleSubmit() {
+    if (!homeTeamId || !awayTeamId) {
+      toast.error("Pick both teams.");
+      return;
+    }
+    if (homeTeamId === awayTeamId) {
+      toast.error("Home and away must differ.");
+      return;
+    }
+
+    const weekNum = week.trim() === "" ? null : Number(week);
+    if (weekNum !== null && !Number.isFinite(weekNum)) {
+      toast.error("Week must be a number.");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createFixtureAction({
+        leagueId,
+        seasonId,
+        homeTeamId,
+        awayTeamId,
+        scheduledAt: scheduledAt.trim() === "" ? null : scheduledAt,
+        week: weekNum,
+        venue: venue.trim() === "" ? null : venue,
+      });
+      if (result.ok) {
+        toast.success("Fixture created.");
+        setOpen(false);
+        reset();
+      } else {
+        toast.error(mapError(result.error));
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>New fixture</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New fixture</DialogTitle>
+          <DialogDescription>
+            Schedule a single game between two teams in this season.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="fix-home">Home team</Label>
+            <Select value={homeTeamId} onValueChange={setHomeTeamId}>
+              <SelectTrigger id="fix-home">
+                <SelectValue placeholder="Select home team" />
+              </SelectTrigger>
+              <SelectContent>
+                {teams.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="fix-away">Away team</Label>
+            <Select value={awayTeamId} onValueChange={setAwayTeamId}>
+              <SelectTrigger id="fix-away">
+                <SelectValue placeholder="Select away team" />
+              </SelectTrigger>
+              <SelectContent>
+                {teams.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="fix-week">Week</Label>
+              <Input
+                id="fix-week"
+                inputMode="numeric"
+                placeholder="1"
+                value={week}
+                onChange={(e) => setWeek(e.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="fix-date">Date / time</Label>
+              <Input
+                id="fix-date"
+                type="datetime-local"
+                value={scheduledAt}
+                onChange={(e) => setScheduledAt(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="fix-venue">Venue</Label>
+            <Input
+              id="fix-venue"
+              placeholder="(optional)"
+              value={venue}
+              onChange={(e) => setVenue(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={pending}>
+            {pending ? "Creating…" : "Create fixture"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function mapError(code: string): string {
+  switch (code) {
+    case "flag_disabled":
+      return "Schedules feature is disabled.";
+    case "unauthorized":
+      return "Sign in required.";
+    case "league_not_found":
+      return "League not found in your visible leagues.";
+    case "league_not_owned":
+      return "League access denied.";
+    case "not_admin":
+      return "Only org admins can create fixtures.";
+    case "home_and_away_must_differ":
+      return "Home and away teams must differ.";
+    case "season_not_found":
+      return "Season not found.";
+    case "team_not_found":
+      return "Team not found.";
+    case "teams_outside_league":
+      return "Both teams must belong to this league.";
+    default:
+      return code;
+  }
+}

--- a/apps/web/src/components/schedule/RecordResultDialog.tsx
+++ b/apps/web/src/components/schedule/RecordResultDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/8bit/dialog";
+import { Button } from "@/components/ui/8bit/button";
+import { Label } from "@/components/ui/8bit/label";
+import { Input } from "@/components/ui/8bit/input";
+import { recordGameResultAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+
+export interface RecordResultDialogProps {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  /** Pre-fill from existing result if one was already recorded. */
+  initialHomeScore: number | null;
+  initialAwayScore: number | null;
+  /** Trigger label — different copy when a result already exists. */
+  triggerLabel: string;
+}
+
+export default function RecordResultDialog({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+  initialHomeScore,
+  initialAwayScore,
+  triggerLabel,
+}: RecordResultDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [homeScore, setHomeScore] = useState<string>(
+    initialHomeScore === null ? "" : String(initialHomeScore),
+  );
+  const [awayScore, setAwayScore] = useState<string>(
+    initialAwayScore === null ? "" : String(initialAwayScore),
+  );
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit() {
+    const home = Number(homeScore);
+    const away = Number(awayScore);
+    if (
+      !Number.isFinite(home) ||
+      !Number.isFinite(away) ||
+      home < 0 ||
+      away < 0
+    ) {
+      toast.error("Scores must be non-negative numbers.");
+      return;
+    }
+    startTransition(async () => {
+      const result = await recordGameResultAction({
+        leagueId,
+        fixtureId,
+        homeScore: home,
+        awayScore: away,
+      });
+      if (result.ok) {
+        toast.success("Result recorded.");
+        setOpen(false);
+      } else {
+        toast.error(mapError(result.error));
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          {triggerLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Record game result</DialogTitle>
+          <DialogDescription>
+            {homeTeamName} vs {awayTeamName}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid grid-cols-2 gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="res-home">{homeTeamName} (home)</Label>
+            <Input
+              id="res-home"
+              inputMode="numeric"
+              value={homeScore}
+              onChange={(e) => setHomeScore(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="res-away">{awayTeamName} (away)</Label>
+            <Input
+              id="res-away"
+              inputMode="numeric"
+              value={awayScore}
+              onChange={(e) => setAwayScore(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={pending}>
+            {pending ? "Saving…" : "Save result"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function mapError(code: string): string {
+  switch (code) {
+    case "flag_disabled":
+      return "Schedules feature is disabled.";
+    case "unauthorized":
+      return "Sign in required.";
+    case "league_not_found":
+      return "League not found.";
+    case "league_not_owned":
+      return "League access denied.";
+    case "not_admin":
+      return "Only org admins can record results.";
+    case "invalid_score":
+      return "Scores must be non-negative numbers.";
+    case "fixture_not_found":
+      return "Fixture not found.";
+    default:
+      return code;
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 7 Story 6 — adds the org-gated schedule page that drives fixture/result entry.

**Route**: \`/dashboard/leagues/[id]/schedule\` (org-gated, behind \`schedules_standings_v1\`).

**UI**:
- Per-week table sections (\"Unscheduled\" bucket for fixtures missing a week).
- Score column hydrates from \`gameResults\` when status = \`final\`; em-dash otherwise.
- Admin-only \"New fixture\" + per-row \"Record result\" / \"Edit result\" triggers.
- Cross-links to standings + back to league detail.

**Actions** (\`actions.ts\`):
- \`createFixtureAction\` — flag → session → league access → org:admin auth chain before delegating.
- \`recordGameResultAction\` — same chain; non-negative score validation; revalidates schedule + both standings paths.
- \`deleteFixtureAction\` — same chain; revalidates same paths.

**Components**: \`FixtureFormDialog\`, \`RecordResultDialog\` — both 8bit Dialog primitives, sonner toasts, friendly error mapping.

Also folds in the missed \`lib_standings\` codegen artifact from PR #170 so type-checks stay clean across deployments.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 267 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)