### PR TITLE
Team page forks a private copy (Phase 1 slice 3) (WSM-000115)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1298,7 +1298,9 @@ export const forkTeamToWorkspace = mutationGeneric({
     const refTeam = await ctx.db.get(args.sourceTeamId);
     if (!refTeam) throw new Error("Source team not found");
     const refLeague = await ctx.db.get(refTeam.leagueId);
-    if (!refLeague || !refLeague.isPublic) {
+    // Forkable = a public reference league we've marked claimable (the curated
+    // "discovery data we allow"). Workspace leagues (private) aren't forkable.
+    if (!refLeague || !refLeague.isPublic || !refLeague.claimable) {
       throw new Error("Team is not forkable");
     }
 

--- a/apps/web/src/app/api/teams/[id]/claim/route.ts
+++ b/apps/web/src/app/api/teams/[id]/claim/route.ts
@@ -1,16 +1,17 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { claimTeam } from "@/lib/data-api";
-import { claimTeamForOrg } from "@/lib/authorization";
+import { forkTeamToWorkspace } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 
 /**
- * Claim a team (WSM-000110/111). Resolves an org the user admins to own the
- * team — never making them set one up first:
+ * Add a team to the caller's org — forking it into their PRIVATE workspace
+ * (WSM-000110/111/115). Resolves an org the user admins, never making them set
+ * one up first:
  *   1. the active org, if they admin it; else
  *   2. any org they already admin; else
  *   3. a freshly created org (they become its admin) — org-on-claim onboarding.
- * Then sets the team's owner to that org and subscribes the user (scoped).
+ * Then forks the reference team (+ roster) into that org's workspace and returns
+ * the workspace team to redirect to (the editable copy).
  */
 export async function POST(
   request: NextRequest,
@@ -55,24 +56,25 @@ export async function POST(
       }
     }
 
-    // For a just-created org we already know the user is its admin, so skip the
-    // redundant (and possibly not-yet-propagated) membership re-check.
-    const { leagueId } = createdOrg
-      ? await claimTeam(userId, targetOrgId, teamId)
-      : await claimTeamForOrg(userId, targetOrgId, teamId);
+    // targetOrgId is always an org this user admins (active/found/just-created),
+    // so fork directly into it. Fork = a private editable copy of the team.
+    const {
+      teamId: workspaceTeamId,
+      leagueId,
+      created,
+    } = await forkTeamToWorkspace(targetOrgId, teamId);
 
     return NextResponse.json({
-      message: "Claimed",
+      message: "Added",
+      teamId: workspaceTeamId,
       leagueId,
       orgId: targetOrgId,
       createdOrg,
+      created,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    if (msg.includes("admin")) {
-      return NextResponse.json({ error: msg }, { status: 403 });
-    }
-    if (msg.includes("not claimable") || msg.includes("already claimed")) {
+    if (msg.includes("not forkable")) {
       return NextResponse.json({ error: msg }, { status: 409 });
     }
     return handleApiError(error, "/api/teams/[id]/claim");

--- a/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/claim-team-button.tsx
@@ -7,8 +7,9 @@ import { toast } from "sonner";
 import { ShieldCheck } from "lucide-react";
 
 /**
- * Converts a followed team into an owned, editable one (WSM-000110). On success
- * the team belongs to the user's active org and the roster becomes editable.
+ * Forks a reference team into the user's private workspace (WSM-000110/115). On
+ * success the server returns the new workspace team (an editable private copy);
+ * we redirect there. Creates the user's org automatically if they have none.
  */
 export function ClaimTeamButton({
   teamId,
@@ -32,12 +33,18 @@ export function ClaimTeamButton({
       if (res.ok) {
         toast.success(
           body.createdOrg
-            ? `${teamName} is yours — we set up your coaching organization. You can now manage the roster.`
-            : `${teamName} is yours — you can now manage the roster.`,
+            ? `Added ${teamName} — we set up your organization. Here's your editable copy.`
+            : `Added ${teamName} to your teams — here's your editable copy.`,
         );
-        router.refresh();
+        // Go to the new private workspace team (the editable copy), not the
+        // read-only reference we forked from.
+        if (body.teamId) {
+          router.push(`/dashboard/teams/${body.teamId}`);
+        } else {
+          router.refresh();
+        }
       } else {
-        toast.error(body.error ?? "Could not claim this team.");
+        toast.error(body.error ?? "Could not add this team.");
       }
     } finally {
       setLoading(false);
@@ -47,7 +54,7 @@ export function ClaimTeamButton({
   return (
     <Button onClick={claim} disabled={loading} size="sm">
       <ShieldCheck className="mr-1 h-4 w-4" />
-      {loading ? "Claiming…" : "Claim this team"}
+      {loading ? "Adding…" : "Add to my teams"}
     </Button>
   );
 }

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
   getLeagueClaimable,
-  getTeamOwnerOrgId,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam } from "@/lib/authorization";
@@ -44,17 +43,13 @@ export default async function TeamDetailPage({
     canManageTeam(id, userId),
   ]);
 
-  // Claim affordance (WSM-000110/111): a followed team in a claimable template
-  // league can be claimed → owned + editable. Offered whenever the user can't
-  // already manage it and the team is unclaimed — no org prerequisite, since
-  // the claim creates one for the coach (org-on-claim). Degrades to no offer.
-  let offerClaim = false;
+  // Fork affordance (WSM-000115): a reference team in a forkable league can be
+  // copied into the user's private workspace (editable). Offered whenever the
+  // user can't already manage this (read-only reference) team and the league is
+  // forkable — no org prerequisite (the fork creates one). Degrades to no offer.
+  let offerFork = false;
   if (!canManage) {
-    const [claimable, ownerOrgId] = await Promise.all([
-      getLeagueClaimable(team.leagueId).catch(() => false),
-      getTeamOwnerOrgId(id).catch(() => null),
-    ]);
-    offerClaim = claimable && !ownerOrgId;
+    offerFork = await getLeagueClaimable(team.leagueId).catch(() => false);
   }
 
   // WSM-000090: attribute snapshots feed the Madden stat columns.
@@ -89,13 +84,14 @@ export default async function TeamDetailPage({
         &larr; {back.label}
       </Link>
 
-      {offerClaim && (
+      {offerFork && (
         <div className="mb-4 rounded-md border border-primary/40 bg-primary/5 p-4">
           <p className="text-sm font-medium text-foreground">Coach here?</p>
           <p className="mt-1 text-sm text-muted-foreground">
-            Claim {team.name} to manage its roster and depth chart — it becomes
-            yours to edit. We&rsquo;ll set up your coaching organization if you
-            don&rsquo;t have one yet.
+            Add {team.name} to your teams — you&rsquo;ll get your own private
+            copy to manage (roster, depth chart, stats), separate from everyone
+            else. We&rsquo;ll set up your organization if you don&rsquo;t have
+            one yet.
           </p>
           <div className="mt-3">
             <ClaimTeamButton teamId={team.id} teamName={team.name} />


### PR DESCRIPTION
Makes the fork engine (#231) usable end-to-end through the UI. The team-page "Coach here?" affordance now **forks a private copy** instead of claiming the shared record.

## Flow
On a forkable reference team you can't already manage → **"Add to my teams"** → the team + roster are copied into your **private org workspace** → you're redirected to that **editable copy**. The reference stays read-only/untouched. Your org is created automatically if you have none (org-on-claim carries over).

## Why no new visibility/auth layer
A workspace league is **org-owned** (`orgId` set), so it's already in `visibleLeagueIds` and editable via the existing org-league auth. Slice 3 leverages that — the fork "just works" in the dashboard.

## Changes
- `forkTeamToWorkspace` now gates on `claimable` (curated "discovery data we allow"); **NFL marked claimable in prod** — safe now since fork = private copy (this is the original "make NFL claimable" ask, done correctly).
- Claim route → fork; returns the workspace `teamId`. Button redirects there; copy → "Add to my teams".
- Team page offers fork on any forkable reference team.

## Verification
tsc, lint, **330 tests**, `next build` ✓. Convex deployed. Fork engine itself verified in #231 (91/91 players).

## Known wart → later slices
A followed reference league + its forked copy can both show in the switcher until the **Discover-rewire / migration** slices retire the follow-subscription path. `claimTeam`/`claimTeamForOrg` are now unused (retired in migration).

## Remaining Phase 1
ratings-via-`sourcePlayerId` · Discover import → fork · migrate + retire shared-edit path · intra-org roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)