### PR TITLE
feat(web): Madden stat columns in the roster table (WSM-000090)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1975,6 +1975,50 @@ export const getSeasonAttributesByPosition = queryGeneric({
 });
 
 /*
+ * WSM-000090 — per-team attribute snapshots for the Madden-style
+ * roster stat columns. One row per team player that has a snapshot
+ * for the given season; players without one are simply absent (the
+ * UI renders an em dash). Access control lives in the data-api layer
+ * (league visibility), matching getPlayersByTeam.
+ */
+export const getTeamAttributeSnapshots = queryGeneric({
+  args: {
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+  },
+  returns: v.array(
+    v.object({
+      playerId: v.string(),
+      weightedOverall: v.union(v.number(), v.null()),
+      attributes: v.record(v.string(), v.number()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+
+    const snapshots = [];
+    for (const player of players) {
+      // Leading-field index form — see ingestPlayerAttributes for why.
+      const candidates = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) => q.eq("playerId", player._id))
+        .collect();
+      const row = candidates.find((r) => r.seasonId === args.seasonId);
+      if (!row) continue;
+      snapshots.push({
+        playerId: player._id as string,
+        weightedOverall: row.weightedOverall,
+        attributes: safeParseAttributes(row.attributesJson),
+      });
+    }
+    return snapshots;
+  },
+});
+
+/*
  * Phase 2 — Public read primitives (Sprint 6B / WSM-000059).
  *
  * The public viewer in WSM-000061 hits these without a Clerk session.

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -1,9 +1,16 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getTeam, getPlayersByTeam } from "@/lib/data-api";
+import {
+  getTeam,
+  getPlayersByTeam,
+  getSeasons,
+  getTeamAttributeSnapshots,
+} from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam } from "@/lib/authorization";
+import { playerAttributesV1 } from "@/lib/flags";
+import type { PlayerSnapshot } from "@/lib/attributes/headline-columns";
 import TeamManagement from "./team-management";
 
 export default async function TeamDetailPage({
@@ -23,6 +30,24 @@ export default async function TeamDetailPage({
     canManageTeam(id, userId),
   ]);
 
+  // WSM-000090: attribute snapshots feed the Madden stat columns.
+  // Phase 2-gated; resolved against the league's active season, same
+  // rule as the depth-chart page. Failure here must never take down
+  // the roster — columns simply don't render.
+  let snapshots: ReadonlyMap<string, PlayerSnapshot> = new Map();
+  if (await playerAttributesV1()) {
+    const seasons = await getSeasons([team.leagueId]).catch(() => []);
+    const activeSeason =
+      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+    if (activeSeason) {
+      snapshots = await getTeamAttributeSnapshots(
+        id,
+        activeSeason.id,
+        orgContext,
+      ).catch(() => new Map());
+    }
+  }
+
   return (
     <div>
       <Link
@@ -32,7 +57,12 @@ export default async function TeamDetailPage({
         &larr; Back to Teams
       </Link>
 
-      <TeamManagement team={team} players={players} canManage={canManage} />
+      <TeamManagement
+        team={team}
+        players={players}
+        canManage={canManage}
+        attributeSnapshots={Object.fromEntries(snapshots)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -10,6 +10,11 @@ import { DataTable, type Column } from "@/components/data-table";
 import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
 import { StatusBadge } from "@/components/status-badge";
 import { abbreviateName } from "@/lib/position-group";
+import {
+  lookupAttribute,
+  presentHeadlineKeys,
+  type PlayerSnapshot,
+} from "@/lib/attributes/headline-columns";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/8bit/button";
 import { Card, CardContent } from "@/components/ui/8bit/card";
@@ -20,6 +25,9 @@ interface TeamManagementProps {
   team: TeamDto;
   players: PlayerDto[];
   canManage: boolean;
+  /** WSM-000090: playerId → attribute snapshot; empty when Phase 2 is
+      dark or the season has no ingested attributes. */
+  attributeSnapshots?: Record<string, PlayerSnapshot>;
 }
 
 type ModalState =
@@ -33,7 +41,9 @@ export default function TeamManagement({
   team,
   players,
   canManage,
+  attributeSnapshots = {},
 }: TeamManagementProps) {
+  const snapshots = new Map(Object.entries(attributeSnapshots));
   const router = useRouter();
   const [modal, setModal] = useState<ModalState>({ type: "none" });
   const [isDeleting, setIsDeleting] = useState(false);
@@ -68,6 +78,13 @@ export default function TeamManagement({
   // attached to the row before render so it survives user re-sorting.
   type RosterRow = PlayerDto & { slot?: number } & Record<string, unknown>;
 
+  // Headline attribute columns render only for keys at least one
+  // player on the team actually has (WSM-000090).
+  const statKeys = presentHeadlineKeys(
+    snapshots,
+    players.map((p) => p.id),
+  );
+
   function buildColumns(withSlot: boolean): Column<RosterRow>[] {
     return [
       ...(withSlot
@@ -99,6 +116,49 @@ export default function TeamManagement({
         sortable: true,
         render: (p) => p.jerseyNumber ?? "\u2014",
       },
+      // Madden stat columns (WSM-000090) — only when snapshots exist.
+      ...(snapshots.size > 0
+        ? [
+            {
+              key: "ovr",
+              header: "OVR",
+              sortable: true,
+              accessor: (p: RosterRow) =>
+                snapshots.get(p.id as string)?.weightedOverall ?? null,
+              render: (p: RosterRow) => {
+                const ovr = snapshots.get(p.id as string)?.weightedOverall;
+                return ovr != null ? (
+                  <span className="font-mono font-semibold text-accent">
+                    {Math.round(ovr)}
+                  </span>
+                ) : (
+                  "—"
+                );
+              },
+            } satisfies Column<RosterRow>,
+            ...statKeys.map(
+              (key) =>
+                ({
+                  key: `attr_${key}`,
+                  header: key,
+                  sortable: true,
+                  accessor: (p: RosterRow) =>
+                    lookupAttribute(snapshots.get(p.id as string), key),
+                  render: (p: RosterRow) => {
+                    const value = lookupAttribute(
+                      snapshots.get(p.id as string),
+                      key,
+                    );
+                    return value != null ? (
+                      <span className="font-mono">{Math.round(value)}</span>
+                    ) : (
+                      "—"
+                    );
+                  },
+                }) satisfies Column<RosterRow>,
+            ),
+          ]
+        : []),
       {
         key: "status",
         header: "Status",

--- a/apps/web/src/lib/__tests__/headline-columns.test.ts
+++ b/apps/web/src/lib/__tests__/headline-columns.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  lookupAttribute,
+  presentHeadlineKeys,
+  type PlayerSnapshot,
+} from "../attributes/headline-columns";
+
+const snap = (
+  attributes: Record<string, number>,
+  weightedOverall: number | null = 80,
+): PlayerSnapshot => ({ weightedOverall, attributes });
+
+describe("lookupAttribute (WSM-000090)", () => {
+  it("matches keys case-insensitively", () => {
+    expect(lookupAttribute(snap({ spd: 91 }), "SPD")).toBe(91);
+    expect(lookupAttribute(snap({ Speed: 91 }), "speed")).toBe(91);
+  });
+
+  it("returns null for missing snapshot or key", () => {
+    expect(lookupAttribute(undefined, "SPD")).toBeNull();
+    expect(lookupAttribute(snap({ STR: 70 }), "SPD")).toBeNull();
+  });
+});
+
+describe("presentHeadlineKeys (WSM-000090)", () => {
+  it("includes only keys at least one player has", () => {
+    const snapshots = new Map<string, PlayerSnapshot>([
+      ["p1", snap({ SPD: 90, AWR: 75 })],
+      ["p2", snap({ STR: 88 })],
+    ]);
+    expect(presentHeadlineKeys(snapshots, ["p1", "p2"])).toEqual([
+      "SPD",
+      "STR",
+      "AWR",
+    ]);
+  });
+
+  it("ignores snapshots for players outside the visible set", () => {
+    const snapshots = new Map<string, PlayerSnapshot>([
+      ["hidden", snap({ AGI: 99 })],
+    ]);
+    expect(presentHeadlineKeys(snapshots, ["p1"])).toEqual([]);
+  });
+
+  it("returns empty for no snapshots — no empty stat columns", () => {
+    expect(presentHeadlineKeys(new Map(), ["p1", "p2"])).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/attributes/headline-columns.ts
+++ b/apps/web/src/lib/attributes/headline-columns.ts
@@ -1,0 +1,47 @@
+/**
+ * Madden-style headline attribute columns for the roster table
+ * (WSM-000090). `attributesJson` keys are source-defined (PFF/Madden/
+ * admin uploads), so nothing here is guaranteed to exist — a column
+ * renders only when at least one player in the visible set has the
+ * key. Keys are matched case-insensitively against the snapshot map.
+ */
+
+export interface PlayerSnapshot {
+  weightedOverall: number | null;
+  attributes: Record<string, number>;
+}
+
+/** Generic headline set; per-group tuning is config-only later. */
+export const HEADLINE_ATTRIBUTE_KEYS = [
+  "SPD",
+  "STR",
+  "AGI",
+  "AWR",
+] as const;
+
+export function lookupAttribute(
+  snapshot: PlayerSnapshot | undefined,
+  key: string,
+): number | null {
+  if (!snapshot) return null;
+  const target = key.toLowerCase();
+  for (const [k, v] of Object.entries(snapshot.attributes)) {
+    if (k.toLowerCase() === target) return v;
+  }
+  return null;
+}
+
+/**
+ * The headline keys worth rendering for a set of players: a column
+ * appears only if at least one visible player has a value for it.
+ */
+export function presentHeadlineKeys(
+  snapshots: ReadonlyMap<string, PlayerSnapshot>,
+  playerIds: readonly string[],
+): string[] {
+  return HEADLINE_ATTRIBUTE_KEYS.filter((key) =>
+    playerIds.some(
+      (id) => lookupAttribute(snapshots.get(id), key) !== null,
+    ),
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -230,6 +230,14 @@ const refs = {
       ingestedAt: string;
     }>
   >("sports:getSeasonAttributesByPosition"),
+  getTeamAttributeSnapshots: queryRef<
+    { teamId: string; seasonId: string },
+    Array<{
+      playerId: string;
+      weightedOverall: number | null;
+      attributes: Record<string, number>;
+    }>
+  >("sports:getTeamAttributeSnapshots"),
   getLeagueVisibility: queryRef<
     { leagueId: string },
     { isPublic: boolean } | null
@@ -516,6 +524,28 @@ export async function getPlayersByTeam(
   const teamLeagueId = await getTeamLeagueId(teamId);
   requireLeagueAccessLocal(teamLeagueId, orgContext);
   return queryConvex(refs.listPlayersByTeam, { teamId });
+}
+
+/** WSM-000090: playerId → snapshot map for the roster stat columns. */
+export async function getTeamAttributeSnapshots(
+  teamId: string,
+  seasonId: string,
+  orgContext: OrgContext,
+): Promise<
+  Map<string, { weightedOverall: number | null; attributes: Record<string, number> }>
+> {
+  const teamLeagueId = await getTeamLeagueId(teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  const rows = await queryConvex(refs.getTeamAttributeSnapshots, {
+    teamId,
+    seasonId,
+  });
+  return new Map(
+    rows.map((r) => [
+      r.playerId,
+      { weightedOverall: r.weightedOverall, attributes: r.attributes },
+    ]),
+  );
 }
 
 export async function getSeasons(


### PR DESCRIPTION
Closes #196. **Do not merge until preview QA passes** — this is the preview-testing route agreed on the issue (flags default on in previews per WSM-000078).

## Summary
- New `sports:getTeamAttributeSnapshots` Convex query: per-player point reads over `by_playerId_seasonId` for the league's active season; access-checked in data-api like `getPlayersByTeam`
- Roster table gains **OVR** (weightedOverall, sortable, accent-styled) + headline attribute columns (**SPD/STR/AGI/AWR**) — a column renders only if at least one teammate has the key (`attributesJson` keys are source-defined); em dash per missing player
- Strictly additive: with `player_attributes_v1` off or no ingested snapshots, the table is byte-identical to today (no empty stat columns)
- Slot column continues to show depth order even when sorted by OVR

## Preview QA setup (already done)
- Dev Convex deployment (`laudable-reindeer-759`) has the new functions, an **active 2026 NFL Season**, and **91 sample snapshots for the Arizona Cardinals** (deterministic SPD/STR/AGI/AWR + OVR)
- Branch-scoped `NEXT_PUBLIC_CONVEX_URL` (preview) → dev deployment
- Outstanding: `CONVEX_ADMIN_KEY` (preview) — dev-deployment deploy key, then redeploy the preview

## Test plan
- [x] type-check, 290 unit tests (+5 headline-columns), lint (pre-existing warning only)
- [ ] Preview: Cardinals roster shows OVR + stat columns on every tab; sorting by OVR works; Test Hawks (no snapshots) unchanged; 375px → columns scroll in-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)