### PR TITLE
fix(web): run NFL sync in background, poll for result (WSM-000084)

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,3 +1,5 @@
 .vercel
 playwright-report/
 test-results/
+
+.env.local

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@sports-management/api-contracts": "workspace:*",
     "@sports-management/shared-types": "workspace:*",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/functions": "^3.7.1",
     "@vercel/og": "^0.11.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/api/import/__tests__/nfl-sync-route.test.ts
+++ b/apps/web/src/app/api/import/__tests__/nfl-sync-route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAuth = vi.fn();
+const mockSyncNfl = vi.fn();
+const mockWaitUntil = vi.fn();
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@vercel/functions", () => ({
+  waitUntil: (p: Promise<unknown>) => mockWaitUntil(p),
+}));
+
+vi.mock("@/lib/sync/nfl-sync", () => ({
+  syncNfl: (...args: unknown[]) => mockSyncNfl(...args),
+}));
+
+import { POST } from "../nfl-sync/route";
+
+describe("POST /api/import/nfl-sync (WSM-000084)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSyncNfl.mockResolvedValue({ adapterErrors: [] });
+  });
+
+  it("returns 401 without a user", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await POST();
+    expect(res.status).toBe(401);
+    expect(mockSyncNfl).not.toHaveBeenCalled();
+  });
+
+  it("returns 202 with requestedAt immediately and runs the sync in the background", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    // Never-resolving sync — the response must not wait for it.
+    mockSyncNfl.mockReturnValue(new Promise(() => {}));
+
+    const res = await POST();
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(new Date(body.requestedAt).toString()).not.toBe("Invalid Date");
+    expect(mockSyncNfl).toHaveBeenCalledWith({ skipToggleCheck: true });
+    expect(mockWaitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows background sync failures without rejecting the handed-off promise", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockSyncNfl.mockRejectedValue(new Error("ESPN unreachable"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST();
+    expect(res.status).toBe(202);
+
+    // The promise handed to waitUntil must resolve (not reject) on failure.
+    await expect(mockWaitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/app/api/import/nfl-sync/route.ts
+++ b/apps/web/src/app/api/import/nfl-sync/route.ts
@@ -1,21 +1,42 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 import { syncNfl } from "@/lib/sync/nfl-sync";
-import { handleApiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
+/**
+ * POST /api/import/nfl-sync
+ *
+ * Kicks off the ESPN NFL sync in the background and returns 202
+ * immediately. A full sync upserts ~3k players and runs for minutes —
+ * longer than mobile browsers and proxies will hold a single request
+ * (WSM-000084). Clients poll /api/import/nfl-sync-config and compare
+ * `lastSyncReport.startedAt` against the `requestedAt` returned here;
+ * syncNfl persists its report (success or failure) when it finishes.
+ */
 export async function POST() {
   const { userId } = await auth();
   if (!userId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  try {
-    const report = await syncNfl({ skipToggleCheck: true });
-    return NextResponse.json(report);
-  } catch (error) {
-    return handleApiError(error, "/api/import/nfl-sync POST");
-  }
+  const requestedAt = new Date().toISOString();
+
+  waitUntil(
+    syncNfl({ skipToggleCheck: true }).catch((err: unknown) => {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          route: "/api/import/nfl-sync POST",
+          message: `Background NFL sync failed before writing a report: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        }),
+      );
+    }),
+  );
+
+  return NextResponse.json({ accepted: true, requestedAt }, { status: 202 });
 }

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { SyncConfig, SyncReport } from "@sports-management/shared-types";
 import { Button } from "@/components/ui/8bit/button";
@@ -152,6 +152,21 @@ export function NflSyncCard() {
     }
   }, [state]);
 
+  // A full sync runs for minutes — longer than mobile browsers and proxies
+  // hold a single request (WSM-000084). The POST returns 202 immediately;
+  // we poll the persisted sync report until one newer than our request
+  // shows up. mountedRef stops polling after unmount.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const POLL_INTERVAL_MS = 5000;
+  const POLL_TIMEOUT_MS = 8 * 60 * 1000;
+
   const handleSyncNow = useCallback(async () => {
     if (state.phase !== "ready") return;
     setState({ ...state, syncing: true });
@@ -159,23 +174,40 @@ export function NflSyncCard() {
     try {
       const res = await fetch("/api/import/nfl-sync", { method: "POST" });
       if (!res.ok) throw new Error(`Sync failed: ${res.status}`);
-      const report: SyncReport = await res.json();
+      const { requestedAt }: { requestedAt: string } = await res.json();
 
-      setState({
-        phase: "ready",
-        config: { ...state.config, lastSyncReport: report },
-        syncing: false,
-      });
+      const deadline = Date.now() + POLL_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        if (!mountedRef.current) return;
 
-      if (
-        report.adapterErrors.length > 0 ||
-        (report.importResult?.errors?.length ?? 0) > 0
-      ) {
-        toast.warning("Sync completed with errors");
-      } else {
-        toast.success("NFL sync completed successfully");
+        const configRes = await fetch("/api/import/nfl-sync-config");
+        if (!configRes.ok) continue; // transient — keep polling
+        const config: SyncConfig = await configRes.json();
+        const report = config.lastSyncReport;
+
+        // ISO-8601 strings compare chronologically.
+        if (!report || report.startedAt < requestedAt) continue;
+
+        setState({ phase: "ready", config, syncing: false });
+        if (
+          report.adapterErrors.length > 0 ||
+          (report.importResult?.errors?.length ?? 0) > 0
+        ) {
+          toast.warning("Sync completed with errors");
+        } else {
+          toast.success("NFL sync completed successfully");
+        }
+        return;
       }
+
+      if (!mountedRef.current) return;
+      setState({ ...state, syncing: false });
+      toast.info(
+        "Sync is still running in the background. Refresh this page later to see the result.",
+      );
     } catch (err) {
+      if (!mountedRef.current) return;
       setState({ ...state, syncing: false });
       toast.error(
         err instanceof Error ? err.message : "Sync failed",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@vercel/functions':
+        specifier: ^3.7.1
+        version: 3.7.1(ws@8.20.0)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
@@ -3309,9 +3312,32 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
+  '@vercel/functions@3.7.1':
+    resolution: {integrity: sha512-7PsCL2Vz4MKz4t+Nxu8u4mu/t66y1xv9I0njb3EYoFoFCsXchOChT7YFgXZYFQiUXFEifBpnoLma4e+ep7cKKA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
+
   '@vercel/og@0.11.1':
     resolution: {integrity: sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==}
     engines: {node: '>=16'}
+
+  '@vercel/oidc@3.6.1':
+    resolution: {integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==}
+    engines: {node: '>= 20'}
 
   '@vercel/speed-insights@2.0.0':
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
@@ -5932,6 +5958,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -7343,6 +7373,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
 
@@ -7409,6 +7447,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -10757,12 +10798,33 @@ snapshots:
       next: 15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/functions@3.7.1(ws@8.20.0)':
+    dependencies:
+      '@vercel/oidc': 3.6.1
+    optionalDependencies:
+      ws: 8.20.0
+
   '@vercel/og@0.11.1':
     dependencies:
       '@resvg/resvg-wasm': 2.4.0
       satori: 0.25.0
     optionalDependencies:
       sharp: 0.34.5
+
+  '@vercel/oidc@3.6.1':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+      jose: 5.10.0
 
   '@vercel/speed-insights@2.0.0(next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
@@ -13805,6 +13867,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -15302,6 +15366,15 @@ snapshots:
 
   ws@8.20.0: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-name-validator@3.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -15368,3 +15441,5 @@ snapshots:
   yoga-layout@3.2.1: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}


### PR DESCRIPTION
Closes #184.

## Summary
- `POST /api/import/nfl-sync` now starts the sync via `waitUntil` (`@vercel/functions`, new dep) and returns **202 + `requestedAt`** immediately, instead of holding the connection for the full ~2m20s sync that mobile browsers/proxies kill.
- `NflSyncCard` polls `/api/import/nfl-sync-config` every 5s (8-min cap) and resolves success/warning from the **persisted** sync report (`lastSyncReport.startedAt >= requestedAt`). Failed syncs persist a report with `adapterErrors`, so failures surface through the same path. Poll timeout shows "still running in background" instead of a false failure.
- 3 new route tests: 401 unauth, 202-without-awaiting-sync, background-failure swallowed + logged.

## Context
Found during WSM-000079 cutover verification (#178): a fully successful prod sync (1 league / 8 divisions / 32 teams / 2,922 players, 0 errors) showed a failure toast on mobile. Per-player upsert batching (the other idea in #184) is left for a follow-up if sync duration itself becomes a problem.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check` — clean
- [x] `pnpm --filter @sports-management/web test:unit` — 276 passed (+3)
- [x] `pnpm --filter @sports-management/web lint` — only the documented pre-existing warning
- [ ] Post-merge: Sync Now from a phone reports success while the sync runs server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)