### PR TITLE
Team-claim engine (Hybrid fork model) (WSM-000109)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -7,6 +7,11 @@ export default defineSchema({
     orgId: v.union(v.string(), v.null()),
     isPublic: v.boolean(),
     inviteToken: v.union(v.string(), v.null()),
+    // Hybrid fork model (WSM-000109): when true, individual teams in this
+    // (public template) league can be CLAIMED by a coach's org — the league
+    // stays shared/read-only, but a claimed team becomes editable by its
+    // owner. Reference leagues (NFL) leave this false/undefined.
+    claimable: v.optional(v.boolean()),
   })
     .index("by_name", ["name"])
     .index("by_orgId", ["orgId"])
@@ -30,10 +35,15 @@ export default defineSchema({
     location: v.string(),
     logoUrl: v.union(v.string(), v.null()),
     rosterLimit: v.union(v.number(), v.null()),
+    // Hybrid fork model (WSM-000109): the Clerk org that CLAIMED this team in a
+    // claimable league. null/undefined = unclaimed. An admin of this org can
+    // edit the team + its roster even though the league itself is shared.
+    ownerOrgId: v.optional(v.union(v.string(), v.null())),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_divisionId", ["divisionId"])
-    .index("by_leagueId_name", ["leagueId", "name"]),
+    .index("by_leagueId_name", ["leagueId", "name"])
+    .index("by_ownerOrgId", ["ownerOrgId"]),
 
   players: defineTable({
     name: v.string(),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -503,6 +503,16 @@ export const getTeamLeagueId = queryGeneric({
   },
 });
 
+/** Hybrid fork model (WSM-000109): the org that claimed this team, or null. */
+export const getTeamOwnerOrgId = queryGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.teamId);
+    return doc?.ownerOrgId ?? null;
+  },
+});
+
 export const listPlayers = queryGeneric({
   args: { leagueIds: v.array(v.id("leagues")) },
   returns: v.array(
@@ -1258,6 +1268,59 @@ export const unsubscribeFromLeague = mutationGeneric({
       await ctx.db.delete(existing._id);
     }
     return null;
+  },
+});
+
+/**
+ * Claim a team within a claimable (public template) league (WSM-000109). Sets
+ * the team's ownerOrgId so an admin of that org can edit it, and subscribes the
+ * user to the league scoped to the claimed team (merging with any existing
+ * scope) so it shows up in their dashboard. The org:admin check is enforced in
+ * the Next.js layer before this runs. Idempotent and re-claim-safe for the same
+ * org; rejects claiming a team another org already owns.
+ */
+export const claimTeam = mutationGeneric({
+  args: {
+    userId: v.string(),
+    orgId: v.string(),
+    teamId: v.id("teams"),
+  },
+  returns: v.object({ leagueId: v.string() }),
+  handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("Team not found");
+    const league = await ctx.db.get(team.leagueId);
+    if (!league || !league.isPublic || !league.claimable) {
+      throw new Error("Team is not claimable");
+    }
+    if (team.ownerOrgId && team.ownerOrgId !== args.orgId) {
+      throw new Error("Team already claimed by another org");
+    }
+
+    await ctx.db.patch(args.teamId, { ownerOrgId: args.orgId });
+
+    // Subscribe (scoped to the claimed team) so it's visible + in the switcher.
+    const existing =
+      (
+        await ctx.db
+          .query("leagueSubscriptions")
+          .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+          .collect()
+      ).find((s) => s.leagueId === team.leagueId) ?? null;
+    const merged = Array.from(
+      new Set([...(existing?.teamIds ?? []), args.teamId]),
+    );
+    if (existing) {
+      await ctx.db.patch(existing._id, { teamIds: merged });
+    } else {
+      await ctx.db.insert("leagueSubscriptions", {
+        userId: args.userId,
+        leagueId: team.leagueId,
+        teamIds: merged,
+      });
+    }
+
+    return { leagueId: team.leagueId as string };
   },
 });
 
@@ -2275,6 +2338,21 @@ export const setLeaguePublic = mutationGeneric({
     const league = await ctx.db.get(args.leagueId);
     if (!league) throw new Error("league_not_found");
     await ctx.db.patch(args.leagueId, { isPublic: args.isPublic });
+    return null;
+  },
+});
+
+/** Mark a (public template) league's teams claimable by coaches (WSM-000109). */
+export const setLeagueClaimable = mutationGeneric({
+  args: {
+    leagueId: v.id("leagues"),
+    claimable: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) throw new Error("league_not_found");
+    await ctx.db.patch(args.leagueId, { claimable: args.claimable });
     return null;
   },
 });

--- a/apps/web/scripts/seed-ghsa-cobb.mts
+++ b/apps/web/scripts/seed-ghsa-cobb.mts
@@ -78,7 +78,9 @@ async function main() {
   console.log(`  league ${league.created ? "created" : "exists"}: ${leagueId}`);
 
   await m("sports:setLeaguePublic", { leagueId, isPublic: true });
-  console.log("  league set public");
+  // Hybrid fork (WSM-000109): coaches can claim their school in this template.
+  await m("sports:setLeagueClaimable", { leagueId, claimable: true });
+  console.log("  league set public + claimable");
 
   const divisionByClass = new Map<string, string>();
   for (const cls of classes) {

--- a/apps/web/src/lib/__tests__/authorization.test.ts
+++ b/apps/web/src/lib/__tests__/authorization.test.ts
@@ -3,16 +3,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const {
   mockGetTeamLeagueId,
   mockGetLeagueOrgId,
+  mockGetTeamOwnerOrgId,
+  mockClaimTeam,
   mockGetOrganizationMembershipList,
 } = vi.hoisted(() => ({
   mockGetTeamLeagueId: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
+  mockGetTeamOwnerOrgId: vi.fn(),
+  mockClaimTeam: vi.fn(),
   mockGetOrganizationMembershipList: vi.fn(),
 }));
 
 vi.mock("../data-api", () => ({
   getTeamLeagueId: mockGetTeamLeagueId,
   getLeagueOrgId: mockGetLeagueOrgId,
+  getTeamOwnerOrgId: mockGetTeamOwnerOrgId,
+  claimTeam: mockClaimTeam,
+  getVisibleLeagueContext: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({
@@ -31,6 +38,8 @@ import { authorizeTeamMutation, canManageTeam } from "../authorization";
 describe("authorizeTeamMutation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: team is unclaimed unless a test says otherwise.
+    mockGetTeamOwnerOrgId.mockResolvedValue(null);
   });
 
   it("returns not authorized when team is not found", async () => {
@@ -82,6 +91,34 @@ describe("authorizeTeamMutation", () => {
     });
 
     const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+  });
+
+  // WSM-000109: a claimed team in a shared/public league is editable by an
+  // admin of the org that claimed it, even though the league org is null.
+  it("authorizes an admin of the team's owner org (claimed team)", async () => {
+    mockGetTeamLeagueId.mockResolvedValue("league_pub");
+    mockGetLeagueOrgId.mockResolvedValue(null); // public template league
+    mockGetTeamOwnerOrgId.mockResolvedValue("org_coach");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_coach" }, role: "org:admin" }],
+    });
+
+    const result = await authorizeTeamMutation("team_claimed", "user_1");
+
+    expect(result).toEqual({ userId: "user_1", isAuthorized: true });
+  });
+
+  it("denies a non-admin member of the team's owner org", async () => {
+    mockGetTeamLeagueId.mockResolvedValue("league_pub");
+    mockGetLeagueOrgId.mockResolvedValue(null);
+    mockGetTeamOwnerOrgId.mockResolvedValue("org_coach");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_coach" }, role: "org:member" }],
+    });
+
+    const result = await authorizeTeamMutation("team_claimed", "user_1");
 
     expect(result).toEqual({ userId: "user_1", isAuthorized: false });
   });

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -1,6 +1,12 @@
 import { auth, currentUser, clerkClient } from "@clerk/nextjs/server";
 import type { Tier } from "./tiers";
-import { getTeamLeagueId, getLeagueOrgId } from "./data-api";
+import {
+  getTeamLeagueId,
+  getLeagueOrgId,
+  getTeamOwnerOrgId,
+  claimTeam,
+} from "./data-api";
+import { requireOrgAdmin } from "./org-context";
 
 export interface AuthorizationResult {
   userId: string;
@@ -8,11 +14,14 @@ export interface AuthorizationResult {
 }
 
 /**
- * Authorize a mutation on a team. The chain is:
- * teamId -> team.leagueId (Convex) -> league.orgId (Convex) -> requireOrgAdmin
+ * Authorize a mutation on a team. Edit rights come from being an `org:admin`
+ * of EITHER:
+ *   - the league's own org (owns the whole league), or
+ *   - the org that CLAIMED this team (WSM-000109 Hybrid fork) — so a coach can
+ *     edit their claimed team inside a shared/public template league.
  *
- * Public leagues (null orgId) -> mutations denied (read-only).
- * Org leagues -> only org:admin can mutate.
+ * A team with neither a league org nor an owner org (e.g. an unclaimed team in
+ * a public reference league) is read-only.
  */
 export async function authorizeTeamMutation(
   teamId: string,
@@ -20,29 +29,48 @@ export async function authorizeTeamMutation(
 ): Promise<AuthorizationResult> {
   try {
     const leagueId = await getTeamLeagueId(teamId);
-    const orgId = await getLeagueOrgId(leagueId);
+    const [leagueOrgId, ownerOrgId] = await Promise.all([
+      getLeagueOrgId(leagueId),
+      // Resilient if the Convex query deploys after the web: a missing owner
+      // just means no team-claim grant — league-org auth still applies.
+      getTeamOwnerOrgId(teamId).catch(() => null),
+    ]);
 
-    // Public leagues are read-only
-    if (!orgId) {
+    const candidateOrgIds = [leagueOrgId, ownerOrgId].filter(
+      (id): id is string => Boolean(id),
+    );
+    if (candidateOrgIds.length === 0) {
       return { userId, isAuthorized: false };
     }
 
-    // Check if user is org admin
     const client = await clerkClient();
     const memberships = await client.users.getOrganizationMembershipList({
       userId,
     });
-    const membership = memberships.data.find(
-      (m) => m.organization.id === orgId,
+    const isAuthorized = memberships.data.some(
+      (m) =>
+        candidateOrgIds.includes(m.organization.id) &&
+        m.role === "org:admin",
     );
 
-    return {
-      userId,
-      isAuthorized: membership?.role === "org:admin",
-    };
+    return { userId, isAuthorized };
   } catch {
     return { userId, isAuthorized: false };
   }
+}
+
+/**
+ * Claim a team into an org the user administers (WSM-000109). Verifies the
+ * user is an `org:admin` of `orgId` before claiming — the org-admin gate the
+ * Convex mutation can't enforce itself. Returns the claimed team's leagueId.
+ */
+export async function claimTeamForOrg(
+  userId: string,
+  orgId: string,
+  teamId: string,
+): Promise<{ leagueId: string }> {
+  await requireOrgAdmin(orgId, userId); // throws if not an admin of orgId
+  return claimTeam(userId, orgId, teamId);
 }
 
 /**

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -106,6 +106,17 @@ const refs = {
   getTeamLeagueId: queryRef<{ teamId: string }, string | null>(
     "sports:getTeamLeagueId",
   ),
+  getTeamOwnerOrgId: queryRef<{ teamId: string }, string | null>(
+    "sports:getTeamOwnerOrgId",
+  ),
+  claimTeam: mutationRef<
+    { userId: string; orgId: string; teamId: string },
+    { leagueId: string }
+  >("sports:claimTeam"),
+  setLeagueClaimable: mutationRef<
+    { leagueId: string; claimable: boolean },
+    null
+  >("sports:setLeagueClaimable"),
   listPlayers: queryRef<{ leagueIds: string[] }, PlayerDto[]>("sports:listPlayers"),
   listPlayersByTeam: queryRef<{ teamId: string }, PlayerDto[]>(
     "sports:listPlayersByTeam",
@@ -554,6 +565,32 @@ export async function getTeamLeagueId(teamId: string): Promise<string> {
   const leagueId = await queryConvex(refs.getTeamLeagueId, { teamId });
   if (!leagueId) throw new Error("Team not found");
   return leagueId;
+}
+
+/** WSM-000109: the org that claimed this team, or null if unclaimed. */
+export async function getTeamOwnerOrgId(
+  teamId: string,
+): Promise<string | null> {
+  return queryConvex(refs.getTeamOwnerOrgId, { teamId });
+}
+
+/**
+ * WSM-000109: claim a team into an org. Raw wrapper — the caller MUST verify
+ * the user is an admin of `orgId` first (see claimTeamForOrg in authorization).
+ */
+export async function claimTeam(
+  userId: string,
+  orgId: string,
+  teamId: string,
+): Promise<{ leagueId: string }> {
+  return mutateConvex(refs.claimTeam, { userId, orgId, teamId });
+}
+
+export async function setLeagueClaimable(
+  leagueId: string,
+  claimable: boolean,
+): Promise<void> {
+  await mutateConvex(refs.setLeagueClaimable, { leagueId, claimable });
 }
 
 export async function getPlayers(


### PR DESCRIPTION
The foundation for the coach platform (parallel track while coach-interview research runs). Implements the **Hybrid fork** decision as a **team-claim** rather than a whole-league copy.

## Design decision
A coach **claims their team *within* a shared/public template league** (e.g. Cobb County Football). The league and the other 15 schools stay shared/read-only — so **real GHSA standings & schedule context is preserved** — but the claimed team gets an `ownerOrgId` and becomes **editable by an admin of that org**. No per-coach duplicate of the whole league.

Claiming also **auto-subscribes** the coach scoped to their team (merging à la carte scope), so it lands in their dashboard + switcher.

## What's in this slice (engine only — no UI yet)
- **Schema:** `teams.ownerOrgId` (+ `by_ownerOrgId` index), `leagues.claimable`. Both optional → backward-compatible.
- **Convex:** `claimTeam` (sets owner + scoped subscription; rejects claiming another org's team), `getTeamOwnerOrgId`, `setLeagueClaimable`.
- **Auth:** `authorizeTeamMutation` grants edit to an `org:admin` of the league's org **OR** the team's owner org — made **resilient** (owner lookup failure → league-org auth) so deploy order can't regress editing. `claimTeamForOrg` enforces the org:admin gate the Convex mutation can't.
- **Seed:** Cobb County league marked claimable.

## Verification
- tsc clean, **330 unit tests** (+2: admin-of-owner-org authorizes, non-admin denied), **`next build` ✓**
- **Convex deployed to prod** (additive: fields + index + 3 fns)

## Next slices
- Claim UI ("Claim this team" on a claimable team → pick org → editable + default active league)
- Mark Cobb claimable in prod (re-run seed — authorized step)
- Coach onboarding (create/join an org if none)

Refs the coach-platform strategy (docs/research/coach-platform-competitive-teardown.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)