### PR TITLE
Workspace ratings via sourcePlayerId (Phase 1 slice 2) (WSM-000116)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2168,10 +2168,14 @@ export const getPlayerDevelopment = queryGeneric({
   args: { playerId: v.id("players") },
   returns: v.array(playerDevelopmentRowValidator),
   handler: async (ctx, args) => {
+    // Workspace fork (WSM-000116): development history lives on the reference
+    // player, so resolve through sourcePlayerId when present.
+    const player = await ctx.db.get(args.playerId);
+    const developmentPlayerId = player?.sourcePlayerId ?? args.playerId;
     const rows = await ctx.db
       .query("playerAttributes")
       .withIndex("by_playerId_seasonId", (q) =>
-        q.eq("playerId", args.playerId),
+        q.eq("playerId", developmentPlayerId),
       )
       .collect();
 
@@ -2401,9 +2405,13 @@ export const getPlayerMaddenRating = queryGeneric({
   args: { playerId: v.id("players") },
   returns: v.union(maddenRatingValidator, v.null()),
   handler: async (ctx, args) => {
+    // Workspace fork (WSM-000116): ratings live on the reference player, so
+    // resolve through sourcePlayerId when present.
+    const player = await ctx.db.get(args.playerId);
+    const ratingPlayerId = player?.sourcePlayerId ?? args.playerId;
     const row = await ctx.db
       .query("maddenRatings")
-      .withIndex("by_playerId", (q) => q.eq("playerId", args.playerId))
+      .withIndex("by_playerId", (q) => q.eq("playerId", ratingPlayerId))
       .unique();
     if (!row) return null;
     return {
@@ -2428,9 +2436,11 @@ export const getTeamMaddenOveralls = queryGeneric({
       .collect();
     const out: Array<{ playerId: string; overall: number }> = [];
     for (const player of players) {
+      // Workspace fork (WSM-000116): resolve ratings via the source player.
+      const ratingPlayerId = player.sourcePlayerId ?? player._id;
       const row = await ctx.db
         .query("maddenRatings")
-        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+        .withIndex("by_playerId", (q) => q.eq("playerId", ratingPlayerId))
         .unique();
       if (row) out.push({ playerId: player._id as string, overall: row.overall });
     }


### PR DESCRIPTION
Forked workspace players carry a `sourcePlayerId` but no ratings of their own (those live on the reference player). This resolves ratings through that link so a **forked team shows real Madden numbers + development history**, not blanks.

## Changes (Convex read queries)
- `getPlayerMaddenRating` + `getTeamMaddenOveralls` → resolve via `sourcePlayerId` (Madden card + MAD column).
- `getPlayerDevelopment` → resolve via `sourcePlayerId` (the dev chart works cleanly — no season param needed).

Reference players (`sourcePlayerId` null) are unchanged — **regression-verified on prod**: reference Bills still returns 50 Madden overalls (Allen 99).

## Deferred (noted)
Season-scoped **SPRT snapshots** (`getTeamAttributeSnapshots` / `getPlayerSeasonAttributes`) need an active season, and forks don't copy seasons — so they degrade to empty (no error) for workspace teams. A later slice will resolve SPRT for workspace via the source season.

## Verification
tsc, lint, **330 tests**, `next build` ✓. Convex deployed. Fork engine verified in #231; reference resolution verified above.

## Remaining Phase 1
Discover import → fork · migrate + retire follow/shared-edit path (fixes the dual-NFL switcher wart) · SPRT-for-workspace · intra-org roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)