### PR TITLE
test(web): schedules + standings e2e (WSM-000074)

### DIFF
--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -99,6 +99,30 @@ async function deleteFixtureByKey(
         deleted += 1;
       }
     }
+
+    // Phase 3 cascade — drop any fixtures + gameResults attached to the
+    // league's seasons before the parent rows go away. Required for the
+    // schedules e2e (WSM-000074).
+    for (const season of seasons as Array<{ _id: Id<"seasons"> }>) {
+      const seasonFixtures = (await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
+        .collect()) as Array<{ _id: Id<"fixtures"> }>;
+      for (const fixture of seasonFixtures) {
+        const results = (await ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q: any) =>
+            q.eq("fixtureId", fixture._id),
+          )
+          .collect()) as Array<{ _id: Id<"gameResults"> }>;
+        for (const row of results) {
+          await ctx.db.delete(row._id);
+          deleted += 1;
+        }
+        await ctx.db.delete(fixture._id);
+        deleted += 1;
+      }
+    }
     for (const row of players) {
       await ctx.db.delete(row._id);
       deleted += 1;
@@ -222,5 +246,91 @@ export const resetRosterFixture = mutation({
     assertSeedEnabled();
     const deleted = await deleteFixtureByKey(ctx as any, args.fixtureKey);
     return { deleted };
+  },
+});
+
+/*
+ * Schedule fixture seed (Sprint 7 / WSM-000074).
+ *
+ * Creates a league + active season + two teams so the e2e spec
+ * has the inputs it needs to create a `fixtures` row.
+ * Reuses `deleteFixtureByKey` for cleanup (which now cascades through
+ * fixtures + gameResults).
+ */
+
+const scheduleFixtureResultValidator = v.object({
+  fixtureKey: v.string(),
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  homeTeamId: v.id("teams"),
+  awayTeamId: v.id("teams"),
+  homeTeamName: v.string(),
+  awayTeamName: v.string(),
+});
+
+export const createScheduleFixture = mutation({
+  args: {
+    fixtureKey: v.string(),
+    clerkOrgId: v.union(v.string(), v.null()),
+    homeTeamName: v.optional(v.string()),
+    awayTeamName: v.optional(v.string()),
+  },
+  returns: scheduleFixtureResultValidator,
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    await deleteFixtureByKey(ctx as any, args.fixtureKey);
+
+    const homeTeamName = args.homeTeamName ?? "E2E Home Team";
+    const awayTeamName = args.awayTeamName ?? "E2E Away Team";
+
+    const leagueId = await ctx.db.insert("leagues", {
+      name: fixtureLeagueName(args.fixtureKey),
+      orgId: args.clerkOrgId,
+      isPublic: false,
+      inviteToken: null,
+    });
+
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "E2E Season",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+
+    const homeTeamId = await ctx.db.insert("teams", {
+      name: homeTeamName,
+      leagueId,
+      divisionId: null,
+      city: "Home City",
+      stadium: "Home Stadium",
+      foundedYear: null,
+      location: "Home City, HC",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+
+    const awayTeamId = await ctx.db.insert("teams", {
+      name: awayTeamName,
+      leagueId,
+      divisionId: null,
+      city: "Away City",
+      stadium: "Away Stadium",
+      foundedYear: null,
+      location: "Away City, AC",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+
+    return {
+      fixtureKey: args.fixtureKey,
+      leagueId,
+      seasonId,
+      homeTeamId,
+      awayTeamId,
+      homeTeamName,
+      awayTeamName,
+    };
   },
 });

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -1,0 +1,108 @@
+/**
+ * Schedule fixture seed harness — Playwright side.
+ *
+ * Wraps the Convex `e2eSeed:createScheduleFixture` mutation so the
+ * Phase 3 e2e (WSM-000074) can stand up a deterministic
+ * league + season + two-team fixture and tear it down cleanly.
+ *
+ * Runtime prerequisites match `seed-roster.ts`:
+ *   - `CONVEX_ENABLE_E2E_SEED=1` on the target Convex deployment
+ *   - `NEXT_PUBLIC_CONVEX_URL` (+ `CONVEX_ADMIN_KEY` for non-local)
+ *   - `E2E_CLERK_ORG_ID` to scope the seeded league to the test org
+ */
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
+
+export interface ScheduleFixtureConfig {
+  fixtureKey: string;
+  clerkOrgId: string | null;
+  homeTeamName?: string;
+  awayTeamName?: string;
+}
+
+export interface ScheduleFixtureResult {
+  fixtureKey: string;
+  leagueId: string;
+  seasonId: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+}
+
+const createFixtureRef = makeFunctionReference<
+  "mutation",
+  any,
+  ScheduleFixtureResult
+>("e2eSeed:createScheduleFixture");
+
+const resetFixtureRef = makeFunctionReference<
+  "mutation",
+  any,
+  { deleted: number }
+>("e2eSeed:resetRosterFixture");
+
+function getSeedClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+
+  if (!url) {
+    throw new Error(
+      "[seed-schedule] NEXT_PUBLIC_CONVEX_URL is required to run the e2e seed harness.",
+    );
+  }
+  const isLocalDeployment =
+    url.includes("127.0.0.1") || url.includes("localhost");
+  if (!adminKey && !isLocalDeployment) {
+    throw new Error(
+      "[seed-schedule] CONVEX_ADMIN_KEY is required for non-local deployments.",
+    );
+  }
+
+  const client = new ConvexHttpClient(url);
+  if (adminKey) {
+    (
+      client as ConvexHttpClient & { setAdminAuth?: (key: string) => void }
+    ).setAdminAuth?.(adminKey);
+  }
+  return client;
+}
+
+export async function createScheduleFixture(
+  config: ScheduleFixtureConfig,
+): Promise<ScheduleFixtureResult> {
+  const client = getSeedClient();
+  try {
+    return await client.mutation(createFixtureRef, config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("e2e_seed_disabled")) {
+      throw new Error(
+        "[seed-schedule] Convex rejected the seed mutation — set CONVEX_ENABLE_E2E_SEED=1 on the target deployment.",
+      );
+    }
+    throw err;
+  }
+}
+
+export async function resetScheduleFixture(
+  fixtureKey: string,
+): Promise<{ deleted: number }> {
+  const client = getSeedClient();
+  return client.mutation(resetFixtureRef, { fixtureKey });
+}
+
+export async function withScheduleFixture(
+  config: ScheduleFixtureConfig,
+): Promise<{
+  fixture: ScheduleFixtureResult;
+  teardown: () => Promise<void>;
+}> {
+  const fixture = await createScheduleFixture(config);
+  return {
+    fixture,
+    teardown: async () => {
+      await resetScheduleFixture(config.fixtureKey);
+    },
+  };
+}

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+/*
+ * Schedules & standings (Phase 3 / WSM-000074) e2e smoke.
+ *
+ * Walks the admin's schedule loop end-to-end:
+ *   1. Admin opens /dashboard/leagues/[id]/schedule.
+ *   2. Creates a fixture between two seeded teams via FixtureFormDialog.
+ *   3. Opens RecordResultDialog, enters a final score.
+ *   4. Standings page shows the winner with W=1 + matching PF.
+ *   5. League starts private — public /leagues/[id]/standings 404s.
+ *   6. Admin flips Make-public on the league detail page.
+ *   7. Public standings route renders with the same row.
+ *
+ * Same runtime prerequisites as the player-attributes spec
+ * (WSM-000064): CONVEX_ENABLE_E2E_SEED=1 on target Convex,
+ * E2E_CLERK_USER_ID + E2E_CLERK_ORG_ID in the Playwright env.
+ */
+test.describe.serial(
+  "Schedules & standings — fixture loop (WSM-000074)",
+  () => {
+    let fixture: ScheduleFixtureResult | null = null;
+    let teardown: (() => Promise<void>) | null = null;
+
+    test.beforeAll(async () => {
+      const orgId = getTestOrgId();
+      test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+      const handle = await withScheduleFixture({
+        fixtureKey: "schedules-standings-smoke",
+        clerkOrgId: orgId,
+        homeTeamName: "E2E Home Hawks",
+        awayTeamName: "E2E Away Owls",
+      });
+      fixture = handle.fixture;
+      teardown = handle.teardown;
+    });
+
+    test.afterAll(async () => {
+      if (teardown) await teardown();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await setupClerkTestingToken({ page });
+      await signInTestUser(page);
+    });
+
+    test("admin creates a fixture, records the result, standings update", async ({
+      page,
+    }) => {
+      if (!fixture) test.skip();
+      const leagueId = fixture!.leagueId;
+
+      // 1. Open the schedule page.
+      await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+      await expect(
+        page.getByRole("heading", { name: /Schedule/ }),
+      ).toBeVisible();
+
+      // 2. Create a fixture.
+      await page.getByRole("button", { name: "New fixture" }).click();
+      const fixtureDialog = page.getByRole("dialog");
+      await expect(fixtureDialog).toBeVisible();
+
+      await fixtureDialog.getByLabel("Home team").click();
+      await page.getByRole("option", { name: "E2E Home Hawks" }).click();
+      await fixtureDialog.getByLabel("Away team").click();
+      await page.getByRole("option", { name: "E2E Away Owls" }).click();
+      await fixtureDialog.getByLabel("Week").fill("1");
+
+      await fixtureDialog
+        .getByRole("button", { name: "Create fixture" })
+        .click();
+      await expect(fixtureDialog).toBeHidden();
+
+      // The new row appears in Week 1.
+      await expect(page.getByText("Week 1")).toBeVisible();
+      await expect(
+        page.getByRole("cell", { name: "E2E Home Hawks" }),
+      ).toBeVisible();
+
+      // 3. Record the result.
+      await page.getByRole("button", { name: "Record result" }).click();
+      const resultDialog = page.getByRole("dialog");
+      await expect(resultDialog).toBeVisible();
+
+      await resultDialog.getByLabel(/E2E Home Hawks/).fill("21");
+      await resultDialog.getByLabel(/E2E Away Owls/).fill("10");
+      await resultDialog.getByRole("button", { name: "Save result" }).click();
+      await expect(resultDialog).toBeHidden();
+
+      // The schedule row now shows 21 – 10 + status final.
+      await expect(page.getByText("21 – 10")).toBeVisible();
+      await expect(page.getByText("final").first()).toBeVisible();
+
+      // 4. Standings page reflects the result.
+      await page.goto(`/dashboard/leagues/${leagueId}/standings`);
+      await expect(
+        page.getByRole("heading", { name: /Season standings/ }),
+      ).toBeVisible();
+      // Hawks row: 1 W, 21 PF, 10 PA, +11 differential, league rank 1.
+      const hawksRow = page.locator("tr").filter({ hasText: "E2E Home Hawks" });
+      await expect(hawksRow).toBeVisible();
+      await expect(hawksRow).toContainText("1"); // wins column
+      await expect(hawksRow).toContainText("+11");
+    });
+
+    test("league public toggle gates the public standings viewer", async ({
+      page,
+    }) => {
+      if (!fixture) test.skip();
+      const leagueId = fixture!.leagueId;
+
+      // Public viewer with a private league → 404.
+      const privateResp = await page.goto(`/leagues/${leagueId}/standings`);
+      expect(privateResp?.status()).toBe(404);
+
+      // Flip public via the admin toggle on the league detail page.
+      await page.goto(`/dashboard/leagues/${leagueId}`);
+      await page.getByRole("button", { name: /Make public/ }).click();
+      await expect(
+        page.getByRole("button", { name: /Make private/ }),
+      ).toBeVisible();
+
+      // Public route now renders the same standings table.
+      await page.goto(`/leagues/${leagueId}/standings`);
+      await expect(
+        page.getByRole("heading", { name: "Standings" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("cell", { name: "E2E Home Hawks" }),
+      ).toBeVisible();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Sprint 7 Story 9 — full Phase 3 e2e mirroring the WSM-000064 pattern.

**Scenarios** (sharing one fixture, in a \`describe.serial\` block):
1. Admin opens schedule → \"New fixture\" → picks two teams + week 1 → saves → row appears. Then \"Record result\" → enters 21–10 → standings page reflects the win (1 W + 21 PF + 10 PA + +11 differential).
2. Public viewer 404s while private → admin flips Make-public → public \`/leagues/[id]/standings\` renders the same row.

**Seed harness changes**:
- New \`e2eSeed:createScheduleFixture\` mutation: league + active season + two named teams.
- \`deleteFixtureByKey\` now cascades through \`fixtures\` + \`gameResults\` so tests don't leave orphans.
- New \`e2e/helpers/seed-schedule.ts\` wraps with the same \`withScheduleFixture\` shape as the roster harness.

Same runtime prerequisites as the prior e2e specs (CONVEX_ENABLE_E2E_SEED=1, E2E_CLERK_USER_ID, E2E_CLERK_ORG_ID).

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 267 passed
- [ ] Local Playwright run against \`pnpm dev\` + \`pnpm exec convex dev\` (manual; CI skips Playwright by design — same as WSM-000064)

🤖 Generated with [Claude Code](https://claude.com/claude-code)