### PR TITLE
feat(web): years active on player profile (WSM-000088 follow-up)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -45,6 +45,8 @@ export default defineSchema({
     dateOfBirth: v.union(v.string(), v.null()),
     status: v.string(),
     headshotUrl: v.union(v.string(), v.null()),
+    // Optional: pre-experienceYears documents validate without backfill.
+    experienceYears: v.optional(v.union(v.number(), v.null())),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_teamId", ["teamId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -81,6 +81,7 @@ function toPlayerDto(doc: {
   dateOfBirth: string | null;
   status: string;
   headshotUrl: string | null;
+  experienceYears?: number | null;
 }) {
   return {
     id: doc._id,
@@ -92,6 +93,7 @@ function toPlayerDto(doc: {
     dateOfBirth: doc.dateOfBirth ?? null,
     status: doc.status,
     headshotUrl: doc.headshotUrl ?? null,
+    experienceYears: doc.experienceYears ?? null,
   };
 }
 
@@ -498,6 +500,7 @@ export const listPlayers = queryGeneric({
       dateOfBirth: v.union(v.string(), v.null()),
       status: v.string(),
       headshotUrl: v.union(v.string(), v.null()),
+      experienceYears: v.union(v.number(), v.null()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -526,6 +529,7 @@ export const listPlayersByTeam = queryGeneric({
       dateOfBirth: v.union(v.string(), v.null()),
       status: v.string(),
       headshotUrl: v.union(v.string(), v.null()),
+      experienceYears: v.union(v.number(), v.null()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -550,6 +554,7 @@ export const getPlayer = queryGeneric({
       dateOfBirth: v.union(v.string(), v.null()),
       status: v.string(),
       headshotUrl: v.union(v.string(), v.null()),
+      experienceYears: v.union(v.number(), v.null()),
     }),
     v.null(),
   ),
@@ -820,6 +825,7 @@ export const upsertPlayer = mutationGeneric({
     dateOfBirth: v.union(v.string(), v.null()),
     status: v.string(),
     headshotUrl: v.union(v.string(), v.null()),
+    experienceYears: v.optional(v.union(v.number(), v.null())),
   },
   returns: v.object({
     dto: v.object({
@@ -832,6 +838,7 @@ export const upsertPlayer = mutationGeneric({
       dateOfBirth: v.union(v.string(), v.null()),
       status: v.string(),
       headshotUrl: v.union(v.string(), v.null()),
+      experienceYears: v.union(v.number(), v.null()),
     }),
     created: v.boolean(),
   }),
@@ -852,6 +859,7 @@ export const upsertPlayer = mutationGeneric({
         dateOfBirth: args.dateOfBirth,
         status: args.status,
         headshotUrl: args.headshotUrl,
+        experienceYears: args.experienceYears ?? null,
       });
       return {
         dto: toPlayerDto({
@@ -862,6 +870,7 @@ export const upsertPlayer = mutationGeneric({
           dateOfBirth: args.dateOfBirth,
           status: args.status,
           headshotUrl: args.headshotUrl,
+          experienceYears: args.experienceYears ?? null,
         }),
         created: false,
       };
@@ -882,6 +891,7 @@ export const upsertPlayer = mutationGeneric({
         dateOfBirth: args.dateOfBirth,
         status: args.status,
         headshotUrl: args.headshotUrl,
+        experienceYears: args.experienceYears ?? null,
       },
       created: true,
     };
@@ -999,6 +1009,7 @@ export const createPlayer = mutationGeneric({
     dateOfBirth: v.union(v.string(), v.null()),
     status: v.string(),
     headshotUrl: v.union(v.string(), v.null()),
+    experienceYears: v.optional(v.union(v.number(), v.null())),
   }),
   handler: async (ctx, args) => {
     const team = await ctx.db.get(args.teamId);
@@ -1010,6 +1021,7 @@ export const createPlayer = mutationGeneric({
       ...args,
       leagueId: team.leagueId,
       headshotUrl: null,
+      experienceYears: null,
       positionGroup: null,
     });
 
@@ -1023,6 +1035,7 @@ export const createPlayer = mutationGeneric({
       dateOfBirth: args.dateOfBirth,
       status: args.status,
       headshotUrl: null,
+      experienceYears: null,
     };
   },
 });
@@ -1048,6 +1061,7 @@ export const updatePlayer = mutationGeneric({
       dateOfBirth: v.union(v.string(), v.null()),
       status: v.string(),
       headshotUrl: v.union(v.string(), v.null()),
+      experienceYears: v.union(v.number(), v.null()),
     }),
     v.null(),
   ),

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -112,6 +112,18 @@ export default async function PlayerProfilePage({
                 <dd className="mt-1 text-foreground">{age}</dd>
               </div>
             )}
+            {player.experienceYears != null && (
+              <div>
+                <dt className="font-medium text-muted-foreground">
+                  Years active
+                </dt>
+                <dd className="mt-1 text-foreground">
+                  {player.experienceYears === 0
+                    ? "Rookie"
+                    : `${player.experienceYears} ${player.experienceYears === 1 ? "yr" : "yrs"}`}
+                </dd>
+              </div>
+            )}
           </dl>
 
           {developmentEnabled && (

--- a/apps/web/src/lib/adapters/espn-nfl.ts
+++ b/apps/web/src/lib/adapters/espn-nfl.ts
@@ -62,6 +62,7 @@ interface EspnRosterResponse {
       position: { abbreviation: string };
       status?: { name: string };
       headshot?: { href: string };
+      experience?: { years?: number };
     }[];
   }[];
 }
@@ -131,6 +132,7 @@ export class EspnNflAdapter implements IDataSourceAdapter {
                   : null,
                 status: athlete.status?.name ?? "Active",
                 headshotUrl: athlete.headshot?.href ?? null,
+                experienceYears: athlete.experience?.years ?? null,
               })),
             );
           } catch {

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -152,6 +152,7 @@ const refs = {
       dateOfBirth: string | null;
       status: string;
       headshotUrl: string | null;
+      experienceYears: number | null;
     },
     { dto: PlayerDto; created: boolean }
   >("sports:upsertPlayer"),
@@ -734,6 +735,7 @@ export async function bulkImportLeague(
             dateOfBirth: player.dateOfBirth ?? null,
             status: player.status ?? "Active",
             headshotUrl: player.headshotUrl ?? null,
+            experienceYears: player.experienceYears ?? null,
           });
           if (playerResult.created) created.players++;
           else updated.players++;

--- a/packages/api-contracts/src/import-schema.ts
+++ b/packages/api-contracts/src/import-schema.ts
@@ -7,6 +7,7 @@ const PlayerImportSchema = z.object({
   dateOfBirth: z.string().nullable().optional(),
   status: z.string().min(1).optional().default("Active"),
   headshotUrl: z.string().url().nullable().optional(),
+  experienceYears: z.number().int().min(0).nullable().optional(),
 });
 
 const TeamImportSchema = z.object({

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -53,6 +53,7 @@ export const PlayerDtoSchema = z.object({
   dateOfBirth: z.string().nullable(),
   status: z.string(),
   headshotUrl: z.string().nullable(),
+  experienceYears: z.number().nullable(),
 }) satisfies z.ZodType<PlayerDto>;
 
 export const RosterAssignmentDtoSchema = z.object({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -40,6 +40,7 @@ export interface PlayerDto {
   dateOfBirth: string | null;
   status: string;
   headshotUrl: string | null;
+  experienceYears: number | null;
 }
 
 export interface SeasonDto {


### PR DESCRIPTION
## Summary
- `experienceYears` threaded end-to-end: ESPN adapter (`experience.years`) → import schema → `upsertPlayer` → players table (optional field — existing docs validate without backfill) → `PlayerDto` → profile page
- Profile shows **Years active**: "Rookie" for 0, "N yrs" otherwise; hidden when unknown (JSON-imported players)
- Convex functions already deployed to both deployments; values populate on the next NFL sync run

## Test plan
- [x] type-check across packages (api-contracts rebuilt), 285 unit tests, lint (pre-existing warning only)
- [ ] Post-merge + post-sync: NFL player profiles show years active

🤖 Generated with [Claude Code](https://claude.com/claude-code)