### PR TITLE
Fork-to-workspace engine (org isolation, Phase 1 slice 1) (WSM-000114)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -12,6 +12,11 @@ export default defineSchema({
     // stays shared/read-only, but a claimed team becomes editable by its
     // owner. Reference leagues (NFL) leave this false/undefined.
     claimable: v.optional(v.boolean()),
+    // Org workspace model (WSM-000113/114): a workspace league (orgId set,
+    // isPublic false) is a private fork of a reference league. sourceLeagueId
+    // points to the reference it was forked from. Reference leagues leave it
+    // unset.
+    sourceLeagueId: v.optional(v.id("leagues")),
   })
     .index("by_name", ["name"])
     .index("by_orgId", ["orgId"])
@@ -39,6 +44,9 @@ export default defineSchema({
     // claimable league. null/undefined = unclaimed. An admin of this org can
     // edit the team + its roster even though the league itself is shared.
     ownerOrgId: v.optional(v.union(v.string(), v.null())),
+    // Org workspace (WSM-000114): a workspace team's link to the reference team
+    // it was forked from. Ratings + provenance resolve through it.
+    sourceTeamId: v.optional(v.id("teams")),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_divisionId", ["divisionId"])
@@ -57,6 +65,10 @@ export default defineSchema({
     headshotUrl: v.union(v.string(), v.null()),
     // Optional: pre-experienceYears documents validate without backfill.
     experienceYears: v.optional(v.union(v.number(), v.null())),
+    // Org workspace (WSM-000114): a workspace player's link to the reference
+    // player it was forked from — SPRT/Madden ratings resolve through it so
+    // they stay live without duplicating the rating pipeline per org.
+    sourcePlayerId: v.optional(v.id("players")),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_teamId", ["teamId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1279,6 +1279,132 @@ export const unsubscribeFromLeague = mutationGeneric({
  * the Next.js layer before this runs. Idempotent and re-claim-safe for the same
  * org; rejects claiming a team another org already owns.
  */
+/**
+ * Fork a reference team into an org's PRIVATE workspace (WSM-000114). Creates
+ * (or reuses) the org's workspace league for the source league, then copies the
+ * team + its roster into it — `orgId`-owned, isolated from the reference and
+ * other orgs. Idempotent per (org, sourceTeam). Source links let ratings +
+ * provenance resolve back to the reference. This replaces the shared-edit
+ * claimTeam path under the private-only workspace model (RFC §11).
+ */
+export const forkTeamToWorkspace = mutationGeneric({
+  args: { orgId: v.string(), sourceTeamId: v.id("teams") },
+  returns: v.object({
+    teamId: v.string(),
+    leagueId: v.string(),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const refTeam = await ctx.db.get(args.sourceTeamId);
+    if (!refTeam) throw new Error("Source team not found");
+    const refLeague = await ctx.db.get(refTeam.leagueId);
+    if (!refLeague || !refLeague.isPublic) {
+      throw new Error("Team is not forkable");
+    }
+
+    // Get-or-create the org's workspace league for this reference league.
+    let workspaceLeague =
+      (
+        await ctx.db
+          .query("leagues")
+          .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))
+          .collect()
+      ).find((l) => l.sourceLeagueId === refLeague._id) ?? null;
+    if (!workspaceLeague) {
+      const id = await ctx.db.insert("leagues", {
+        name: refLeague.name,
+        orgId: args.orgId,
+        isPublic: false,
+        inviteToken: null,
+        sourceLeagueId: refLeague._id,
+      });
+      workspaceLeague = await ctx.db.get(id);
+    }
+    const workspaceLeagueId = workspaceLeague!._id;
+
+    // Idempotent: already forked this team into the workspace?
+    const existing =
+      (
+        await ctx.db
+          .query("teams")
+          .withIndex("by_leagueId", (q) =>
+            q.eq("leagueId", workspaceLeagueId),
+          )
+          .collect()
+      ).find((t) => t.sourceTeamId === args.sourceTeamId) ?? null;
+    if (existing) {
+      return {
+        teamId: existing._id as string,
+        leagueId: workspaceLeagueId as string,
+        created: false,
+      };
+    }
+
+    // Mirror the team's division into the workspace (by name).
+    let workspaceDivisionId: Id<"divisions"> | null = null;
+    if (refTeam.divisionId) {
+      const refDiv = await ctx.db.get(refTeam.divisionId);
+      if (refDiv) {
+        const existingDiv =
+          (
+            await ctx.db
+              .query("divisions")
+              .withIndex("by_leagueId", (q) =>
+                q.eq("leagueId", workspaceLeagueId),
+              )
+              .collect()
+          ).find((d) => d.name === refDiv.name) ?? null;
+        workspaceDivisionId = existingDiv
+          ? existingDiv._id
+          : await ctx.db.insert("divisions", {
+              name: refDiv.name,
+              leagueId: workspaceLeagueId,
+            });
+      }
+    }
+
+    const newTeamId = await ctx.db.insert("teams", {
+      name: refTeam.name,
+      leagueId: workspaceLeagueId,
+      divisionId: workspaceDivisionId,
+      city: refTeam.city,
+      stadium: refTeam.stadium,
+      foundedYear: refTeam.foundedYear,
+      location: refTeam.location,
+      logoUrl: refTeam.logoUrl,
+      rosterLimit: refTeam.rosterLimit,
+      ownerOrgId: args.orgId,
+      sourceTeamId: args.sourceTeamId,
+    });
+
+    const refPlayers = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.sourceTeamId))
+      .collect();
+    for (const p of refPlayers) {
+      await ctx.db.insert("players", {
+        name: p.name,
+        leagueId: workspaceLeagueId,
+        teamId: newTeamId,
+        position: p.position,
+        positionGroup: p.positionGroup,
+        jerseyNumber: p.jerseyNumber,
+        dateOfBirth: p.dateOfBirth,
+        status: p.status,
+        headshotUrl: p.headshotUrl,
+        experienceYears: p.experienceYears,
+        sourcePlayerId: p._id,
+      });
+    }
+
+    return {
+      teamId: newTeamId as string,
+      leagueId: workspaceLeagueId as string,
+      created: true,
+    };
+  },
+});
+
 export const claimTeam = mutationGeneric({
   args: {
     userId: v.string(),

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -5,6 +5,7 @@ import {
   getLeagueOrgId,
   getTeamOwnerOrgId,
   claimTeam,
+  forkTeamToWorkspace,
 } from "./data-api";
 import { requireOrgAdmin } from "./org-context";
 
@@ -71,6 +72,20 @@ export async function claimTeamForOrg(
 ): Promise<{ leagueId: string }> {
   await requireOrgAdmin(orgId, userId); // throws if not an admin of orgId
   return claimTeam(userId, orgId, teamId);
+}
+
+/**
+ * Fork a reference team into an org's private workspace (WSM-000114), verifying
+ * the user admins the org first. The private-workspace replacement for
+ * claimTeamForOrg under the isolation model (RFC §11).
+ */
+export async function forkTeamForOrg(
+  userId: string,
+  orgId: string,
+  sourceTeamId: string,
+): Promise<{ teamId: string; leagueId: string; created: boolean }> {
+  await requireOrgAdmin(orgId, userId);
+  return forkTeamToWorkspace(orgId, sourceTeamId);
 }
 
 /**

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -113,6 +113,10 @@ const refs = {
     { userId: string; orgId: string; teamId: string },
     { leagueId: string }
   >("sports:claimTeam"),
+  forkTeamToWorkspace: mutationRef<
+    { orgId: string; sourceTeamId: string },
+    { teamId: string; leagueId: string; created: boolean }
+  >("sports:forkTeamToWorkspace"),
   setLeagueClaimable: mutationRef<
     { leagueId: string; claimable: boolean },
     null
@@ -587,6 +591,17 @@ export async function claimTeam(
   teamId: string,
 ): Promise<{ leagueId: string }> {
   return mutateConvex(refs.claimTeam, { userId, orgId, teamId });
+}
+
+/**
+ * WSM-000114: fork a reference team into the org's private workspace. Raw
+ * wrapper — caller MUST verify org admin first (see forkTeamForOrg).
+ */
+export async function forkTeamToWorkspace(
+  orgId: string,
+  sourceTeamId: string,
+): Promise<{ teamId: string; leagueId: string; created: boolean }> {
+  return mutateConvex(refs.forkTeamToWorkspace, { orgId, sourceTeamId });
 }
 
 export async function setLeagueClaimable(


### PR DESCRIPTION
First slice of the multi-tenant refactor (RFC #230). The **fork primitive** that replaces the shared-edit `claimTeam` under the private-only workspace model.

## What it does
Forking a reference team **copies it + its roster into the org's own private league** — `orgId`-owned, `isPublic=false`, isolated from the reference and every other org. Source links (`sourceLeagueId`/`sourceTeamId`/`sourcePlayerId`) preserve provenance and let ratings resolve back to the reference (next slice).

- **Schema:** the three optional source-link fields (backward-compatible).
- **`forkTeamToWorkspace(orgId, sourceTeamId)`:** get-or-create the org's workspace league for that source, mirror the division, copy the team + players. **Idempotent** per (org, sourceTeam).
- **`forkTeamForOrg`** (org-admin gated), parallel to the claim orchestration it supersedes.

## Verification
End-to-end on dev: forked Buffalo Bills → a private workspace league + team with **91/91 players copied**; re-fork returned `created=false`, same team (no dup). Convex deployed to prod (additive). tsc, lint, **330 tests**, `next build` — all green.

## Next slices (Phase 1)
1. Ratings resolve via `sourcePlayerId` (workspace players show live SPRT/Madden).
2. Rewire import/claim → **fork** (Discover + team page).
3. Workspace-scoped visibility/auth everywhere.
4. Migrate existing test claims → forks; retire the shared-edit path.
5. Intra-org roles (admin/coach/viewer).

Engine only — not yet wired to UI. `claimTeam` stays until the rewire slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)