### PR TITLE
Fix broken prod build: next/headers in client bundle

### DIFF
--- a/apps/web/src/app/dashboard/_components/league-switcher.tsx
+++ b/apps/web/src/app/dashboard/_components/league-switcher.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
 } from "@/components/ui/dropdown-menu";
-import { ACTIVE_LEAGUE_COOKIE } from "@/lib/active-league";
+import { ACTIVE_LEAGUE_COOKIE } from "@/lib/active-league-cookie";
 
 interface LeagueOption {
   id: string;

--- a/apps/web/src/lib/active-league-cookie.ts
+++ b/apps/web/src/lib/active-league-cookie.ts
@@ -1,0 +1,7 @@
+/**
+ * The active-league preference cookie name. Lives in its own module — with NO
+ * server-only imports — so both the server resolver (active-league.ts, which
+ * imports `next/headers`) and the client switcher can share it without dragging
+ * `next/headers` into the client bundle (WSM-000103 build fix).
+ */
+export const ACTIVE_LEAGUE_COOKIE = "activeLeagueId";

--- a/apps/web/src/lib/active-league.ts
+++ b/apps/web/src/lib/active-league.ts
@@ -3,14 +3,19 @@ import { cookies } from "next/headers";
 import type { LeagueDto } from "@sports-management/shared-types";
 import { resolveOrgContext, type OrgContext } from "./org-context";
 import { getLeagues } from "./data-api";
+import { ACTIVE_LEAGUE_COOKIE } from "./active-league-cookie";
 
 /**
  * Global "active league" context (WSM-000103). The dashboard focuses on one
  * league at a time (Convex-deployment-switcher style); the active league is a
  * preference cookie, read server-side so SSR pages scope their queries without
  * a round-trip. Falls back to the first visible league.
+ *
+ * The cookie name is re-exported from the client-safe module so existing
+ * server importers keep working; the client switcher imports it directly from
+ * there to avoid pulling `next/headers` into the client bundle.
  */
-export const ACTIVE_LEAGUE_COOKIE = "activeLeagueId";
+export { ACTIVE_LEAGUE_COOKIE };
 
 export interface ActiveLeagueContext {
   orgContext: OrgContext;


### PR DESCRIPTION
**Production builds have been failing since the league switcher (#217) merged** — the domain is pinned to a stale deploy, so the switcher, à la carte import, and the seeded Cobb County league are **not live**.

## Cause
The client `LeagueSwitcher` imported `ACTIVE_LEAGUE_COOKIE` from `active-league.ts`, which also imports `cookies` from `next/headers`. That pulls `next/headers` into the client bundle → `next build` fails ("only works in a Server Component"). `tsc --noEmit` doesn't enforce the client/server boundary, so it passed locally but broke on Vercel.

## Fix
Move the cookie-name constant into `lib/active-league-cookie.ts` (no server-only imports). The client switcher imports from there; the server resolver re-exports it for compatibility.

## Verification
- **Real `next build`**: ✓ Compiled successfully, ✓ static generation 20/20 (the check tsc can't do)

Process note: I'll add `next build` (not just `tsc`) to the pre-merge gate so the client/server boundary is caught locally next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)