### PR TITLE
feat(web): public standings viewer (WSM-000073)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2477,3 +2477,81 @@ export const computeDivisionStandings = query({
     });
   },
 });
+
+/*
+ * Phase 3 — Public standings (Sprint 7 / WSM-000073).
+ *
+ * Returns null when the league isn't opt-in public OR has no seasons.
+ * Layered defense alongside the page-level `publicLeagueGuard`.
+ */
+
+export const computeStandingsPublic = query({
+  args: { leagueId: v.id("leagues") },
+  returns: v.union(
+    v.object({
+      seasonName: v.string(),
+      rows: v.array(standingValidator),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league || !league.isPublic) return null;
+
+    const seasonRows = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    if (seasonRows.length === 0) return null;
+
+    const activeSeason =
+      seasonRows.find((s) => s.status === "active") ?? seasonRows[0];
+
+    const teamRows = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+
+    const fixtureRows = await ctx.db
+      .query("fixtures")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", activeSeason._id))
+      .collect();
+
+    const finalFixtureIds = fixtureRows
+      .filter((f) => f.status === "final")
+      .map((f) => f._id);
+
+    const resultRows = (
+      await Promise.all(
+        finalFixtureIds.map((fid) =>
+          ctx.db
+            .query("gameResults")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", fid))
+            .first(),
+        ),
+      )
+    ).filter((r): r is NonNullable<typeof r> => r !== null);
+
+    const rows = computeStandingsPure({
+      teams: teamRows.map((t) => ({
+        _id: t._id,
+        name: t.name,
+        divisionId: t.divisionId,
+      })),
+      fixtures: fixtureRows.map((f) => ({
+        _id: f._id,
+        seasonId: f.seasonId,
+        homeTeamId: f.homeTeamId,
+        awayTeamId: f.awayTeamId,
+        status: f.status,
+      })),
+      results: resultRows.map((r) => ({
+        fixtureId: r.fixtureId,
+        homeScore: r.homeScore,
+        awayScore: r.awayScore,
+      })),
+    });
+
+    return { seasonName: activeSeason.name, rows };
+  },
+});

--- a/apps/web/src/app/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/leagues/[id]/standings/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import { computeStandingsPublic } from "@/lib/data-api";
+import { publicLeagueGuard } from "@/lib/public-league-guard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
+import StandingsTable from "@/components/schedule/StandingsTable";
+
+/*
+ * Public viewer route (Phase 3 / WSM-000073).
+ *
+ * NO Clerk session required. `publicLeagueGuard` 404s if the league
+ * isn't opt-in public. The Convex query layers the same check in
+ * `computeStandingsPublic` so a stale or skipped middleware can't
+ * leak data.
+ */
+export default async function PublicLeagueStandingsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) notFound();
+
+  const { id: leagueId } = await params;
+  await publicLeagueGuard(leagueId);
+
+  const standings = await computeStandingsPublic(leagueId);
+  if (standings === null) notFound();
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link
+        href={`/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Standings</h1>
+        <p className="text-sm text-muted-foreground">{standings.seasonName}</p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Season standings</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {standings.rows.length === 0 ? (
+            <p className="px-6 py-8 text-center text-sm text-muted-foreground">
+              No teams or no recorded results yet for {standings.seasonName}.
+            </p>
+          ) : (
+            <StandingsTable rows={standings.rows} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -361,6 +361,10 @@ const refs = {
     { seasonId: string; divisionId: string },
     Standing[]
   >("sports:computeDivisionStandings"),
+  computeStandingsPublic: queryRef<
+    { leagueId: string },
+    { seasonName: string; rows: Standing[] } | null
+  >("sports:computeStandingsPublic"),
 };
 
 function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
@@ -1071,4 +1075,10 @@ export async function computeDivisionStandings(
   divisionId: string,
 ): Promise<Standing[]> {
   return queryConvex(refs.computeDivisionStandings, { seasonId, divisionId });
+}
+
+export async function computeStandingsPublic(
+  leagueId: string,
+): Promise<{ seasonName: string; rows: Standing[] } | null> {
+  return queryConvex(refs.computeStandingsPublic, { leagueId });
 }


### PR DESCRIPTION
## Summary

Sprint 7 Story 8 — adds the unauthenticated public mirror of WSM-000072. Same \`StandingsTable\` component so the two surfaces never drift.

**Route**: \`/leagues/[id]/standings\` (public, behind \`schedules_standings_v1\` + \`leagues.isPublic\`).

**Two-layer visibility defense**:
- Page guard: \`publicLeagueGuard(leagueId)\` 404s when not public.
- Query guard: \`computeStandingsPublic\` returns null on the same condition.

**New Convex query** \`computeStandingsPublic({ leagueId })\` packages the active season pick + standings rows into one round-trip — \`{ seasonName, rows }\`.

Middleware already whitelists \`/leagues/(.*)\` from WSM-000061; no middleware change.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 267 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)