### PR TITLE
fix(web): render en dash in pagination label instead of literal –

### DIFF
--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -168,7 +168,7 @@ export function DataTable<T extends Record<string, unknown>>({
       {totalPages > 1 && (
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
-            Showing {safeCurrentPage * pageSize + 1}\u2013
+            Showing {safeCurrentPage * pageSize + 1}{"\u2013"}
             {Math.min((safeCurrentPage + 1) * pageSize, sorted.length)} of{" "}
             {sorted.length}
           </span>


### PR DESCRIPTION
Spotted by the owner on the phone: DataTable pagination read "Showing 1–10 of 91". JSX text nodes don't process backslash escapes — the dash now lives in a JS string expression.

**Merge note:** intentionally held until the WSM-000087 Convex cutover completes (a deploy before `CONVEX_ADMIN_KEY` is re-added would build against the prod Convex deployment with no key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)