### PR TITLE
Player form: position pick-list + jersey duplicate warning (WSM-000119)

### DIFF
--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -25,10 +25,47 @@ import {
 } from "@/components/ui/8bit/select";
 import { toast } from "sonner";
 
+// Football position pick-list (WSM-000119). Common positions first, then the
+// granular variants. ATH = athlete/unspecified.
+const POSITION_OPTIONS = [
+  "QB",
+  "RB",
+  "FB",
+  "WR",
+  "TE",
+  "OL",
+  "LT",
+  "LG",
+  "C",
+  "RG",
+  "RT",
+  "DL",
+  "DE",
+  "DT",
+  "NT",
+  "EDGE",
+  "LB",
+  "OLB",
+  "MLB",
+  "ILB",
+  "DB",
+  "CB",
+  "S",
+  "FS",
+  "SS",
+  "K",
+  "P",
+  "LS",
+  "ATH",
+];
+
 interface PlayerFormProps {
   mode: "create" | "edit";
   teamId: string;
   player?: PlayerDto;
+  /** Jersey numbers already on the roster (excluding this player) — for the
+      duplicate warning (WSM-000119). Duplicates are allowed (e.g. college). */
+  existingJerseyNumbers?: number[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
@@ -38,6 +75,7 @@ export default function PlayerForm({
   mode,
   teamId,
   player,
+  existingJerseyNumbers = [],
   open,
   onOpenChange,
   onSuccess,
@@ -51,6 +89,11 @@ export default function PlayerForm({
   const [status, setStatus] = useState(player?.status ?? "Active");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  // Duplicate jersey is allowed (e.g. college) but flagged (WSM-000119).
+  const jerseyTaken =
+    jerseyNumber !== "" &&
+    existingJerseyNumbers.includes(Number(jerseyNumber));
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -66,6 +109,12 @@ export default function PlayerForm({
         dateOfBirth: dateOfBirth || null,
         status,
       };
+
+      if (jerseyTaken) {
+        toast.warning(
+          `#${jerseyNumber} is already used on this roster — saved anyway.`,
+        );
+      }
 
       if (mode === "create") {
         const parsed = CreatePlayerInputSchema.safeParse(data);
@@ -145,13 +194,18 @@ export default function PlayerForm({
 
           <div className="space-y-2">
             <Label htmlFor="player-position">Position *</Label>
-            <Input
-              id="player-position"
-              type="text"
-              required
-              value={position}
-              onChange={(e) => setPosition(e.target.value)}
-            />
+            <Select value={position} onValueChange={setPosition}>
+              <SelectTrigger id="player-position">
+                <SelectValue placeholder="Select a position" />
+              </SelectTrigger>
+              <SelectContent>
+                {POSITION_OPTIONS.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-2">
@@ -159,9 +213,18 @@ export default function PlayerForm({
             <Input
               id="player-jersey"
               type="number"
+              min={0}
+              max={99}
               value={jerseyNumber}
               onChange={(e) => setJerseyNumber(e.target.value)}
+              aria-invalid={jerseyTaken}
             />
+            {jerseyTaken && (
+              <p className="text-xs text-yellow-600 dark:text-yellow-500">
+                #{jerseyNumber} is already on this roster — allowed, but it&rsquo;s
+                a duplicate.
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -338,6 +338,9 @@ export default function TeamManagement({
       <PlayerForm
         mode="create"
         teamId={team.id}
+        existingJerseyNumbers={players
+          .map((p) => p.jerseyNumber)
+          .filter((n): n is number => n != null)}
         open={modal.type === "addPlayer"}
         onOpenChange={(open) => !open && setModal({ type: "none" })}
         onSuccess={handleSuccess}
@@ -348,6 +351,10 @@ export default function TeamManagement({
           mode="edit"
           teamId={team.id}
           player={modal.player}
+          existingJerseyNumbers={players
+            .filter((p) => p.id !== modal.player.id)
+            .map((p) => p.jerseyNumber)
+            .filter((n): n is number => n != null)}
           open
           onOpenChange={(open) => !open && setModal({ type: "none" })}
           onSuccess={handleSuccess}


### PR DESCRIPTION
From your screenshot — Position and Jersey were free text.

- **Position** → a **pick-list** of football positions (QB, RB, WR, …, K/P/LS, ATH).
- **Jersey Number** → numeric entry, now flags a **duplicate** (inline warning while typing + a toast on save) when the number's already on the roster. **Duplicates are allowed** (college teams do this) — just surfaced.
- The form gets the team's existing jersey numbers (excluding the player being edited).

tsc, lint, **330 tests**, `next build` ✓. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)