### PR TITLE
feat(web): remove a team from a league (WSM-000120)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1160,6 +1160,84 @@ export const deletePlayer = mutationGeneric({
   },
 });
 
+/*
+ * Remove a single team from a league (WSM-000120). Cascades every row that
+ * references the team so no orphans survive:
+ *   players → their playerAttributes / maddenRatings / rosterAssignments
+ *   depthChartEntries (all seasons) · rosterAuditLog
+ *   fixtures (home or away) → their gameResults
+ * Scoped to one team, so it stays comfortably inside mutation limits (unlike a
+ * whole forked-NFL league delete). Idempotent: a missing team is a no-op.
+ */
+export const deleteTeam = mutationGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) return null;
+
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    for (const player of players) {
+      const attributes = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", player._id),
+        )
+        .collect();
+      for (const row of attributes) await ctx.db.delete(row._id);
+
+      const madden = await ctx.db
+        .query("maddenRatings")
+        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+        .collect();
+      for (const row of madden) await ctx.db.delete(row._id);
+
+      const assignments = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+        .collect();
+      for (const row of assignments) await ctx.db.delete(row._id);
+
+      await ctx.db.delete(player._id);
+    }
+
+    const depthEntries = await ctx.db
+      .query("depthChartEntries")
+      .withIndex("by_team_season", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    for (const row of depthEntries) await ctx.db.delete(row._id);
+
+    const auditRows = await ctx.db
+      .query("rosterAuditLog")
+      .withIndex("by_teamId_createdAt", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    for (const row of auditRows) await ctx.db.delete(row._id);
+
+    const homeFixtures = await ctx.db
+      .query("fixtures")
+      .withIndex("by_homeTeamId", (q) => q.eq("homeTeamId", args.teamId))
+      .collect();
+    const awayFixtures = await ctx.db
+      .query("fixtures")
+      .withIndex("by_awayTeamId", (q) => q.eq("awayTeamId", args.teamId))
+      .collect();
+    for (const fixture of [...homeFixtures, ...awayFixtures]) {
+      const results = await ctx.db
+        .query("gameResults")
+        .withIndex("by_fixtureId", (q) => q.eq("fixtureId", fixture._id))
+        .collect();
+      for (const row of results) await ctx.db.delete(row._id);
+      await ctx.db.delete(fixture._id);
+    }
+
+    await ctx.db.delete(args.teamId);
+    return null;
+  },
+});
+
 export const upsertSeason = mutationGeneric({
   args: {
     name: v.string(),

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -1,6 +1,11 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { getTeam, getPlayersByTeam, updateTeam } from "@/lib/data-api";
+import {
+  getTeam,
+  getPlayersByTeam,
+  updateTeam,
+  deleteTeam,
+} from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
 import { authorizeTeamMutation } from "@/lib/authorization";
@@ -58,6 +63,33 @@ export async function PUT(
   try {
     const data = await updateTeam(id, parsed.data);
     return NextResponse.json(data);
+  } catch (error) {
+    return handleApiError(error, `/api/teams/${id}`);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const authorization = await authorizeTeamMutation(id, userId);
+  if (!authorization.isAuthorized) {
+    return NextResponse.json(
+      { error: "You are not authorized to manage this team" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    await deleteTeam(id);
+    return NextResponse.json({ success: true });
   } catch (error) {
     return handleApiError(error, `/api/teams/${id}`);
   }

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -35,6 +35,7 @@ interface TeamManagementProps {
 type ModalState =
   | { type: "none" }
   | { type: "editTeam" }
+  | { type: "deleteTeam" }
   | { type: "addPlayer" }
   | { type: "editPlayer"; player: PlayerDto }
   | { type: "deletePlayer"; player: PlayerDto };
@@ -72,6 +73,25 @@ export default function TeamManagement({
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to delete player";
+      toast.error(message);
+      setIsDeleting(false);
+    }
+  }
+
+  async function handleDeleteTeam() {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/teams/${team.id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "Failed to remove team");
+      }
+      toast.success(`${team.name} removed`);
+      // The team no longer exists — return to its league rather than refresh.
+      router.push(`/dashboard/leagues/${team.leagueId}`);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to remove team";
       toast.error(message);
       setIsDeleting(false);
     }
@@ -201,14 +221,25 @@ export default function TeamManagement({
           <div className="flex items-start justify-between">
             <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
             {canManage && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setModal({ type: "editTeam" })}
-              >
-                <Pencil className="mr-1 h-3 w-3" />
-                Edit Team
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setModal({ type: "editTeam" })}
+                >
+                  <Pencil className="mr-1 h-3 w-3" />
+                  Edit Team
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setModal({ type: "deleteTeam" })}
+                >
+                  <Trash2 className="mr-1 h-3 w-3" />
+                  Remove Team
+                </Button>
+              </div>
             )}
           </div>
           <dl className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
@@ -361,6 +392,19 @@ export default function TeamManagement({
           isOpen
           isDeleting={isDeleting}
           onConfirm={() => handleDeletePlayer(modal.player.id)}
+          onCancel={() => setModal({ type: "none" })}
+        />
+      )}
+
+      {modal.type === "deleteTeam" && (
+        <DeleteConfirm
+          title="Remove Team"
+          message={`Remove ${team.name} and its ${players.length} player${
+            players.length === 1 ? "" : "s"
+          } from this league? This also deletes the team's depth charts and schedule. This action cannot be undone.`}
+          isOpen
+          isDeleting={isDeleting}
+          onConfirm={handleDeleteTeam}
           onCancel={() => setModal({ type: "none" })}
         />
       )}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -229,6 +229,7 @@ const refs = {
     PlayerDto | null
   >("sports:updatePlayer"),
   deletePlayer: mutationRef<{ playerId: string }, null>("sports:deletePlayer"),
+  deleteTeam: mutationRef<{ teamId: string }, null>("sports:deleteTeam"),
   setSyncEnabled: mutationRef<{ enabled: boolean }, null>("sports:setSyncEnabled"),
   writeSyncReport: mutationRef<{ reportJson: string }, null>(
     "sports:writeSyncReport",
@@ -757,6 +758,10 @@ export async function updatePlayer(
 
 export async function deletePlayer(id: string): Promise<null> {
   return mutateConvex(refs.deletePlayer, { playerId: id });
+}
+
+export async function deleteTeam(id: string): Promise<null> {
+  return mutateConvex(refs.deleteTeam, { teamId: id });
 }
 
 export async function createTeam(input: CreateTeamInput): Promise<TeamDto> {


### PR DESCRIPTION
## What
Adds the ability to **remove an individual team from a league** — the missing counterpart to whole-league delete.

## Why
Reported by the user while testing on mobile: _"There is no way to unsubscribe or remove teams from a league."_ Until now you could only delete an entire league, not prune a single team out of one.

## Changes
- **`convex/sports.ts`** — new `deleteTeam(teamId)` mutation. Cascades every row that references the team so nothing orphans:
  - players → their `playerAttributes`, `maddenRatings`, `rosterAssignments`
  - `depthChartEntries` (all seasons) · `rosterAuditLog`
  - `fixtures` (home **or** away) → their `gameResults`
  - Scoped to one team, so it stays well inside Convex mutation limits (unlike a whole forked-NFL league delete). Idempotent — a missing team is a no-op.
- **`data-api.ts`** — `deleteTeam` ref + wrapper.
- **`api/teams/[id]/route.ts`** — `DELETE` handler, gated by the existing `authorizeTeamMutation` (org:admin of the league's org **or** the team's owner org).
- **`team-management.tsx`** — "Remove Team" button (canManage only) next to Edit Team; confirm dialog names the roster size and notes depth charts/schedule are also removed; redirects to the league on success.

## Auth
Reuses `authorizeTeamMutation` — same gate as team edit. Non-admins get 403; the button only renders for `canManage`.

## Verification
- ✅ `tsc --noEmit`
- ✅ `next lint` (no new warnings)
- ✅ `vitest run` — 330/330
- ✅ `next build`
- ✅ Convex mutation deployed to prod (`terrific-aardvark-395`), additive/backward-compatible — no indexes deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)