### PR TITLE
fix(web): contain table overflow on phones (WSM-000085)

### DIFF
--- a/apps/web/e2e/tests/mobile-overflow.spec.ts
+++ b/apps/web/e2e/tests/mobile-overflow.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withRosterFixture,
+  getTestOrgId,
+  type RosterFixtureResult,
+} from "../helpers/seed-roster";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+// WSM-000085: no dashboard page may scroll horizontally on a phone.
+// Wide tables must scroll inside their own container (overflow-x-auto),
+// which only works while every flex ancestor can shrink (min-w-0).
+const PHONE = { width: 375, height: 812 };
+
+async function expectNoPageOverflow(page: Page, path: string) {
+  await page.goto(path);
+  await page.waitForLoadState("networkidle");
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  // 1px slack for subpixel rounding.
+  expect(
+    scrollWidth,
+    `${path} scrolls horizontally (${scrollWidth}px content in ${clientWidth}px viewport)`,
+  ).toBeLessThanOrEqual(clientWidth + 1);
+}
+
+test.describe.serial("Mobile — no horizontal page overflow (WSM-000085)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withRosterFixture({
+      fixtureKey: "mobile-overflow",
+      clerkOrgId: orgId,
+      teamName: "E2E Mobile Overflow Team",
+      rosterLimit: 53,
+      seedActivePlayers: 12,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await setupClerkTestingToken({ page });
+    await signInTestUser(page);
+  });
+
+  test("dashboard overview fits the viewport", async ({ page }) => {
+    await expectNoPageOverflow(page, "/dashboard");
+  });
+
+  test("teams list fits the viewport", async ({ page }) => {
+    await expectNoPageOverflow(page, "/dashboard/teams");
+  });
+
+  test("players list fits the viewport", async ({ page }) => {
+    await expectNoPageOverflow(page, "/dashboard/players");
+  });
+
+  test("team page with a seeded roster table fits the viewport", async ({
+    page,
+  }) => {
+    await expectNoPageOverflow(page, `/dashboard/teams/${fixture!.teamId}`);
+  });
+
+  test("leagues page fits the viewport", async ({ page }) => {
+    await expectNoPageOverflow(page, "/dashboard/leagues");
+  });
+});

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -24,6 +24,9 @@ type CardState =
   | { phase: "error"; message: string }
   | { phase: "ready"; config: SyncConfig; syncing: boolean };
 
+const POLL_INTERVAL_MS = 5000;
+const POLL_TIMEOUT_MS = 8 * 60 * 1000;
+
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const seconds = Math.round(ms / 1000);
@@ -163,9 +166,6 @@ export function NflSyncCard() {
       mountedRef.current = false;
     };
   }, []);
-
-  const POLL_INTERVAL_MS = 5000;
-  const POLL_TIMEOUT_MS = 8 * 60 * 1000;
 
   const handleSyncNow = useCallback(async () => {
     if (state.phase !== "ready") return;

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -18,7 +18,10 @@ export default function DashboardLayout({
         <Sidebar />
       </aside>
 
-      <div className="flex flex-1 flex-col">
+      {/* min-w-0 lets this flex child shrink below its content's intrinsic
+          width — without it, wide tables push the page wider than the phone
+          viewport and overflow-x-auto containers never engage. */}
+      <div className="flex min-w-0 flex-1 flex-col">
         {/* Mobile header with hamburger */}
         <MobileHeader />
 

--- a/apps/web/src/components/schedule/StandingsTable.tsx
+++ b/apps/web/src/components/schedule/StandingsTable.tsx
@@ -12,65 +12,69 @@ export interface StandingsTableProps {
  */
 export default function StandingsTable({ rows }: StandingsTableProps) {
   return (
-    <table className="w-full text-sm">
-      <thead>
-        <tr className="border-b-2 border-border bg-muted text-left text-foreground">
-          <th className="px-4 py-2 font-mono text-xs uppercase">Rank</th>
-          <th className="px-4 py-2 font-mono text-xs uppercase">Team</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">W</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">L</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">T</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">PF</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">PA</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">+/−</th>
-          <th className="px-4 py-2 text-right font-mono text-xs uppercase">
-            Div Rank
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => {
-          const diff = row.pointsFor - row.pointsAgainst;
-          return (
-            <tr key={row.teamId} className="border-b border-border">
-              <td className="px-4 py-2 font-mono text-foreground">
-                {row.leagueRank}
-              </td>
-              <td className="px-4 py-2 text-foreground">{row.teamName}</td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {row.wins}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {row.losses}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {row.ties}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {row.pointsFor}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {row.pointsAgainst}
-              </td>
-              <td
-                className={`px-4 py-2 text-right font-mono ${
-                  diff > 0
-                    ? "text-accent"
-                    : diff < 0
-                      ? "text-destructive"
-                      : "text-muted-foreground"
-                }`}
-              >
-                {diff > 0 ? "+" : ""}
-                {diff}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-muted-foreground">
-                {row.divisionRank}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+    // Nine columns never fit a phone — scroll the table inside its own
+    // container instead of widening the page (WSM-000085).
+    <div className="w-full overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b-2 border-border bg-muted text-left text-foreground">
+            <th className="px-4 py-2 font-mono text-xs uppercase">Rank</th>
+            <th className="px-4 py-2 font-mono text-xs uppercase">Team</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">W</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">L</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">T</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">PF</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">PA</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">+/−</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+              Div Rank
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const diff = row.pointsFor - row.pointsAgainst;
+            return (
+              <tr key={row.teamId} className="border-b border-border">
+                <td className="px-4 py-2 font-mono text-foreground">
+                  {row.leagueRank}
+                </td>
+                <td className="px-4 py-2 text-foreground">{row.teamName}</td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
+                  {row.wins}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
+                  {row.losses}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
+                  {row.ties}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
+                  {row.pointsFor}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
+                  {row.pointsAgainst}
+                </td>
+                <td
+                  className={`px-4 py-2 text-right font-mono ${
+                    diff > 0
+                      ? "text-accent"
+                      : diff < 0
+                        ? "text-destructive"
+                        : "text-muted-foreground"
+                  }`}
+                >
+                  {diff > 0 ? "+" : ""}
+                  {diff}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                  {row.divisionRank}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
Part of #185 (first slice: page-level horizontal overflow, the worst mobile offender per the owner's phone screenshots).

## Summary
- **Root cause:** the dashboard content column (`flex flex-1 flex-col`) had no `min-w-0`, so the flex child couldn't shrink below the widest table's intrinsic width — wide tables dragged the whole page wider than the viewport and the existing `overflow-x-auto` wrapper in `ui/table.tsx` never engaged. One class fixes containment for every dashboard page.
- `StandingsTable` (raw 9-column table, also used on the public viewer) wrapped in its own `overflow-x-auto` container.
- New `mobile-overflow.spec.ts`: asserts `scrollWidth <= clientWidth` at 375×812 on /dashboard, teams, players, leagues, and a seeded team page with a roster table.
- Drive-by: hoists #186's poll constants to module scope, clearing the `exhaustive-deps` lint warning that PR introduced.

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`, `test:unit` (281), `build` — all clean; lint back to only the documented pre-existing warning
- [ ] e2e spec runs in the standard local harness (not run here — local Convex backend env wasn't reproducible in this session; spec follows the existing `mobile-navigation.spec.ts` + `withRosterFixture` patterns)
- [ ] Post-merge: owner re-checks the Cardinals team page on the phone — header, team card, and tab strip should fit; the table scrolls within its own container

Remaining #185 scope (follow-ups): touch drag for the depth chart, 44px touch targets on the import flow, stacked-card option for tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)