### PR TITLE
feat(web): standings UI org-gated (WSM-000072)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -1,0 +1,108 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import {
+  computeStandings,
+  getDivisions,
+  getLeague,
+  getSeasons,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
+import StandingsTable from "@/components/schedule/StandingsTable";
+
+export default async function LeagueStandingsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: leagueId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  const allSeasons = await getSeasons([leagueId]);
+  const activeSeason =
+    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+
+  if (!activeSeason) {
+    return (
+      <div>
+        <Link
+          href={`/dashboard/leagues/${leagueId}`}
+          className="mb-4 inline-block text-sm text-primary hover:underline"
+        >
+          &larr; Back to League
+        </Link>
+        <h2 className="mb-4 text-2xl font-bold text-foreground">
+          {league.name}
+        </h2>
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            No seasons in this league yet — standings unavailable.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const standings = await computeStandings(activeSeason.id);
+  const divisions = await getDivisions([leagueId]);
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">{league.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Standings · {activeSeason.name}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Link
+            href={`/dashboard/leagues/${leagueId}/schedule`}
+            className="text-sm text-primary hover:underline"
+          >
+            Schedule &rarr;
+          </Link>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Season standings</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {standings.length === 0 ? (
+            <p className="px-6 py-8 text-center text-sm text-muted-foreground">
+              No teams or no recorded results yet for {activeSeason.name}.
+            </p>
+          ) : (
+            <StandingsTable rows={standings} />
+          )}
+        </CardContent>
+      </Card>
+
+      {divisions.length > 0 ? (
+        <p className="mt-4 text-xs text-muted-foreground">
+          Division ranks are computed across {divisions.length}{" "}
+          {divisions.length === 1 ? "division" : "divisions"} in this league.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/schedule/StandingsTable.tsx
+++ b/apps/web/src/components/schedule/StandingsTable.tsx
@@ -1,0 +1,76 @@
+import type { Standing } from "@sports-management/shared-types";
+
+export interface StandingsTableProps {
+  rows: Standing[];
+}
+
+/**
+ * Pure server component — renders a Standing[] as the canonical
+ * 8-bit standings table. Re-used by the org-gated page (WSM-000072)
+ * and the public viewer (WSM-000073), so any shape changes ripple to
+ * both surfaces in one place.
+ */
+export default function StandingsTable({ rows }: StandingsTableProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b-2 border-border bg-muted text-left text-foreground">
+          <th className="px-4 py-2 font-mono text-xs uppercase">Rank</th>
+          <th className="px-4 py-2 font-mono text-xs uppercase">Team</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">W</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">L</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">T</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">PF</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">PA</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">+/−</th>
+          <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+            Div Rank
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const diff = row.pointsFor - row.pointsAgainst;
+          return (
+            <tr key={row.teamId} className="border-b border-border">
+              <td className="px-4 py-2 font-mono text-foreground">
+                {row.leagueRank}
+              </td>
+              <td className="px-4 py-2 text-foreground">{row.teamName}</td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {row.wins}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {row.losses}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {row.ties}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {row.pointsFor}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {row.pointsAgainst}
+              </td>
+              <td
+                className={`px-4 py-2 text-right font-mono ${
+                  diff > 0
+                    ? "text-accent"
+                    : diff < 0
+                      ? "text-destructive"
+                      : "text-muted-foreground"
+                }`}
+              >
+                {diff > 0 ? "+" : ""}
+                {diff}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                {row.divisionRank}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint 7 Story 7 — adds the org-gated standings page using the WSM-000070 \`computeStandings\` query.

**Route**: \`/dashboard/leagues/[id]/standings\` (org-gated, behind \`schedules_standings_v1\`).

**UI**:
- Picks the league's active season (or first available as fallback).
- Single 8bit table: Rank | Team | W | L | T | PF | PA | +/− | Div Rank.
- Empty states: no seasons → \"no seasons\" card; no recorded results → empty-table copy.
- Cross-link to schedule page in the header.

**StandingsTable component** lives in \`components/schedule/\` so the public viewer (WSM-000073) renders the same shape with zero divergence.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 267 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)