### PR TITLE
SPRT career-history backfill + multi-season development chart (WSM-000094)

### DIFF
--- a/apps/web/scripts/backfill-sprt-career.mts
+++ b/apps/web/scripts/backfill-sprt-career.mts
@@ -1,0 +1,181 @@
+/**
+ * SPRT career-history backfill (WSM-000094).
+ *
+ * One-time backfill that gives every rostered player a multi-season SPRT
+ * trend on their development chart. For each completed NFL year in the
+ * range, it ensures a dated `completed` season record exists per public
+ * league (idempotent via upsertSeason) and ingests that year's SPRT
+ * ratings, matched to our roster by ESPN id — exactly like the weekly
+ * refresh, but looped over history.
+ *
+ * Design notes:
+ *  - The latest completed season's data already lives in each league's
+ *    *active* season (the weekly cron owns it), so the default range stops
+ *    at the prior year to avoid a duplicate point. Override with --to.
+ *  - A player only matches in years they actually played (ESPN id join), so
+ *    no synthetic history is invented — a 2018 rookie simply has no 2017 row.
+ *  - Leagues with zero matches in a year are left untouched (no empty season
+ *    is created), so non-NFL leagues are never polluted.
+ *  - nflverse publishes `stats_player_week_<year>` + `roster_<year>` back to
+ *    1999; a missing/renamed asset for a year is logged and skipped, not fatal.
+ *
+ * Usage:
+ *   NEXT_PUBLIC_CONVEX_URL=<prod-url> CONVEX_ADMIN_KEY=<key> \
+ *     npx tsx apps/web/scripts/backfill-sprt-career.mts \
+ *       [--from 1999] [--to 2024] [--league-id <id>] [--write]
+ *   Dry-run by default: reports per-year match counts, writes nothing.
+ */
+import { ConvexHttpClient } from "convex/browser";
+import {
+  fetchSprtRatingsByEspnId,
+  espnIdFromHeadshot,
+  ATTR_GROUP,
+} from "../src/lib/ratings/nflverse.js";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const has = (name: string) => process.argv.includes(`--${name}`);
+
+const FROM = Number(arg("from") ?? 1999);
+const TO = Number(arg("to") ?? new Date().getUTCFullYear() - 1);
+const ONLY_LEAGUE = arg("league-id");
+const WRITE = has("write");
+
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+if (!CONVEX_URL) {
+  console.error("NEXT_PUBLIC_CONVEX_URL is required (point it at the target deployment).");
+  process.exit(1);
+}
+if (!Number.isInteger(FROM) || !Number.isInteger(TO) || FROM > TO) {
+  console.error(`Invalid range --from ${FROM} --to ${TO}.`);
+  process.exit(1);
+}
+
+type LeaguePlayer = { playerId: string; espn: string | null };
+type IngestRow = {
+  playerId: string;
+  positionGroup: string;
+  attributesJson: string;
+  weightedOverall: number | null;
+};
+
+async function main() {
+  const client = new ConvexHttpClient(CONVEX_URL!);
+  const adminKey = process.env.CONVEX_ADMIN_KEY;
+  if (adminKey) {
+    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  }
+  const q = (name: string, args: unknown) =>
+    client.query(name as never, args as never) as Promise<unknown>;
+  const m = (name: string, args: unknown) =>
+    client.mutation(name as never, args as never) as Promise<unknown>;
+
+  console.log(
+    `SPRT career backfill — years ${FROM}–${TO}, ${WRITE ? "WRITE" : "DRY RUN"}, ` +
+      `deployment ${CONVEX_URL}`,
+  );
+
+  // Resolve target leagues, then each league's roster (ESPN id) once.
+  const leagues = ONLY_LEAGUE
+    ? [{ id: ONLY_LEAGUE, name: ONLY_LEAGUE }]
+    : ((await q("sports:listPublicLeagues", {})) as { id: string; name: string }[]);
+
+  const leaguePlayers = new Map<string, LeaguePlayer[]>();
+  for (const league of leagues) {
+    const teams = (await q("sports:listTeamsByLeague", {
+      leagueId: league.id,
+    })) as { id: string }[];
+    const roster: LeaguePlayer[] = [];
+    for (const team of teams) {
+      const players = (await q("sports:listPlayersByTeam", {
+        teamId: team.id,
+      })) as { id: string; headshotUrl: string | null }[];
+      for (const p of players) {
+        roster.push({ playerId: p.id, espn: espnIdFromHeadshot(p.headshotUrl) });
+      }
+    }
+    leaguePlayers.set(league.id, roster);
+    console.log(`  league ${league.name}: ${roster.length} players`);
+  }
+
+  let totalSeasons = 0;
+  let totalWritten = 0;
+
+  for (let year = FROM; year <= TO; year++) {
+    let ratings;
+    try {
+      ratings = await fetchSprtRatingsByEspnId(year);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`  ${year}: skipped — ${msg}`);
+      continue;
+    }
+
+    for (const league of leagues) {
+      const roster = leaguePlayers.get(league.id) ?? [];
+      const rows: IngestRow[] = [];
+      for (const p of roster) {
+        const rating = p.espn ? ratings.get(p.espn) : undefined;
+        if (!rating) continue;
+        rows.push({
+          playerId: p.playerId,
+          positionGroup: ATTR_GROUP[rating.positionGroup],
+          attributesJson: JSON.stringify({
+            ...rating.attributes,
+            OVR: rating.overall,
+          }),
+          weightedOverall: rating.overall,
+        });
+      }
+
+      if (rows.length === 0) {
+        console.log(`  ${year} · ${league.name}: 0 matches — skipped`);
+        continue;
+      }
+
+      if (!WRITE) {
+        console.log(`  ${year} · ${league.name}: ${rows.length} matches (dry run)`);
+        continue;
+      }
+
+      const season = (await m("sports:upsertSeason", {
+        name: `${year} NFL Season`,
+        leagueId: league.id,
+        startDate: `${year}-09-01`,
+        endDate: `${year + 1}-02-15`,
+        status: "completed",
+      })) as { dto: { id: string }; created: boolean };
+      if (season.created) totalSeasons += 1;
+
+      await m("sports:clearSeasonPlayerAttributes", {
+        seasonId: season.dto.id,
+      });
+      let written = 0;
+      for (let i = 0; i < rows.length; i += 500) {
+        const res = (await m("sports:ingestPlayerAttributesBatch", {
+          seasonId: season.dto.id,
+          rows: rows.slice(i, i + 500),
+        })) as { created: number; updated: number };
+        written += res.created + res.updated;
+      }
+      totalWritten += written;
+      console.log(
+        `  ${year} · ${league.name}: ${rows.length} matched, wrote ${written}` +
+          `${season.created ? " (new season)" : ""}`,
+      );
+    }
+  }
+
+  console.log(
+    WRITE
+      ? `Done — ${totalSeasons} seasons created, ${totalWritten} attribute rows written.`
+      : "Dry run complete — pass --write to backfill.",
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -13,6 +13,7 @@ import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
 import AttributesUploadDialog from "@/components/attributes/AttributesUploadDialog";
+import { seasonYearLabel } from "@/lib/attributes/season-label";
 import { trackPlayerAttributesView } from "@/lib/analytics";
 
 export default async function PlayerDevelopmentPage({
@@ -51,7 +52,7 @@ export default async function PlayerDevelopmentPage({
   const seasons = playerLeagueId ? await getSeasons([playerLeagueId]) : [];
 
   const points = development.map((row) => ({
-    x: row.seasonName,
+    x: seasonYearLabel(row.seasonName),
     y: row.weightedOverall,
   }));
 

--- a/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
+++ b/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
@@ -5,6 +5,7 @@ import { getPlayerDevelopmentPublic } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
+import { seasonYearLabel } from "@/lib/attributes/season-label";
 import { trackPlayerAttributesView } from "@/lib/analytics";
 
 /*
@@ -35,7 +36,7 @@ export default async function PublicPlayerDevelopmentPage({
   void trackPlayerAttributesView({ playerId, route: "public" });
 
   const points = development.map((row) => ({
-    x: row.seasonName,
+    x: seasonYearLabel(row.seasonName),
     y: row.weightedOverall,
   }));
 

--- a/apps/web/src/components/attributes/PixelLineChart.tsx
+++ b/apps/web/src/components/attributes/PixelLineChart.tsx
@@ -131,20 +131,27 @@ export default function PixelLineChart({
         </text>
       ))}
 
-      {/* X-axis labels under each point */}
-      {points.map((p, i) => (
-        <text
-          key={`x-${i}`}
-          x={xPos(i)}
-          y={height - PADDING.bottom + 16}
-          textAnchor="middle"
-          fill="var(--color-muted-foreground)"
-          fontSize={10}
-          style={{ fontFamily: "var(--font-mono)" }}
-        >
-          {p.x}
-        </text>
-      ))}
+      {/* X-axis labels — thinned so a long career (20+ seasons) doesn't
+          overlap into mush. Plot every point, but label at most ~8, always
+          keeping the first and last tick. */}
+      {points.map((p, i) => {
+        const stride = Math.max(1, Math.ceil(points.length / 8));
+        const show = i % stride === 0 || i === points.length - 1;
+        if (!show) return null;
+        return (
+          <text
+            key={`x-${i}`}
+            x={xPos(i)}
+            y={height - PADDING.bottom + 16}
+            textAnchor="middle"
+            fill="var(--color-muted-foreground)"
+            fontSize={10}
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            {p.x}
+          </text>
+        );
+      })}
 
       {/* Chunky line segments */}
       {segments.map((s, i) => (

--- a/apps/web/src/lib/__tests__/season-label.test.ts
+++ b/apps/web/src/lib/__tests__/season-label.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { seasonYearLabel } from "../attributes/season-label";
+
+describe("seasonYearLabel (WSM-000094)", () => {
+  it("extracts the four-digit year from a season name", () => {
+    expect(seasonYearLabel("2026 NFL Season")).toBe("2026");
+    expect(seasonYearLabel("1999 NFL Season")).toBe("1999");
+  });
+
+  it("finds the year regardless of position", () => {
+    expect(seasonYearLabel("NFL Season 2024")).toBe("2024");
+  });
+
+  it("falls back to the full name when there is no year", () => {
+    expect(seasonYearLabel("Preseason")).toBe("Preseason");
+  });
+});

--- a/apps/web/src/lib/attributes/season-label.ts
+++ b/apps/web/src/lib/attributes/season-label.ts
@@ -1,0 +1,10 @@
+/**
+ * Compact x-axis label for the development chart (WSM-000094). A season is
+ * named like "2026 NFL Season"; on a career-length chart the full name
+ * repeats and overlaps, so we render just the four-digit year. Falls back to
+ * the full name when there's no year to extract.
+ */
+export function seasonYearLabel(seasonName: string): string {
+  const match = seasonName.match(/\b(\d{4})\b/);
+  return match ? match[1] : seasonName;
+}


### PR DESCRIPTION
Rebased onto main after #205 merged (the original #206 auto-closed when its base branch was deleted).

Gives every rostered player a real multi-season SPRT trend on their development chart. One-time, idempotent, dry-run-by-default backfill (`scripts/backfill-sprt-career.mts`) that upserts a dated `completed` season per public league and ingests each year's SPRT ratings, matched by ESPN id — same engine + zero-match safety guard as the weekly refresh. nflverse assets verified back to 1999; validated against prod (872 matched for 2024, ramping to ~3 in 2008).

Chart readability: x-axis labels thinned + year-only (`seasonYearLabel`).

Verification: tsc clean, 311 unit tests, lint baseline.

Activation (credentialed): `backfill-sprt-career.mts --from 1999 --to 2024 --write` against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)