### PR TITLE
Default active league to an owned league (WSM-000105)

### DIFF
--- a/apps/web/src/lib/active-league.ts
+++ b/apps/web/src/lib/active-league.ts
@@ -35,8 +35,18 @@ export const resolveActiveLeague = cache(
     const orgContext = await resolveOrgContext(userId);
     const leagues = await getLeagues(orgContext.visibleLeagueIds);
     const cookieVal = (await cookies()).get(ACTIVE_LEAGUE_COOKIE)?.value;
+    // Default order (WSM-000105): an explicit switcher choice (cookie) wins;
+    // otherwise prefer a league the user's org OWNS (their primary) over any
+    // followed/subscribed public league; finally fall back to the first
+    // visible league. `leagues` is name-sorted, so each pick is deterministic.
+    const owned = leagues.filter(
+      (l) => l.orgId !== null && orgContext.orgIds.includes(l.orgId),
+    );
     const activeLeagueId =
-      (cookieVal && leagues.some((l) => l.id === cookieVal) ? cookieVal : null) ??
+      (cookieVal && leagues.some((l) => l.id === cookieVal)
+        ? cookieVal
+        : null) ??
+      owned[0]?.id ??
       leagues[0]?.id ??
       null;
     return { orgContext, leagues, activeLeagueId };


### PR DESCRIPTION
The global switcher defaulted to the **first league alphabetically** when no cookie was set. Now it prefers a league the user's org **owns** (`league.orgId ∈ orgContext.orgIds`) over any followed/subscribed public league.

Order: explicit switcher choice (cookie) → first **owned** league → first visible (fallback for subscription-only users). `leagues` is name-sorted so each pick is deterministic.

**Note:** currently both prod public leagues (NFL, Cobb) are `orgId=null` (standalone public), so no user owns a league yet — this takes effect once a user owns one (e.g. via the editability/fork model under discussion).

Verification: tsc clean, 328 tests, **`next build` ✓** (added to the pre-merge gate after the client/server boundary bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)