### PR TITLE
Team back link reflects origin (WSM-000102)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -94,7 +94,7 @@ export default async function LeaguesPage() {
                                 {divTeams.map((team) => (
                                   <Link
                                     key={team.id}
-                                    href={`/dashboard/teams/${team.id}`}
+                                    href={`/dashboard/teams/${team.id}?from=leagues`}
                                     className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-card"
                                   >
                                     <Users className="h-3.5 w-3.5 text-muted-foreground" />

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -16,13 +16,23 @@ import TeamManagement from "./team-management";
 
 export default async function TeamDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string }>;
 }) {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
   const { id } = await params;
+  // Back link reflects where the user came from (WSM-000102): a team reached
+  // from the Leagues page should go back to Leagues, not Teams. Linking pages
+  // pass `?from`; default is the Teams list.
+  const { from } = await searchParams;
+  const back =
+    from === "leagues"
+      ? { href: "/dashboard/leagues", label: "Back to Leagues" }
+      : { href: "/dashboard/teams", label: "Back to Teams" };
   const orgContext = await resolveOrgContext(userId);
 
   const [team, players, canManage] = await Promise.all([
@@ -57,10 +67,10 @@ export default async function TeamDetailPage({
   return (
     <div>
       <Link
-        href="/dashboard/teams"
+        href={back.href}
         className="mb-4 inline-block text-sm text-primary hover:underline"
       >
-        &larr; Back to Teams
+        &larr; {back.label}
       </Link>
 
       <TeamManagement


### PR DESCRIPTION
**Bug:** opening a team from the **Leagues** page showed "← Back to Teams", which navigates to a list the user never came from.

**Fix:** the team detail page reads a `?from` hint. The Leagues page tags its team links with `?from=leagues`, so the back link becomes "← Back to Leagues" → `/dashboard/leagues`. All other entry points (Teams list, etc.) keep the default "← Back to Teams". Minimal and extensible — new origins just add a `from` value.

Verification: tsc clean, lint baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)