### PR TITLE
Show real subscription state on discover (WSM-000099)

### DIFF
--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import { Button } from "@/components/ui/8bit/button";
 import { Badge } from "@/components/ui/badge";
-import { Trophy } from "lucide-react";
+import { Trophy, CheckCircle2 } from "lucide-react";
 
 interface League {
   id: string;
@@ -68,8 +68,16 @@ export default function DiscoverLeagues({
               </div>
             </CardHeader>
             <CardContent>
-              <div className="flex items-center justify-between">
-                <Badge variant="outline">Public</Badge>
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Public</Badge>
+                  {isSubscribed && (
+                    <Badge className="gap-1 bg-accent text-accent-foreground">
+                      <CheckCircle2 className="h-3 w-3" />
+                      Subscribed
+                    </Badge>
+                  )}
+                </div>
                 <Button
                   size="sm"
                   variant={isSubscribed ? "outline" : "default"}

--- a/apps/web/src/app/dashboard/discover/page.tsx
+++ b/apps/web/src/app/dashboard/discover/page.tsx
@@ -1,18 +1,22 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getPublicLeagues } from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
 import DiscoverLeagues from "./discover-leagues";
 
 export default async function DiscoverPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const client = await clerkClient();
-  const user = await client.users.getUser(userId);
-  const subscribedLeagueIds =
-    (user.publicMetadata?.subscribedLeagueIds as string[]) ?? [];
-
-  const publicLeagues = await getPublicLeagues();
+  // Subscriptions are the source of truth in Convex (leagueSubscriptions),
+  // not Clerk publicMetadata — the subscribe route only writes Convex, so the
+  // old metadata read was always empty and every card showed "Subscribe"
+  // (WSM-000099). resolveOrgContext returns the real subscribed league ids.
+  const [orgContext, publicLeagues] = await Promise.all([
+    resolveOrgContext(userId),
+    getPublicLeagues(),
+  ]);
+  const subscribedLeagueIds = orgContext.subscribedLeagueIds;
 
   return (
     <div>


### PR DESCRIPTION
**Bug (from a phone screenshot):** the Discover screen showed **"Subscribe"** for NFL even though the user was already subscribed.

**Root cause:** `discover/page.tsx` read `subscribedLeagueIds` from Clerk `publicMetadata`, but the subscribe route (`/api/leagues/subscribe`) only writes the Convex `leagueSubscriptions` table — nothing ever populated that metadata. So the array was always empty: every card rendered "Subscribe", and the Unsubscribe path (which already existed) was unreachable.

**Fix:** read the real subscription state from Convex via `resolveOrgContext(userId).subscribedLeagueIds`, and add a clear **Subscribed** badge (check icon) next to the now-reachable Unsubscribe button.

This is the first slice of the broader discover/subscription request; à la carte (division/team-level) import is planned separately as a larger data-model change.

Verification: tsc clean, lint baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)