### PR TITLE
feat(web): Madden-style compact roster columns + clickable rows (WSM-000088)

### DIFF
--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -9,6 +9,7 @@ import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
 import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
 import { StatusBadge } from "@/components/status-badge";
+import { abbreviateName } from "@/lib/position-group";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/8bit/button";
 import { Card, CardContent } from "@/components/ui/8bit/card";
@@ -62,22 +63,50 @@ export default function TeamManagement({
     }
   }
 
-  const columns: Column<PlayerDto & Record<string, unknown>>[] = [
-    { key: "name", header: "Name", sortable: true },
-    { key: "position", header: "Position", sortable: true },
-    {
-      key: "jerseyNumber",
-      header: "Jersey #",
-      sortable: true,
-      render: (p) => p.jerseyNumber ?? "\u2014",
-    },
-    {
-      key: "status",
-      header: "Status",
-      sortable: true,
-      render: (p) => <StatusBadge status={p.status} />,
-    },
-  ];
+  // Madden-style compact depth chart columns (WSM-000088). `slot` is the
+  // player's depth-order index within the active position-group tab \u2014
+  // attached to the row before render so it survives user re-sorting.
+  type RosterRow = PlayerDto & { slot?: number } & Record<string, unknown>;
+
+  function buildColumns(withSlot: boolean): Column<RosterRow>[] {
+    return [
+      ...(withSlot
+        ? [
+            {
+              key: "slot",
+              header: "Slot",
+              sortable: true,
+              render: (p: RosterRow) => (
+                <span className="font-mono text-muted-foreground">
+                  {p.slot}.
+                </span>
+              ),
+            } satisfies Column<RosterRow>,
+          ]
+        : []),
+      {
+        key: "name",
+        header: "Player",
+        sortable: true,
+        render: (p) => (
+          <span className="font-medium">{abbreviateName(p.name)}</span>
+        ),
+      },
+      { key: "position", header: "Pos", sortable: true },
+      {
+        key: "jerseyNumber",
+        header: "#",
+        sortable: true,
+        render: (p) => p.jerseyNumber ?? "\u2014",
+      },
+      {
+        key: "status",
+        header: "Status",
+        sortable: true,
+        render: (p) => <StatusBadge status={p.status} />,
+      },
+    ];
+  }
 
   return (
     <>
@@ -138,12 +167,19 @@ export default function TeamManagement({
 
       {players.length > 0 ? (
         <PositionGroupTabs players={players}>
-          {(groupPlayers) => (
+          {(groupPlayers, activeTab) => (
             <DataTable
-              data={groupPlayers as (PlayerDto & Record<string, unknown>)[]}
-              columns={columns}
+              data={
+                (activeTab === "All"
+                  ? groupPlayers
+                  : groupPlayers.map((p, i) => ({ ...p, slot: i + 1 }))) as RosterRow[]
+              }
+              columns={buildColumns(activeTab !== "All")}
               searchPlaceholder="Search players..."
               searchKeys={["name", "position", "status"]}
+              onRowClick={(p) =>
+                router.push(`/dashboard/players/${(p as RosterRow).id}`)
+              }
               actions={
                 canManage
                   ? (player) => (

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -29,6 +29,9 @@ interface DataTableProps<T> {
   pageSize?: number;
   emptyMessage?: string;
   actions?: (item: T) => React.ReactNode;
+  /** Makes rows clickable (cursor + hover affordance). Clicks inside the
+      actions cell never trigger this. */
+  onRowClick?: (item: T) => void;
 }
 
 export function DataTable<T extends Record<string, unknown>>({
@@ -39,6 +42,7 @@ export function DataTable<T extends Record<string, unknown>>({
   pageSize = 10,
   emptyMessage = "No results found.",
   actions,
+  onRowClick,
 }: DataTableProps<T>) {
   const [search, setSearch] = useState("");
   const [sortKey, setSortKey] = useState<string | null>(null);
@@ -136,7 +140,11 @@ export function DataTable<T extends Record<string, unknown>>({
           <TableBody>
             {paged.length > 0 ? (
               paged.map((item, i) => (
-                <TableRow key={(item as Record<string, unknown>).id as string ?? i}>
+                <TableRow
+                  key={(item as Record<string, unknown>).id as string ?? i}
+                  onClick={onRowClick ? () => onRowClick(item) : undefined}
+                  className={onRowClick ? "cursor-pointer" : undefined}
+                >
                   {columns.map((col) => (
                     <TableCell key={col.key}>
                       {col.render
@@ -145,7 +153,10 @@ export function DataTable<T extends Record<string, unknown>>({
                     </TableCell>
                   ))}
                   {actions && (
-                    <TableCell className="text-right">
+                    <TableCell
+                      className="text-right"
+                      onClick={(e) => e.stopPropagation()}
+                    >
                       {actions(item)}
                     </TableCell>
                   )}

--- a/apps/web/src/lib/__tests__/position-group.test.ts
+++ b/apps/web/src/lib/__tests__/position-group.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { derivePositionGroup, groupPlayersByPosition } from "../position-group";
+import { abbreviateName, derivePositionGroup, groupPlayersByPosition } from "../position-group";
 
 describe("derivePositionGroup", () => {
   const cases: Array<[string, ReturnType<typeof derivePositionGroup>]> = [
@@ -108,5 +108,23 @@ describe("groupPlayersByPosition (WSM-000086)", () => {
       "RG",
       "RT",
     ]);
+  });
+});
+
+describe("abbreviateName (WSM-000088)", () => {
+  it("abbreviates first name to an initial", () => {
+    expect(abbreviateName("Adam Thielen")).toBe("A. Thielen");
+  });
+
+  it("keeps multi-part last names", () => {
+    expect(abbreviateName("Terrace Marshall Jr")).toBe("T. Marshall Jr");
+  });
+
+  it("passes single-word names through", () => {
+    expect(abbreviateName("Neymar")).toBe("Neymar");
+  });
+
+  it("trims and collapses whitespace", () => {
+    expect(abbreviateName("  Bam   Knight  ")).toBe("B. Knight");
   });
 });

--- a/apps/web/src/lib/position-group.ts
+++ b/apps/web/src/lib/position-group.ts
@@ -82,6 +82,17 @@ export function derivePositionGroup(position: string): PositionGroup | null {
   return POSITION_TO_GROUP[normalized] ?? null;
 }
 
+/**
+ * Madden-style name abbreviation: "Adam Thielen" → "A. Thielen".
+ * Single-word names and empty strings pass through; multi-part last
+ * names keep everything after the first word ("T. Marshall Jr").
+ */
+export function abbreviateName(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length < 2) return name.trim();
+  return `${parts[0][0]}. ${parts.slice(1).join(" ")}`;
+}
+
 interface Positioned {
   position: string;
   jerseyNumber?: number | null;


### PR DESCRIPTION
Closes #192.

## Summary
- Roster table compresses to **Slot | Player | Pos | # | Status** — names abbreviate Madden-style via `abbreviateName` ("Adam Thielen" → "A. Thielen", "Terrace Marshall Jr" → "T. Marshall Jr")
- **Slot numbers** show the depth-order index within the active position-group tab (1., 2., 3. …), pinned to the row so user re-sorting doesn't lie about depth; the All tab omits them
- **Rows are clickable** → `/dashboard/players/[id]`. `DataTable` gains an `onRowClick` prop; the actions cell stops propagation so edit/delete buttons don't navigate
- Follow-up noted in #192: Madden stat columns (OVR/SPD/…) once Phase 2 attribute snapshots are joined in; `headshotUrl` available for an avatar column

## Test plan
- [x] type-check clean, 285 unit tests pass (+4 for `abbreviateName`), lint at the documented pre-existing warning only
- [ ] Post-merge: owner taps a WR-tab row on the phone → player page opens; slot column reads 1..N

🤖 Generated with [Claude Code](https://claude.com/claude-code)