### PR TITLE
Madden 26 ratings alongside SPRT (WSM-000095)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -146,6 +146,26 @@ export default defineSchema({
     .index("by_seasonId_positionGroup", ["seasonId", "positionGroup"]),
 
   /*
+   * Madden ratings (WSM-000095).
+   *
+   * One row per player — the current Madden NFL snapshot, matched to our
+   * roster by normalized name + team at ingest. Deliberately separate from
+   * `playerAttributes` (which is SPRT, per-season): Madden is a single
+   * current snapshot shown side-by-side with SPRT, and it never feeds the
+   * SPRT career chart. `attributesJson` holds the full Madden attribute map;
+   * `overall` is EA's Overall. Portrait/logo are EA CDN URLs from the source.
+   */
+  maddenRatings: defineTable({
+    playerId: v.id("players"),
+    overall: v.number(),
+    position: v.string(),
+    attributesJson: v.string(),
+    portraitUrl: v.union(v.string(), v.null()),
+    teamLogoUrl: v.union(v.string(), v.null()),
+    ingestedAt: v.string(),
+  }).index("by_playerId", ["playerId"]),
+
+  /*
    * Phase 3 — `schedules_standings_v1` (Sprint 7).
    *
    * One row per scheduled game. `status` transitions

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2131,6 +2131,95 @@ export const getTeamAttributeSnapshots = queryGeneric({
 });
 
 /*
+ * Madden ratings (WSM-000095) — ingest + reads. One row per player; the
+ * ingest upserts by playerId so a re-run refreshes in place.
+ */
+export const ingestMaddenRatingsBatch = mutationGeneric({
+  args: {
+    rows: v.array(
+      v.object({
+        playerId: v.id("players"),
+        overall: v.number(),
+        position: v.string(),
+        attributesJson: v.string(),
+        portraitUrl: v.union(v.string(), v.null()),
+        teamLogoUrl: v.union(v.string(), v.null()),
+      }),
+    ),
+  },
+  returns: v.object({ created: v.number(), updated: v.number() }),
+  handler: async (ctx, args) => {
+    const ingestedAt = new Date().toISOString();
+    let created = 0;
+    let updated = 0;
+    for (const row of args.rows) {
+      const existing = await ctx.db
+        .query("maddenRatings")
+        .withIndex("by_playerId", (q) => q.eq("playerId", row.playerId))
+        .unique();
+      const payload = { ...row, ingestedAt };
+      if (existing) {
+        await ctx.db.replace(existing._id, payload);
+        updated += 1;
+      } else {
+        await ctx.db.insert("maddenRatings", payload);
+        created += 1;
+      }
+    }
+    return { created, updated };
+  },
+});
+
+const maddenRatingValidator = v.object({
+  overall: v.number(),
+  position: v.string(),
+  attributes: v.record(v.string(), v.number()),
+  portraitUrl: v.union(v.string(), v.null()),
+  teamLogoUrl: v.union(v.string(), v.null()),
+});
+
+export const getPlayerMaddenRating = queryGeneric({
+  args: { playerId: v.id("players") },
+  returns: v.union(maddenRatingValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("maddenRatings")
+      .withIndex("by_playerId", (q) => q.eq("playerId", args.playerId))
+      .unique();
+    if (!row) return null;
+    return {
+      overall: row.overall,
+      position: row.position,
+      attributes: safeParseAttributes(row.attributesJson),
+      portraitUrl: row.portraitUrl,
+      teamLogoUrl: row.teamLogoUrl,
+    };
+  },
+});
+
+export const getTeamMaddenOveralls = queryGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.array(
+    v.object({ playerId: v.string(), overall: v.number() }),
+  ),
+  handler: async (ctx, args) => {
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    const out: Array<{ playerId: string; overall: number }> = [];
+    for (const player of players) {
+      const row = await ctx.db
+        .query("maddenRatings")
+        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+        .unique();
+      if (row) out.push({ playerId: player._id as string, overall: row.overall });
+    }
+    return out;
+  },
+});
+
+/*
  * Phase 2 — Public read primitives (Sprint 6B / WSM-000059).
  *
  * The public viewer in WSM-000061 hits these without a Clerk session.

--- a/apps/web/scripts/ingest-madden-ratings.mts
+++ b/apps/web/scripts/ingest-madden-ratings.mts
@@ -1,0 +1,203 @@
+/**
+ * Madden ratings ingest (WSM-000095).
+ *
+ * Pulls the Madden NFL ratings straight from a link-shared Google Sheet via
+ * its no-auth CSV export endpoint (the "sheet as API"), matches each player
+ * to our roster by normalized name + team, and upserts a Madden snapshot per
+ * matched player. Re-runnable: the sheet is the source of truth, so editing it
+ * and re-running refreshes our data. Dry-run by default; pass --write.
+ *
+ * Usage:
+ *   NEXT_PUBLIC_CONVEX_URL=<url> [CONVEX_ADMIN_KEY=<key>] \
+ *     npx tsx apps/web/scripts/ingest-madden-ratings.mts \
+ *       [--sheet-id <id>] [--gid 0] [--write]
+ */
+import { ConvexHttpClient } from "convex/browser";
+import { rosterMatchKey, normalizeName } from "../src/lib/madden/match.js";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const has = (name: string) => process.argv.includes(`--${name}`);
+
+const SHEET_ID = arg("sheet-id") ?? "18i1BI1iAK0oAJG-nNQ9HS2mm2R92dI8axTxbBpPXjAc";
+// Omit gid by default — the first tab's gid isn't always 0, and the bare
+// export endpoint returns the first sheet. Pass --gid to target a specific tab.
+const GID = arg("gid");
+const WRITE = has("write");
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+if (!CONVEX_URL) {
+  console.error("NEXT_PUBLIC_CONVEX_URL is required (point it at the target deployment).");
+  process.exit(1);
+}
+
+function splitCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; }
+      else inQuotes = !inQuotes;
+    } else if (ch === "," && !inQuotes) { out.push(cur); cur = ""; }
+    else cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+function parseCsv(text: string): Record<string, string>[] {
+  // Join physical lines that are split inside quoted cells.
+  const rows: string[] = [];
+  let buf = "";
+  let quotes = 0;
+  for (const line of text.split(/\r?\n/)) {
+    buf = buf ? `${buf}\n${line}` : line;
+    quotes += (line.match(/"/g) ?? []).length;
+    if (quotes % 2 === 0) {
+      if (buf.length) rows.push(buf);
+      buf = "";
+      quotes = 0;
+    }
+  }
+  if (buf.length) rows.push(buf);
+  if (rows.length === 0) return [];
+  const headers = splitCsvLine(rows[0]);
+  return rows.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, i) => (row[h] = cells[i] ?? ""));
+    return row;
+  });
+}
+
+type MaddenEntry = {
+  overall: number;
+  position: string;
+  attributesJson: string;
+  portraitUrl: string | null;
+  teamLogoUrl: string | null;
+};
+
+async function main() {
+  const url =
+    `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv` +
+    (GID ? `&gid=${GID}` : "");
+  console.log(`Madden ingest — ${WRITE ? "WRITE" : "DRY RUN"}\n  sheet ${url}\n  deployment ${CONVEX_URL}`);
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    console.error(`Sheet fetch failed (${res.status}). Is it shared "anyone with link"?`);
+    process.exit(1);
+  }
+  const sheet = parseCsv(await res.text());
+  if (sheet.length === 0) {
+    console.error("Sheet is empty.");
+    process.exit(1);
+  }
+  const headers = Object.keys(sheet[0]);
+  const logoIdx = headers.indexOf("Team Logo");
+  const attrCols = logoIdx >= 0 ? headers.slice(logoIdx + 1) : [];
+
+  // Build two Madden indexes: name+team (primary) and name-only (fallback for
+  // players we and Madden have on different teams, e.g. a recent trade). The
+  // name-only fallback is used only when the name is unique in the sheet.
+  const maddenByKey = new Map<string, MaddenEntry>();
+  const maddenByName = new Map<string, MaddenEntry[]>();
+  for (const r of sheet) {
+    const name = `${r["First Name"] ?? ""} ${r["Last Name"] ?? ""}`.trim();
+    const team = r["Team"] ?? "";
+    if (!name || !team) continue;
+    const attributes: Record<string, number> = {};
+    for (const col of attrCols) {
+      if (col === "OVERALL") continue;
+      const n = Number(r[col]);
+      if (Number.isFinite(n)) attributes[col] = n;
+    }
+    const entry: MaddenEntry = {
+      overall: Number(r["Overall"]) || 0,
+      position: r["Position"] ?? "",
+      attributesJson: JSON.stringify(attributes),
+      portraitUrl: r["Player Image"] || null,
+      teamLogoUrl: r["Team Logo"] || null,
+    };
+    maddenByKey.set(rosterMatchKey(name, team), entry);
+    const nameKey = normalizeName(name);
+    const list = maddenByName.get(nameKey) ?? [];
+    list.push(entry);
+    maddenByName.set(nameKey, list);
+  }
+  console.log(`  parsed ${maddenByKey.size} Madden players, ${attrCols.length} attribute columns`);
+
+  function matchPlayer(name: string, team: string): MaddenEntry | null {
+    const exact = maddenByKey.get(rosterMatchKey(name, team));
+    if (exact) return exact;
+    const byName = maddenByName.get(normalizeName(name));
+    return byName && byName.length === 1 ? byName[0] : null;
+  }
+
+  const client = new ConvexHttpClient(CONVEX_URL!);
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+  if (adminKey) {
+    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  }
+  const q = (name: string, args: unknown) =>
+    client.query(name as never, args as never) as Promise<unknown>;
+  const m = (name: string, args: unknown) =>
+    client.mutation(name as never, args as never) as Promise<unknown>;
+
+  const leagues = (await q("sports:listPublicLeagues", {})) as { id: string; name: string }[];
+  const rows: Array<{
+    playerId: string;
+    overall: number;
+    position: string;
+    attributesJson: string;
+    portraitUrl: string | null;
+    teamLogoUrl: string | null;
+  }> = [];
+  let rosterCount = 0;
+  const unmatchedSample: string[] = [];
+
+  for (const league of leagues) {
+    const teams = (await q("sports:listTeamsByLeague", { leagueId: league.id })) as {
+      id: string; name: string;
+    }[];
+    for (const team of teams) {
+      const players = (await q("sports:listPlayersByTeam", { teamId: team.id })) as {
+        id: string; name: string;
+      }[];
+      for (const p of players) {
+        rosterCount += 1;
+        const entry = matchPlayer(p.name, team.name);
+        if (!entry) {
+          if (unmatchedSample.length < 15) unmatchedSample.push(`${p.name} (${team.name})`);
+          continue;
+        }
+        rows.push({ playerId: p.id, ...entry });
+      }
+    }
+  }
+
+  console.log(`  roster ${rosterCount} players · matched ${rows.length} · unmatched ${rosterCount - rows.length}`);
+  if (unmatchedSample.length) {
+    console.log(`  sample unmatched: ${unmatchedSample.slice(0, 10).join("; ")}`);
+  }
+
+  if (!WRITE) {
+    console.log("DRY RUN — pass --write to ingest. No data written.");
+    return;
+  }
+  let written = 0;
+  for (let i = 0; i < rows.length; i += 500) {
+    const res2 = (await m("sports:ingestMaddenRatingsBatch", {
+      rows: rows.slice(i, i + 500),
+    })) as { created: number; updated: number };
+    written += res2.created + res2.updated;
+  }
+  console.log(`Wrote ${written} Madden snapshots.`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -2,10 +2,17 @@ import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import { getPlayer, getTeam, getSeasons, getPlayerSeasonAttributes } from "@/lib/data-api";
+import {
+  getPlayer,
+  getTeam,
+  getSeasons,
+  getPlayerSeasonAttributes,
+  getPlayerMaddenRating,
+} from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { derivePositionGroup } from "@/lib/position-group";
 import { orderedComponents } from "@/lib/ratings/component-labels";
+import { orderedMaddenAttributes } from "@/lib/madden/attributes";
 import { playerAttributesV1 } from "@/lib/flags";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import { Button } from "@/components/ui/8bit/button";
@@ -70,6 +77,15 @@ export default async function PlayerProfilePage({
     }
   }
   const components = rating ? orderedComponents(rating.attributes) : [];
+
+  // Madden rating (WSM-000095) — the player's current Madden snapshot, shown
+  // side-by-side with SPRT. Independent of season; never blocks the page.
+  const madden = attributesEnabled
+    ? await getPlayerMaddenRating(playerId, orgContext).catch(() => null)
+    : null;
+  const maddenAttributes = madden
+    ? orderedMaddenAttributes(madden.attributes)
+    : [];
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -207,6 +223,50 @@ export default async function PlayerProfilePage({
             <p className="mt-4 text-xs text-muted-foreground">
               SPRT Rating is our own metric derived from open NFL performance
               data (nflverse).
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {madden && (
+        <Card className="mt-6">
+          <CardContent className="pt-6">
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-lg font-semibold text-foreground">
+                Madden 26
+              </h3>
+              <span className="font-mono text-2xl font-bold text-primary">
+                {madden.overall}
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  OVR
+                </span>
+              </span>
+            </div>
+
+            {maddenAttributes.length > 0 && (
+              <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+                {maddenAttributes.map((a) => (
+                  <div
+                    key={a.key}
+                    className="flex items-center justify-between gap-2"
+                  >
+                    <dt className="truncate text-xs text-muted-foreground">
+                      {a.label}
+                    </dt>
+                    <dd
+                      className={`shrink-0 font-mono text-sm font-semibold ${
+                        a.value >= 90 ? "text-accent" : "text-foreground"
+                      }`}
+                    >
+                      {a.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+
+            <p className="mt-4 text-xs text-muted-foreground">
+              Madden NFL 26 player ratings (EA Sports).
             </p>
           </CardContent>
         </Card>

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   getPlayersByTeam,
   getSeasons,
   getTeamAttributeSnapshots,
+  getTeamMaddenOveralls,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam } from "@/lib/authorization";
@@ -35,6 +36,7 @@ export default async function TeamDetailPage({
   // rule as the depth-chart page. Failure here must never take down
   // the roster — columns simply don't render.
   let snapshots: ReadonlyMap<string, PlayerSnapshot> = new Map();
+  let maddenOveralls: ReadonlyMap<string, number> = new Map();
   if (await playerAttributesV1()) {
     const seasons = await getSeasons([team.leagueId]).catch(() => []);
     const activeSeason =
@@ -46,6 +48,10 @@ export default async function TeamDetailPage({
         orgContext,
       ).catch(() => new Map());
     }
+    // WSM-000095: Madden overall per player, shown beside SPRT. Season-agnostic.
+    maddenOveralls = await getTeamMaddenOveralls(id, orgContext).catch(
+      () => new Map(),
+    );
   }
 
   return (
@@ -62,6 +68,7 @@ export default async function TeamDetailPage({
         players={players}
         canManage={canManage}
         attributeSnapshots={Object.fromEntries(snapshots)}
+        maddenOveralls={Object.fromEntries(maddenOveralls)}
       />
     </div>
   );

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -29,6 +29,8 @@ interface TeamManagementProps {
   /** WSM-000090: playerId → attribute snapshot; empty when Phase 2 is
       dark or the season has no ingested attributes. */
   attributeSnapshots?: Record<string, PlayerSnapshot>;
+  /** WSM-000095: playerId → Madden overall; empty when none ingested. */
+  maddenOveralls?: Record<string, number>;
 }
 
 type ModalState =
@@ -43,8 +45,10 @@ export default function TeamManagement({
   players,
   canManage,
   attributeSnapshots = {},
+  maddenOveralls = {},
 }: TeamManagementProps) {
   const snapshots = new Map(Object.entries(attributeSnapshots));
+  const madden = new Map(Object.entries(maddenOveralls));
   const router = useRouter();
   const [modal, setModal] = useState<ModalState>({ type: "none" });
   const [isDeleting, setIsDeleting] = useState(false);
@@ -126,7 +130,7 @@ export default function TeamManagement({
         ? [
             {
               key: "ovr",
-              header: "OVR",
+              header: "SPRT",
               sortable: true,
               accessor: (p: RosterRow) =>
                 snapshots.get(p.id as string)?.weightedOverall ?? null,
@@ -162,6 +166,27 @@ export default function TeamManagement({
                   },
                 }) satisfies Column<RosterRow>,
             ),
+          ]
+        : []),
+      // Madden overall (WSM-000095) — independent of SPRT, shown side by side.
+      ...(madden.size > 0
+        ? [
+            {
+              key: "mad",
+              header: "MAD",
+              sortable: true,
+              accessor: (p: RosterRow) => madden.get(p.id as string) ?? null,
+              render: (p: RosterRow) => {
+                const ovr = madden.get(p.id as string);
+                return ovr != null ? (
+                  <span className="font-mono font-semibold text-primary">
+                    {ovr}
+                  </span>
+                ) : (
+                  "—"
+                );
+              },
+            } satisfies Column<RosterRow>,
           ]
         : []),
       {
@@ -230,11 +255,11 @@ export default function TeamManagement({
         )}
       </div>
 
-      {snapshots.size > 0 && (
+      {(snapshots.size > 0 || madden.size > 0) && (
         <p className="mb-3 text-xs text-muted-foreground">
-          OVR is the SPRT Rating — our own metric derived from open NFL
-          performance data (nflverse). Players without enough recent snaps are
-          unrated.
+          SPRT is our own rating from open NFL data (nflverse); MAD is the
+          Madden NFL 26 overall (EA Sports). Players without enough recent
+          snaps are unrated.
         </p>
       )}
 

--- a/apps/web/src/lib/__tests__/madden-attributes.test.ts
+++ b/apps/web/src/lib/__tests__/madden-attributes.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  maddenAttributeLabel,
+  orderedMaddenAttributes,
+} from "../madden/attributes";
+
+describe("maddenAttributeLabel (WSM-000095)", () => {
+  it("maps known keys to friendly labels", () => {
+    expect(maddenAttributeLabel("THROWACCURACYSHORT")).toBe(
+      "Throw Accuracy (Short)",
+    );
+    expect(maddenAttributeLabel("ZONECOVERAGE")).toBe("Zone Coverage");
+    expect(maddenAttributeLabel("SPEED")).toBe("Speed");
+  });
+
+  it("falls back to a title-cased label for unknown keys", () => {
+    expect(maddenAttributeLabel("NEWTRAIT")).toBe("Newtrait");
+  });
+});
+
+describe("orderedMaddenAttributes (WSM-000095)", () => {
+  it("drops the duplicated OVERALL key and sorts by value descending", () => {
+    const out = orderedMaddenAttributes({
+      OVERALL: 99,
+      SPEED: 88,
+      THROWPOWER: 97,
+      AWARENESS: 96,
+    });
+    expect(out.map((a) => a.key)).toEqual([
+      "THROWPOWER",
+      "AWARENESS",
+      "SPEED",
+    ]);
+    expect(out[0].label).toBe("Throw Power");
+  });
+});

--- a/apps/web/src/lib/__tests__/madden-match.test.ts
+++ b/apps/web/src/lib/__tests__/madden-match.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeName,
+  normalizeTeam,
+  rosterMatchKey,
+} from "../madden/match";
+
+describe("normalizeName (WSM-000095)", () => {
+  it("lowercases and strips punctuation", () => {
+    expect(normalizeName("Ja'Marr Chase")).toBe("jamarr chase");
+  });
+
+  it("drops generational suffixes so Jr./Sr. variants align", () => {
+    expect(normalizeName("Michael Pittman Jr.")).toBe("michael pittman");
+    expect(normalizeName("Michael Pittman")).toBe("michael pittman");
+  });
+
+  it("collapses whitespace", () => {
+    expect(normalizeName("  Josh   Allen ")).toBe("josh allen");
+  });
+});
+
+describe("normalizeTeam (WSM-000095)", () => {
+  it("normalizes case and spacing", () => {
+    expect(normalizeTeam("Buffalo Bills")).toBe("buffalo bills");
+  });
+});
+
+describe("rosterMatchKey (WSM-000095)", () => {
+  it("joins normalized name and team", () => {
+    expect(rosterMatchKey("Josh Allen", "Buffalo Bills")).toBe(
+      "josh allen|buffalo bills",
+    );
+  });
+
+  it("produces the same key for suffix and punctuation variants", () => {
+    expect(rosterMatchKey("Ja'Marr Chase", "Cincinnati Bengals")).toBe(
+      rosterMatchKey("JaMarr Chase", "Cincinnati Bengals"),
+    );
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -262,6 +262,20 @@ const refs = {
       attributes: Record<string, number>;
     }>
   >("sports:getTeamAttributeSnapshots"),
+  getPlayerMaddenRating: queryRef<
+    { playerId: string },
+    {
+      overall: number;
+      position: string;
+      attributes: Record<string, number>;
+      portraitUrl: string | null;
+      teamLogoUrl: string | null;
+    } | null
+  >("sports:getPlayerMaddenRating"),
+  getTeamMaddenOveralls: queryRef<
+    { teamId: string },
+    Array<{ playerId: string; overall: number }>
+  >("sports:getTeamMaddenOveralls"),
   getLeagueVisibility: queryRef<
     { leagueId: string },
     { isPublic: boolean } | null
@@ -587,6 +601,35 @@ export async function getTeamAttributeSnapshots(
       { weightedOverall: r.weightedOverall, attributes: r.attributes },
     ]),
   );
+}
+
+/** WSM-000095: one player's Madden snapshot for the profile card. */
+export async function getPlayerMaddenRating(
+  playerId: string,
+  orgContext: OrgContext,
+): Promise<{
+  overall: number;
+  position: string;
+  attributes: Record<string, number>;
+  portraitUrl: string | null;
+  teamLogoUrl: string | null;
+} | null> {
+  const player = await queryConvex(refs.getPlayer, { playerId });
+  if (!player) return null;
+  const teamLeagueId = await getTeamLeagueId(player.teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  return queryConvex(refs.getPlayerMaddenRating, { playerId });
+}
+
+/** WSM-000095: playerId → Madden overall map for the roster MAD column. */
+export async function getTeamMaddenOveralls(
+  teamId: string,
+  orgContext: OrgContext,
+): Promise<Map<string, number>> {
+  const teamLeagueId = await getTeamLeagueId(teamId);
+  requireLeagueAccessLocal(teamLeagueId, orgContext);
+  const rows = await queryConvex(refs.getTeamMaddenOveralls, { teamId });
+  return new Map(rows.map((r) => [r.playerId, r.overall]));
 }
 
 export async function getSeasons(

--- a/apps/web/src/lib/madden/attributes.ts
+++ b/apps/web/src/lib/madden/attributes.ts
@@ -1,0 +1,80 @@
+/**
+ * Madden attribute display helpers (WSM-000095). Source keys are ALL-CAPS
+ * with no separators (THROWACCURACYSHORT), so humanizing relies on an explicit
+ * label map with a title-cased fallback for anything new EA adds.
+ */
+const MADDEN_LABELS: Record<string, string> = {
+  ACCELERATION: "Acceleration",
+  AGILITY: "Agility",
+  JUMPING: "Jumping",
+  STAMINA: "Stamina",
+  STRENGTH: "Strength",
+  AWARENESS: "Awareness",
+  BCVISION: "BC Vision",
+  BLOCKSHEDDING: "Block Shedding",
+  BREAKSACK: "Break Sack",
+  BREAKTACKLE: "Break Tackle",
+  CARRYING: "Carrying",
+  CATCHINTRAFFIC: "Catch in Traffic",
+  CATCHING: "Catching",
+  CHANGEOFDIRECTION: "Change of Direction",
+  DEEPROUTERUNNING: "Deep Route Running",
+  FINESSEMOVES: "Finesse Moves",
+  HITPOWER: "Hit Power",
+  IMPACTBLOCKING: "Impact Blocking",
+  INJURY: "Injury",
+  JUKEMOVE: "Juke Move",
+  KICKACCURACY: "Kick Accuracy",
+  KICKPOWER: "Kick Power",
+  KICKRETURN: "Kick Return",
+  LEADBLOCK: "Lead Block",
+  MANCOVERAGE: "Man Coverage",
+  MEDIUMROUTERUNNING: "Medium Route Running",
+  PASSBLOCK: "Pass Block",
+  PASSBLOCKFINESSE: "Pass Block Finesse",
+  PASSBLOCKPOWER: "Pass Block Power",
+  PLAYACTION: "Play Action",
+  PLAYRECOGNITION: "Play Recognition",
+  POWERMOVES: "Power Moves",
+  PRESS: "Press",
+  PURSUIT: "Pursuit",
+  RELEASE: "Release",
+  RUNBLOCK: "Run Block",
+  RUNBLOCKFINESSE: "Run Block Finesse",
+  RUNBLOCKPOWER: "Run Block Power",
+  SHORTROUTERUNNING: "Short Route Running",
+  SPECTACULARCATCH: "Spectacular Catch",
+  SPEED: "Speed",
+  SPINMOVE: "Spin Move",
+  STIFFARM: "Stiff Arm",
+  TACKLE: "Tackle",
+  THROWACCURACYDEEP: "Throw Accuracy (Deep)",
+  THROWACCURACYMID: "Throw Accuracy (Mid)",
+  THROWACCURACYSHORT: "Throw Accuracy (Short)",
+  THROWONTHERUN: "Throw on the Run",
+  THROWPOWER: "Throw Power",
+  THROWUNDERPRESSURE: "Throw Under Pressure",
+  TOUGHNESS: "Toughness",
+  TRUCKING: "Trucking",
+  ZONECOVERAGE: "Zone Coverage",
+};
+
+export function maddenAttributeLabel(key: string): string {
+  const known = MADDEN_LABELS[key];
+  if (known) return known;
+  const lower = key.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+/**
+ * Orders Madden attributes for display: drops the duplicated OVERALL key,
+ * sorts by value descending so a player's elite traits surface first.
+ */
+export function orderedMaddenAttributes(
+  attributes: Record<string, number>,
+): Array<{ key: string; label: string; value: number }> {
+  return Object.entries(attributes)
+    .filter(([key]) => key !== "OVERALL")
+    .map(([key, value]) => ({ key, label: maddenAttributeLabel(key), value }))
+    .sort((a, b) => b.value - a.value);
+}

--- a/apps/web/src/lib/madden/match.ts
+++ b/apps/web/src/lib/madden/match.ts
@@ -1,0 +1,32 @@
+/**
+ * Roster-match keys for Madden ingest (WSM-000095). The Madden sheet has no
+ * shared id with our ESPN-sourced roster, so we join on normalized
+ * name + team. Normalization lowercases, strips generational suffixes and
+ * punctuation, and collapses whitespace so "Ja'Marr Chase" / "JaMarr Chase"
+ * and "Michael Pittman Jr." / "Michael Pittman" line up.
+ */
+const SUFFIXES = new Set(["jr", "sr", "ii", "iii", "iv", "v"]);
+
+export function normalizeName(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[.'’`]/g, "")
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const parts = cleaned.split(" ").filter((p) => !SUFFIXES.has(p));
+  return parts.join(" ");
+}
+
+export function normalizeTeam(team: string): string {
+  return team
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Composite join key: "first last|city nickname". */
+export function rosterMatchKey(name: string, team: string): string {
+  return `${normalizeName(name)}|${normalizeTeam(team)}`;
+}


### PR DESCRIPTION
Augments SPRT with the real **Madden NFL 26** ratings, shown side by side — answering "Josh Allen should be higher" (Madden 99 vs SPRT 84). SPRT stays our open-data metric and keeps owning the multi-season career chart, which Madden (a single current snapshot) can't feed.

> **Stacked on #205** (base retargets to `main` once #205 merges).

## Data pipeline — "sheet as API"
The Madden numbers live in a link-shared Google Sheet. `scripts/ingest-madden-ratings.mts` pulls them **live** from the sheet's no-auth CSV export endpoint (`/export?format=csv`), so editing the sheet and re-running refreshes our data — no manual export, no API key. Dry-run by default.

**Matching** (the sheet has no ESPN id): normalized **name + team**, with a **name-only fallback** when the name is unique in the sheet — this catches players we and Madden list on different teams after a trade (e.g. Andrew Billings: CHI in Madden, ARI on our roster).

**Validated against prod (dry run):** 1,866 Madden players parsed; **1,637 matched** to our roster. The unmatched remainder are rookies/UDFAs/camp bodies Madden doesn't rate.

New `maddenRatings` table — one row per player, deliberately separate from the per-season SPRT `playerAttributes` so the two ratings never blend.

## UI
- **Player profile:** a "Madden 26" card with OVR + the **full attribute set** (~50), sorted strongest-first, elite (90+) values highlighted.
- **Roster table:** a **MAD** column beside **SPRT** (the SPRT column was relabeled from OVR). Both gated on `player_attributes_v1`.

## Licensing
Madden ratings are EA's, publicly published each year and supplied by the operator — ingested as provided data, **not scraped** (consistent with declining the PFF scrape earlier).

## Activation (separate, credentialed steps)
1. Deploy Convex (new table + 3 functions) to prod.
2. Run the ingest with the prod admin key:
   ```
   NEXT_PUBLIC_CONVEX_URL=https://terrific-aardvark-395.convex.cloud CONVEX_ADMIN_KEY=… \
     npx tsx apps/web/scripts/ingest-madden-ratings.mts --write
   ```

## Verification
- `tsc --noEmit` clean
- 317 unit tests pass (6 new: match + attribute helpers)
- lint at baseline
- ingest dry-run validated against prod (reads + sheet fetch)

Refs #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)