### PR TITLE
League CRUD — create, rename, delete (WSM-000118)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -752,6 +752,132 @@ export const upsertLeague = mutationGeneric({
   },
 });
 
+/** Create a new org-owned league (WSM-000118). Name unique within the org. */
+export const createLeague = mutationGeneric({
+  args: { name: v.string(), orgId: v.string() },
+  returns: v.object({ id: v.string(), name: v.string() }),
+  handler: async (ctx, args) => {
+    const name = args.name.trim();
+    if (!name) throw new Error("League name is required");
+    const dupe = (
+      await ctx.db
+        .query("leagues")
+        .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))
+        .collect()
+    ).some((l) => l.name === name);
+    if (dupe) throw new Error("You already have a league with that name");
+    const id = await ctx.db.insert("leagues", {
+      name,
+      orgId: args.orgId,
+      isPublic: false,
+      inviteToken: null,
+    });
+    return { id: id as string, name };
+  },
+});
+
+/** Rename a league (WSM-000118). Auth enforced in the calling server action. */
+export const renameLeague = mutationGeneric({
+  args: { leagueId: v.id("leagues"), name: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const name = args.name.trim();
+    if (!name) throw new Error("League name is required");
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) throw new Error("league_not_found");
+    await ctx.db.patch(args.leagueId, { name });
+    return null;
+  },
+});
+
+/**
+ * Delete a league and everything under it (WSM-000118): subscriptions, audit
+ * log, roster assignments, seasons + fixtures + game results + player
+ * attributes, depth-chart entries, players, teams, divisions. Auth enforced in
+ * the calling server action (org:admin of the league's org).
+ */
+export const deleteLeague = mutationGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) return null;
+
+    for (const s of await ctx.db
+      .query("leagueSubscriptions")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(s._id);
+    for (const a of await ctx.db
+      .query("rosterAuditLog")
+      .withIndex("by_leagueId_createdAt", (q) =>
+        q.eq("leagueId", args.leagueId),
+      )
+      .collect())
+      await ctx.db.delete(a._id);
+    for (const r of await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_leagueId_seasonId", (q) =>
+        q.eq("leagueId", args.leagueId),
+      )
+      .collect())
+      await ctx.db.delete(r._id);
+
+    const seasons = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    for (const season of seasons) {
+      const fixtures = await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", season._id))
+        .collect();
+      for (const f of fixtures) {
+        for (const gr of await ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+          .collect())
+          await ctx.db.delete(gr._id);
+        await ctx.db.delete(f._id);
+      }
+      for (const pa of await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_seasonId_positionGroup", (q) =>
+          q.eq("seasonId", season._id),
+        )
+        .collect())
+        await ctx.db.delete(pa._id);
+      await ctx.db.delete(season._id);
+    }
+
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    for (const team of teams) {
+      for (const dce of await ctx.db
+        .query("depthChartEntries")
+        .withIndex("by_team_season", (q) => q.eq("teamId", team._id))
+        .collect())
+        await ctx.db.delete(dce._id);
+    }
+    for (const p of await ctx.db
+      .query("players")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(p._id);
+    for (const t of teams) await ctx.db.delete(t._id);
+    for (const d of await ctx.db
+      .query("divisions")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(d._id);
+
+    await ctx.db.delete(args.leagueId);
+    return null;
+  },
+});
+
 export const upsertDivision = mutationGeneric({
   args: {
     name: v.string(),

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -10,6 +10,7 @@ import InviteForm from "./invite-form";
 import InvitationList from "./invitation-list";
 import InviteLinkSection from "./invite-link-section";
 import LeaguePublicToggle from "./league-public-toggle";
+import { RenameLeagueForm, DeleteLeagueButton } from "../leagues-actions";
 
 export default async function LeagueDetailPage({
   params,
@@ -46,13 +47,25 @@ export default async function LeagueDetailPage({
 
       <Card>
         <CardHeader>
-          <div className="flex items-center gap-3">
-            <Trophy className="h-5 w-5 text-primary" />
-            <CardTitle>{league.name}</CardTitle>
-            {league.orgId ? (
-              <Badge variant="secondary">Organization</Badge>
-            ) : (
-              <Badge variant="outline">Public</Badge>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-3">
+              <Trophy className="h-5 w-5 shrink-0 text-primary" />
+              <CardTitle className="truncate">{league.name}</CardTitle>
+              {league.orgId ? (
+                <Badge variant="secondary" className="shrink-0">
+                  Organization
+                </Badge>
+              ) : (
+                <Badge variant="outline" className="shrink-0">
+                  Public
+                </Badge>
+              )}
+            </div>
+            {isAdmin && league.orgId && (
+              <div className="flex items-center gap-1">
+                <RenameLeagueForm leagueId={id} currentName={league.name} />
+                <DeleteLeagueButton leagueId={id} leagueName={league.name} />
+              </div>
             )}
           </div>
         </CardHeader>

--- a/apps/web/src/app/dashboard/leagues/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/actions.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import {
+  createLeague as createLeagueMutation,
+  renameLeague as renameLeagueMutation,
+  deleteLeague as deleteLeagueMutation,
+  getLeagueOrgId,
+} from "@/lib/data-api";
+import { getUserRoleInOrg } from "@/lib/org-context";
+
+type Result<T = unknown> =
+  | ({ ok: true } & T)
+  | { ok: false; error: string };
+
+/** Resolve an org the user admins to own a new league — never blocking them. */
+async function resolveAdminOrg(
+  userId: string,
+  activeOrgId: string | null | undefined,
+  activeRole: string | null | undefined,
+  newOrgName: string,
+): Promise<string> {
+  if (activeOrgId && activeRole === "org:admin") return activeOrgId;
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
+  const admin = memberships.data.find((m) => m.role === "org:admin");
+  if (admin) return admin.organization.id;
+  const org = await client.organizations.createOrganization({
+    name: newOrgName,
+    createdBy: userId,
+  });
+  return org.id;
+}
+
+export async function createLeagueAction(
+  name: string,
+): Promise<Result<{ id: string }>> {
+  const { userId, orgId, orgRole } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "League name is required." };
+
+  try {
+    const targetOrg = await resolveAdminOrg(userId, orgId, orgRole, trimmed);
+    const { id } = await createLeagueMutation(trimmed, targetOrg);
+    revalidatePath("/dashboard/leagues");
+    return { ok: true, id };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not create league.",
+    };
+  }
+}
+
+/** Shared org-admin gate for editing/removing an existing league. */
+async function requireLeagueAdmin(
+  leagueId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "This league can't be edited." };
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+  return { ok: true };
+}
+
+export async function renameLeagueAction(
+  leagueId: string,
+  name: string,
+): Promise<Result> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "League name is required." };
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+  await renameLeagueMutation(leagueId, trimmed);
+  revalidatePath("/dashboard/leagues");
+  revalidatePath(`/dashboard/leagues/${leagueId}`);
+  return { ok: true };
+}
+
+export async function deleteLeagueAction(leagueId: string): Promise<Result> {
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+  await deleteLeagueMutation(leagueId);
+  revalidatePath("/dashboard/leagues");
+  return { ok: true };
+}

--- a/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/8bit/button";
+import { toast } from "sonner";
+import { Plus, Trash2, Pencil } from "lucide-react";
+import {
+  createLeagueAction,
+  deleteLeagueAction,
+  renameLeagueAction,
+} from "./actions";
+
+const inputClass =
+  "rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground";
+
+export function CreateLeagueButton() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    const res = await createLeagueAction(trimmed);
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`Created ${trimmed}.`);
+      setName("");
+      setOpen(false);
+      router.push(`/dashboard/leagues/${res.id}`);
+    } else {
+      toast.error(res.error);
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <Plus className="mr-1 h-4 w-4" />
+        New league
+      </Button>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") setOpen(false);
+        }}
+        placeholder="League name"
+        className={inputClass}
+      />
+      <Button size="sm" disabled={busy} onClick={submit}>
+        {busy ? "…" : "Create"}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => {
+          setOpen(false);
+          setName("");
+        }}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+export function DeleteLeagueButton({
+  leagueId,
+  leagueName,
+}: {
+  leagueId: string;
+  leagueName: string;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function remove() {
+    if (
+      !window.confirm(
+        `Delete "${leagueName}" and everything in it (teams, players, schedule)? This can't be undone.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    const res = await deleteLeagueAction(leagueId);
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`Deleted ${leagueName}.`);
+      router.refresh();
+    } else {
+      toast.error(res.error);
+    }
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      disabled={busy}
+      onClick={remove}
+      aria-label={`Delete ${leagueName}`}
+    >
+      <Trash2 className="h-4 w-4 text-destructive" />
+    </Button>
+  );
+}
+
+export function RenameLeagueForm({
+  leagueId,
+  currentName,
+}: {
+  leagueId: string;
+  currentName: string;
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(currentName);
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === currentName) {
+      setEditing(false);
+      return;
+    }
+    setBusy(true);
+    const res = await renameLeagueAction(leagueId, trimmed);
+    setBusy(false);
+    if (res.ok) {
+      toast.success("League renamed.");
+      setEditing(false);
+      router.refresh();
+    } else {
+      toast.error(res.error);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => setEditing(true)}
+        aria-label="Rename league"
+      >
+        <Pencil className="mr-1 h-3.5 w-3.5" />
+        Rename
+      </Button>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") setEditing(false);
+        }}
+        className={inputClass}
+      />
+      <Button size="sm" disabled={busy} onClick={submit}>
+        {busy ? "…" : "Save"}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/c
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
 import { Trophy, Layers, Users } from "lucide-react";
+import { CreateLeagueButton, DeleteLeagueButton } from "./leagues-actions";
 
 export default async function LeaguesPage() {
   const { userId } = await auth();
@@ -37,13 +38,16 @@ export default async function LeaguesPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Leagues</h2>
+      <div className="mb-6 flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-foreground">Leagues</h2>
+        <CreateLeagueButton />
+      </div>
 
       {leagues.length === 0 ? (
         <EmptyState
           icon={Trophy}
-          title="No leagues found"
-          description="Leagues will appear here once created in the system."
+          title="No leagues yet"
+          description="Create a league, or add teams from Discover, to get started."
         />
       ) : (
         <div className="space-y-6">
@@ -53,17 +57,26 @@ export default async function LeaguesPage() {
             return (
               <Card key={league.id}>
                 <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <Trophy className="h-5 w-5 text-primary" />
-                    <CardTitle>
-                      <Link href={`/dashboard/leagues/${league.id}`} className="hover:underline">
-                        {league.name}
-                      </Link>
-                    </CardTitle>
-                    <Badge variant="secondary">
-                      {leagueDivisions.length} division
-                      {leagueDivisions.length !== 1 ? "s" : ""}
-                    </Badge>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <Trophy className="h-5 w-5 shrink-0 text-primary" />
+                      <CardTitle className="truncate">
+                        <Link
+                          href={`/dashboard/leagues/${league.id}`}
+                          className="hover:underline"
+                        >
+                          {league.name}
+                        </Link>
+                      </CardTitle>
+                      <Badge variant="secondary" className="shrink-0">
+                        {leagueDivisions.length} division
+                        {leagueDivisions.length !== 1 ? "s" : ""}
+                      </Badge>
+                    </div>
+                    <DeleteLeagueButton
+                      leagueId={league.id}
+                      leagueName={league.name}
+                    />
                   </div>
                 </CardHeader>
                 <CardContent>

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -152,6 +152,14 @@ const refs = {
     { name: string; orgId: string | null },
     { dto: LeagueDto; created: boolean }
   >("sports:upsertLeague"),
+  createLeague: mutationRef<
+    { name: string; orgId: string },
+    { id: string; name: string }
+  >("sports:createLeague"),
+  renameLeague: mutationRef<{ leagueId: string; name: string }, null>(
+    "sports:renameLeague",
+  ),
+  deleteLeague: mutationRef<{ leagueId: string }, null>("sports:deleteLeague"),
   clearSeasonPlayerAttributes: mutationRef<
     { seasonId: string },
     { deleted: number }
@@ -510,6 +518,25 @@ export async function setLeagueInviteToken(
 
 export async function getLeagueOrgId(leagueId: string): Promise<string | null> {
   return queryConvex(refs.getLeagueOrgId, { leagueId });
+}
+
+/** WSM-000118: league CRUD. Auth enforced in the calling server actions. */
+export async function createLeague(
+  name: string,
+  orgId: string,
+): Promise<{ id: string; name: string }> {
+  return mutateConvex(refs.createLeague, { name, orgId });
+}
+
+export async function renameLeague(
+  leagueId: string,
+  name: string,
+): Promise<void> {
+  await mutateConvex(refs.renameLeague, { leagueId, name });
+}
+
+export async function deleteLeague(leagueId: string): Promise<void> {
+  await mutateConvex(refs.deleteLeague, { leagueId });
 }
 
 export async function getLeagues(visibleLeagueIds: string[]): Promise<LeagueDto[]> {


### PR DESCRIPTION
From your testing: the Leagues area was confusing — no way to **create, edit, or remove** leagues. This adds all three, org-admin gated.

## Changes
- **Convex:** `createLeague` (name unique *within the org* — `upsertLeague` matched by name globally, wrong for multi-tenant), `renameLeague`, and `deleteLeague` (cascades: subscriptions → audit log → roster assignments → seasons/fixtures/game-results/player-attributes → depth-chart entries → players → teams → divisions → league).
- **Server actions** enforce `org:admin` of the league's org; create resolves (or creates) the user's org like the fork flow.
- **UI:** **New league** on the Leagues list + per-league **delete**; **Rename** + **Delete** on the league detail page (admins only).

## Verification
tsc, lint, **330 tests**, `next build` ✓. Convex deployed.

## Known limit
A very large workspace league (forked NFL ≈ 2,900 players) may exceed a single mutation's write limit on delete — **batched deletion is a follow-up**. Normal leagues (your Soak Test League, HS teams) delete fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)