### PR TITLE
Mobile depth-chart touch drag, starter-first slots, responsive dev chart (WSM-000085)

### DIFF
--- a/apps/web/e2e/tests/coach-depth-chart.spec.ts
+++ b/apps/web/e2e/tests/coach-depth-chart.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { TEAMS } from "../helpers/test-data";
+import {
+  withRosterFixture,
+  getTestOrgId,
+  type RosterFixtureResult,
+} from "../helpers/seed-roster";
+import { signInTestUser } from "../helpers/clerk-signin";
 
 test.describe("Depth Chart (WSM-000007)", () => {
   test.beforeEach(async ({ page }) => {
@@ -22,6 +28,64 @@ test.describe("Depth Chart (WSM-000007)", () => {
       name: /404|Not Found|Page not found/i,
     });
     await expect(notFoundHeading).toHaveCount(0);
+  });
+});
+
+// WSM-000085: on a phone the depth-chart board must be usable by touch — the
+// drag handles need to render and meet the 44px minimum touch target. The
+// reorder gesture itself is a 200ms press-and-hold (TouchSensor); we assert
+// the handles are present and tappable rather than simulating the hold, which
+// is brittle across engines.
+const PHONE = { width: 375, height: 812 };
+
+test.describe.serial("Depth Chart — mobile touch targets (WSM-000085)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withRosterFixture({
+      fixtureKey: "depth-chart-mobile",
+      clerkOrgId: orgId,
+      teamName: "E2E Depth Chart Mobile Team",
+      rosterLimit: 53,
+      seedActivePlayers: 3,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await setupClerkTestingToken({ page });
+    await signInTestUser(page);
+  });
+
+  test("drag handles render and meet the 44px touch target", async ({
+    page,
+  }) => {
+    await page.goto(`/dashboard/teams/${fixture!.teamId}/depth-chart`);
+    await page.waitForLoadState("networkidle");
+
+    const handles = page.getByRole("button", { name: /^Drag / });
+    await expect(handles.first()).toBeVisible();
+    expect(await handles.count()).toBeGreaterThanOrEqual(3);
+
+    // Every handle must be at least 44px in both dimensions.
+    const count = await handles.count();
+    for (let i = 0; i < count; i++) {
+      const box = await handles.nth(i).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+    }
   });
 
   test.fixme(

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -8,6 +8,7 @@ import TeamEditForm from "../../_components/team-edit-form";
 import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
 import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
+import { orderByDepth } from "@/lib/roster/depth-order";
 import { StatusBadge } from "@/components/status-badge";
 import { abbreviateName } from "@/lib/position-group";
 import {
@@ -84,6 +85,10 @@ export default function TeamManagement({
     snapshots,
     players.map((p) => p.id),
   );
+
+  // Depth order for a position group (slot 1 = starter) keyed off SPRT OVR.
+  const depthOvr = (p: PlayerDto) =>
+    snapshots.get(p.id)?.weightedOverall ?? null;
 
   function buildColumns(withSlot: boolean): Column<RosterRow>[] {
     return [
@@ -240,7 +245,10 @@ export default function TeamManagement({
               data={
                 (activeTab === "All"
                   ? groupPlayers
-                  : groupPlayers.map((p, i) => ({ ...p, slot: i + 1 }))) as RosterRow[]
+                  : orderByDepth(groupPlayers, depthOvr).map((p, i) => ({
+                      ...p,
+                      slot: i + 1,
+                    }))) as RosterRow[]
               }
               columns={buildColumns(activeTab !== "All")}
               searchPlaceholder="Search players..."

--- a/apps/web/src/components/attributes/PixelLineChart.tsx
+++ b/apps/web/src/components/attributes/PixelLineChart.tsx
@@ -46,10 +46,10 @@ export default function PixelLineChart({
   if (points.length === 0) {
     return (
       <svg
-        width={width}
-        height={height}
+        viewBox={`0 0 ${width} ${height}`}
         role="img"
         aria-label={ariaLabel}
+        className="h-auto w-full"
         style={{ imageRendering: "pixelated" }}
       >
         <rect
@@ -99,10 +99,10 @@ export default function PixelLineChart({
 
   return (
     <svg
-      width={width}
-      height={height}
+      viewBox={`0 0 ${width} ${height}`}
       role="img"
       aria-label={ariaLabel}
+      className="h-auto w-full"
       style={{ imageRendering: "pixelated" }}
     >
       {/* Plot area background */}

--- a/apps/web/src/components/depth-chart/PositionColumn.tsx
+++ b/apps/web/src/components/depth-chart/PositionColumn.tsx
@@ -5,7 +5,8 @@ import {
   DndContext,
   closestCenter,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -43,8 +44,19 @@ export default function PositionColumn({
   const [items, setItems] = useState<PlayerDto[]>(players);
   const [pending, startTransition] = useTransition();
 
+  // A single PointerSensor can't tell a drag from a scroll on a touchscreen,
+  // so on a phone the board either refused to pick up players or hijacked the
+  // page scroll (WSM-000085). Split the sensors: mouse drags start instantly
+  // after a tiny move, while touch requires a 200ms press-and-hold — that hold
+  // distinguishes "pick up this player" from "scroll the list", and dnd-kit
+  // manages touch-action during the delay so the page still scrolls normally.
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 8 },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
@@ -148,7 +160,11 @@ function SortableRow({
     >
       <button
         type="button"
-        className={`text-muted-foreground ${disabled ? "cursor-not-allowed opacity-40" : "cursor-grab active:cursor-grabbing hover:text-muted-foreground"}`}
+        // 44px touch target (WSM-000085): the grip icon stays small, but the
+        // hit area is a full 44px square pulled back with -my-2 so the row
+        // height is unchanged. touch-none + select-none keep the press-and-hold
+        // from triggering page scroll, text selection, or the long-press menu.
+        className={`-my-2 flex h-11 w-11 shrink-0 touch-none select-none items-center justify-center text-muted-foreground ${disabled ? "cursor-not-allowed opacity-40" : "cursor-grab active:cursor-grabbing hover:text-foreground"}`}
         aria-label={`Drag ${player.name}`}
         disabled={disabled}
         {...attributes}

--- a/apps/web/src/lib/__tests__/depth-order.test.ts
+++ b/apps/web/src/lib/__tests__/depth-order.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import type { PlayerDto } from "@sports-management/shared-types";
+import { orderByDepth } from "../roster/depth-order";
+
+// Minimal player factory — only the fields orderByDepth reads.
+function player(
+  id: string,
+  jerseyNumber: number | null,
+): PlayerDto {
+  return { id, jerseyNumber } as PlayerDto;
+}
+
+describe("orderByDepth (WSM-000088 follow-up)", () => {
+  it("puts the highest-OVR player in slot 1 regardless of jersey number", () => {
+    // The reported bug: Josh Allen (#17, OVR 84) sat in slot 3 behind unrated
+    // backups with lower jersey numbers.
+    const ovr: Record<string, number | null> = {
+      buechele: null,
+      kAllen: null,
+      jAllen: 84,
+    };
+    const group = [
+      player("buechele", 6),
+      player("kAllen", 11),
+      player("jAllen", 17),
+    ];
+    const ordered = orderByDepth(group, (p) => ovr[p.id]);
+    expect(ordered.map((p) => p.id)).toEqual(["jAllen", "buechele", "kAllen"]);
+  });
+
+  it("sorts multiple rated players by OVR descending", () => {
+    const ovr: Record<string, number> = { a: 70, b: 92, c: 81 };
+    const group = [player("a", 1), player("b", 2), player("c", 3)];
+    const ordered = orderByDepth(group, (p) => ovr[p.id]);
+    expect(ordered.map((p) => p.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("ranks unrated players after rated ones", () => {
+    const ovr: Record<string, number | null> = { rated: 60, unrated: null };
+    const group = [player("unrated", 1), player("rated", 99)];
+    const ordered = orderByDepth(group, (p) => ovr[p.id]);
+    expect(ordered.map((p) => p.id)).toEqual(["rated", "unrated"]);
+  });
+
+  it("breaks ties (all unrated) by ascending jersey number", () => {
+    const group = [player("c", 17), player("a", 6), player("b", 11)];
+    const ordered = orderByDepth(group, () => null);
+    expect(ordered.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const group = [player("a", 2), player("b", 1)];
+    const snapshot = [...group];
+    orderByDepth(group, () => null);
+    expect(group).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/lib/roster/depth-order.ts
+++ b/apps/web/src/lib/roster/depth-order.ts
@@ -1,0 +1,27 @@
+import type { PlayerDto } from "@sports-management/shared-types";
+
+/**
+ * Orders a position group by depth so slot 1 is the starter: highest SPRT
+ * OVR first, unrated players after, ties broken by ascending jersey number.
+ * `getOvr` returns the player's OVR or null when unrated. Pure — never mutates
+ * the input array.
+ *
+ * Without this, a group followed roster-insertion order (effectively jersey
+ * number), which buried a high-numbered starter like a #17 QB below unrated
+ * backups (WSM-000088 follow-up).
+ */
+export function orderByDepth(
+  players: PlayerDto[],
+  getOvr: (player: PlayerDto) => number | null,
+): PlayerDto[] {
+  return [...players].sort((a, b) => {
+    const aOvr = getOvr(a);
+    const bOvr = getOvr(b);
+    if (aOvr !== bOvr) {
+      if (aOvr == null) return 1;
+      if (bOvr == null) return -1;
+      return bOvr - aOvr;
+    }
+    return (a.jerseyNumber ?? Infinity) - (b.jerseyNumber ?? Infinity);
+  });
+}


### PR DESCRIPTION
Mobile/depth-chart usability fixes surfaced while driving the production app from a phone (follow-up to the WSM-000079 cutover, #178).

## Changes

### 1. Touch-drag the depth chart on mobile (WSM-000085)
A single `PointerSensor` can't tell a drag from a scroll on a touchscreen, so the depth-chart board was unusable on a phone. Split the dnd-kit sensors:
- `MouseSensor` (instant, 4px distance) for desktop
- `TouchSensor` with a **200ms press-and-hold** activation for touch — the hold distinguishes "pick up this player" from "scroll the list"; dnd-kit manages `touch-action` during the delay so the page still scrolls normally
- `KeyboardSensor` retained for a11y

Grip handle enlarged to a **44px touch target** (icon unchanged, hit area expanded with `-my-2` so row height is unaffected) with `touch-none select-none` so the hold doesn't trigger scroll, selection, or the long-press menu.

Adds a 375px mobile e2e spec asserting the handles render and meet 44px, backed by the seed-roster fixture.

### 2. Order roster slots by SPRT OVR so the starter is slot 1 (WSM-000088)
The position-group roster table numbered slots by roster-insertion order (effectively jersey number), so Josh Allen (#17, OVR 84) showed in **slot 3** behind two unrated backups. Now each group is ordered by SPRT OVR descending (rated starters first, unrated after, jersey as tiebreak) before slotting. Extracted into a pure, unit-tested helper (`orderByDepth`).

### 3. Responsive development chart on mobile (WSM-000085)
`PixelLineChart` rendered at a fixed 480px, overflowing its card on a phone. Swapped fixed width/height for a `viewBox` + `w-full h-auto` so the SVG scales to its container while keeping the 8-bit aspect ratio.

## Verification
- `tsc --noEmit` clean
- 308 unit tests pass (5 new for `orderByDepth`)
- lint at baseline
- New mobile e2e spec (runs against a seeded Convex deployment)

Refs #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)