### PR TITLE
À la carte league import — pick divisions/teams (WSM-000100)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -110,6 +110,11 @@ export default defineSchema({
   leagueSubscriptions: defineTable({
     userId: v.string(),
     leagueId: v.id("leagues"),
+    // À la carte import (WSM-000100): the teams the user chose to import from
+    // this league. undefined/empty = "import all" (backward-compatible with
+    // pre-feature rows). A display filter on the Teams/Players lists, not an
+    // access boundary — the league stays fully viewable (standings, detail).
+    teamIds: v.optional(v.array(v.id("teams"))),
   })
     .index("by_userId", ["userId"])
     .index("by_userId_leagueId", ["userId", "leagueId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -208,6 +208,15 @@ export const getVisibleLeagueContext = queryGeneric({
   returns: v.object({
     visibleLeagueIds: v.array(v.string()),
     subscribedLeagueIds: v.array(v.string()),
+    // À la carte scopes (WSM-000100): one entry per PARTIAL subscription
+    // (teamIds set & non-empty). Full ("import all") subscriptions are omitted
+    // so the consumer treats them as unrestricted.
+    subscriptionScopes: v.array(
+      v.object({
+        leagueId: v.string(),
+        teamIds: v.array(v.string()),
+      }),
+    ),
   }),
   handler: async (ctx, args) => {
     const subscriptionDocs = await ctx.db
@@ -216,6 +225,12 @@ export const getVisibleLeagueContext = queryGeneric({
       .collect();
 
     const subscribedLeagueIds = subscriptionDocs.map((doc) => doc.leagueId);
+    const subscriptionScopes = subscriptionDocs
+      .filter((doc) => doc.teamIds && doc.teamIds.length > 0)
+      .map((doc) => ({
+        leagueId: doc.leagueId as string,
+        teamIds: (doc.teamIds ?? []).map((id: string) => id),
+      }));
     const orgLeagueDocs = await Promise.all(
       args.orgIds.map((orgId) =>
         ctx.db
@@ -235,6 +250,7 @@ export const getVisibleLeagueContext = queryGeneric({
     return {
       visibleLeagueIds,
       subscribedLeagueIds,
+      subscriptionScopes,
     };
   },
 });
@@ -1188,6 +1204,9 @@ export const subscribeToLeague = mutationGeneric({
   args: {
     userId: v.string(),
     leagueId: v.id("leagues"),
+    // À la carte (WSM-000100): the teams to import. Omitted/empty = import all.
+    // Doubles as an update-scope path — re-calling patches an existing row.
+    teamIds: v.optional(v.array(v.id("teams"))),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -1195,6 +1214,9 @@ export const subscribeToLeague = mutationGeneric({
     if (!league || !league.isPublic) {
       throw new Error("League not found or not public");
     }
+
+    // Normalize: undefined/empty selection means "import all" (no teamIds).
+    const teamIds = args.teamIds && args.teamIds.length > 0 ? args.teamIds : undefined;
 
     const existing =
       (
@@ -1204,8 +1226,14 @@ export const subscribeToLeague = mutationGeneric({
           .collect()
       ).find((subscription) => subscription.leagueId === args.leagueId) ?? null;
 
-    if (!existing) {
-      await ctx.db.insert("leagueSubscriptions", args);
+    if (existing) {
+      await ctx.db.patch(existing._id, { teamIds });
+    } else {
+      await ctx.db.insert("leagueSubscriptions", {
+        userId: args.userId,
+        leagueId: args.leagueId,
+        teamIds,
+      });
     }
     return null;
   },

--- a/apps/web/src/app/api/leagues/subscribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/leagues/subscribe/__tests__/route.test.ts
@@ -75,7 +75,38 @@ describe("POST /api/leagues/subscribe", () => {
 
     const body = await res.json();
     expect(body.message).toBe("Subscribed");
-    expect(mockSubscribeToLeague).toHaveBeenCalledWith("user_1", "lg_pub");
+    // No team selection → "import all" (undefined scope). (WSM-000100)
+    expect(mockSubscribeToLeague).toHaveBeenCalledWith(
+      "user_1",
+      "lg_pub",
+      undefined,
+    );
+  });
+
+  it("passes an à la carte team selection through (WSM-000100)", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockSubscribeToLeague.mockResolvedValue(undefined);
+
+    const res = await POST(
+      makeRequest({ leagueId: "lg_pub", teamIds: ["t1", "t2"] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockSubscribeToLeague).toHaveBeenCalledWith("user_1", "lg_pub", [
+      "t1",
+      "t2",
+    ]);
+  });
+
+  it("ignores a non-array teamIds (treats as import all)", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_1" });
+    mockSubscribeToLeague.mockResolvedValue(undefined);
+
+    await POST(makeRequest({ leagueId: "lg_pub", teamIds: "nope" }));
+    expect(mockSubscribeToLeague).toHaveBeenCalledWith(
+      "user_1",
+      "lg_pub",
+      undefined,
+    );
   });
 
   it("idempotent — Convex mutation absorbs the dup write", async () => {

--- a/apps/web/src/app/api/leagues/subscribe/route.ts
+++ b/apps/web/src/app/api/leagues/subscribe/route.ts
@@ -13,20 +13,25 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { leagueId } = await request.json();
+    const { leagueId, teamIds } = await request.json();
     if (!leagueId || typeof leagueId !== "string") {
       return NextResponse.json(
         { error: "leagueId is required" },
         { status: 400 },
       );
     }
+    // À la carte (WSM-000100): optional team selection. A non-array or empty
+    // selection means "import all".
+    const scopedTeamIds =
+      Array.isArray(teamIds) && teamIds.every((t) => typeof t === "string")
+        ? (teamIds as string[])
+        : undefined;
 
     // The Convex `subscribeToLeague` mutation enforces the public-league
     // check (throws "League not found or not public") and idempotently
-    // writes to the `leagueSubscriptions` table. We surface the error
-    // back to the client at 404 to preserve the prior contract.
+    // upserts the `leagueSubscriptions` row (including the team scope).
     try {
-      await subscribeToLeague(userId, leagueId);
+      await subscribeToLeague(userId, leagueId, scopedTeamIds);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("not found") || msg.includes("not public")) {

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -1,100 +1,284 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/8bit/card";
 import { Button } from "@/components/ui/8bit/button";
 import { Badge } from "@/components/ui/badge";
-import { Trophy, CheckCircle2 } from "lucide-react";
+import { Trophy, CheckCircle2, ChevronDown, ChevronUp } from "lucide-react";
 
-interface League {
+export interface DiscoverLeague {
   id: string;
   name: string;
-  orgId: string | null;
+  subscribed: boolean;
+  /** null = imported all (or not subscribed); array = the imported subset. */
+  importedTeamIds: string[] | null;
+  divisions: { id: string; name: string }[];
+  teams: { id: string; name: string; divisionId: string }[];
 }
 
 export default function DiscoverLeagues({
   leagues,
-  subscribedIds,
 }: {
-  leagues: League[];
-  subscribedIds: string[];
+  leagues: DiscoverLeague[];
 }) {
+  if (leagues.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No public leagues available.
+      </p>
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      {leagues.map((league) => (
+        <LeagueImportCard key={league.id} league={league} />
+      ))}
+    </div>
+  );
+}
+
+function LeagueImportCard({ league }: { league: DiscoverLeague }) {
   const router = useRouter();
-  const [loadingId, setLoadingId] = useState<string | null>(null);
-  const [currentSubscribed, setCurrentSubscribed] =
-    useState<string[]>(subscribedIds);
+  const { divisions, teams } = league;
+  const allTeamIds = useMemo(() => teams.map((t) => t.id), [teams]);
 
-  async function handleToggle(leagueId: string, isSubscribed: boolean) {
-    setLoadingId(leagueId);
+  const [subscribed, setSubscribed] = useState(league.subscribed);
+  const [importAll, setImportAll] = useState(league.importedTeamIds === null);
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(league.importedTeamIds ?? allTeamIds),
+  );
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // Group teams by division for the tree; ungrouped fall into "Other".
+  const groups = useMemo(() => {
+    const byDivision = new Map<string, typeof teams>();
+    for (const team of teams) {
+      const list = byDivision.get(team.divisionId) ?? [];
+      list.push(team);
+      byDivision.set(team.divisionId, list);
+    }
+    const named = divisions
+      .map((d) => ({
+        id: d.id,
+        name: d.name,
+        teams: byDivision.get(d.id) ?? [],
+      }))
+      .filter((g) => g.teams.length > 0);
+    const knownIds = new Set(divisions.map((d) => d.id));
+    const other = teams.filter((t) => !knownIds.has(t.divisionId));
+    if (other.length > 0) {
+      named.push({ id: "__other", name: "Other", teams: other });
+    }
+    return named;
+  }, [divisions, teams]);
+
+  function toggleTeam(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleDivision(teamIds: string[], fullySelected: boolean) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of teamIds) {
+        if (fullySelected) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  const canSubmit = importAll || selected.size > 0;
+
+  async function save() {
+    setLoading(true);
     try {
+      const teamIds = importAll ? [] : Array.from(selected);
       const res = await fetch("/api/leagues/subscribe", {
-        method: isSubscribed ? "DELETE" : "POST",
+        method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ leagueId }),
+        body: JSON.stringify({ leagueId: league.id, teamIds }),
       });
-
       if (res.ok) {
-        setCurrentSubscribed((prev) =>
-          isSubscribed
-            ? prev.filter((id) => id !== leagueId)
-            : [...prev, leagueId],
-        );
+        setSubscribed(true);
+        setExpanded(false);
         router.refresh();
       }
     } finally {
-      setLoadingId(null);
+      setLoading(false);
     }
   }
 
-  if (leagues.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">No public leagues available.</p>
-    );
+  async function unsubscribe() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/leagues/subscribe", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ leagueId: league.id }),
+      });
+      if (res.ok) {
+        setSubscribed(false);
+        setExpanded(false);
+        router.refresh();
+      }
+    } finally {
+      setLoading(false);
+    }
   }
 
-  return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {leagues.map((league) => {
-        const isSubscribed = currentSubscribed.includes(league.id);
-        const isLoading = loadingId === league.id;
+  const summary = !subscribed
+    ? null
+    : importAll
+      ? "All teams"
+      : `${selected.size} of ${allTeamIds.length} teams`;
 
-        return (
-          <Card key={league.id}>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Trophy className="h-4 w-4 text-primary" />
-                <CardTitle className="text-base">{league.name}</CardTitle>
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Trophy className="h-4 w-4 text-primary" />
+          <CardTitle className="text-base">{league.name}</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">Public</Badge>
+          {subscribed && (
+            <Badge className="gap-1 bg-accent text-accent-foreground">
+              <CheckCircle2 className="h-3 w-3" />
+              Subscribed · {summary}
+            </Badge>
+          )}
+        </div>
+
+        {league.teams.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center gap-1 text-sm text-primary hover:underline"
+          >
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            {subscribed ? "Edit import" : "Choose what to import"}
+          </button>
+        )}
+
+        {expanded && league.teams.length > 0 && (
+          <div className="rounded-md border border-border p-3">
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={importAll}
+                onChange={(e) => setImportAll(e.target.checked)}
+              />
+              Import all teams
+            </label>
+
+            {!importAll && (
+              <div className="mt-3 space-y-3">
+                {groups.map((group) => {
+                  const ids = group.teams.map((t) => t.id);
+                  const selCount = ids.filter((id) => selected.has(id)).length;
+                  const fully = selCount === ids.length;
+                  return (
+                    <div key={group.id}>
+                      <DivisionCheckbox
+                        label={group.name}
+                        checked={fully}
+                        indeterminate={selCount > 0 && !fully}
+                        onToggle={() => toggleDivision(ids, fully)}
+                      />
+                      <div className="ml-6 mt-1 grid grid-cols-1 gap-1 sm:grid-cols-2">
+                        {group.teams.map((team) => (
+                          <label
+                            key={team.id}
+                            className="flex items-center gap-2 text-sm text-muted-foreground"
+                          >
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4 accent-primary"
+                              checked={selected.has(team.id)}
+                              onChange={() => toggleTeam(team.id)}
+                            />
+                            <span className="truncate">{team.name}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+                {!canSubmit && (
+                  <p className="text-xs text-destructive">
+                    Pick at least one team, or choose Import all.
+                  </p>
+                )}
               </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
-                  <Badge variant="outline">Public</Badge>
-                  {isSubscribed && (
-                    <Badge className="gap-1 bg-accent text-accent-foreground">
-                      <CheckCircle2 className="h-3 w-3" />
-                      Subscribed
-                    </Badge>
-                  )}
-                </div>
-                <Button
-                  size="sm"
-                  variant={isSubscribed ? "outline" : "default"}
-                  disabled={isLoading}
-                  onClick={() => handleToggle(league.id, isSubscribed)}
-                >
-                  {isLoading
-                    ? "..."
-                    : isSubscribed
-                      ? "Unsubscribe"
-                      : "Subscribe"}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        );
-      })}
-    </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button size="sm" disabled={loading || !canSubmit} onClick={save}>
+            {loading ? "..." : subscribed ? "Save changes" : "Subscribe"}
+          </Button>
+          {subscribed && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={loading}
+              onClick={unsubscribe}
+            >
+              Unsubscribe
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Native checkbox with a controllable indeterminate state. */
+function DivisionCheckbox({
+  label,
+  checked,
+  indeterminate,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  indeterminate: boolean;
+  onToggle: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <label className="flex items-center gap-2 text-sm font-medium text-foreground">
+      <input
+        ref={ref}
+        type="checkbox"
+        className="h-4 w-4 accent-primary"
+        checked={checked}
+        onChange={onToggle}
+      />
+      {label}
+    </label>
   );
 }

--- a/apps/web/src/app/dashboard/discover/page.tsx
+++ b/apps/web/src/app/dashboard/discover/page.tsx
@@ -1,22 +1,42 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getPublicLeagues } from "@/lib/data-api";
+import { getPublicLeagues, getPublicLeagueImportTree } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import DiscoverLeagues from "./discover-leagues";
+import DiscoverLeagues, { type DiscoverLeague } from "./discover-leagues";
 
 export default async function DiscoverPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  // Subscriptions are the source of truth in Convex (leagueSubscriptions),
-  // not Clerk publicMetadata — the subscribe route only writes Convex, so the
-  // old metadata read was always empty and every card showed "Subscribe"
-  // (WSM-000099). resolveOrgContext returns the real subscribed league ids.
+  // Subscriptions (and à la carte team scopes) are the source of truth in
+  // Convex; resolveOrgContext carries both (WSM-000099 / WSM-000100).
   const [orgContext, publicLeagues] = await Promise.all([
     resolveOrgContext(userId),
     getPublicLeagues(),
   ]);
-  const subscribedLeagueIds = orgContext.subscribedLeagueIds;
+
+  // Each public league carries its division/team tree so the card can offer
+  // à la carte selection, plus the user's current import state.
+  const leagues: DiscoverLeague[] = await Promise.all(
+    publicLeagues.map(async (league) => {
+      const { teams, divisions } = await getPublicLeagueImportTree(
+        league.id,
+      ).catch(() => ({ teams: [], divisions: [] }));
+      return {
+        id: league.id,
+        name: league.name,
+        subscribed: orgContext.subscribedLeagueIds.includes(league.id),
+        // null = imported all (or not subscribed); array = the imported subset.
+        importedTeamIds: orgContext.subscriptionTeamScopes[league.id] ?? null,
+        divisions: divisions.map((d) => ({ id: d.id, name: d.name })),
+        teams: teams.map((t) => ({
+          id: t.id,
+          name: t.name,
+          divisionId: t.divisionId,
+        })),
+      };
+    }),
+  );
 
   return (
     <div>
@@ -24,12 +44,10 @@ export default async function DiscoverPage() {
         Discover Leagues
       </h2>
       <p className="mb-6 text-sm text-muted-foreground">
-        Browse public leagues and add them to your dashboard.
+        Browse public leagues and import them. Import everything, or pick the
+        divisions and teams you want.
       </p>
-      <DiscoverLeagues
-        leagues={publicLeagues}
-        subscribedIds={subscribedLeagueIds}
-      />
+      <DiscoverLeagues leagues={leagues} />
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/players/page.tsx
+++ b/apps/web/src/app/dashboard/players/page.tsx
@@ -2,16 +2,23 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getPlayers } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
+import { playersInScope } from "@/lib/subscription-scope";
 import { PlayersTable } from "./players-table";
 
 export default async function PlayersPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  // Scoped to the active league from the global switcher (WSM-000103) — the
-  // flat all-leagues dump is gone; the switcher is the league picker now.
-  const { activeLeagueId } = await resolveActiveLeague(userId);
-  const players = activeLeagueId ? await getPlayers([activeLeagueId]) : [];
+  // Active league (WSM-000103), then à la carte imported teams within it
+  // (WSM-000100): a partial import shows only players on the imported teams.
+  const { orgContext, activeLeagueId } = await resolveActiveLeague(userId);
+  const players = activeLeagueId
+    ? playersInScope(
+        await getPlayers([activeLeagueId]),
+        activeLeagueId,
+        orgContext,
+      )
+    : [];
 
   return (
     <div>

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -30,6 +30,7 @@ export default async function DepthChartPage({
     orgIds: [],
     visibleLeagueIds: [],
     subscribedLeagueIds: [],
+    subscriptionTeamScopes: {},
   }).catch(() => null);
   if (!team) notFound();
 
@@ -66,6 +67,7 @@ export default async function DepthChartPage({
       orgIds: [orgId],
       visibleLeagueIds: [team.leagueId],
       subscribedLeagueIds: [],
+      subscriptionTeamScopes: {},
     }),
     getDepthChartByTeamSeason(teamId, activeSeason.id),
   ]);

--- a/apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/audit/page.tsx
@@ -33,6 +33,7 @@ export default async function RosterAuditPage({
     orgIds: [],
     visibleLeagueIds: [leagueId],
     subscribedLeagueIds: [],
+    subscriptionTeamScopes: {},
   }).catch(() => null);
   if (!team) notFound();
 
@@ -67,6 +68,7 @@ export default async function RosterAuditPage({
       orgIds: [orgId],
       visibleLeagueIds: [team.leagueId],
       subscribedLeagueIds: [],
+      subscriptionTeamScopes: {},
     }),
     getRosterAssignmentHistory({
       teamId,

--- a/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
@@ -37,6 +37,7 @@ export default async function RosterPage({
     orgIds: [],
     visibleLeagueIds: [leagueId],
     subscribedLeagueIds: [],
+    subscriptionTeamScopes: {},
   }).catch(() => null);
   if (!team) notFound();
 
@@ -72,6 +73,7 @@ export default async function RosterPage({
       orgIds: [orgId],
       visibleLeagueIds: [team.leagueId],
       subscribedLeagueIds: [],
+      subscriptionTeamScopes: {},
     }),
     getRosterBySeasonTeam(activeSeason.id, teamId),
     getTeamRosterLimitStatus(activeSeason.id, teamId),

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -3,14 +3,18 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getTeams } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
+import { teamsInScope } from "@/lib/subscription-scope";
 
 export default async function TeamsPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  // Scoped to the active league chosen in the global switcher (WSM-000103).
-  const { activeLeagueId } = await resolveActiveLeague(userId);
-  const teams = activeLeagueId ? await getTeams([activeLeagueId]) : [];
+  // Scoped to the active league (WSM-000103), then to the à la carte imported
+  // teams within it (WSM-000100) — a partial import shows only those teams.
+  const { orgContext, activeLeagueId } = await resolveActiveLeague(userId);
+  const teams = activeLeagueId
+    ? teamsInScope(await getTeams([activeLeagueId]), activeLeagueId, orgContext)
+    : [];
 
   return (
     <div>

--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -43,6 +43,9 @@ describe("resolveOrgContext", () => {
     mockGetVisibleLeagueContext.mockResolvedValue({
       visibleLeagueIds: ["league_1", "league_2", "league_pub_1"],
       subscribedLeagueIds: ["league_pub_1"],
+      subscriptionScopes: [
+        { leagueId: "league_pub_1", teamIds: ["team_a", "team_b"] },
+      ],
     });
 
     const ctx = await resolveOrgContext("user_123");
@@ -55,6 +58,10 @@ describe("resolveOrgContext", () => {
       "league_pub_1",
     ]);
     expect(ctx.subscribedLeagueIds).toEqual(["league_pub_1"]);
+    // À la carte scopes map leagueId → imported teamIds (WSM-000100).
+    expect(ctx.subscriptionTeamScopes).toEqual({
+      league_pub_1: ["team_a", "team_b"],
+    });
     expect(mockGetVisibleLeagueContext).toHaveBeenCalledWith("user_123", [
       "org_abc",
       "org_def",
@@ -66,6 +73,7 @@ describe("resolveOrgContext", () => {
     mockGetVisibleLeagueContext.mockResolvedValue({
       visibleLeagueIds: [],
       subscribedLeagueIds: [],
+      subscriptionScopes: [],
     });
 
     const ctx = await resolveOrgContext("user_no_orgs");
@@ -84,6 +92,7 @@ describe("resolveOrgContext", () => {
     mockGetVisibleLeagueContext.mockResolvedValue({
       visibleLeagueIds: ["league_pub_1", "league_pub_2"],
       subscribedLeagueIds: ["league_pub_1", "league_pub_2"],
+      subscriptionScopes: [],
     });
 
     const ctx = await resolveOrgContext("user_with_subs");
@@ -108,6 +117,7 @@ describe("resolveOrgContext", () => {
     mockGetVisibleLeagueContext.mockResolvedValue({
       visibleLeagueIds: [],
       subscribedLeagueIds: [],
+      subscriptionScopes: [],
     });
 
     const ctx = await resolveOrgContext("user_many_orgs");
@@ -128,6 +138,7 @@ describe("requireLeagueAccess", () => {
       orgIds: ["org_1"],
       visibleLeagueIds: ["lg_1", "lg_2"],
       subscribedLeagueIds: [],
+      subscriptionTeamScopes: {},
     };
     expect(() => requireLeagueAccess("lg_1", ctx)).not.toThrow();
   });
@@ -138,6 +149,7 @@ describe("requireLeagueAccess", () => {
       orgIds: ["org_1"],
       visibleLeagueIds: ["lg_1"],
       subscribedLeagueIds: [],
+      subscriptionTeamScopes: {},
     };
     expect(() => requireLeagueAccess("lg_other", ctx)).toThrow(
       "You do not have access to this league",

--- a/apps/web/src/lib/__tests__/subscription-scope.test.ts
+++ b/apps/web/src/lib/__tests__/subscription-scope.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import type { OrgContext } from "../org-context";
+import { teamsInScope, playersInScope } from "../subscription-scope";
+
+function ctx(scopes: Record<string, string[]>): OrgContext {
+  return {
+    userId: "u",
+    orgIds: [],
+    visibleLeagueIds: [],
+    subscribedLeagueIds: [],
+    subscriptionTeamScopes: scopes,
+  };
+}
+
+const teams = [{ id: "t1" }, { id: "t2" }, { id: "t3" }];
+const players = [
+  { teamId: "t1" },
+  { teamId: "t2" },
+  { teamId: "t3" },
+];
+
+describe("teamsInScope (WSM-000100)", () => {
+  it("returns all teams when the league has no scope (import all)", () => {
+    expect(teamsInScope(teams, "lg", ctx({}))).toEqual(teams);
+  });
+
+  it("filters to the imported teams when scoped", () => {
+    const out = teamsInScope(teams, "lg", ctx({ lg: ["t1", "t3"] }));
+    expect(out.map((t) => t.id)).toEqual(["t1", "t3"]);
+  });
+
+  it("an empty scope is treated as import-all, not import-none", () => {
+    expect(teamsInScope(teams, "lg", ctx({ lg: [] }))).toEqual(teams);
+  });
+
+  it("only the named league is scoped", () => {
+    expect(teamsInScope(teams, "other", ctx({ lg: ["t1"] }))).toEqual(teams);
+  });
+});
+
+describe("playersInScope (WSM-000100)", () => {
+  it("returns all players when unscoped", () => {
+    expect(playersInScope(players, "lg", ctx({}))).toEqual(players);
+  });
+
+  it("filters players by their team's membership in the scope", () => {
+    const out = playersInScope(players, "lg", ctx({ lg: ["t2"] }));
+    expect(out.map((p) => p.teamId)).toEqual(["t2"]);
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -67,7 +67,11 @@ function mutationRef<Args extends object, Return>(name: string) {
 const refs = {
   getVisibleLeagueContext: queryRef<
     { orgIds: string[]; userId: string },
-    { visibleLeagueIds: string[]; subscribedLeagueIds: string[] }
+    {
+      visibleLeagueIds: string[];
+      subscribedLeagueIds: string[];
+      subscriptionScopes: Array<{ leagueId: string; teamIds: string[] }>;
+    }
   >("sports:getVisibleLeagueContext"),
   listPublicLeagues: queryRef<Record<string, never>, LeagueDto[]>(
     "sports:listPublicLeagues",
@@ -186,9 +190,10 @@ const refs = {
     { leagueId: string; token: string | null },
     null
   >("sports:setLeagueInviteToken"),
-  subscribeToLeague: mutationRef<{ userId: string; leagueId: string }, null>(
-    "sports:subscribeToLeague",
-  ),
+  subscribeToLeague: mutationRef<
+    { userId: string; leagueId: string; teamIds?: string[] },
+    null
+  >("sports:subscribeToLeague"),
   unsubscribeFromLeague: mutationRef<{ userId: string; leagueId: string }, null>(
     "sports:unsubscribeFromLeague",
   ),
@@ -448,6 +453,21 @@ export async function getPublicLeagues(): Promise<LeagueDto[]> {
   return queryConvex(refs.listPublicLeagues, {});
 }
 
+/**
+ * Teams + divisions for a PUBLIC league's à la carte import tree (WSM-000100).
+ * The league id must come from getPublicLeagues — public leagues are browseable
+ * for import, so there's no org-access gate here.
+ */
+export async function getPublicLeagueImportTree(
+  leagueId: string,
+): Promise<{ teams: TeamDto[]; divisions: DivisionDto[] }> {
+  const [teams, divisions] = await Promise.all([
+    queryConvex(refs.listTeamsByLeague, { leagueId }),
+    queryConvex(refs.listDivisions, { leagueIds: [leagueId] }),
+  ]);
+  return { teams, divisions };
+}
+
 export async function getLeagueByInviteToken(
   token: string,
 ): Promise<{ leagueId: string; orgId: string | null; name: string } | null> {
@@ -698,8 +718,9 @@ export async function upsertSeason(input: {
 export async function subscribeToLeague(
   userId: string,
   leagueId: string,
+  teamIds?: string[],
 ): Promise<void> {
-  await mutateConvex(refs.subscribeToLeague, { userId, leagueId });
+  await mutateConvex(refs.subscribeToLeague, { userId, leagueId, teamIds });
 }
 
 export async function unsubscribeFromLeague(

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -7,6 +7,13 @@ export interface OrgContext {
   orgIds: string[];
   visibleLeagueIds: string[];
   subscribedLeagueIds: string[];
+  /**
+   * À la carte import scopes (WSM-000100): leagueId → the team ids the user
+   * imported from that league. Only present for PARTIAL subscriptions; a
+   * league absent from this map means "all teams". A display filter for the
+   * Teams/Players lists — not an access boundary.
+   */
+  subscriptionTeamScopes: Record<string, string[]>;
 }
 
 /**
@@ -47,10 +54,23 @@ export const resolveOrgContext = cache(
     // Single Convex query resolves both visible-league fan-out (via the
     // `leagues.by_orgId` index for each org the user belongs to) and the
     // subscribed-league set (via `leagueSubscriptions.by_userId`).
-    const { visibleLeagueIds, subscribedLeagueIds } =
+    const { visibleLeagueIds, subscribedLeagueIds, subscriptionScopes } =
       await getVisibleLeagueContextFromConvex(userId, orgIds);
 
-    return { userId, orgIds, visibleLeagueIds, subscribedLeagueIds };
+    // `?? []` keeps this resilient if the web deploys ahead of the Convex
+    // function that adds subscriptionScopes — no scopes just means "import all".
+    const subscriptionTeamScopes: Record<string, string[]> = {};
+    for (const scope of subscriptionScopes ?? []) {
+      subscriptionTeamScopes[scope.leagueId] = scope.teamIds;
+    }
+
+    return {
+      userId,
+      orgIds,
+      visibleLeagueIds,
+      subscribedLeagueIds,
+      subscriptionTeamScopes,
+    };
   },
 );
 

--- a/apps/web/src/lib/subscription-scope.ts
+++ b/apps/web/src/lib/subscription-scope.ts
@@ -1,0 +1,29 @@
+import type { OrgContext } from "./org-context";
+
+/**
+ * À la carte import filters (WSM-000100). When the user imported only some
+ * teams from a league, the Teams/Players *lists* show just those teams. A
+ * league with no scope entry means "import all" → no filtering. This is a
+ * display filter only; team/player detail and standings stay fully reachable.
+ */
+export function teamsInScope<T extends { id: string }>(
+  teams: T[],
+  leagueId: string,
+  orgContext: OrgContext,
+): T[] {
+  const scope = orgContext.subscriptionTeamScopes[leagueId];
+  if (!scope || scope.length === 0) return teams;
+  const allowed = new Set(scope);
+  return teams.filter((team) => allowed.has(team.id));
+}
+
+export function playersInScope<T extends { teamId: string }>(
+  players: T[],
+  leagueId: string,
+  orgContext: OrgContext,
+): T[] {
+  const scope = orgContext.subscriptionTeamScopes[leagueId];
+  if (!scope || scope.length === 0) return players;
+  const allowed = new Set(scope);
+  return players.filter((player) => allowed.has(player.teamId));
+}


### PR DESCRIPTION
Discover can now import a league **wholesale** or just the **divisions/teams you want** — checkbox-based, with **Import all as the default**.

## Behavior (your pick)
Lists filter to your imported teams; **standings/schedules and team/player detail stay full-league**. So the scope is a *display filter*, not an access boundary — subscribing makes the whole league viewable; à la carte just curates your Teams/Players lists.

## Data model
- `leagueSubscriptions.teamIds` (optional). Empty/undefined = import all — **backward-compatible** with existing rows.
- `subscribeToLeague(userId, leagueId, teamIds?)` upserts the scope (doubles as edit-scope).
- `getVisibleLeagueContext` returns per-league scopes for partial subscriptions → `OrgContext.subscriptionTeamScopes`.

## Filtering
Pure, tested helper (`teamsInScope` / `playersInScope`) applied in the Teams and Players list pages only. Empty scope = import-all (never import-none).

## Discover UI
Collapsible checkbox tree per league: **Import all** → divisions (with indeterminate state) → teams. Edit-after-subscribe, a "3 of 8 teams" summary badge, and Unsubscribe. Requires ≥1 team (or Import all) to submit.

## Composes with #217
The global switcher picks *which league*; this picks *which teams within it*.

## Deploy
Convex already deployed to prod (additive: optional `teamIds` + scopes). `OrgContext` defaults missing scopes to "import all", so the web is safe even if it leads the Convex deploy.

## Verification
- tsc clean, lint baseline
- **328 unit tests** (+8: subscription-scope ×6, à la carte route ×2, org-context scope assertion)

Closes the à la carte portion of #185-era discover work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)