### PR TITLE
Claim-team UI (WSM-000110)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2342,6 +2342,16 @@ export const setLeaguePublic = mutationGeneric({
   },
 });
 
+/** Whether a league's teams can be claimed by coaches (WSM-000109). */
+export const getLeagueClaimable = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    return league?.claimable === true;
+  },
+});
+
 /** Mark a (public template) league's teams claimable by coaches (WSM-000109). */
 export const setLeagueClaimable = mutationGeneric({
   args: {

--- a/apps/web/src/app/api/teams/[id]/claim/route.ts
+++ b/apps/web/src/app/api/teams/[id]/claim/route.ts
@@ -1,0 +1,44 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { claimTeamForOrg } from "@/lib/authorization";
+import { handleApiError } from "@/lib/api-error";
+
+/**
+ * Claim a team into the caller's active organization (WSM-000110). Requires an
+ * active org and org:admin (enforced in claimTeamForOrg). On success the team
+ * is owned + editable by the org and subscribed (scoped) for the user.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!orgId) {
+    return NextResponse.json(
+      {
+        error:
+          "Select or create an organization before claiming a team — it becomes the owner.",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const { id: teamId } = await params;
+    const { leagueId } = await claimTeamForOrg(userId, orgId, teamId);
+    return NextResponse.json({ message: "Claimed", leagueId });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // Friendly status for the expected rejections.
+    if (msg.includes("admin")) {
+      return NextResponse.json({ error: msg }, { status: 403 });
+    }
+    if (msg.includes("not claimable") || msg.includes("already claimed")) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    return handleApiError(error, "/api/teams/[id]/claim");
+  }
+}

--- a/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/8bit/button";
+import { toast } from "sonner";
+import { ShieldCheck } from "lucide-react";
+
+/**
+ * Converts a followed team into an owned, editable one (WSM-000110). On success
+ * the team belongs to the user's active org and the roster becomes editable.
+ */
+export function ClaimTeamButton({
+  teamId,
+  teamName,
+}: {
+  teamId: string;
+  teamName: string;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function claim() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/teams/${teamId}/claim`, { method: "POST" });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok) {
+        toast.success(`${teamName} is yours — you can now manage the roster.`);
+        router.refresh();
+      } else {
+        toast.error(body.error ?? "Could not claim this team.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button onClick={claim} disabled={loading} size="sm">
+      <ShieldCheck className="mr-1 h-4 w-4" />
+      {loading ? "Claiming…" : "Claim this team"}
+    </Button>
+  );
+}

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -7,12 +7,15 @@ import {
   getSeasons,
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
+  getLeagueClaimable,
+  getTeamOwnerOrgId,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam } from "@/lib/authorization";
 import { playerAttributesV1 } from "@/lib/flags";
 import type { PlayerSnapshot } from "@/lib/attributes/headline-columns";
 import TeamManagement from "./team-management";
+import { ClaimTeamButton } from "./claim-team-button";
 
 export default async function TeamDetailPage({
   params,
@@ -21,7 +24,7 @@ export default async function TeamDetailPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ from?: string }>;
 }) {
-  const { userId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
   if (!userId) redirect("/sign-in");
 
   const { id } = await params;
@@ -40,6 +43,20 @@ export default async function TeamDetailPage({
     getPlayersByTeam(id, orgContext),
     canManageTeam(id, userId),
   ]);
+
+  // Claim affordance (WSM-000110): a followed team in a claimable template
+  // league can be claimed → owned + editable. Only relevant when the user
+  // can't already manage it. Failures degrade to "no claim offered".
+  let claim: { eligible: boolean } | null = null;
+  if (!canManage) {
+    const [claimable, ownerOrgId] = await Promise.all([
+      getLeagueClaimable(team.leagueId).catch(() => false),
+      getTeamOwnerOrgId(id).catch(() => null),
+    ]);
+    if (claimable && !ownerOrgId) {
+      claim = { eligible: Boolean(orgId) && orgRole === "org:admin" };
+    }
+  }
 
   // WSM-000090: attribute snapshots feed the Madden stat columns.
   // Phase 2-gated; resolved against the league's active season, same
@@ -72,6 +89,26 @@ export default async function TeamDetailPage({
       >
         &larr; {back.label}
       </Link>
+
+      {claim && (
+        <div className="mb-4 rounded-md border border-primary/40 bg-primary/5 p-4">
+          <p className="text-sm font-medium text-foreground">Coach here?</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Claim {team.name} to manage its roster and depth chart — it becomes
+            yours to edit.
+          </p>
+          <div className="mt-3">
+            {claim.eligible ? (
+              <ClaimTeamButton teamId={team.id} teamName={team.name} />
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                You need to be an admin of an organization to claim a team —
+                create or select one from your account menu first.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
 
       <TeamManagement
         team={team}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -117,6 +117,9 @@ const refs = {
     { leagueId: string; claimable: boolean },
     null
   >("sports:setLeagueClaimable"),
+  getLeagueClaimable: queryRef<{ leagueId: string }, boolean>(
+    "sports:getLeagueClaimable",
+  ),
   listPlayers: queryRef<{ leagueIds: string[] }, PlayerDto[]>("sports:listPlayers"),
   listPlayersByTeam: queryRef<{ teamId: string }, PlayerDto[]>(
     "sports:listPlayersByTeam",
@@ -591,6 +594,11 @@ export async function setLeagueClaimable(
   claimable: boolean,
 ): Promise<void> {
   await mutateConvex(refs.setLeagueClaimable, { leagueId, claimable });
+}
+
+/** WSM-000109: whether a league's teams can be claimed by coaches. */
+export async function getLeagueClaimable(leagueId: string): Promise<boolean> {
+  return queryConvex(refs.getLeagueClaimable, { leagueId });
 }
 
 export async function getPlayers(


### PR DESCRIPTION
The coach-facing front door for the Hybrid fork engine (#226). Converts a *followed* team into an *owned, editable* one.

## Flow
A coach imports their school (à la carte) → opens the team → sees **"Coach here? Claim {team}"** → one click:
- sets the team's `ownerOrgId` to the coach's **active org**,
- subscribes them scoped to that team,
- and the roster/depth chart become **editable** (auth now grants via team ownership).

## What's here
- `getLeagueClaimable` (Convex + data-api).
- `POST /api/teams/[id]/claim` → `claimTeamForOrg` (enforces **org:admin of the active org**; friendly **400** no-org / **403** not-admin / **409** already-claimed).
- `ClaimTeamButton` + a "Coach here?" card on the team page — shown only when the league is **claimable**, the team is **unclaimed**, and the user **can't already manage** it. Non-admins get a "create/select an org" hint.
- Every claim lookup degrades gracefully (no offer) on failure.

## Verification
- tsc clean, lint baseline, **330 tests**, **`next build` ✓**
- **Convex deployed** (additive `getLeagueClaimable`)

## Activation (separate authorized step)
Mark the **Cobb County** league `claimable` in prod (re-run the seed, which now sets it) so the claim affordance appears for its teams.

## Next
Coach onboarding (create/join an org when none), and surfacing claim from Discover for not-yet-subscribed leagues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)