### PR TITLE
Org-on-claim onboarding (WSM-000111)

### DIFF
--- a/apps/web/src/app/api/teams/[id]/claim/route.ts
+++ b/apps/web/src/app/api/teams/[id]/claim/route.ts
@@ -1,38 +1,74 @@
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
+import { claimTeam } from "@/lib/data-api";
 import { claimTeamForOrg } from "@/lib/authorization";
 import { handleApiError } from "@/lib/api-error";
 
 /**
- * Claim a team into the caller's active organization (WSM-000110). Requires an
- * active org and org:admin (enforced in claimTeamForOrg). On success the team
- * is owned + editable by the org and subscribed (scoped) for the user.
+ * Claim a team (WSM-000110/111). Resolves an org the user admins to own the
+ * team — never making them set one up first:
+ *   1. the active org, if they admin it; else
+ *   2. any org they already admin; else
+ *   3. a freshly created org (they become its admin) — org-on-claim onboarding.
+ * Then sets the team's owner to that org and subscribes the user (scoped).
  */
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { userId, orgId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (!orgId) {
-    return NextResponse.json(
-      {
-        error:
-          "Select or create an organization before claiming a team — it becomes the owner.",
-      },
-      { status: 400 },
-    );
   }
 
   try {
     const { id: teamId } = await params;
-    const { leagueId } = await claimTeamForOrg(userId, orgId, teamId);
-    return NextResponse.json({ message: "Claimed", leagueId });
+    const body = await request.json().catch(() => ({}));
+    const teamName =
+      typeof body?.teamName === "string" && body.teamName.trim()
+        ? body.teamName.trim()
+        : "My Team";
+
+    const client = await clerkClient();
+    let createdOrg = false;
+    let targetOrgId: string;
+
+    if (orgId && orgRole === "org:admin") {
+      targetOrgId = orgId;
+    } else {
+      const memberships = await client.users.getOrganizationMembershipList({
+        userId,
+      });
+      const adminMembership = memberships.data.find(
+        (m) => m.role === "org:admin",
+      );
+      if (adminMembership) {
+        targetOrgId = adminMembership.organization.id;
+      } else {
+        // Org-on-claim: stand up the coach's organization behind the scenes.
+        const org = await client.organizations.createOrganization({
+          name: teamName,
+          createdBy: userId,
+        });
+        targetOrgId = org.id;
+        createdOrg = true;
+      }
+    }
+
+    // For a just-created org we already know the user is its admin, so skip the
+    // redundant (and possibly not-yet-propagated) membership re-check.
+    const { leagueId } = createdOrg
+      ? await claimTeam(userId, targetOrgId, teamId)
+      : await claimTeamForOrg(userId, targetOrgId, teamId);
+
+    return NextResponse.json({
+      message: "Claimed",
+      leagueId,
+      orgId: targetOrgId,
+      createdOrg,
+    });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    // Friendly status for the expected rejections.
     if (msg.includes("admin")) {
       return NextResponse.json({ error: msg }, { status: 403 });
     }

--- a/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
@@ -23,10 +23,18 @@ export function ClaimTeamButton({
   async function claim() {
     setLoading(true);
     try {
-      const res = await fetch(`/api/teams/${teamId}/claim`, { method: "POST" });
+      const res = await fetch(`/api/teams/${teamId}/claim`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ teamName }),
+      });
       const body = await res.json().catch(() => ({}));
       if (res.ok) {
-        toast.success(`${teamName} is yours — you can now manage the roster.`);
+        toast.success(
+          body.createdOrg
+            ? `${teamName} is yours — we set up your coaching organization. You can now manage the roster.`
+            : `${teamName} is yours — you can now manage the roster.`,
+        );
         router.refresh();
       } else {
         toast.error(body.error ?? "Could not claim this team.");

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function TeamDetailPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ from?: string }>;
 }) {
-  const { userId, orgId, orgRole } = await auth();
+  const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
   const { id } = await params;
@@ -44,18 +44,17 @@ export default async function TeamDetailPage({
     canManageTeam(id, userId),
   ]);
 
-  // Claim affordance (WSM-000110): a followed team in a claimable template
-  // league can be claimed → owned + editable. Only relevant when the user
-  // can't already manage it. Failures degrade to "no claim offered".
-  let claim: { eligible: boolean } | null = null;
+  // Claim affordance (WSM-000110/111): a followed team in a claimable template
+  // league can be claimed → owned + editable. Offered whenever the user can't
+  // already manage it and the team is unclaimed — no org prerequisite, since
+  // the claim creates one for the coach (org-on-claim). Degrades to no offer.
+  let offerClaim = false;
   if (!canManage) {
     const [claimable, ownerOrgId] = await Promise.all([
       getLeagueClaimable(team.leagueId).catch(() => false),
       getTeamOwnerOrgId(id).catch(() => null),
     ]);
-    if (claimable && !ownerOrgId) {
-      claim = { eligible: Boolean(orgId) && orgRole === "org:admin" };
-    }
+    offerClaim = claimable && !ownerOrgId;
   }
 
   // WSM-000090: attribute snapshots feed the Madden stat columns.
@@ -90,22 +89,16 @@ export default async function TeamDetailPage({
         &larr; {back.label}
       </Link>
 
-      {claim && (
+      {offerClaim && (
         <div className="mb-4 rounded-md border border-primary/40 bg-primary/5 p-4">
           <p className="text-sm font-medium text-foreground">Coach here?</p>
           <p className="mt-1 text-sm text-muted-foreground">
             Claim {team.name} to manage its roster and depth chart — it becomes
-            yours to edit.
+            yours to edit. We&rsquo;ll set up your coaching organization if you
+            don&rsquo;t have one yet.
           </p>
           <div className="mt-3">
-            {claim.eligible ? (
-              <ClaimTeamButton teamId={team.id} teamName={team.name} />
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                You need to be an admin of an organization to claim a team —
-                create or select one from your account menu first.
-              </p>
-            )}
+            <ClaimTeamButton teamId={team.id} teamName={team.name} />
           </div>
         </div>
       )}


### PR DESCRIPTION
Removes the "create an organization first" wall from the claim flow. A coach just taps **Claim** and we handle the org behind the scenes.

## Resolve-an-org logic (claim route)
1. the **active org**, if the user admins it; else
2. **any org they already admin** (so a coach who has one — even if not active — reuses it; no duplicates on repeat claims); else
3. a **freshly created org** (Clerk `createOrganization`, the user becomes its admin) — org-on-claim onboarding.

Then claims the team into that org. For a just-created org we skip the redundant membership re-check (we know they're the admin / avoids propagation races).

## UI
- The "Coach here?" card now **always** shows **Claim this team** when the team is claimable + unclaimed + unmanaged — no eligibility gate.
- Copy + success toast explain that claiming sets up the coaching organization when needed.

## Verification
- tsc clean, lint baseline, **330 tests**, **`next build` ✓**
- No Convex change (org creation is Clerk-side; `claimTeam` already live)

Completes the coach onboarding for the Hybrid fork flow — a coach goes from Discover → import → **Claim** → editable team, with the org created automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)