### PR TITLE
feat(web): weekly SPRT rating refresh cron (WSM-000092)

### DIFF
--- a/apps/web/scripts/ingest-sprt-ratings.mts
+++ b/apps/web/scripts/ingest-sprt-ratings.mts
@@ -1,29 +1,25 @@
 /**
- * SPRT Rating ingest (WSM-000091).
+ * SPRT Rating ingest — CLI form (WSM-000091/92).
  *
- * Pulls a completed season's open NFL data from nflverse (player_stats +
- * rosters — published release assets, not scraped), computes our own SPRT
- * ratings, matches nflverse players to our roster via ESPN id, and loads
- * them through ingestPlayerAttributesBatch. Dry-run by default; pass
- * --write to actually ingest.
+ * Ad-hoc / specific-season ingest. The weekly automated refresh lives in
+ * the cron (src/app/api/cron/sprt-refresh); both share the rating engine
+ * in src/lib/ratings. Pulls a season's open nflverse data, computes SPRT
+ * ratings, matches to our roster via ESPN id, and loads through
+ * ingestPlayerAttributesBatch. Dry-run by default; pass --write.
  *
  * Usage:
  *   npx tsx apps/web/scripts/ingest-sprt-ratings.mts \
  *     --season-id <convexSeasonId> --league-id <convexLeagueId> \
- *     --data-year 2024 [--prod] [--write]
- *
- * Player → ESPN id: our players store ESPN headshot URLs like
- * .../full/4870808.png; nflverse rosters carry espn_id. We join on that,
- * falling back to normalized name within the same team.
+ *     [--data-year 2025] [--write]
+ *   (NEXT_PUBLIC_CONVEX_URL env points at the target deployment.)
  */
 import { ConvexHttpClient } from "convex/browser";
 import {
-  computeSprtRatings,
-  type SeasonStatLine,
-  type RatingPositionGroup,
-} from "../src/lib/ratings/sprt.js";
-
-const NFLVERSE = "https://github.com/nflverse/nflverse-data/releases/download";
+  fetchSprtRatingsByEspnId,
+  resolveLatestDataYear,
+  espnIdFromHeadshot,
+  ATTR_GROUP,
+} from "../src/lib/ratings/nflverse.js";
 
 function arg(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);
@@ -33,161 +29,44 @@ const has = (name: string) => process.argv.includes(`--${name}`);
 
 const SEASON_ID = arg("season-id");
 const LEAGUE_ID = arg("league-id");
-// Default to the most recent completed season. nflverse publishes the
-// unified stats_player_week_<year>.csv (offense + defense in one file)
-// for 2025+; older years used separate player_stats files.
-const DATA_YEAR = arg("data-year") ?? "2025";
 const WRITE = has("write");
 
 if (!SEASON_ID || !LEAGUE_ID) {
   console.error("Required: --season-id <id> --league-id <id>");
   process.exit(1);
 }
-
 const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
-const ADMIN_KEY = process.env.CONVEX_ADMIN_KEY;
 if (!CONVEX_URL) {
   console.error("NEXT_PUBLIC_CONVEX_URL is required.");
   process.exit(1);
 }
 
-const GROUP_MAP: Record<string, RatingPositionGroup> = {
-  QB: "QB",
-  RB: "RB", HB: "RB", FB: "RB",
-  WR: "WR",
-  TE: "TE",
-  DE: "DL", DT: "DL", NT: "DL", EDGE: "DL", DL: "DL",
-  OLB: "LB", MLB: "LB", ILB: "LB", LB: "LB",
-  CB: "DB", S: "DB", FS: "DB", SS: "DB", NB: "DB", DB: "DB",
-};
-
-const ATTR_GROUP: Record<RatingPositionGroup, string> = {
-  QB: "QB", RB: "RB", WR: "WR", TE: "TE", DL: "DL", LB: "LB", DB: "DB",
-};
-
-function parseCsv(text: string): Record<string, string>[] {
-  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
-  const headers = splitCsvLine(lines[0]);
-  return lines.slice(1).map((line) => {
-    const cells = splitCsvLine(line);
-    const row: Record<string, string> = {};
-    headers.forEach((h, i) => (row[h] = cells[i] ?? ""));
-    return row;
-  });
-}
-
-function splitCsvLine(line: string): string[] {
-  const out: string[] = [];
-  let cur = "";
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') {
-      if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; }
-      else inQuotes = !inQuotes;
-    } else if (ch === "," && !inQuotes) { out.push(cur); cur = ""; }
-    else cur += ch;
-  }
-  out.push(cur);
-  return out;
-}
-
-async function fetchCsv(url: string): Promise<Record<string, string>[]> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`nflverse fetch ${res.status}: ${url}`);
-  return parseCsv(await res.text());
-}
-
-const num = (s: string | undefined) => {
-  const n = Number(s);
-  return Number.isFinite(n) ? n : 0;
-};
-
-const normName = (s: string) =>
-  s.toLowerCase().replace(/[^a-z]/g, "");
-
-const espnIdFromHeadshot = (url: string | null): string | null => {
-  if (!url) return null;
-  const m = url.match(/\/(\d+)\.png/);
-  return m ? m[1] : null;
-};
-
 async function main() {
-  console.log(`SPRT ingest — data year ${DATA_YEAR}, ${WRITE ? "WRITE" : "DRY RUN"}`);
-
-  // 1. nflverse data — unified weekly stats (offense + defense) + rosters
-  const [weekly, rosters] = await Promise.all([
-    fetchCsv(`${NFLVERSE}/stats_player/stats_player_week_${DATA_YEAR}.csv`),
-    fetchCsv(`${NFLVERSE}/rosters/roster_${DATA_YEAR}.csv`),
-  ]);
-  console.log(`nflverse: ${weekly.length} weekly stat rows, ${rosters.length} roster rows`);
-
-  // 2. espn_id → gsis_id (player_id) from rosters
-  const gsisToEspn = new Map<string, string>();
-  for (const r of rosters) {
-    if (r.gsis_id && r.espn_id) gsisToEspn.set(r.gsis_id, r.espn_id);
+  const dataYear =
+    Number(arg("data-year")) ||
+    (await resolveLatestDataYear(new Date().getUTCFullYear()));
+  if (!dataYear) {
+    console.error("No nflverse season data found.");
+    process.exit(1);
   }
+  console.log(`SPRT ingest — data year ${dataYear}, ${WRITE ? "WRITE" : "DRY RUN"}`);
 
-  // 3. aggregate season stat lines per gsis player_id
-  const lines = new Map<string, SeasonStatLine & { position: string }>();
-  const acc = (id: string, pos: string) => {
-    let l = lines.get(id);
-    if (!l) { l = { games: 0, position: pos } as SeasonStatLine & { position: string }; lines.set(id, l); }
-    return l;
-  };
-  // Unified file: one row per player per week carries both offense and
-  // defense columns. We count a game once and accumulate every stat.
-  for (const r of weekly) {
-    if (r.season_type !== "REG") continue;
-    const l = acc(r.player_id, r.position);
-    l.games += 1;
-    l.passingEpa = (l.passingEpa ?? 0) + num(r.passing_epa);
-    l.passingYards = (l.passingYards ?? 0) + num(r.passing_yards);
-    l.passingTds = (l.passingTds ?? 0) + num(r.passing_tds);
-    l.interceptions = (l.interceptions ?? 0) + num(r.passing_interceptions);
-    l.carries = (l.carries ?? 0) + num(r.carries);
-    l.rushingYards = (l.rushingYards ?? 0) + num(r.rushing_yards);
-    l.rushingTds = (l.rushingTds ?? 0) + num(r.rushing_tds);
-    l.rushingEpa = (l.rushingEpa ?? 0) + num(r.rushing_epa);
-    l.receptions = (l.receptions ?? 0) + num(r.receptions);
-    l.targets = (l.targets ?? 0) + num(r.targets);
-    l.receivingYards = (l.receivingYards ?? 0) + num(r.receiving_yards);
-    l.receivingTds = (l.receivingTds ?? 0) + num(r.receiving_tds);
-    l.receivingEpa = (l.receivingEpa ?? 0) + num(r.receiving_epa);
-    l.receivingYac = (l.receivingYac ?? 0) + num(r.receiving_yards_after_catch);
-    // 2025 splits tackles into solo + assists (no single def_tackles).
-    l.defTackles =
-      (l.defTackles ?? 0) + num(r.def_tackles_solo) + num(r.def_tackle_assists);
-    l.defSacks = (l.defSacks ?? 0) + num(r.def_sacks);
-    l.defQbHits = (l.defQbHits ?? 0) + num(r.def_qb_hits);
-    l.defInterceptions = (l.defInterceptions ?? 0) + num(r.def_interceptions);
-    l.defPassDefended = (l.defPassDefended ?? 0) + num(r.def_pass_defended);
-    l.defTacklesForLoss = (l.defTacklesForLoss ?? 0) + num(r.def_tackles_for_loss);
-  }
+  const ratings = await fetchSprtRatingsByEspnId(dataYear);
+  console.log(`computed ${ratings.size} SPRT ratings (by espn_id)`);
 
-  // 4. build rating inputs keyed by espn_id
-  const byEspn = new Map<string, { group: RatingPositionGroup; stats: SeasonStatLine }>();
-  for (const [gsis, line] of lines) {
-    const espn = gsisToEspn.get(gsis);
-    const group = GROUP_MAP[(line.position ?? "").toUpperCase()];
-    if (!espn || !group) continue;
-    byEspn.set(espn, { group, stats: line });
-  }
-  const ratings = computeSprtRatings(
-    [...byEspn.entries()].map(([id, v]) => ({ id, group: v.group, stats: v.stats })),
-  );
-  console.log(`computed ${ratings.size} SPRT ratings (qualified, by espn_id)`);
-
-  // 5. match to our roster
   const client = new ConvexHttpClient(CONVEX_URL);
-  if (ADMIN_KEY) (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(ADMIN_KEY);
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+  if (adminKey) {
+    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  }
   const teams = (await client.query("sports:listTeamsByLeague" as never, { leagueId: LEAGUE_ID } as never)) as { id: string }[];
 
   const rows: { playerId: string; positionGroup: string; attributesJson: string; weightedOverall: number | null }[] = [];
-  let matched = 0, unmatched = 0;
+  let matched = 0;
+  let unmatched = 0;
   for (const team of teams) {
     const players = (await client.query("sports:listPlayersByTeam" as never, { teamId: team.id } as never)) as {
-      id: string; name: string; headshotUrl: string | null;
+      id: string; headshotUrl: string | null;
     }[];
     for (const p of players) {
       const espn = espnIdFromHeadshot(p.headshotUrl);
@@ -203,22 +82,20 @@ async function main() {
     }
   }
   console.log(`matched ${matched} players, ${unmatched} without a rating (em dash)`);
-  const sample = rows.slice(0, 5).map((r) => `${r.weightedOverall} ${r.positionGroup}`);
-  console.log("sample overalls:", sample.join(", "));
 
   if (!WRITE) {
     console.log("DRY RUN — pass --write to ingest. No data written.");
     return;
   }
-  let created = 0, updated = 0;
+  const cleared = (await client.mutation("sports:clearSeasonPlayerAttributes" as never, { seasonId: SEASON_ID } as never)) as { deleted: number };
+  let written = 0;
   for (let i = 0; i < rows.length; i += 500) {
-    const chunk = rows.slice(i, i + 500);
     const res = (await client.mutation("sports:ingestPlayerAttributesBatch" as never, {
-      seasonId: SEASON_ID, rows: chunk,
+      seasonId: SEASON_ID, rows: rows.slice(i, i + 500),
     } as never)) as { created: number; updated: number };
-    created += res.created; updated += res.updated;
+    written += res.created + res.updated;
   }
-  console.log(`INGESTED created=${created} updated=${updated}`);
+  console.log(`cleared ${cleared.deleted}, wrote ${written}`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/apps/web/src/app/api/cron/sprt-refresh/route.ts
+++ b/apps/web/src/app/api/cron/sprt-refresh/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+import { refreshSprtRatings } from "@/lib/ratings/sprt-refresh";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 min — nflverse fetch + per-league ingest
+
+/**
+ * Weekly SPRT rating refresh (WSM-000092). Pulls the latest nflverse
+ * season and recomputes ratings for every public league's active
+ * season. Bearer-auth via CRON_SECRET, matching the nfl-sync cron.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const report = await refreshSprtRatings();
+    console.log(
+      JSON.stringify({ level: "info", route: "/api/cron/sprt-refresh", report }),
+    );
+    return Response.json(report);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        route: "/api/cron/sprt-refresh",
+        message: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return new Response("SPRT refresh failed", { status: 500 });
+  }
+}

--- a/apps/web/src/lib/__tests__/sprt-refresh.test.ts
+++ b/apps/web/src/lib/__tests__/sprt-refresh.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Convex client + nflverse fetch so we test the orchestrator's
+// branching (skip-on-no-matches, clear-then-write) without network/DB.
+const queryMock = vi.fn();
+const mutationMock = vi.fn();
+vi.mock("../convex-client", () => ({
+  getConvexClient: () => ({ query: queryMock, mutation: mutationMock }),
+}));
+
+const ratingsByEspn = new Map([
+  ["111", { positionGroup: "QB" as const, overall: 88, attributes: { efficiency: 90 } }],
+]);
+vi.mock("../ratings/nflverse", async (orig) => {
+  const actual = (await orig()) as object;
+  return {
+    ...actual,
+    resolveLatestDataYear: vi.fn(async () => 2025),
+    fetchSprtRatingsByEspnId: vi.fn(async () => ratingsByEspn),
+  };
+});
+
+import { refreshSprtRatings } from "../ratings/sprt-refresh";
+
+beforeEach(() => {
+  queryMock.mockReset();
+  mutationMock.mockReset();
+});
+
+function wireQueries(opts: {
+  leagues: { id: string; name: string }[];
+  seasons: Record<string, { id: string; status: string }[]>;
+  teams: Record<string, { id: string }[]>;
+  players: Record<string, { id: string; headshotUrl: string | null }[]>;
+}) {
+  queryMock.mockImplementation((_ref: unknown, args: Record<string, unknown>) => {
+    if (args && "leagueIds" in args) return opts.seasons[(args.leagueIds as string[])[0]] ?? [];
+    if (args && "leagueId" in args) return opts.teams[args.leagueId as string] ?? [];
+    if (args && "teamId" in args) return opts.players[args.teamId as string] ?? [];
+    return opts.leagues; // listPublicLeagues ({} args)
+  });
+}
+
+describe("refreshSprtRatings (WSM-000092)", () => {
+  it("clears and writes for a league with matches", async () => {
+    wireQueries({
+      leagues: [{ id: "L1", name: "NFL" }],
+      seasons: { L1: [{ id: "S1", status: "active" }] },
+      teams: { L1: [{ id: "T1" }] },
+      players: {
+        T1: [
+          { id: "p1", headshotUrl: "https://a.espncdn.com/i/headshots/nfl/players/full/111.png" },
+          { id: "p2", headshotUrl: "https://a.espncdn.com/i/headshots/nfl/players/full/999.png" },
+        ],
+      },
+    });
+    mutationMock.mockImplementation((_ref: unknown, args: Record<string, unknown>) =>
+      "rows" in args ? { created: (args.rows as unknown[]).length, updated: 0 } : { deleted: 5 },
+    );
+
+    const report = await refreshSprtRatings(new Date(Date.UTC(2026, 5, 12)));
+    expect(report.dataYear).toBe(2025);
+    expect(report.leagues[0].matched).toBe(1); // only p1's espn id (111) has a rating
+    expect(report.leagues[0].cleared).toBe(5);
+    expect(report.leagues[0].written).toBe(1);
+  });
+
+  it("skips a league with zero matches without clearing", async () => {
+    wireQueries({
+      leagues: [{ id: "L2", name: "Rec League" }],
+      seasons: { L2: [{ id: "S2", status: "active" }] },
+      teams: { L2: [{ id: "T9" }] },
+      players: { T9: [{ id: "x", headshotUrl: null }] },
+    });
+
+    const report = await refreshSprtRatings(new Date(Date.UTC(2026, 5, 12)));
+    expect(report.leagues[0].skipped).toBe("no nflverse matches");
+    expect(report.leagues[0].cleared).toBe(0);
+    expect(mutationMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a league with no season", async () => {
+    wireQueries({
+      leagues: [{ id: "L3", name: "Empty" }],
+      seasons: { L3: [] },
+      teams: {},
+      players: {},
+    });
+    const report = await refreshSprtRatings(new Date(Date.UTC(2026, 5, 12)));
+    expect(report.leagues[0].skipped).toBe("no season");
+    expect(mutationMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -127,6 +127,22 @@ const refs = {
     { name: string; orgId: string | null },
     { dto: LeagueDto; created: boolean }
   >("sports:upsertLeague"),
+  clearSeasonPlayerAttributes: mutationRef<
+    { seasonId: string },
+    { deleted: number }
+  >("sports:clearSeasonPlayerAttributes"),
+  ingestPlayerAttributesBatch: mutationRef<
+    {
+      seasonId: string;
+      rows: Array<{
+        playerId: string;
+        positionGroup: string;
+        attributesJson: string;
+        weightedOverall: number | null;
+      }>;
+    },
+    { created: number; updated: number }
+  >("sports:ingestPlayerAttributesBatch"),
   upsertDivision: mutationRef<
     { name: string; leagueId: string },
     { dto: DivisionDto; created: boolean }

--- a/apps/web/src/lib/ratings/nflverse.ts
+++ b/apps/web/src/lib/ratings/nflverse.ts
@@ -1,0 +1,165 @@
+/**
+ * nflverse data acquisition for the SPRT rating engine (WSM-000091/92).
+ *
+ * Fetches a season's open, permissively-licensed NFL production data
+ * (published release assets — not scraped) and computes SPRT ratings
+ * keyed by ESPN player id, so callers can join to our ESPN-sourced
+ * roster. Shared by the CLI ingest script and the weekly cron.
+ */
+import {
+  computeSprtRatings,
+  type SeasonStatLine,
+  type RatingPositionGroup,
+  type SprtRating,
+} from "./sprt";
+
+const NFLVERSE =
+  "https://github.com/nflverse/nflverse-data/releases/download";
+
+const GROUP_MAP: Record<string, RatingPositionGroup> = {
+  QB: "QB",
+  RB: "RB", HB: "RB", FB: "RB",
+  WR: "WR",
+  TE: "TE",
+  DE: "DL", DT: "DL", NT: "DL", EDGE: "DL", DL: "DL",
+  OLB: "LB", MLB: "LB", ILB: "LB", LB: "LB",
+  CB: "DB", S: "DB", FS: "DB", SS: "DB", NB: "DB", DB: "DB",
+};
+
+/** Roster `attributes.positionGroup` literals (K/P excluded from SPRT). */
+export const ATTR_GROUP: Record<RatingPositionGroup, string> = {
+  QB: "QB", RB: "RB", WR: "WR", TE: "TE", DL: "DL", LB: "LB", DB: "DB",
+};
+
+/** Our players store ESPN headshot URLs like .../full/4870808.png. */
+export function espnIdFromHeadshot(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const m = url.match(/\/(\d+)\.png/);
+  return m ? m[1] : null;
+}
+
+function splitCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; }
+      else inQuotes = !inQuotes;
+    } else if (ch === "," && !inQuotes) { out.push(cur); cur = ""; }
+    else cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) return [];
+  const headers = splitCsvLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, i) => (row[h] = cells[i] ?? ""));
+    return row;
+  });
+}
+
+async function fetchCsv(url: string): Promise<Record<string, string>[] | null> {
+  const res = await fetch(url);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`nflverse fetch ${res.status}: ${url}`);
+  return parseCsv(await res.text());
+}
+
+const num = (s: string | undefined) => {
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * The latest nflverse season year whose unified weekly stats asset
+ * exists, probing `currentYear` then `currentYear - 1`. In-season the
+ * current year is present and grows weekly; off-season it falls back to
+ * the prior completed season. Returns null if neither exists.
+ */
+export async function resolveLatestDataYear(
+  currentYear: number,
+): Promise<number | null> {
+  for (const year of [currentYear, currentYear - 1]) {
+    const res = await fetch(
+      `${NFLVERSE}/stats_player/stats_player_week_${year}.csv`,
+      { method: "HEAD" },
+    );
+    if (res.ok) return year;
+  }
+  return null;
+}
+
+/**
+ * Fetches the season's data and returns SPRT ratings keyed by ESPN id.
+ */
+export async function fetchSprtRatingsByEspnId(
+  dataYear: number,
+): Promise<Map<string, SprtRating>> {
+  const [weekly, rosters] = await Promise.all([
+    fetchCsv(`${NFLVERSE}/stats_player/stats_player_week_${dataYear}.csv`),
+    fetchCsv(`${NFLVERSE}/rosters/roster_${dataYear}.csv`),
+  ]);
+  if (!weekly || !rosters) {
+    throw new Error(`nflverse data missing for ${dataYear}`);
+  }
+
+  const gsisToEspn = new Map<string, string>();
+  for (const r of rosters) {
+    if (r.gsis_id && r.espn_id) gsisToEspn.set(r.gsis_id, r.espn_id);
+  }
+
+  const lines = new Map<string, SeasonStatLine & { position: string }>();
+  const acc = (id: string, pos: string) => {
+    let l = lines.get(id);
+    if (!l) {
+      l = { games: 0, position: pos } as SeasonStatLine & { position: string };
+      lines.set(id, l);
+    }
+    return l;
+  };
+  for (const r of weekly) {
+    if (r.season_type !== "REG") continue;
+    const l = acc(r.player_id, r.position);
+    l.games += 1;
+    l.passingEpa = (l.passingEpa ?? 0) + num(r.passing_epa);
+    l.passingYards = (l.passingYards ?? 0) + num(r.passing_yards);
+    l.passingTds = (l.passingTds ?? 0) + num(r.passing_tds);
+    l.interceptions = (l.interceptions ?? 0) + num(r.passing_interceptions);
+    l.carries = (l.carries ?? 0) + num(r.carries);
+    l.rushingYards = (l.rushingYards ?? 0) + num(r.rushing_yards);
+    l.rushingTds = (l.rushingTds ?? 0) + num(r.rushing_tds);
+    l.rushingEpa = (l.rushingEpa ?? 0) + num(r.rushing_epa);
+    l.receptions = (l.receptions ?? 0) + num(r.receptions);
+    l.targets = (l.targets ?? 0) + num(r.targets);
+    l.receivingYards = (l.receivingYards ?? 0) + num(r.receiving_yards);
+    l.receivingTds = (l.receivingTds ?? 0) + num(r.receiving_tds);
+    l.receivingEpa = (l.receivingEpa ?? 0) + num(r.receiving_epa);
+    l.receivingYac =
+      (l.receivingYac ?? 0) + num(r.receiving_yards_after_catch);
+    l.defTackles =
+      (l.defTackles ?? 0) + num(r.def_tackles_solo) + num(r.def_tackle_assists);
+    l.defSacks = (l.defSacks ?? 0) + num(r.def_sacks);
+    l.defQbHits = (l.defQbHits ?? 0) + num(r.def_qb_hits);
+    l.defInterceptions = (l.defInterceptions ?? 0) + num(r.def_interceptions);
+    l.defPassDefended = (l.defPassDefended ?? 0) + num(r.def_pass_defended);
+    l.defTacklesForLoss =
+      (l.defTacklesForLoss ?? 0) + num(r.def_tackles_for_loss);
+  }
+
+  const inputs: { id: string; group: RatingPositionGroup; stats: SeasonStatLine }[] = [];
+  for (const [gsis, line] of lines) {
+    const espn = gsisToEspn.get(gsis);
+    const group = GROUP_MAP[(line.position ?? "").toUpperCase()];
+    if (!espn || !group) continue;
+    inputs.push({ id: espn, group, stats: line });
+  }
+  return computeSprtRatings(inputs);
+}

--- a/apps/web/src/lib/ratings/sprt-refresh.ts
+++ b/apps/web/src/lib/ratings/sprt-refresh.ts
@@ -1,0 +1,151 @@
+/**
+ * SPRT refresh orchestrator (WSM-000092) — the server-side form of the
+ * CLI ingest, driven by the weekly cron. Pulls the latest nflverse
+ * season, then for each public league's active season: matches players
+ * by ESPN id, and (only when there are matches) clears the season's
+ * snapshots and writes fresh SPRT ratings. Leagues with zero matches —
+ * e.g. non-NFL leagues with admin-uploaded attributes — are skipped
+ * untouched, so the refresh never wipes data it can't replace.
+ */
+import { getConvexClient } from "../convex-client";
+import { makeFunctionReference } from "convex/server";
+import type { LeagueDto, SeasonDto, TeamDto, PlayerDto } from "@sports-management/shared-types";
+import {
+  fetchSprtRatingsByEspnId,
+  resolveLatestDataYear,
+  espnIdFromHeadshot,
+  ATTR_GROUP,
+} from "./nflverse";
+
+export interface SprtRefreshReport {
+  dataYear: number | null;
+  leagues: Array<{
+    leagueId: string;
+    leagueName: string;
+    seasonId: string | null;
+    matched: number;
+    cleared: number;
+    written: number;
+    skipped?: string;
+  }>;
+}
+
+type IngestRow = {
+  playerId: string;
+  positionGroup: string;
+  attributesJson: string;
+  weightedOverall: number | null;
+};
+
+export async function refreshSprtRatings(
+  now: Date = new Date(),
+): Promise<SprtRefreshReport> {
+  const client = getConvexClient();
+  const q = <A, R>(name: string, args: A) =>
+    (client as unknown as { query: (r: unknown, a: unknown) => Promise<R> }).query(
+      makeFunctionReference<"query">(name),
+      args,
+    );
+  const m = <A, R>(name: string, args: A) =>
+    (client as unknown as { mutation: (r: unknown, a: unknown) => Promise<R> }).mutation(
+      makeFunctionReference<"mutation">(name),
+      args,
+    );
+
+  const dataYear = await resolveLatestDataYear(now.getUTCFullYear());
+  const report: SprtRefreshReport = { dataYear, leagues: [] };
+  if (dataYear === null) return report;
+
+  const ratings = await fetchSprtRatingsByEspnId(dataYear);
+
+  const leagues = await q<Record<string, never>, LeagueDto[]>(
+    "sports:listPublicLeagues",
+    {},
+  );
+
+  for (const league of leagues) {
+    const seasons = await q<{ leagueIds: string[] }, SeasonDto[]>(
+      "sports:listSeasons",
+      { leagueIds: [league.id] },
+    );
+    const activeSeason =
+      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+    if (!activeSeason) {
+      report.leagues.push({
+        leagueId: league.id,
+        leagueName: league.name,
+        seasonId: null,
+        matched: 0,
+        cleared: 0,
+        written: 0,
+        skipped: "no season",
+      });
+      continue;
+    }
+
+    const teams = await q<{ leagueId: string }, TeamDto[]>(
+      "sports:listTeamsByLeague",
+      { leagueId: league.id },
+    );
+    const rows: IngestRow[] = [];
+    for (const team of teams) {
+      const players = await q<{ teamId: string }, PlayerDto[]>(
+        "sports:listPlayersByTeam",
+        { teamId: team.id },
+      );
+      for (const p of players) {
+        const espn = espnIdFromHeadshot(p.headshotUrl);
+        const rating = espn ? ratings.get(espn) : undefined;
+        if (!rating) continue;
+        rows.push({
+          playerId: p.id,
+          positionGroup: ATTR_GROUP[rating.positionGroup],
+          attributesJson: JSON.stringify({ ...rating.attributes, OVR: rating.overall }),
+          weightedOverall: rating.overall,
+        });
+      }
+    }
+
+    // No matches → not an NFL-synced league; leave its data alone.
+    if (rows.length === 0) {
+      report.leagues.push({
+        leagueId: league.id,
+        leagueName: league.name,
+        seasonId: activeSeason.id,
+        matched: 0,
+        cleared: 0,
+        written: 0,
+        skipped: "no nflverse matches",
+      });
+      continue;
+    }
+
+    const { deleted } = await m<{ seasonId: string }, { deleted: number }>(
+      "sports:clearSeasonPlayerAttributes",
+      { seasonId: activeSeason.id },
+    );
+    let written = 0;
+    for (let i = 0; i < rows.length; i += 500) {
+      const chunk = rows.slice(i, i + 500);
+      const res = await m<
+        { seasonId: string; rows: IngestRow[] },
+        { created: number; updated: number }
+      >("sports:ingestPlayerAttributesBatch", {
+        seasonId: activeSeason.id,
+        rows: chunk,
+      });
+      written += res.created + res.updated;
+    }
+
+    report.leagues.push({
+      leagueId: league.id,
+      leagueName: league.name,
+      seasonId: activeSeason.id,
+      matched: rows.length,
+      cleared: deleted,
+      written,
+    });
+  }
+
+  return report;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -10,6 +10,10 @@ const isPublicRoute = createRouteMatcher([
   "/api/health",
   "/api/stripe/webhook",
   "/api/webhooks/clerk",
+  // Vercel Cron routes carry no Clerk session — they authenticate via a
+  // CRON_SECRET bearer check inside each handler. Without this, Clerk's
+  // auth.protect() blocks the invocation before that check runs.
+  "/api/cron/(.*)",
   "/join(.*)",
   // Public viewer routes (Phase 2 / WSM-000061). Per-league opt-in via
   // `leagues.isPublic`; the route handlers enforce visibility through

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/nfl-sync",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/sprt-refresh",
+      "schedule": "0 9 * * 2"
     }
   ]
 }


### PR DESCRIPTION
Closes #201 (WSM-000092). Automates the SPRT ratings ingest (#200).

## Summary
- **Cron** `/api/cron/sprt-refresh` at **Tue 09:00 UTC** (after the week's games + the daily roster sync). Pulls the latest nflverse season — `resolveLatestDataYear` probes current year then prior, so it auto-follows seasons — and recomputes ratings for **every public league's active season**.
- **Safe per-league**: matches players by ESPN id; if zero matches (e.g. a non-NFL rec league with admin-uploaded attributes), it **skips without clearing**. Only clears+writes where it has real replacements.
- Extracts nflverse fetch/compute into `lib/ratings/nflverse.ts`, shared by cron and the CLI script — no divergence.
- Structured info/error logging (unattended job).

## Two latent fixes (both blocked the existing nfl-sync cron too)
- `/api/cron/*` was **not** in the Clerk public-route matcher → `auth.protect()` blocked cron invocations before the handler's bearer check. Added.
- `CRON_SECRET` was **never set** in production → Vercel wasn't injecting the auth header, so the handler check 401'd. Generated + added.

## Test plan
- [x] type-check, 299 unit tests (+3 orchestrator: clear+write, skip-no-match, skip-no-season), lint (pre-existing warning only)
- [ ] Post-merge: manually trigger the cron from the Vercel dashboard (or `curl` with the secret) and confirm the report; then the Tuesday run is hands-off