### PR TITLE
feat(web): Madden-style position-grouped roster view (WSM-000086)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -7,6 +7,7 @@ import PlayerForm from "../../_components/player-form";
 import TeamEditForm from "../../_components/team-edit-form";
 import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
+import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
 import { StatusBadge } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/8bit/button";
@@ -136,45 +137,49 @@ export default function TeamManagement({
       </div>
 
       {players.length > 0 ? (
-        <DataTable
-          data={players as (PlayerDto & Record<string, unknown>)[]}
-          columns={columns}
-          searchPlaceholder="Search players..."
-          searchKeys={["name", "position", "status"]}
-          actions={
-            canManage
-              ? (player) => (
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        setModal({
-                          type: "editPlayer",
-                          player: player as unknown as PlayerDto,
-                        })
-                      }
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-destructive hover:text-destructive"
-                      onClick={() =>
-                        setModal({
-                          type: "deletePlayer",
-                          player: player as unknown as PlayerDto,
-                        })
-                      }
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                )
-              : undefined
-          }
-        />
+        <PositionGroupTabs players={players}>
+          {(groupPlayers) => (
+            <DataTable
+              data={groupPlayers as (PlayerDto & Record<string, unknown>)[]}
+              columns={columns}
+              searchPlaceholder="Search players..."
+              searchKeys={["name", "position", "status"]}
+              actions={
+                canManage
+                  ? (player) => (
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            setModal({
+                              type: "editPlayer",
+                              player: player as unknown as PlayerDto,
+                            })
+                          }
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() =>
+                            setModal({
+                              type: "deletePlayer",
+                              player: player as unknown as PlayerDto,
+                            })
+                          }
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    )
+                  : undefined
+              }
+            />
+          )}
+        </PositionGroupTabs>
       ) : (
         <EmptyState
           icon={UserCircle}

--- a/apps/web/src/components/roster/PositionGroupTabs.tsx
+++ b/apps/web/src/components/roster/PositionGroupTabs.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  groupPlayersByPosition,
+  OTHER_GROUP,
+  type RosterGroup,
+} from "@/lib/position-group";
+
+const ALL_TAB = "All" as const;
+type Tab = typeof ALL_TAB | RosterGroup;
+
+interface Positioned {
+  position: string;
+  jerseyNumber?: number | null;
+  name: string;
+}
+
+interface PositionGroupTabsProps<T extends Positioned> {
+  players: T[];
+  /** Renders the player list for the active tab (already filtered + ordered). */
+  children: (players: T[], activeTab: Tab) => ReactNode;
+}
+
+/**
+ * Madden-style roster navigation (WSM-000086): one tab per non-empty
+ * position group in football order (QB → RB → … → K/P → Other), plus All.
+ * The strip scrolls horizontally so 10 tabs survive a phone viewport.
+ */
+export function PositionGroupTabs<T extends Positioned>({
+  players,
+  children,
+}: PositionGroupTabsProps<T>) {
+  const [activeTab, setActiveTab] = useState<Tab>(ALL_TAB);
+
+  const grouped = useMemo(() => groupPlayersByPosition(players), [players]);
+
+  const tabs: Tab[] = [ALL_TAB, ...grouped.map((g) => g.group)];
+
+  // A previously selected group can empty out after a delete — fall back.
+  const effectiveTab =
+    activeTab !== ALL_TAB && !grouped.some((g) => g.group === activeTab)
+      ? ALL_TAB
+      : activeTab;
+  const activePlayers =
+    effectiveTab === ALL_TAB
+      ? players
+      : (grouped.find((g) => g.group === effectiveTab)?.players ?? []);
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="tablist"
+        aria-label="Position groups"
+        className="flex gap-1 overflow-x-auto pb-1 -mx-1 px-1"
+      >
+        {tabs.map((tab) => {
+          const count =
+            tab === ALL_TAB
+              ? players.length
+              : (grouped.find((g) => g.group === tab)?.players.length ?? 0);
+          const isActive = tab === effectiveTab;
+          return (
+            <button
+              key={tab}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveTab(tab)}
+              className={`shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+              }`}
+            >
+              {tab === OTHER_GROUP ? "Other" : tab}
+              <span className="ml-1.5 text-xs opacity-70">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+      {children(activePlayers, effectiveTab)}
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/position-group.test.ts
+++ b/apps/web/src/lib/__tests__/position-group.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { derivePositionGroup } from "../position-group";
+import { derivePositionGroup, groupPlayersByPosition } from "../position-group";
 
 describe("derivePositionGroup", () => {
   const cases: Array<[string, ReturnType<typeof derivePositionGroup>]> = [
@@ -44,5 +44,69 @@ describe("derivePositionGroup", () => {
 
   it("returns null for an empty string", () => {
     expect(derivePositionGroup("")).toBeNull();
+  });
+});
+
+describe("groupPlayersByPosition (WSM-000086)", () => {
+  const p = (name: string, position: string, jerseyNumber: number | null = null) => ({
+    name,
+    position,
+    jerseyNumber,
+  });
+
+  it("orders groups in canonical football order and omits empty groups", () => {
+    const grouped = groupPlayersByPosition([
+      p("Corner", "CB"),
+      p("Passer", "QB"),
+      p("Tackle", "LT"),
+    ]);
+    expect(grouped.map((g) => g.group)).toEqual(["QB", "OL", "DB"]);
+  });
+
+  it("maps common ESPN abbreviations (RB, G, OT) instead of dropping them", () => {
+    expect(derivePositionGroup("RB")).toBe("RB");
+    expect(derivePositionGroup("G")).toBe("OL");
+    expect(derivePositionGroup("OT")).toBe("OL");
+  });
+
+  it("buckets unknown positions into a trailing Other group", () => {
+    const grouped = groupPlayersByPosition([p("Mystery", "XYZ"), p("Passer", "QB")]);
+    expect(grouped.map((g) => g.group)).toEqual(["QB", "Other"]);
+    expect(grouped[1].players[0].name).toBe("Mystery");
+  });
+
+  it("sorts within a group by position order, then jersey, then name", () => {
+    const grouped = groupPlayersByPosition([
+      p("Right Tackle", "RT", 71),
+      p("Center Two", "C", 60),
+      p("Center One", "C", 52),
+      p("Left Tackle", "LT", 78),
+      p("No Jersey Center", "C"),
+    ]);
+    expect(grouped[0].group).toBe("OL");
+    expect(grouped[0].players.map((x) => x.name)).toEqual([
+      "Left Tackle",
+      "Center One",
+      "Center Two",
+      "No Jersey Center",
+      "Right Tackle",
+    ]);
+  });
+
+  it("reads the offensive line left to right", () => {
+    const grouped = groupPlayersByPosition([
+      p("RG", "RG", 1),
+      p("C", "C", 1),
+      p("LT", "LT", 1),
+      p("RT", "RT", 1),
+      p("LG", "LG", 1),
+    ]);
+    expect(grouped[0].players.map((x) => x.position)).toEqual([
+      "LT",
+      "LG",
+      "C",
+      "RG",
+      "RT",
+    ]);
   });
 });

--- a/apps/web/src/lib/position-group.ts
+++ b/apps/web/src/lib/position-group.ts
@@ -9,9 +9,14 @@ export type PositionGroup =
   | "DB"
   | "K/P";
 
+/** Bucket for positions `derivePositionGroup` can't map — shown last, never dropped. */
+export const OTHER_GROUP = "Other" as const;
+export type RosterGroup = PositionGroup | typeof OTHER_GROUP;
+
 const POSITION_TO_GROUP: Readonly<Record<string, PositionGroup>> = {
   QB: "QB",
   HB: "RB",
+  RB: "RB",
   FB: "RB",
   WR: "WR",
   TE: "TE",
@@ -20,23 +25,114 @@ const POSITION_TO_GROUP: Readonly<Record<string, PositionGroup>> = {
   C: "OL",
   RG: "OL",
   RT: "OL",
+  G: "OL",
+  OG: "OL",
+  OT: "OL",
+  OL: "OL",
   DE: "DL",
   DT: "DL",
   NT: "DL",
+  EDGE: "DL",
+  DL: "DL",
   OLB: "LB",
   MLB: "LB",
   ILB: "LB",
+  LB: "LB",
   CB: "DB",
   S: "DB",
   FS: "DB",
   SS: "DB",
   NB: "DB",
+  DB: "DB",
   K: "K/P",
+  PK: "K/P",
   P: "K/P",
   LS: "K/P",
+};
+
+/** Canonical football ordering — offense, defense, special teams. */
+export const POSITION_GROUP_ORDER: readonly PositionGroup[] = [
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OL",
+  "DL",
+  "LB",
+  "DB",
+  "K/P",
+];
+
+/**
+ * Display order of positions inside a group (e.g. the offensive line reads
+ * left-to-right). Positions absent from their group's list sort after the
+ * listed ones, alphabetically.
+ */
+const POSITION_ORDER_IN_GROUP: Readonly<Partial<Record<PositionGroup, readonly string[]>>> = {
+  RB: ["HB", "RB", "FB"],
+  OL: ["LT", "LG", "C", "RG", "RT", "G", "OG", "OT", "OL"],
+  DL: ["DE", "EDGE", "DT", "NT", "DL"],
+  LB: ["OLB", "MLB", "ILB", "LB"],
+  DB: ["CB", "NB", "FS", "SS", "S", "DB"],
+  "K/P": ["K", "PK", "P", "LS"],
 };
 
 export function derivePositionGroup(position: string): PositionGroup | null {
   const normalized = position.trim().toUpperCase();
   return POSITION_TO_GROUP[normalized] ?? null;
+}
+
+interface Positioned {
+  position: string;
+  jerseyNumber?: number | null;
+  name: string;
+}
+
+export interface GroupedRoster<T extends Positioned> {
+  group: RosterGroup;
+  players: T[];
+}
+
+function positionRank(group: RosterGroup, position: string): number {
+  if (group === OTHER_GROUP) return 0;
+  const order = POSITION_ORDER_IN_GROUP[group];
+  if (!order) return 0;
+  const idx = order.indexOf(position.trim().toUpperCase());
+  return idx === -1 ? order.length : idx;
+}
+
+/**
+ * Groups players into Madden-style position groups, ordered QB → RB → WR →
+ * TE → OL → DL → LB → DB → K/P, with unmappable positions in a trailing
+ * "Other" group. Within a group: position order, then jersey number, then
+ * name. Empty groups are omitted.
+ */
+export function groupPlayersByPosition<T extends Positioned>(
+  players: readonly T[],
+): GroupedRoster<T>[] {
+  const buckets = new Map<RosterGroup, T[]>();
+  for (const player of players) {
+    const group = derivePositionGroup(player.position) ?? OTHER_GROUP;
+    const bucket = buckets.get(group);
+    if (bucket) bucket.push(player);
+    else buckets.set(group, [player]);
+  }
+
+  const orderedGroups: RosterGroup[] = [...POSITION_GROUP_ORDER, OTHER_GROUP];
+  const result: GroupedRoster<T>[] = [];
+  for (const group of orderedGroups) {
+    const bucket = buckets.get(group);
+    if (!bucket) continue;
+    bucket.sort((a, b) => {
+      const rankDiff =
+        positionRank(group, a.position) - positionRank(group, b.position);
+      if (rankDiff !== 0) return rankDiff;
+      const aJersey = a.jerseyNumber ?? Number.MAX_SAFE_INTEGER;
+      const bJersey = b.jerseyNumber ?? Number.MAX_SAFE_INTEGER;
+      if (aJersey !== bJersey) return aJersey - bJersey;
+      return a.name.localeCompare(b.name);
+    });
+    result.push({ group, players: bucket });
+  }
+  return result;
 }


### PR DESCRIPTION
Closes #187.

## Summary
- Team rosters now browse by position group in football order — **QB → RB → WR → TE → OL → DL → LB → DB → K/P** — via a horizontally scrollable tab strip (phone-friendly; feeds #185), with per-tab player counts and an **All** tab preserving the old flat table + search.
- `groupPlayersByPosition()` in `position-group.ts`: canonical group ordering, within-group position ordering (OL reads LT→LG→C→RG→RT), then jersey number, then name.
- Position map extended with the abbreviations the ESPN sync actually emits (`RB`, `G`, `OG`, `OT`, `EDGE`, `PK`) — previously `RB` mapped to nothing. Unknown positions land in a trailing **Other** tab, never dropped.
- Add/edit/delete player actions work unchanged on every tab.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check` — clean
- [x] `pnpm --filter @sports-management/web test:unit` — 281 passed (+5: group order, ESPN mapping, Other bucket, within-group sort, OL left-to-right)
- [x] `pnpm --filter @sports-management/web lint` — only the documented pre-existing warning
- [ ] Post-merge: browse an NFL team roster on the phone — tabs render, OL reads left-to-right, no horizontal page overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)