### PR TITLE
Global active-league switcher (WSM-000103)

### DIFF
--- a/apps/web/src/app/dashboard/_components/league-switcher.tsx
+++ b/apps/web/src/app/dashboard/_components/league-switcher.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { Trophy, ChevronsUpDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from "@/components/ui/dropdown-menu";
+import { ACTIVE_LEAGUE_COOKIE } from "@/lib/active-league";
+
+interface LeagueOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Global league switcher (WSM-000103). Sets the active-league preference cookie
+ * and refreshes so server components re-scope to the chosen league. Renders
+ * nothing when the user has no leagues.
+ */
+export function LeagueSwitcher({
+  leagues,
+  activeLeagueId,
+}: {
+  leagues: LeagueOption[];
+  activeLeagueId: string | null;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  if (leagues.length === 0) return null;
+
+  const active = leagues.find((l) => l.id === activeLeagueId) ?? null;
+
+  function select(id: string) {
+    if (id === activeLeagueId) return;
+    // Preference cookie — read by server components on the next request.
+    document.cookie = `${ACTIVE_LEAGUE_COOKIE}=${id}; path=/; max-age=31536000; samesite=lax`;
+    startTransition(() => router.refresh());
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-60"
+        disabled={isPending}
+        aria-label="Switch league"
+      >
+        <Trophy className="h-4 w-4 shrink-0 text-primary" />
+        <span className="max-w-[10rem] truncate">
+          {active?.name ?? "Select league"}
+        </span>
+        <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuLabel>Active league</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={activeLeagueId ?? ""}
+          onValueChange={select}
+        >
+          {leagues.map((league) => (
+            <DropdownMenuRadioItem key={league.id} value={league.id}>
+              {league.name}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -6,12 +6,24 @@ import { UserButton } from "@clerk/nextjs";
 import { Button } from "@/components/ui/8bit/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import Sidebar from "./sidebar";
+import { LeagueSwitcher } from "./league-switcher";
 
-export default function MobileHeader() {
+interface LeagueOption {
+  id: string;
+  name: string;
+}
+
+export default function MobileHeader({
+  leagues,
+  activeLeagueId,
+}: {
+  leagues: LeagueOption[];
+  activeLeagueId: string | null;
+}) {
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="flex items-center justify-between border-b border-border px-4 py-3 lg:hidden">
+    <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3 lg:hidden">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="Open navigation menu">
@@ -22,7 +34,11 @@ export default function MobileHeader() {
           <Sidebar onNavigate={() => setOpen(false)} />
         </SheetContent>
       </Sheet>
-      <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
+      {leagues.length > 0 ? (
+        <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
+      ) : (
+        <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
+      )}
       <UserButton />
     </header>
   );

--- a/apps/web/src/app/dashboard/divisions/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/page.tsx
@@ -1,15 +1,16 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getDivisions, getLeagues } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveActiveLeague } from "@/lib/active-league";
 import { DivisionsTable } from "./divisions-table";
 
 export default async function DivisionsPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const orgContext = await resolveOrgContext(userId);
-  const ids = orgContext.visibleLeagueIds;
+  // Scoped to the active league from the global switcher (WSM-000103).
+  const { activeLeagueId } = await resolveActiveLeague(userId);
+  const ids = activeLeagueId ? [activeLeagueId] : [];
 
   const [divisions, leagues] = await Promise.all([
     getDivisions(ids),

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,12 +1,20 @@
 import { UserButton } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 import Sidebar from "./_components/sidebar";
 import MobileHeader from "./_components/mobile-header";
+import { LeagueSwitcher } from "./_components/league-switcher";
+import { resolveActiveLeague } from "@/lib/active-league";
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { userId } = await auth();
+  const { leagues, activeLeagueId } = userId
+    ? await resolveActiveLeague(userId)
+    : { leagues: [], activeLeagueId: null };
+
   return (
     <div className="flex min-h-screen">
       <a href="#main-content" className="skip-to-content">
@@ -23,11 +31,11 @@ export default function DashboardLayout({
           viewport and overflow-x-auto containers never engage. */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Mobile header with hamburger */}
-        <MobileHeader />
+        <MobileHeader leagues={leagues} activeLeagueId={activeLeagueId} />
 
-        {/* Desktop header */}
+        {/* Desktop header — the league switcher is the focus anchor (WSM-000103) */}
         <header className="hidden items-center justify-between border-b border-border px-8 py-4 lg:flex">
-          <h1 className="text-xl font-bold text-foreground">Dashboard</h1>
+          <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
           <UserButton />
         </header>
 

--- a/apps/web/src/app/dashboard/players/page.tsx
+++ b/apps/web/src/app/dashboard/players/page.tsx
@@ -1,15 +1,17 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getPlayers } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveActiveLeague } from "@/lib/active-league";
 import { PlayersTable } from "./players-table";
 
 export default async function PlayersPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const orgContext = await resolveOrgContext(userId);
-  const players = await getPlayers(orgContext.visibleLeagueIds);
+  // Scoped to the active league from the global switcher (WSM-000103) — the
+  // flat all-leagues dump is gone; the switcher is the league picker now.
+  const { activeLeagueId } = await resolveActiveLeague(userId);
+  const players = activeLeagueId ? await getPlayers([activeLeagueId]) : [];
 
   return (
     <div>

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -2,14 +2,15 @@ import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getTeams } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveActiveLeague } from "@/lib/active-league";
 
 export default async function TeamsPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const orgContext = await resolveOrgContext(userId);
-  const teams = await getTeams(orgContext.visibleLeagueIds);
+  // Scoped to the active league chosen in the global switcher (WSM-000103).
+  const { activeLeagueId } = await resolveActiveLeague(userId);
+  const teams = activeLeagueId ? await getTeams([activeLeagueId]) : [];
 
   return (
     <div>

--- a/apps/web/src/lib/active-league.ts
+++ b/apps/web/src/lib/active-league.ts
@@ -1,0 +1,39 @@
+import { cache } from "react";
+import { cookies } from "next/headers";
+import type { LeagueDto } from "@sports-management/shared-types";
+import { resolveOrgContext, type OrgContext } from "./org-context";
+import { getLeagues } from "./data-api";
+
+/**
+ * Global "active league" context (WSM-000103). The dashboard focuses on one
+ * league at a time (Convex-deployment-switcher style); the active league is a
+ * preference cookie, read server-side so SSR pages scope their queries without
+ * a round-trip. Falls back to the first visible league.
+ */
+export const ACTIVE_LEAGUE_COOKIE = "activeLeagueId";
+
+export interface ActiveLeagueContext {
+  orgContext: OrgContext;
+  /** The user's visible leagues, name-sorted (from getLeagues). */
+  leagues: LeagueDto[];
+  /** The active league id, or null when the user has no leagues. */
+  activeLeagueId: string | null;
+}
+
+/**
+ * Resolves the active league: the cookie value when it's still visible, else
+ * the first visible league. Cached per request so the layout and the page that
+ * renders inside it share one resolution.
+ */
+export const resolveActiveLeague = cache(
+  async (userId: string): Promise<ActiveLeagueContext> => {
+    const orgContext = await resolveOrgContext(userId);
+    const leagues = await getLeagues(orgContext.visibleLeagueIds);
+    const cookieVal = (await cookies()).get(ACTIVE_LEAGUE_COOKIE)?.value;
+    const activeLeagueId =
+      (cookieVal && leagues.some((l) => l.id === cookieVal) ? cookieVal : null) ??
+      leagues[0]?.id ??
+      null;
+    return { orgContext, leagues, activeLeagueId };
+  },
+);


### PR DESCRIPTION
Your insight: per-tab "choose a league first" pickers are a band-aid — the real pattern is a **global league switcher** (the Convex deployment-switcher model). You pick the active league once in the top bar, and every data tab scopes to it.

## What
- **`active-league.ts`** — the active league is a preference **cookie**, resolved server-side (cookie when still visible, else first visible league) and `cache()`d per request so the layout and the page share one resolution.
- **`LeagueSwitcher`** — top-bar dropdown (desktop header + mobile header) listing your leagues with the active one checked. Selecting sets the cookie and `router.refresh()`es so server components re-scope. Renders nothing when you have no leagues.
- **Rescoped tabs** — **Teams / Players / Divisions** now query only the active league instead of all `visibleLeagueIds`. Standings/Schedules are already per-league by route.

## Mode
Pure "always one active league" (your pick) — no "All leagues" view.

## Supersedes
This replaces the per-tab Players picker from #215 (the switcher *is* the picker now). **I'll close #215** in favor of this.

## Composes with
À la carte import (WSM-000100, still to build) is orthogonal — it's *which teams within* the active league; this is *which league*.

## Verification
- tsc clean, 320 unit tests, lint baseline
- Cookie set client-side (non-httpOnly preference), read by SSR via `next/headers` `cookies()`; invalid/stale cookie falls back to the first visible league

🤖 Generated with [Claude Code](https://claude.com/claude-code)