### PR TITLE
feat(web): Phase 3 analytics + cutover docs + Sprint 7 closeout (WSM-000075)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -11,6 +11,10 @@ import {
   recordGameResult,
 } from "@/lib/data-api";
 import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+import {
+  trackFixtureCreated,
+  trackResultRecorded,
+} from "@/lib/analytics";
 
 interface CreateFixtureActionInput {
   leagueId: string;
@@ -76,6 +80,10 @@ export async function createFixtureAction(
     });
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    void trackFixtureCreated({
+      leagueId: input.leagueId,
+      seasonId: input.seasonId,
+    });
     return { ok: true, id: fixture.id };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -118,6 +126,12 @@ export async function recordGameResultAction(
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
     revalidatePath(`/leagues/${input.leagueId}/standings`);
+    void trackResultRecorded({
+      leagueId: input.leagueId,
+      fixtureId: input.fixtureId,
+      homeScore: input.homeScore,
+      awayScore: input.awayScore,
+    });
     return { ok: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -11,6 +11,7 @@ import {
 import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import StandingsTable from "@/components/schedule/StandingsTable";
+import { trackStandingsView } from "@/lib/analytics";
 
 export default async function LeagueStandingsPage({
   params,
@@ -55,6 +56,7 @@ export default async function LeagueStandingsPage({
 
   const standings = await computeStandings(activeSeason.id);
   const divisions = await getDivisions([leagueId]);
+  void trackStandingsView({ leagueId, route: "dashboard" });
 
   return (
     <div>

--- a/apps/web/src/app/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/leagues/[id]/standings/page.tsx
@@ -5,6 +5,7 @@ import { computeStandingsPublic } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import StandingsTable from "@/components/schedule/StandingsTable";
+import { trackStandingsView } from "@/lib/analytics";
 
 /*
  * Public viewer route (Phase 3 / WSM-000073).
@@ -27,6 +28,7 @@ export default async function PublicLeagueStandingsPage({
 
   const standings = await computeStandingsPublic(leagueId);
   if (standings === null) notFound();
+  void trackStandingsView({ leagueId, route: "public" });
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -116,3 +116,40 @@ export function trackPlayerAttributesIngest(props: {
     source: props.source,
   });
 }
+
+// --- Phase 3 (schedules_standings_v1) ----------------------------
+
+export function trackFixtureCreated(props: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<void> {
+  return safeTrack("fixture_created", {
+    leagueId: props.leagueId,
+    seasonId: props.seasonId,
+  });
+}
+
+export function trackResultRecorded(props: {
+  leagueId: string;
+  fixtureId: string;
+  homeScore: number;
+  awayScore: number;
+}): Promise<void> {
+  return safeTrack("result_recorded", {
+    leagueId: props.leagueId,
+    fixtureId: props.fixtureId,
+    homeScore: props.homeScore,
+    awayScore: props.awayScore,
+  });
+}
+
+export function trackStandingsView(props: {
+  leagueId: string;
+  /** "dashboard" or "public" — distinguishes the two viewer routes. */
+  route: "dashboard" | "public";
+}): Promise<void> {
+  return safeTrack("standings_view", {
+    leagueId: props.leagueId,
+    route: props.route,
+  });
+}

--- a/docs/roster-management.md
+++ b/docs/roster-management.md
@@ -15,6 +15,32 @@ We are adding **roster management** on top of the existing League / Division / T
 
 ## 1. Overview
 
+### Phase 3 — LIVE (2026-04-29)
+
+Phase 3 (schedules + computed standings + public standings viewer) is merged to `main` behind the `schedules_standings_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 7 across ten PRs, one per story:
+
+| Story | PR | What shipped |
+|-------|----|--------------|
+| WSM-000066 | #166 | `fixtures` + `gameResults` tables + DTOs (`FixtureDto`, `GameResultDto`, `Standing`) |
+| WSM-000067 | #167 | `schedules_standings_v1` feature flag + tests |
+| WSM-000068 | #168 | Fixture mutations: `createFixture` (with same-team + cross-league guards), `updateFixture`, `deleteFixture` (cascades to results), `listFixturesBySeason`, `getFixture` |
+| WSM-000069 | #169 | `recordGameResult` mutation (idempotent, flips fixture status to `final` in same transaction) + `getResultByFixture` |
+| WSM-000070 | #170 | `computeStandings` + `computeDivisionStandings` queries with full tiebreaker chain (head-to-head → division record → points-differential) + 10 unit-test cases |
+| WSM-000071 | #171 | UI: `/dashboard/leagues/[id]/schedule` (org-gated) + `FixtureFormDialog` + `RecordResultDialog` + server actions |
+| WSM-000072 | #172 | UI: `/dashboard/leagues/[id]/standings` (org-gated) + reusable `StandingsTable` component |
+| WSM-000073 | #173 | UI: `/leagues/[id]/standings` (public viewer) + `computeStandingsPublic` query (layered visibility defense) |
+| WSM-000074 | #174 | Playwright e2e: full create-fixture → record-result → standings-update path + public-toggle gating |
+| WSM-000075 | this PR | Analytics events + `docs/roster-management.md` cutover + Sprint 7 verification + closeout |
+
+**Flag flip pending:** prod flip to `on` is gated on a preview-deploy manual QA pass + analytics verification per `docs/sprints/SPRINT_7_VERIFICATION.md`.
+
+**Routes added:**
+- `/dashboard/leagues/[id]/schedule` — org-gated per-week fixture list + admin dialogs
+- `/dashboard/leagues/[id]/standings` — org-gated computed standings table
+- `/leagues/[id]/standings` — public viewer (gated by `leagues.isPublic`)
+
+**Analytics events:** `fixture_created`, `result_recorded`, `standings_view`, `flag_exposure(schedules_standings_v1)`.
+
 ### Phase 2 — LIVE (2026-04-29)
 
 Phase 2 (player attributes & development + public viewer) is merged to `main` behind the `player_attributes_v1` Vercel flag. Production default is `off`; dev default is `on`. Shipped via Sprint 6B across twelve PRs, one per story:

--- a/docs/sprints/SPRINT_7_CLOSEOUT.md
+++ b/docs/sprints/SPRINT_7_CLOSEOUT.md
@@ -1,0 +1,182 @@
+# Sprint 7 — Phase 3 (Schedules & Standings) Close-Out
+
+> **Sprint:** 2026-04-29 (single-day burst, immediately after Sprint 6B)
+> **Companion docs:** [SPRINT_7_VERIFICATION.md](./SPRINT_7_VERIFICATION.md) — criteria matrix + locked decisions
+> **Stories shipped:** WSM-000066..WSM-000075 (10 PRs)
+> **Feature flag:** `schedules_standings_v1` (production default: off)
+
+Phase 3 delivers per-season fixtures, per-fixture game results, computed standings (org + public), an admin schedule + result entry surface, e2e coverage, and analytics. All ten stories landed as separate PRs.
+
+Per-story implementation notes below.
+
+---
+
+## WSM-000066 — Schema: `fixtures` + `gameResults`
+
+**PR:** #166
+
+### Files touched
+- `apps/web/convex/schema.ts` — two new tables with indexes (`by_seasonId`, `by_seasonId_week`, `by_homeTeamId`, `by_awayTeamId`, `by_fixtureId`)
+- `packages/shared-types/src/index.ts` — `FixtureDto`, `GameResultDto`, `Standing`
+
+### Key decisions
+- `scheduledAt` + `week` nullable for TBD entries.
+- `gameResults.playerStatsJson` reserved for Phase 4 — null in v1.
+- `Standing.extended?: Record<string, number>` carved out as the same Phase 4 hook.
+
+---
+
+## WSM-000067 — Flag: `schedules_standings_v1`
+
+**PR:** #167
+
+### Files touched
+- `apps/web/src/lib/flags.ts`
+- `apps/web/src/lib/__tests__/flags.test.ts`
+
+### Key decisions
+- Same shape as `playerAttributesV1` from Sprint 6B; same `pageGuard` / `apiGuard` helpers work unchanged.
+
+---
+
+## WSM-000068 — Fixture mutations + queries
+
+**PR:** #168
+
+### Files touched
+- `apps/web/convex/sports.ts` — `createFixture`, `updateFixture`, `deleteFixture`, `listFixturesBySeason`, `getFixture`
+- `apps/web/src/lib/data-api.ts` — wrappers + `CreateFixtureInput`
+
+### Key decisions
+- `createFixture` validates `homeTeamId !== awayTeamId` + that both teams belong to the same league as the season's `leagueId`.
+- `deleteFixture` cascades to the matching `gameResults` row in the same transaction.
+- Team-name hydration happens in the queries so callers don't fan out for it.
+
+---
+
+## WSM-000069 — Result mutation + per-fixture read
+
+**PR:** #169
+
+### Files touched
+- `apps/web/convex/sports.ts` — `recordGameResult`, `getResultByFixture`
+- `apps/web/src/lib/data-api.ts` — wrappers + `RecordGameResultInput`
+
+### Key decisions
+- `recordGameResult` is idempotent: re-recording replaces the existing row via `db.replace`.
+- Same transaction patches the parent fixture's `status: "final"` so the standings query picks it up immediately.
+
+---
+
+## WSM-000070 — Standings compute + tiebreaker math
+
+**PR:** #170
+
+### Files touched
+- `apps/web/convex/lib/standings.ts` — pure `computeStandingsPure` function
+- `apps/web/convex/sports.ts` — `computeStandings`, `computeDivisionStandings` queries
+- `apps/web/src/lib/data-api.ts` — wrappers
+- `apps/web/src/lib/__tests__/compute-standings.test.ts` — 10 cases
+
+### Key decisions
+- Pure function isolated from Convex `db` so the tiebreaker chain is unit-testable directly.
+- League-wide ordering drives `leagueRank`; per-division ordering uses the same comparator.
+- Division ranks are assigned across the full sort even when a `divisionFilter` shrinks the output rows — preserves the league-wide story while letting callers slice the table.
+
+---
+
+## WSM-000071 — Schedule UI (org-gated)
+
+**PR:** #171
+
+### Files touched
+- `apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx`
+- `apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts`
+- `apps/web/src/components/schedule/FixtureFormDialog.tsx`
+- `apps/web/src/components/schedule/RecordResultDialog.tsx`
+- `apps/web/src/app/dashboard/leagues/[id]/page.tsx` — added Schedule + Standings links to the admin block
+
+### Key decisions
+- Schedule grouped by week with an "Unscheduled" bucket at the end (null week).
+- "Record result" trigger label flips to "Edit result" when a result already exists; the dialog pre-fills via `getResultByFixture`.
+- Server actions return `{ ok, error? }` discriminated unions instead of throwing — dialogs map known codes to friendly toast copy.
+- Folded in the missed `lib_standings` codegen artifact from PR #170 to keep type-checks clean across deployments.
+
+---
+
+## WSM-000072 — Standings UI (org-gated)
+
+**PR:** #172
+
+### Files touched
+- `apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx`
+- `apps/web/src/components/schedule/StandingsTable.tsx`
+
+### Key decisions
+- Picks the league's active season as default; first-available fallback.
+- Single 8-bit table: Rank | Team | W | L | T | PF | PA | +/− | Div Rank.
+- `StandingsTable` lives in `components/schedule/` so the public viewer reuses identical markup with zero divergence.
+
+---
+
+## WSM-000073 — Standings UI (public)
+
+**PR:** #173
+
+### Files touched
+- `apps/web/src/app/leagues/[id]/standings/page.tsx`
+- `apps/web/convex/sports.ts` — `computeStandingsPublic` query
+- `apps/web/src/lib/data-api.ts` — wrapper
+
+### Key decisions
+- Two-layer defense: `publicLeagueGuard` (page) + `computeStandingsPublic` (query) both enforce `league.isPublic`.
+- The new query packages the active-season pick and the standings rows into one round-trip — `{ seasonName, rows }` — so the page doesn't need a second hop to label the season.
+- Middleware already whitelists `/leagues/(.*)` from WSM-000061 — no middleware change.
+
+---
+
+## WSM-000074 — E2E coverage
+
+**PR:** #174
+
+### Files touched
+- `apps/web/e2e/tests/schedules-standings.spec.ts`
+- `apps/web/e2e/helpers/seed-schedule.ts`
+- `apps/web/convex/e2eSeed.ts` — new `createScheduleFixture` mutation + extended `deleteFixtureByKey` to cascade through fixtures + gameResults
+
+### Key decisions
+- Two scenarios in a single `describe.serial` block share one fixture (matches the WSM-000064 pattern).
+- Seed harness exposes a `withScheduleFixture` helper — same shape as `withRosterFixture` so future schedule-related specs slot in unchanged.
+- CI doesn't run Playwright by design (consistent with WSM-000064); local + preview verification before flag flip.
+
+---
+
+## WSM-000075 — Analytics + docs + closeout
+
+**PR:** this PR
+
+### Files touched
+- `apps/web/src/lib/analytics.ts` — `trackFixtureCreated`, `trackResultRecorded`, `trackStandingsView`
+- `apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx` + `apps/web/src/app/leagues/[id]/standings/page.tsx` — fire-and-forget view event
+- `apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts` — fire-and-forget create + record events
+- `docs/roster-management.md` — Phase 3 — LIVE row appended to §1
+- `docs/sprints/SPRINT_7_VERIFICATION.md` (new)
+- `docs/sprints/SPRINT_7_CLOSEOUT.md` (this file)
+
+---
+
+## Running baseline at sprint close
+
+- `pnpm --filter @sports-management/web type-check` — clean
+- `pnpm --filter @sports-management/web lint` — one pre-existing warning, no new
+- `pnpm --filter @sports-management/web test:unit` — **267 passed** (was 257 at Sprint 6B close; +10 from `compute-standings.test.ts`)
+- `pnpm exec playwright test --grep WSM-000074` — runs against local Convex + dev server (same flow as Sprint 6B's WSM-000064)
+
+## Where Sprint 8 picks up
+
+The product roadmap from `docs/roster-management.md` §5 is now fully shipped behind flags. Natural Sprint 8 candidates:
+
+- **Soak-and-cleanup sprint** — `middleware.ts` → `proxy.ts` migration (Next 16), visual regression for `PixelLineChart` + `StandingsTable`, public viewer landing page polish, address any prod issues that surface from the Phase 2/3 flag flips.
+- **Phase 4 — per-player stat rollups** — wire `gameResults.playerStatsJson` into `playerAttributes` automatically post-game. Closes the loop between Phase 3's results and Phase 2's development charts.
+- **Live PFF/Madden integration** — wire actual feeds into the adapters from WSM-000056. Smaller scope (~3 stories) but requires business decisions on credentials/licensing.
+- **Phase 3.5 polish** — CSV bulk fixture upload + coach-submitted-pending-approval workflow + public schedule view. The deferred items from Sprint 7's locked-decision grill.

--- a/docs/sprints/SPRINT_7_VERIFICATION.md
+++ b/docs/sprints/SPRINT_7_VERIFICATION.md
@@ -1,0 +1,85 @@
+# Sprint 7 — Phase 3 (Schedules & Standings) — Verification Report
+
+> **Status:** Code merged to `main` behind `schedules_standings_v1` flag. Awaiting preview-deploy manual QA + analytics verification before prod flag flip.
+> **Closed (code):** 2026-04-29
+> **Source plan:** `~/.claude/plans/lets-begin-dev-work-mighty-leaf.md` (10 stories WSM-000066..075).
+> **Anchor:** new `fixtures` + `gameResults` tables on Convex; `computeStandings` is computed-on-read (no derived table).
+
+## Locked decisions
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | Fixture entry — manual one-at-a-time or CSV bulk? | Manual one-at-a-time only. CSV deferred to Phase 3.5. |
+| 2 | Public surface — both schedule + standings, or standings only? | Standings only public. Schedule stays org-gated. Reuses WSM-000059's `publicLeagueGuard`. |
+| 3 | Result entry permissions — admin-only, or coach-submits-pending-approval? | Admin-only in v1. Coach workflow deferred. |
+| 4 | Standings storage — derived table or computed-on-read? | Computed-on-read with React `cache()` per-request memoization. Revisit if any league grows past ~500 fixtures. |
+| 5 | Tiebreaker order | wins desc → head-to-head → division win % → points differential desc → team name asc. Locked verbatim from `docs/roster-management.md` §5.4. |
+| 6 | `gameResults.playerStatsJson` parser | Reserved as `string \| null`; null in v1. Phase 4 will define the parser. |
+
+## Criteria Matrix
+
+| # | Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| 1 | `fixtures` + `gameResults` tables + indexes | `apps/web/convex/schema.ts` — `by_seasonId`, `by_seasonId_week`, `by_homeTeamId`, `by_awayTeamId`, `by_fixtureId` | ✓ |
+| 2 | `schedules_standings_v1` flag declared with `pageGuard` / `apiGuard` parity | `apps/web/src/lib/flags.ts` + `flags.test.ts` cases | ✓ |
+| 3 | `createFixture` validates same-team + cross-league before insert | `convex/sports.ts` + `data-api.ts` wrapper | ✓ |
+| 4 | `deleteFixture` cascades to `gameResults` row | `convex/sports.ts` | ✓ |
+| 5 | `recordGameResult` idempotent on `(fixtureId)` + flips parent status to `final` in same transaction | `convex/sports.ts` | ✓ |
+| 6 | `computeStandings` aggregates W/L/T + PF/PA from final fixtures with the full tiebreaker chain | `convex/lib/standings.ts` (pure) + `convex/sports.ts` (Convex query) | ✓ |
+| 7 | `computeDivisionStandings` filters by division while preserving league-wide rank ordering | same | ✓ |
+| 8 | `computeStandingsPublic` gates on `league.isPublic` (layered defense alongside `publicLeagueGuard`) | `convex/sports.ts` | ✓ |
+| 9 | `/dashboard/leagues/[id]/schedule` renders per-week tables + admin dialogs (org-gated) | `apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx` | ✓ |
+| 10 | `/dashboard/leagues/[id]/standings` renders single 8-bit standings table (org-gated) | `apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx` | ✓ |
+| 11 | `/leagues/[id]/standings` renders for the public when isPublic, 404s when private | `apps/web/src/app/leagues/[id]/standings/page.tsx` | ✓ |
+| 12 | League detail page links to schedule + standings for admins | `apps/web/src/app/dashboard/leagues/[id]/page.tsx` | ✓ |
+| 13 | E2E spec exercises create-fixture → record-result → standings → public-viewer toggle | `e2e/tests/schedules-standings.spec.ts` + `e2e/helpers/seed-schedule.ts` | ✓ |
+| 14 | Analytics events emitted: `fixture_created`, `result_recorded`, `standings_view`, `flag_exposure` | `lib/analytics.ts` + standings pages + schedule actions | ✓ |
+| 15 | Type-check + lint clean after every story | each PR's CI | ✓ |
+| 16 | Unit tests still pass | 267/267 (incl. 10 new `compute-standings` cases) | ✓ |
+| 17 | `docs/roster-management.md` Phase 3 — LIVE row appended | this PR | ✓ |
+| 18 | Production flag flip completed | Vercel Flags UI — `schedules_standings_v1` = `on` ≥48h, analytics monitored | ☐ pending preview QA |
+
+## PR / Release Evidence
+
+| Story | Branch | PR | Expected bump |
+| --- | --- | --- | --- |
+| WSM-000066 | `feat/WSM-000066-phase3-schema` | #166 | minor |
+| WSM-000067 | `feat/WSM-000067-phase3-flag` | #167 | minor |
+| WSM-000068 | `feat/WSM-000068-fixture-crud` | #168 | minor |
+| WSM-000069 | `feat/WSM-000069-result-crud` | #169 | minor |
+| WSM-000070 | `feat/WSM-000070-standings-compute` | #170 | minor |
+| WSM-000071 | `feat/WSM-000071-schedule-ui` | #171 | minor |
+| WSM-000072 | `feat/WSM-000072-standings-ui-org` | #172 | minor |
+| WSM-000073 | `feat/WSM-000073-standings-ui-public` | #173 | minor |
+| WSM-000074 | `test/WSM-000074-phase3-e2e` | #174 | no bump (`test:`) |
+| WSM-000075 | `feat/WSM-000075-phase3-closeout` | this PR | minor (`feat:` analytics) |
+
+## Deferred / Sprint 7.5+ candidates
+
+1. **CSV bulk fixture upload** — admin pastes a CSV → batch insert. Re-evaluate if admins complain about manual one-at-a-time entry.
+2. **Coach-submitted result with admin approval** — adds a `gameResults.status: "pending" | "approved"` column + workflow. Open question per design doc §11.
+3. **Public schedule view** — easy mirror of WSM-000071's read query under `/leagues/[id]/schedule` with `publicLeagueGuard`.
+4. **Per-player stats rollup** — `gameResults.playerStatsJson` is reserved but not parsed. Phase 4 territory; would feed `playerAttributes` automatically post-game.
+5. **Auto-generate schedule (round-robin)** — out of scope for v1.
+6. **Visual regression for `StandingsTable`** — same Sprint-6B-deferred concern; bundle with the soak-and-cleanup sprint.
+7. **`middleware.ts` → `proxy.ts` migration (Next 16)** — still flagged from Sprint 6B; out of scope here.
+
+## Flag-flip checklist
+
+Do **not** flip `schedules_standings_v1` to `on` in production until all of the following are checked:
+
+- [ ] Preview-deploy manual QA: sign in as admin → open league schedule → click "New fixture" → pick two teams + week 1 → confirm row appears
+- [ ] Preview-deploy manual QA: click "Record result" on the new row → enter scores → confirm fixture status flips to `final` + score visible
+- [ ] Preview-deploy manual QA: open `/dashboard/leagues/[id]/standings` → confirm winner has W=1 + correct PF/PA + division/league rank
+- [ ] Preview-deploy manual QA: hit `/leagues/[id]/standings` in incognito while league is private → confirm 404
+- [ ] Preview-deploy manual QA: flip the league public on the league detail page → confirm public standings route now renders the same table
+- [ ] Vercel Analytics Explorer shows `fixture_created`, `result_recorded`, `standings_view`, `flag_exposure(schedules_standings_v1)` events from the preview deploy
+- [ ] Soak the flag at on for ≥48h with analytics monitored before declaring Phase 3 shipped
+
+## Risks closed
+
+- **Tiebreaker correctness** — `compute-standings.test.ts` covers head-to-head, division-record fallback, and points-differential fallback explicitly. Locked before any UI was wired.
+- **Cascade delete of fixtures with results** — `deleteFixture` removes the matching `gameResults` row in the same transaction; standings can't double-count an orphan.
+- **Compound-index typing under `mutationGeneric`** — pre-empted by using leading-field-only index lookup + filter (same workaround as `ingestPlayerAttributes` from Sprint 6B).
+- **Public-leak risk** — `leagues.isPublic` is the single chokepoint; both `publicLeagueGuard` (page-level) and `computeStandingsPublic` (query-level) enforce it. Layered defense.
+- **Convex codegen lag** — caught early via `pnpm exec convex dev --once` after every schema-touching commit; the missed `lib_standings` artifact from #170 was rolled into #171.


### PR DESCRIPTION
## Summary

Sprint 7 final story — closes Phase 3.

**Analytics** (\`apps/web/src/lib/analytics.ts\`):
- \`trackFixtureCreated({ leagueId, seasonId })\` — fired from \`createFixtureAction\` after success.
- \`trackResultRecorded({ leagueId, fixtureId, homeScore, awayScore })\` — fired from \`recordGameResultAction\`.
- \`trackStandingsView({ leagueId, route })\` — fire-and-forget on both standings pages; \`route\` distinguishes \`dashboard\` vs \`public\`.
- \`flag_exposure(schedules_standings_v1)\` already wired by the flag's \`decide\` callback (WSM-000067).

**Docs**:
- \`docs/roster-management.md\` §1 — Phase 3 — LIVE row appended (PR table, routes, analytics).
- \`docs/sprints/SPRINT_7_VERIFICATION.md\` (new) — locked decisions, 18-row criteria matrix, PR evidence, deferred candidates, flag-flip checklist, risks closed.
- \`docs/sprints/SPRINT_7_CLOSEOUT.md\` (new) — per-story implementation notes for all 10 PRs + running baseline + Sprint 8 candidates.

## Test plan
- [x] \`pnpm --filter @sports-management/web type-check\` — clean
- [x] \`pnpm --filter @sports-management/web lint\` — no new warnings
- [x] \`pnpm --filter @sports-management/web test:unit\` — 267 passed
- [ ] Preview-deploy manual QA per the new \`SPRINT_7_VERIFICATION.md\` flag-flip checklist (manual; gates the prod \`schedules_standings_v1\` = \`on\` flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)