### PR TITLE
feat(web): SPRT rating breakdown on the player profile (WSM-000093)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2060,6 +2060,39 @@ export const getSeasonAttributesByPosition = queryGeneric({
  * UI renders an em dash). Access control lives in the data-api layer
  * (league visibility), matching getPlayersByTeam.
  */
+/*
+ * WSM-000093 — single-player attribute snapshot for the profile rating
+ * breakdown. Point read via by_playerId_seasonId. Access control lives
+ * in the data-api layer, matching getPlayer.
+ */
+export const getPlayerSeasonAttributes = queryGeneric({
+  args: {
+    playerId: v.id("players"),
+    seasonId: v.id("seasons"),
+  },
+  returns: v.union(
+    v.object({
+      weightedOverall: v.union(v.number(), v.null()),
+      attributes: v.record(v.string(), v.number()),
+      positionGroup: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const candidates = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) => q.eq("playerId", args.playerId))
+      .collect();
+    const row = candidates.find((r) => r.seasonId === args.seasonId);
+    if (!row) return null;
+    return {
+      weightedOverall: row.weightedOverall,
+      attributes: safeParseAttributes(row.attributesJson),
+      positionGroup: row.positionGroup,
+    };
+  },
+});
+
 export const getTeamAttributeSnapshots = queryGeneric({
   args: {
     teamId: v.id("teams"),

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -2,9 +2,10 @@ import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import { getPlayer, getTeam } from "@/lib/data-api";
+import { getPlayer, getTeam, getSeasons, getPlayerSeasonAttributes } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { derivePositionGroup } from "@/lib/position-group";
+import { orderedComponents } from "@/lib/ratings/component-labels";
 import { playerAttributesV1 } from "@/lib/flags";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import { Button } from "@/components/ui/8bit/button";
@@ -48,7 +49,27 @@ export default async function PlayerProfilePage({
   const team = await getTeam(player.teamId, orgContext).catch(() => null);
   const positionGroup = derivePositionGroup(player.position);
   const age = player.dateOfBirth ? ageFrom(player.dateOfBirth) : null;
-  const developmentEnabled = await playerAttributesV1();
+  const attributesEnabled = await playerAttributesV1();
+
+  // SPRT rating breakdown (WSM-000093) — the player's snapshot for the
+  // league's active season, when Phase 2 is on. Never blocks the page.
+  let rating: {
+    weightedOverall: number | null;
+    attributes: Record<string, number>;
+  } | null = null;
+  if (attributesEnabled && team) {
+    const seasons = await getSeasons([team.leagueId]).catch(() => []);
+    const activeSeason =
+      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+    if (activeSeason) {
+      rating = await getPlayerSeasonAttributes(
+        playerId,
+        activeSeason.id,
+        orgContext,
+      ).catch(() => null);
+    }
+  }
+  const components = rating ? orderedComponents(rating.attributes) : [];
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -126,7 +147,7 @@ export default async function PlayerProfilePage({
             )}
           </dl>
 
-          {developmentEnabled && (
+          {attributesEnabled && (
             <div className="mt-6">
               <Button asChild variant="outline" size="sm">
                 <Link href={`/dashboard/players/${player.id}/development`}>
@@ -137,6 +158,59 @@ export default async function PlayerProfilePage({
           )}
         </CardContent>
       </Card>
+
+      {rating && (
+        <Card className="mt-6">
+          <CardContent className="pt-6">
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-lg font-semibold text-foreground">
+                SPRT Rating
+              </h3>
+              {rating.weightedOverall != null && (
+                <span className="font-mono text-2xl font-bold text-accent">
+                  {Math.round(rating.weightedOverall)}
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    OVR
+                  </span>
+                </span>
+              )}
+            </div>
+
+            {components.length > 0 && (
+              <dl className="mt-4 space-y-2">
+                {components.map((c) => (
+                  <div key={c.key} className="flex items-center gap-3">
+                    <dt className="w-32 shrink-0 text-sm text-muted-foreground">
+                      {c.label}
+                    </dt>
+                    <div
+                      className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+                      role="meter"
+                      aria-valuenow={Math.round(c.value)}
+                      aria-valuemin={0}
+                      aria-valuemax={99}
+                      aria-label={c.label}
+                    >
+                      <div
+                        className="h-full rounded-full bg-accent"
+                        style={{ width: `${Math.min(100, (c.value / 99) * 100)}%` }}
+                      />
+                    </div>
+                    <dd className="w-8 shrink-0 text-right font-mono text-sm text-foreground">
+                      {Math.round(c.value)}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+
+            <p className="mt-4 text-xs text-muted-foreground">
+              SPRT Rating is our own metric derived from open NFL performance
+              data (nflverse).
+            </p>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/component-labels.test.ts
+++ b/apps/web/src/lib/__tests__/component-labels.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { componentLabel, orderedComponents } from "../ratings/component-labels";
+
+describe("componentLabel (WSM-000093)", () => {
+  it("maps known keys to friendly labels", () => {
+    expect(componentLabel("rushEff")).toBe("Rush Efficiency");
+    expect(componentLabel("ballHawk")).toBe("Ball Hawk");
+    expect(componentLabel("efficiency")).toBe("Efficiency");
+  });
+
+  it("falls back to a split, title-cased label for unknown camelCase keys", () => {
+    expect(componentLabel("redZoneRate")).toBe("Red Zone Rate");
+    expect(componentLabel("snap_share")).toBe("Snap share");
+  });
+});
+
+describe("orderedComponents (WSM-000093)", () => {
+  it("drops OVR and sorts by value descending", () => {
+    const out = orderedComponents({ OVR: 90, coverage: 70, tackling: 88, ballHawk: 60 });
+    expect(out.map((c) => c.key)).toEqual(["tackling", "coverage", "ballHawk"]);
+    expect(out[0].label).toBe("Tackling");
+  });
+
+  it("returns empty for an OVR-only map", () => {
+    expect(orderedComponents({ OVR: 80 })).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -246,6 +246,14 @@ const refs = {
       ingestedAt: string;
     }>
   >("sports:getSeasonAttributesByPosition"),
+  getPlayerSeasonAttributes: queryRef<
+    { playerId: string; seasonId: string },
+    {
+      weightedOverall: number | null;
+      attributes: Record<string, number>;
+      positionGroup: string;
+    } | null
+  >("sports:getPlayerSeasonAttributes"),
   getTeamAttributeSnapshots: queryRef<
     { teamId: string; seasonId: string },
     Array<{
@@ -540,6 +548,23 @@ export async function getPlayersByTeam(
   const teamLeagueId = await getTeamLeagueId(teamId);
   requireLeagueAccessLocal(teamLeagueId, orgContext);
   return queryConvex(refs.listPlayersByTeam, { teamId });
+}
+
+/** WSM-000093: one player's SPRT snapshot for the profile breakdown. */
+export async function getPlayerSeasonAttributes(
+  playerId: string,
+  seasonId: string,
+  orgContext: OrgContext,
+): Promise<{
+  weightedOverall: number | null;
+  attributes: Record<string, number>;
+  positionGroup: string;
+} | null> {
+  const player = await queryConvex(refs.getPlayer, { playerId });
+  if (!player) return null;
+  const teamLeagueId = await getTeamLeagueId(player.teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  return queryConvex(refs.getPlayerSeasonAttributes, { playerId, seasonId });
 }
 
 /** WSM-000090: playerId → snapshot map for the roster stat columns. */

--- a/apps/web/src/lib/ratings/component-labels.ts
+++ b/apps/web/src/lib/ratings/component-labels.ts
@@ -1,0 +1,49 @@
+/**
+ * Human labels for SPRT rating component keys (WSM-000093). The keys are
+ * produced by the rating model (lib/ratings/sprt.ts); this maps them to
+ * display text for the profile breakdown. Unknown keys fall back to a
+ * title-cased / camelCase-split form so a new component never renders as
+ * a raw identifier.
+ */
+const LABELS: Record<string, string> = {
+  efficiency: "Efficiency",
+  production: "Production",
+  scoring: "Scoring",
+  mobility: "Mobility",
+  rushEff: "Rush Efficiency",
+  volume: "Volume",
+  receiving: "Receiving",
+  explosiveness: "Explosiveness",
+  hands: "Hands",
+  passRush: "Pass Rush",
+  pressure: "Pressure",
+  runStop: "Run Stop",
+  tackling: "Tackling",
+  coverage: "Coverage",
+  ballHawk: "Ball Hawk",
+  OVR: "Overall",
+};
+
+export function componentLabel(key: string): string {
+  const known = LABELS[key];
+  if (known) return known;
+  const spaced = key
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Orders component entries for display: OVR is handled separately by the
+ * caller, so this drops it and sorts the rest by value descending (the
+ * player's strengths first).
+ */
+export function orderedComponents(
+  attributes: Record<string, number>,
+): Array<{ key: string; label: string; value: number }> {
+  return Object.entries(attributes)
+    .filter(([key]) => key !== "OVR")
+    .map(([key, value]) => ({ key, label: componentLabel(key), value }))
+    .sort((a, b) => b.value - a.value);
+}


### PR DESCRIPTION
Closes #203.

## Summary
- Player profile gains an **SPRT Rating** card: OVR + each component (Efficiency, Coverage, Rush Efficiency, Ball Hawk, …) as a labeled 0–99 bar, sorted strengths-first
- New `getPlayerSeasonAttributes` point read (by_playerId_seasonId) + access-checked data-api wrapper
- `lib/ratings/component-labels.ts` humanizes the model's keys; unknown keys split camelCase + title-case so nothing ever renders raw
- Phase 2-gated, resolved against the league's active season; **renders nothing** when flag off / no season / unrated player — rest of profile unchanged
- nflverse attribution note, matching the roster table

## Test plan
- [x] type-check, 303 unit tests (+4 component-labels), lint (pre-existing warning only); query deployed to both Convex deployments
- [ ] Post-merge: open an Eagles player (e.g. DeVonta Smith) → OVR 89 with Efficiency/Volume/Explosiveness/Hands bars; an unrated player shows no card

🤖 Generated with [Claude Code](https://claude.com/claude-code)