### PR TITLE
feat(web): intra-org roles — admin / coach / viewer (WSM-000121)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -149,6 +149,22 @@ export default defineSchema({
   }).index("by_key", ["key"]),
 
   /*
+   * Intra-org capability roles (WSM-000121).
+   *
+   * Clerk owns membership + the admin bit (org:admin). For org:member users we
+   * layer a finer capability role here — "coach" (manage rosters/players) or
+   * "viewer" (read-only). Absence of a row means viewer (the least-privilege
+   * default), so admins and brand-new members need no row. Orphan rows are
+   * harmless: callers always gate on live Clerk membership first, then consult
+   * this table only to split a member into coach vs viewer.
+   */
+  orgMemberRoles: defineTable({
+    orgId: v.string(),
+    userId: v.string(),
+    role: v.string(), // "coach" | "viewer"
+  }).index("by_orgId_userId", ["orgId", "userId"]),
+
+  /*
    * Phase 2 — `player_attributes_v1` (Sprint 6B).
    *
    * One row per player per season. Stores raw source payloads

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2723,6 +2723,88 @@ export const getLeagueClaimable = queryGeneric({
   },
 });
 
+/*
+ * Intra-org capability roles (WSM-000121). The Clerk admin bit and membership
+ * are the source of truth; these functions only persist the coach/viewer split
+ * for org:member users. A missing row means "viewer".
+ */
+// Compound-index `.eq().eq()` chaining doesn't type-check under the generic ctx
+// (the second `.eq` sees an IndexRange), so query the orgId prefix and pick the
+// user in JS — the same pattern used elsewhere in this file.
+export const getOrgMemberRole = queryGeneric({
+  args: { orgId: v.string(), userId: v.string() },
+  returns: v.union(v.literal("coach"), v.literal("viewer"), v.null()),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("orgMemberRoles")
+      .withIndex("by_orgId_userId", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    const row = rows.find((r) => r.userId === args.userId);
+    if (!row) return null;
+    return row.role === "coach" ? "coach" : "viewer";
+  },
+});
+
+export const listOrgMemberRoles = queryGeneric({
+  args: { orgId: v.string() },
+  returns: v.array(
+    v.object({
+      userId: v.string(),
+      role: v.union(v.literal("coach"), v.literal("viewer")),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("orgMemberRoles")
+      .withIndex("by_orgId_userId", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    return rows.map((r) => ({
+      userId: r.userId,
+      role: (r.role === "coach" ? "coach" : "viewer") as "coach" | "viewer",
+    }));
+  },
+});
+
+export const setOrgMemberRole = mutationGeneric({
+  args: {
+    orgId: v.string(),
+    userId: v.string(),
+    role: v.union(v.literal("coach"), v.literal("viewer")),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("orgMemberRoles")
+      .withIndex("by_orgId_userId", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    const existing = rows.find((r) => r.userId === args.userId);
+    if (existing) {
+      await ctx.db.patch(existing._id, { role: args.role });
+    } else {
+      await ctx.db.insert("orgMemberRoles", {
+        orgId: args.orgId,
+        userId: args.userId,
+        role: args.role,
+      });
+    }
+    return null;
+  },
+});
+
+export const deleteOrgMemberRole = mutationGeneric({
+  args: { orgId: v.string(), userId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("orgMemberRoles")
+      .withIndex("by_orgId_userId", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    const existing = rows.find((r) => r.userId === args.userId);
+    if (existing) await ctx.db.delete(existing._id);
+    return null;
+  },
+});
+
 /** Mark a (public template) league's teams claimable by coaches (WSM-000109). */
 export const setLeagueClaimable = mutationGeneric({
   args: {

--- a/apps/web/src/app/api/orgs/[orgId]/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/members/__tests__/route.test.ts
@@ -30,6 +30,12 @@ vi.mock("@/lib/org-context", () => ({
   requireOrgAdmin: mockRequireOrgAdmin,
 }));
 
+vi.mock("@/lib/data-api", () => ({
+  listOrgMemberRoles: vi.fn().mockResolvedValue([]),
+  setOrgMemberRole: vi.fn().mockResolvedValue(undefined),
+  deleteOrgMemberRole: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/lib/api-error", () => ({
   handleApiError: vi.fn().mockReturnValue(
     new Response(JSON.stringify({ error: "Internal server error" }), {
@@ -111,7 +117,10 @@ describe("Members API", () => {
       const data = await res.json();
       expect(data).toHaveLength(2);
       expect(data[0].email).toBe("admin@test.com");
-      expect(data[1].role).toBe("org:member");
+      // Effective capability roles: org:admin → admin; org:member with no
+      // sub-role → viewer (WSM-000121).
+      expect(data[0].role).toBe("admin");
+      expect(data[1].role).toBe("viewer");
     });
   });
 
@@ -124,9 +133,17 @@ describe("Members API", () => {
       expect(res.status).toBe(400);
     });
 
+    it("returns 400 for an unknown role", async () => {
+      const res = await PATCH(
+        makeRequest({ memberUserId: "user_2", role: "org:member" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(400);
+    });
+
     it("returns 400 when demoting last admin", async () => {
       const res = await PATCH(
-        makeRequest({ memberUserId: "user_1", role: "org:member" }),
+        makeRequest({ memberUserId: "user_1", role: "viewer" }),
         makeParams("org_1"),
       );
       expect(res.status).toBe(400);
@@ -134,10 +151,21 @@ describe("Members API", () => {
       expect(data.error).toBe("Cannot demote the last admin");
     });
 
-    it("returns 200 on role update", async () => {
+    it("returns 200 promoting a member to admin", async () => {
       mockUpdateMembership.mockResolvedValue({});
       const res = await PATCH(
-        makeRequest({ memberUserId: "user_2", role: "org:admin" }),
+        makeRequest({ memberUserId: "user_2", role: "admin" }),
+        makeParams("org_1"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("returns 200 setting a member to coach", async () => {
+      mockUpdateMembership.mockResolvedValue({});
+      const res = await PATCH(
+        makeRequest({ memberUserId: "user_2", role: "coach" }),
         makeParams("org_1"),
       );
       expect(res.status).toBe(200);

--- a/apps/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/apps/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -1,6 +1,12 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { requireOrgAdmin } from "@/lib/org-context";
+import {
+  listOrgMemberRoles,
+  setOrgMemberRole,
+  deleteOrgMemberRole,
+} from "@/lib/data-api";
+import { isOrgRole, type OrgRole } from "@/lib/permissions";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET(
@@ -23,15 +29,27 @@ export async function GET(
         organizationId: orgId,
       });
 
-    const data = memberships.data.map((m) => ({
-      userId: m.publicUserData?.userId ?? "",
-      email: m.publicUserData?.identifier ?? "",
-      firstName: m.publicUserData?.firstName ?? "",
-      lastName: m.publicUserData?.lastName ?? "",
-      imageUrl: m.publicUserData?.imageUrl ?? "",
-      role: m.role,
-      createdAt: m.createdAt,
-    }));
+    // Layer the Convex coach/viewer sub-role onto Clerk membership: org:admin
+    // → admin; org:member → stored sub-role, defaulting to viewer (WSM-000121).
+    const subRoles = await listOrgMemberRoles(orgId).catch(() => []);
+    const subRoleByUser = new Map(subRoles.map((r) => [r.userId, r.role]));
+
+    const data = memberships.data.map((m) => {
+      const memberUserId = m.publicUserData?.userId ?? "";
+      const role: OrgRole =
+        m.role === "org:admin"
+          ? "admin"
+          : (subRoleByUser.get(memberUserId) ?? "viewer");
+      return {
+        userId: memberUserId,
+        email: m.publicUserData?.identifier ?? "",
+        firstName: m.publicUserData?.firstName ?? "",
+        lastName: m.publicUserData?.lastName ?? "",
+        imageUrl: m.publicUserData?.imageUrl ?? "",
+        role,
+        createdAt: m.createdAt,
+      };
+    });
 
     return NextResponse.json(data);
   } catch (error) {
@@ -59,16 +77,17 @@ export async function PATCH(
 
     const { memberUserId, role } = await request.json();
 
-    if (!memberUserId || !role || !["org:admin", "org:member"].includes(role)) {
+    if (!memberUserId || !isOrgRole(role)) {
       return NextResponse.json(
-        { error: "Valid memberUserId and role required" },
+        { error: "Valid memberUserId and role (admin/coach/viewer) required" },
         { status: 400 },
       );
     }
 
-    // Prevent demoting last admin
-    if (role === "org:member") {
-      const client = await clerkClient();
+    const client = await clerkClient();
+
+    // Prevent demoting the last admin off the admin role.
+    if (role !== "admin") {
       const memberships =
         await client.organizations.getOrganizationMembershipList({
           organizationId: orgId,
@@ -91,12 +110,22 @@ export async function PATCH(
       }
     }
 
-    const client = await clerkClient();
-    await client.organizations.updateOrganizationMembership({
-      organizationId: orgId,
-      userId: memberUserId,
-      role,
-    });
+    // Clerk owns the admin bit; Convex stores the coach/viewer split for members.
+    if (role === "admin") {
+      await client.organizations.updateOrganizationMembership({
+        organizationId: orgId,
+        userId: memberUserId,
+        role: "org:admin",
+      });
+      await deleteOrgMemberRole(orgId, memberUserId);
+    } else {
+      await client.organizations.updateOrganizationMembership({
+        organizationId: orgId,
+        userId: memberUserId,
+        role: "org:member",
+      });
+      await setOrgMemberRole(orgId, memberUserId, role);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {
@@ -157,6 +186,8 @@ export async function DELETE(
       organizationId: orgId,
       userId: memberUserId,
     });
+    // Drop any coach/viewer sub-role so a re-add starts clean (WSM-000121).
+    await deleteOrgMemberRole(orgId, memberUserId).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/teams/[id]/route.ts
+++ b/apps/web/src/app/api/teams/[id]/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { UpdateTeamInputSchema } from "@sports-management/api-contracts";
-import { authorizeTeamMutation } from "@/lib/authorization";
+import { authorizeTeamMutation, authorizeTeamAdmin } from "@/lib/authorization";
 import { handleApiError } from "@/lib/api-error";
 
 export async function GET(
@@ -79,10 +79,11 @@ export async function DELETE(
 
   const { id } = await params;
 
-  const authorization = await authorizeTeamMutation(id, userId);
+  // Removing a whole team is admin-only — coaches manage rosters, not structure.
+  const authorization = await authorizeTeamAdmin(id, userId);
   if (!authorization.isAuthorized) {
     return NextResponse.json(
-      { error: "You are not authorized to manage this team" },
+      { error: "You are not authorized to remove this team" },
       { status: 403 },
     );
   }

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -3,6 +3,14 @@
 import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/8bit/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/8bit/select";
+import { ORG_ROLES, roleLabel, type OrgRole } from "@/lib/permissions";
 
 interface Member {
   userId: string;
@@ -10,9 +18,15 @@ interface Member {
   firstName: string;
   lastName: string;
   imageUrl: string;
-  role: string;
+  role: OrgRole;
   createdAt: number;
 }
+
+const ROLE_HINT: Record<OrgRole, string> = {
+  admin: "Full control",
+  coach: "Manage rosters & players",
+  viewer: "Read-only",
+};
 
 export default function MemberList({ orgId }: { orgId: string }) {
   const [members, setMembers] = useState<Member[]>([]);
@@ -34,7 +48,7 @@ export default function MemberList({ orgId }: { orgId: string }) {
     load();
   }, [orgId]);
 
-  async function handleRoleChange(memberUserId: string, newRole: string) {
+  async function handleRoleChange(memberUserId: string, newRole: OrgRole) {
     setActionLoading(memberUserId);
     try {
       const res = await fetch(`/api/orgs/${orgId}/members`, {
@@ -112,26 +126,27 @@ export default function MemberList({ orgId }: { orgId: string }) {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <Badge
-                variant={
-                  member.role === "org:admin" ? "default" : "secondary"
-                }
-              >
-                {member.role === "org:admin" ? "Admin" : "Member"}
+              <Badge variant={member.role === "admin" ? "default" : "secondary"}>
+                {roleLabel(member.role)}
               </Badge>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={isLoading}
-                onClick={() =>
-                  handleRoleChange(
-                    member.userId,
-                    member.role === "org:admin" ? "org:member" : "org:admin",
-                  )
+              <Select
+                value={member.role}
+                onValueChange={(value) =>
+                  handleRoleChange(member.userId, value as OrgRole)
                 }
+                disabled={isLoading}
               >
-                {member.role === "org:admin" ? "Demote" : "Promote"}
-              </Button>
+                <SelectTrigger className="w-[120px]" aria-label="Member role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ORG_ROLES.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {roleLabel(r)} — {ROLE_HINT[r]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <Button
                 size="sm"
                 variant="outline"

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -10,7 +10,8 @@ import {
   getLeagueOrgId,
   recordGameResult,
 } from "@/lib/data-api";
-import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import {
   trackFixtureCreated,
   trackResultRecorded,
@@ -31,9 +32,10 @@ interface CreateFixtureActionInput {
  *   1. flag enabled
  *   2. Clerk session present
  *   3. league visible to the user (resolveOrgContext)
- *   4. caller is org:admin of the league's org
+ *   4. caller can manage rosters (admin or coach) of the league's org —
+ *      coaches run schedules/results (WSM-000121)
  */
-async function authorizeAdminAction(
+async function authorizeManagerAction(
   leagueId: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const enabled = await schedulesStandingsV1();
@@ -49,8 +51,8 @@ async function authorizeAdminAction(
   const orgId = await getLeagueOrgId(leagueId);
   if (!orgId) return { ok: false, error: "league_not_owned" };
 
-  const role = await getUserRoleInOrg(orgId, userId);
-  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) return { ok: false, error: "not_authorized" };
 
   return { ok: true };
 }
@@ -58,7 +60,7 @@ async function authorizeAdminAction(
 export async function createFixtureAction(
   input: CreateFixtureActionInput,
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
-  const guard = await authorizeAdminAction(input.leagueId);
+  const guard = await authorizeManagerAction(input.leagueId);
   if (!guard.ok) return guard;
 
   if (input.homeTeamId === input.awayTeamId) {
@@ -101,7 +103,7 @@ interface RecordResultActionInput {
 export async function recordGameResultAction(
   input: RecordResultActionInput,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const guard = await authorizeAdminAction(input.leagueId);
+  const guard = await authorizeManagerAction(input.leagueId);
   if (!guard.ok) return guard;
 
   const { userId } = await auth();
@@ -147,7 +149,7 @@ interface DeleteFixtureActionInput {
 export async function deleteFixtureAction(
   input: DeleteFixtureActionInput,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const guard = await authorizeAdminAction(input.leagueId);
+  const guard = await authorizeManagerAction(input.leagueId);
   if (!guard.ok) return guard;
 
   try {

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -10,7 +10,8 @@ import {
   getTeamsByLeague,
   listFixturesBySeason,
 } from "@/lib/data-api";
-import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/8bit/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
@@ -31,10 +32,11 @@ export default async function LeagueSchedulePage({
   const league = await getLeague(leagueId, orgContext).catch(() => null);
   if (!league) notFound();
 
-  // Admin gate (only admins see "New fixture" + "Record result").
+  // Manager gate: admins and coaches see "New fixture" + "Record result"
+  // (coaches run schedules/results, WSM-000121).
   const orgId = await getLeagueOrgId(leagueId);
-  const role = orgId ? await getUserRoleInOrg(orgId, userId) : null;
-  const isAdmin = role === "org:admin";
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  const isAdmin = canManageRoster(role);
 
   // Pick the active season — fall back to whichever exists if none flagged active.
   const allSeasons = await getSeasons([leagueId]);

--- a/apps/web/src/app/dashboard/players/[id]/development/actions.ts
+++ b/apps/web/src/app/dashboard/players/[id]/development/actions.ts
@@ -9,7 +9,8 @@ import {
   getLeagueOrgId,
   getPlayer,
 } from "@/lib/data-api";
-import { getUserRoleInOrg, resolveOrgContext } from "@/lib/org-context";
+import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import { trackPlayerAttributesIngest } from "@/lib/analytics";
 
 export type AttributeSource = "pff" | "madden" | "admin";
@@ -59,8 +60,8 @@ export async function ingestPlayerAttributesAction(
   const orgId = await getLeagueOrgId(leagueId);
   if (!orgId) return { ok: false, error: "league_not_owned" };
 
-  const role = await getUserRoleInOrg(orgId, userId);
-  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) return { ok: false, error: "not_authorized" };
 
   // Parse raw JSON.
   let parsed: unknown;

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -9,7 +9,8 @@ import {
   getLeagueOrgId,
   getSeasons,
 } from "@/lib/data-api";
-import { resolveOrgContext, getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import { Card, CardContent } from "@/components/ui/8bit/card";
 import PixelLineChart from "@/components/attributes/PixelLineChart";
 import AttributesUploadDialog from "@/components/attributes/AttributesUploadDialog";
@@ -46,9 +47,10 @@ export default async function PlayerDevelopmentPage({
     ? await getLeagueOrgId(playerLeagueId)
     : null;
   const role = playerOrgId
-    ? await getUserRoleInOrg(playerOrgId, userId)
+    ? await resolveOrgRole(playerOrgId, userId)
     : null;
-  const isAdmin = role === "org:admin";
+  // Coaches manage player development data too (WSM-000121).
+  const isAdmin = canManageRoster(role);
   const seasons = playerLeagueId ? await getSeasons([playerLeagueId]) : [];
 
   const points = development.map((row) => ({

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/actions.ts
@@ -7,7 +7,8 @@ import {
   setRosterLocked as setRosterLockedMutation,
   getLeagueOrgId,
 } from "@/lib/data-api";
-import { getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import {
   trackDepthChartReorder,
   trackSeasonLockToggle,
@@ -21,11 +22,11 @@ async function requireFlag() {
   }
 }
 
-async function requireOrgMembership(orgId: string, userId: string) {
-  const role = await getUserRoleInOrg(orgId, userId);
-  if (!role) {
-    throw new Error("not_authorized");
-  }
+// Editing the depth chart needs a manager seat (admin or coach) — viewers are
+// read-only (WSM-000121).
+async function requireRosterManager(orgId: string, userId: string) {
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) throw new Error("not_authorized");
   return role;
 }
 
@@ -42,7 +43,7 @@ export async function reorderDepthChartAction(input: {
 
   const orgId = await getLeagueOrgId(input.leagueId);
   if (!orgId) throw new Error("not_authorized");
-  await requireOrgMembership(orgId, userId);
+  await requireRosterManager(orgId, userId);
 
   const result = await reorderDepthChartMutation({
     teamId: input.teamId,
@@ -68,10 +69,11 @@ export async function setRosterLockedAction(input: {
   const { userId } = await auth();
   if (!userId) throw new Error("not_authenticated");
 
+  // Locking a season's roster is an admin-only structural action (WSM-000121).
   const orgId = await getLeagueOrgId(input.leagueId);
   if (!orgId) throw new Error("not_authorized");
-  const role = await requireOrgMembership(orgId, userId);
-  if (role !== "org:admin") throw new Error("not_authorized");
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageOrgSettings(role)) throw new Error("not_authorized");
 
   const result = await setRosterLockedMutation(input.seasonId, input.locked);
   void trackSeasonLockToggle({

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -9,7 +9,8 @@ import {
   getDepthChartByTeamSeason,
   getLeagueOrgId,
 } from "@/lib/data-api";
-import { getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import DepthChartBoard from "@/components/depth-chart/DepthChartBoard";
 
 export default async function DepthChartPage({
@@ -37,9 +38,11 @@ export default async function DepthChartPage({
   const orgId = await getLeagueOrgId(team.leagueId);
   if (!orgId) notFound();
 
-  const role = await getUserRoleInOrg(orgId, userId);
+  const role = await resolveOrgRole(orgId, userId);
   if (!role) notFound();
-  const isAdmin = role === "org:admin";
+  // Coaches can edit the depth chart; only admins toggle the season lock.
+  const canEdit = canManageRoster(role);
+  const isAdmin = canManageOrgSettings(role);
 
   const seasons = await getSeasons([team.leagueId]);
   const activeSeason =
@@ -88,6 +91,7 @@ export default async function DepthChartPage({
         players={players}
         entries={entries}
         isAdmin={isAdmin}
+        canEdit={canEdit}
       />
     </div>
   );

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
   getLeagueClaimable,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import { canManageTeam } from "@/lib/authorization";
+import { canManageTeam, canAdministerTeam } from "@/lib/authorization";
 import { playerAttributesV1 } from "@/lib/flags";
 import type { PlayerSnapshot } from "@/lib/attributes/headline-columns";
 import TeamManagement from "./team-management";
@@ -37,10 +37,13 @@ export default async function TeamDetailPage({
       : { href: "/dashboard/teams", label: "Back to Teams" };
   const orgContext = await resolveOrgContext(userId);
 
-  const [team, players, canManage] = await Promise.all([
+  // canManage = admin or coach (roster/players/edit); canDelete = admin only
+  // (removing the whole team). WSM-000121 intra-org roles.
+  const [team, players, canManage, canDelete] = await Promise.all([
     getTeam(id, orgContext),
     getPlayersByTeam(id, orgContext),
     canManageTeam(id, userId),
+    canAdministerTeam(id, userId),
   ]);
 
   // Fork affordance (WSM-000115): a reference team in a forkable league can be
@@ -103,6 +106,7 @@ export default async function TeamDetailPage({
         team={team}
         players={players}
         canManage={canManage}
+        canDelete={canDelete}
         attributeSnapshots={Object.fromEntries(snapshots)}
         maddenOveralls={Object.fromEntries(maddenOveralls)}
       />

--- a/apps/web/src/app/dashboard/teams/[id]/roster/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/actions.ts
@@ -8,7 +8,8 @@ import {
   updateRosterStatus as updateRosterStatusMutation,
   getLeagueOrgId,
 } from "@/lib/data-api";
-import { getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import {
   trackRosterAssign,
   trackRosterLimitBlocked,
@@ -22,9 +23,11 @@ async function requireFlag() {
   if (!enabled) throw new Error("flag_disabled");
 }
 
-async function requireOrgMembership(orgId: string, userId: string) {
-  const role = await getUserRoleInOrg(orgId, userId);
-  if (!role) throw new Error("not_authorized");
+// Roster edits need a manager seat (admin or coach) — viewers are read-only
+// (WSM-000121).
+async function requireRosterManager(orgId: string, userId: string) {
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) throw new Error("not_authorized");
   return role;
 }
 
@@ -41,7 +44,7 @@ export async function assignPlayerToRosterAction(input: {
 
   const orgId = await getLeagueOrgId(input.leagueId);
   if (!orgId) throw new Error("not_authorized");
-  await requireOrgMembership(orgId, userId);
+  await requireRosterManager(orgId, userId);
 
   try {
     const result = await assignPlayerToRosterMutation({
@@ -82,7 +85,7 @@ export async function removePlayerFromRosterAction(input: {
 
   const orgId = await getLeagueOrgId(input.leagueId);
   if (!orgId) throw new Error("not_authorized");
-  await requireOrgMembership(orgId, userId);
+  await requireRosterManager(orgId, userId);
 
   await removePlayerFromRosterMutation({
     assignmentId: input.assignmentId,
@@ -109,7 +112,7 @@ export async function updateRosterStatusAction(input: {
 
   const orgId = await getLeagueOrgId(input.leagueId);
   if (!orgId) throw new Error("not_authorized");
-  await requireOrgMembership(orgId, userId);
+  await requireRosterManager(orgId, userId);
 
   const result = await updateRosterStatusMutation({
     assignmentId: input.assignmentId,

--- a/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/roster/page.tsx
@@ -11,7 +11,8 @@ import {
   getRosterBySeasonTeam,
   getTeamRosterLimitStatus,
 } from "@/lib/data-api";
-import { getUserRoleInOrg } from "@/lib/org-context";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import RosterBoard from "@/components/roster/RosterBoard";
 
 export default async function RosterPage({
@@ -44,8 +45,10 @@ export default async function RosterPage({
   const orgId = await getLeagueOrgId(team.leagueId);
   if (!orgId) notFound();
 
-  const role = await getUserRoleInOrg(orgId, userId);
+  const role = await resolveOrgRole(orgId, userId);
   if (!role) notFound();
+  // Coaches + admins edit the roster; viewers see it read-only (WSM-000121).
+  const canManage = canManageRoster(role);
 
   const seasons = await getSeasons([team.leagueId]);
   const activeSeason =
@@ -93,6 +96,7 @@ export default async function RosterPage({
         players={players}
         assignments={assignments}
         limitStatus={limitStatus}
+        canManage={canManage}
       />
     </div>
   );

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -24,7 +24,10 @@ import { toast } from "sonner";
 interface TeamManagementProps {
   team: TeamDto;
   players: PlayerDto[];
+  /** Admin or coach: edit team, manage players/roster (WSM-000121). */
   canManage: boolean;
+  /** Admin only: remove the whole team (WSM-000121). */
+  canDelete?: boolean;
   /** WSM-000090: playerId → attribute snapshot; empty when Phase 2 is
       dark or the season has no ingested attributes. */
   attributeSnapshots?: Record<string, PlayerSnapshot>;
@@ -44,6 +47,7 @@ export default function TeamManagement({
   team,
   players,
   canManage,
+  canDelete = false,
   attributeSnapshots = {},
   maddenOveralls = {},
 }: TeamManagementProps) {
@@ -220,25 +224,29 @@ export default function TeamManagement({
         <CardContent className="pt-6">
           <div className="flex items-start justify-between">
             <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
-            {canManage && (
+            {(canManage || canDelete) && (
               <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setModal({ type: "editTeam" })}
-                >
-                  <Pencil className="mr-1 h-3 w-3" />
-                  Edit Team
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => setModal({ type: "deleteTeam" })}
-                >
-                  <Trash2 className="mr-1 h-3 w-3" />
-                  Remove Team
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setModal({ type: "editTeam" })}
+                  >
+                    <Pencil className="mr-1 h-3 w-3" />
+                    Edit Team
+                  </Button>
+                )}
+                {canDelete && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setModal({ type: "deleteTeam" })}
+                  >
+                    <Trash2 className="mr-1 h-3 w-3" />
+                    Remove Team
+                  </Button>
+                )}
               </div>
             )}
           </div>

--- a/apps/web/src/components/depth-chart/DepthChartBoard.tsx
+++ b/apps/web/src/components/depth-chart/DepthChartBoard.tsx
@@ -16,7 +16,11 @@ interface DepthChartBoardProps {
   season: SeasonDto;
   players: PlayerDto[];
   entries: DepthChartEntryDto[];
+  /** Admin only: can toggle the season roster lock. */
   isAdmin: boolean;
+  /** Admin or coach: can reorder the depth chart. Viewers are read-only
+   *  (WSM-000121). Defaults true to preserve existing callers. */
+  canEdit?: boolean;
 }
 
 export default function DepthChartBoard({
@@ -27,6 +31,7 @@ export default function DepthChartBoard({
   players,
   entries,
   isAdmin,
+  canEdit = true,
 }: DepthChartBoardProps) {
   const [rosterLocked, setRosterLocked] = useState(season.rosterLocked);
 
@@ -102,7 +107,7 @@ export default function DepthChartBoard({
               leagueId={leagueId}
               positionSlot={positionSlot}
               players={slotPlayers}
-              disabled={rosterLocked}
+              disabled={rosterLocked || !canEdit}
             />
           ))}
         </div>

--- a/apps/web/src/components/roster/RosterBoard.tsx
+++ b/apps/web/src/components/roster/RosterBoard.tsx
@@ -24,6 +24,9 @@ export interface RosterBoardProps {
     rosterLimit: number | null;
     remaining: number | null;
   };
+  /** Admin or coach: can edit the roster. Viewers see it read-only
+   *  (WSM-000121). Defaults true to preserve existing callers. */
+  canManage?: boolean;
 }
 
 const NON_ACTIVE_STATUSES = ["ir", "suspended", "released"] as const;
@@ -34,6 +37,7 @@ export default function RosterBoard({
   players,
   assignments,
   limitStatus,
+  canManage = true,
 }: RosterBoardProps) {
   const router = useRouter();
   const [statusFilter, setStatusFilter] =
@@ -120,7 +124,7 @@ export default function RosterBoard({
             leagueId={team.leagueId}
             eligiblePlayers={eligiblePlayers}
             onAssigned={handleMutated}
-            disabled={atLimit || season.rosterLocked}
+            disabled={!canManage || atLimit || season.rosterLocked}
           />
         </div>
       </header>
@@ -155,7 +159,7 @@ export default function RosterBoard({
                 teamId={team.id}
                 seasonId={season.id}
                 leagueId={team.leagueId}
-                disabled={season.rosterLocked}
+                disabled={!canManage || season.rosterLocked}
                 onChanged={handleMutated}
               />
             ))}
@@ -192,7 +196,7 @@ export default function RosterBoard({
           teamId={team.id}
           seasonId={season.id}
           leagueId={team.leagueId}
-          disabled={season.rosterLocked || atLimit}
+          disabled={!canManage || season.rosterLocked || atLimit}
           onChanged={handleMutated}
         />
       </section>

--- a/apps/web/src/lib/__tests__/authorization.test.ts
+++ b/apps/web/src/lib/__tests__/authorization.test.ts
@@ -5,12 +5,14 @@ const {
   mockGetLeagueOrgId,
   mockGetTeamOwnerOrgId,
   mockClaimTeam,
+  mockGetOrgMemberRole,
   mockGetOrganizationMembershipList,
 } = vi.hoisted(() => ({
   mockGetTeamLeagueId: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
   mockGetTeamOwnerOrgId: vi.fn(),
   mockClaimTeam: vi.fn(),
+  mockGetOrgMemberRole: vi.fn(),
   mockGetOrganizationMembershipList: vi.fn(),
 }));
 
@@ -19,6 +21,7 @@ vi.mock("../data-api", () => ({
   getLeagueOrgId: mockGetLeagueOrgId,
   getTeamOwnerOrgId: mockGetTeamOwnerOrgId,
   claimTeam: mockClaimTeam,
+  getOrgMemberRole: mockGetOrgMemberRole,
   getVisibleLeagueContext: vi.fn(),
 }));
 
@@ -38,8 +41,10 @@ import { authorizeTeamMutation, canManageTeam } from "../authorization";
 describe("authorizeTeamMutation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: team is unclaimed unless a test says otherwise.
+    // Default: team is unclaimed and members carry no sub-role (→ viewer)
+    // unless a test says otherwise.
     mockGetTeamOwnerOrgId.mockResolvedValue(null);
+    mockGetOrgMemberRole.mockResolvedValue(null);
   });
 
   it("returns not authorized when team is not found", async () => {
@@ -47,7 +52,7 @@ describe("authorizeTeamMutation", () => {
 
     const result = await authorizeTeamMutation("team_missing", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+    expect(result).toEqual({ userId: "user_1", role: null, isAuthorized: false });
   });
 
   it("returns not authorized for public league (null orgId)", async () => {
@@ -56,7 +61,7 @@ describe("authorizeTeamMutation", () => {
 
     const result = await authorizeTeamMutation("team_1", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+    expect(result).toEqual({ userId: "user_1", role: null, isAuthorized: false });
   });
 
   it("returns authorized for org admin", async () => {
@@ -68,10 +73,31 @@ describe("authorizeTeamMutation", () => {
 
     const result = await authorizeTeamMutation("team_1", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: true });
+    expect(result).toEqual({
+      userId: "user_1",
+      role: "admin",
+      isAuthorized: true,
+    });
   });
 
-  it("returns not authorized for org member (non-admin)", async () => {
+  it("authorizes a coach (org member with coach sub-role)", async () => {
+    mockGetTeamLeagueId.mockResolvedValue("league_1");
+    mockGetLeagueOrgId.mockResolvedValue("org_1");
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [{ organization: { id: "org_1" }, role: "org:member" }],
+    });
+    mockGetOrgMemberRole.mockResolvedValue("coach");
+
+    const result = await authorizeTeamMutation("team_1", "user_1");
+
+    expect(result).toEqual({
+      userId: "user_1",
+      role: "coach",
+      isAuthorized: true,
+    });
+  });
+
+  it("denies a viewer (org member, no sub-role)", async () => {
     mockGetTeamLeagueId.mockResolvedValue("league_1");
     mockGetLeagueOrgId.mockResolvedValue("org_1");
     mockGetOrganizationMembershipList.mockResolvedValue({
@@ -80,7 +106,11 @@ describe("authorizeTeamMutation", () => {
 
     const result = await authorizeTeamMutation("team_1", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+    expect(result).toEqual({
+      userId: "user_1",
+      role: "viewer",
+      isAuthorized: false,
+    });
   });
 
   it("returns not authorized for non-member of org", async () => {
@@ -92,12 +122,12 @@ describe("authorizeTeamMutation", () => {
 
     const result = await authorizeTeamMutation("team_1", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+    expect(result).toEqual({ userId: "user_1", role: null, isAuthorized: false });
   });
 
-  // WSM-000109: a claimed team in a shared/public league is editable by an
-  // admin of the org that claimed it, even though the league org is null.
-  it("authorizes an admin of the team's owner org (claimed team)", async () => {
+  // WSM-000109/121: a forked team in a shared/public league is editable by an
+  // admin (or coach) of the org that owns it, even though the league org is null.
+  it("authorizes an admin of the team's owner org (forked team)", async () => {
     mockGetTeamLeagueId.mockResolvedValue("league_pub");
     mockGetLeagueOrgId.mockResolvedValue(null); // public template league
     mockGetTeamOwnerOrgId.mockResolvedValue("org_coach");
@@ -105,12 +135,16 @@ describe("authorizeTeamMutation", () => {
       data: [{ organization: { id: "org_coach" }, role: "org:admin" }],
     });
 
-    const result = await authorizeTeamMutation("team_claimed", "user_1");
+    const result = await authorizeTeamMutation("team_forked", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: true });
+    expect(result).toEqual({
+      userId: "user_1",
+      role: "admin",
+      isAuthorized: true,
+    });
   });
 
-  it("denies a non-admin member of the team's owner org", async () => {
+  it("denies a viewer member of the team's owner org", async () => {
     mockGetTeamLeagueId.mockResolvedValue("league_pub");
     mockGetLeagueOrgId.mockResolvedValue(null);
     mockGetTeamOwnerOrgId.mockResolvedValue("org_coach");
@@ -118,9 +152,13 @@ describe("authorizeTeamMutation", () => {
       data: [{ organization: { id: "org_coach" }, role: "org:member" }],
     });
 
-    const result = await authorizeTeamMutation("team_claimed", "user_1");
+    const result = await authorizeTeamMutation("team_forked", "user_1");
 
-    expect(result).toEqual({ userId: "user_1", isAuthorized: false });
+    expect(result).toEqual({
+      userId: "user_1",
+      role: "viewer",
+      isAuthorized: false,
+    });
   });
 });
 

--- a/apps/web/src/lib/__tests__/permissions.test.ts
+++ b/apps/web/src/lib/__tests__/permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORG_ROLES,
+  isOrgRole,
+  canManageOrgSettings,
+  canManageRoster,
+  canView,
+  roleLabel,
+  type OrgRole,
+} from "../permissions";
+
+describe("permissions", () => {
+  it("exposes exactly the three roles", () => {
+    expect(ORG_ROLES).toEqual(["admin", "coach", "viewer"]);
+  });
+
+  describe("isOrgRole", () => {
+    it.each(["admin", "coach", "viewer"])("accepts %s", (r) => {
+      expect(isOrgRole(r)).toBe(true);
+    });
+    it.each(["org:admin", "org:member", "", null, undefined, 1])(
+      "rejects %s",
+      (r) => {
+        expect(isOrgRole(r)).toBe(false);
+      },
+    );
+  });
+
+  describe("canManageOrgSettings (admin only)", () => {
+    const cases: Array<[OrgRole | null, boolean]> = [
+      ["admin", true],
+      ["coach", false],
+      ["viewer", false],
+      [null, false],
+    ];
+    it.each(cases)("%s → %s", (role, expected) => {
+      expect(canManageOrgSettings(role)).toBe(expected);
+    });
+  });
+
+  describe("canManageRoster (admin or coach)", () => {
+    const cases: Array<[OrgRole | null, boolean]> = [
+      ["admin", true],
+      ["coach", true],
+      ["viewer", false],
+      [null, false],
+    ];
+    it.each(cases)("%s → %s", (role, expected) => {
+      expect(canManageRoster(role)).toBe(expected);
+    });
+  });
+
+  describe("canView (any seat)", () => {
+    const cases: Array<[OrgRole | null, boolean]> = [
+      ["admin", true],
+      ["coach", true],
+      ["viewer", true],
+      [null, false],
+    ];
+    it.each(cases)("%s → %s", (role, expected) => {
+      expect(canView(role)).toBe(expected);
+    });
+  });
+
+  it("labels roles with a capital", () => {
+    expect(roleLabel("admin")).toBe("Admin");
+    expect(roleLabel("coach")).toBe("Coach");
+    expect(roleLabel("viewer")).toBe("Viewer");
+  });
+});

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -7,56 +7,75 @@ import {
   claimTeam,
   forkTeamToWorkspace,
 } from "./data-api";
-import { requireOrgAdmin } from "./org-context";
+import { requireOrgAdmin, resolveBestOrgRole } from "./org-context";
+import {
+  canManageRoster,
+  canManageOrgSettings,
+  type OrgRole,
+} from "./permissions";
 
 export interface AuthorizationResult {
   userId: string;
   isAuthorized: boolean;
+  /** The user's strongest role across the team's league/owner orgs (WSM-000121),
+   *  or null if they hold no seat. Lets callers gate finer than a boolean. */
+  role: OrgRole | null;
 }
 
 /**
- * Authorize a mutation on a team. Edit rights come from being an `org:admin`
- * of EITHER:
+ * Resolve a user's effective role on a team (WSM-000121). Rights flow from a
+ * seat in EITHER:
  *   - the league's own org (owns the whole league), or
- *   - the org that CLAIMED this team (WSM-000109 Hybrid fork) — so a coach can
- *     edit their claimed team inside a shared/public template league.
+ *   - the org that forked/claimed this team into its workspace — so a coach can
+ *     manage their team inside a shared/public template league.
  *
- * A team with neither a league org nor an owner org (e.g. an unclaimed team in
- * a public reference league) is read-only.
+ * Returns the STRONGEST role across both. A team with neither a league org nor
+ * an owner org (an unclaimed team in a public reference league) is read-only.
+ */
+export async function resolveTeamRole(
+  teamId: string,
+  userId: string,
+): Promise<OrgRole | null> {
+  const leagueId = await getTeamLeagueId(teamId);
+  const [leagueOrgId, ownerOrgId] = await Promise.all([
+    getLeagueOrgId(leagueId),
+    // Resilient if the Convex query deploys after the web: a missing owner
+    // just means no team-fork grant — league-org auth still applies.
+    getTeamOwnerOrgId(teamId).catch(() => null),
+  ]);
+  return resolveBestOrgRole([leagueOrgId, ownerOrgId], userId);
+}
+
+/**
+ * Authorize a roster/player/team-edit mutation on a team. Granted to admin OR
+ * coach of the team's league/owner org (WSM-000121). For admin-only operations
+ * (team deletion) use `authorizeTeamAdmin`.
  */
 export async function authorizeTeamMutation(
   teamId: string,
   userId: string,
 ): Promise<AuthorizationResult> {
   try {
-    const leagueId = await getTeamLeagueId(teamId);
-    const [leagueOrgId, ownerOrgId] = await Promise.all([
-      getLeagueOrgId(leagueId),
-      // Resilient if the Convex query deploys after the web: a missing owner
-      // just means no team-claim grant — league-org auth still applies.
-      getTeamOwnerOrgId(teamId).catch(() => null),
-    ]);
-
-    const candidateOrgIds = [leagueOrgId, ownerOrgId].filter(
-      (id): id is string => Boolean(id),
-    );
-    if (candidateOrgIds.length === 0) {
-      return { userId, isAuthorized: false };
-    }
-
-    const client = await clerkClient();
-    const memberships = await client.users.getOrganizationMembershipList({
-      userId,
-    });
-    const isAuthorized = memberships.data.some(
-      (m) =>
-        candidateOrgIds.includes(m.organization.id) &&
-        m.role === "org:admin",
-    );
-
-    return { userId, isAuthorized };
+    const role = await resolveTeamRole(teamId, userId);
+    return { userId, role, isAuthorized: canManageRoster(role) };
   } catch {
-    return { userId, isAuthorized: false };
+    return { userId, role: null, isAuthorized: false };
+  }
+}
+
+/**
+ * Authorize an admin-only operation on a team (deletion). Requires admin of the
+ * team's league or owner org — coach is not enough.
+ */
+export async function authorizeTeamAdmin(
+  teamId: string,
+  userId: string,
+): Promise<AuthorizationResult> {
+  try {
+    const role = await resolveTeamRole(teamId, userId);
+    return { userId, role, isAuthorized: canManageOrgSettings(role) };
+  } catch {
+    return { userId, role: null, isAuthorized: false };
   }
 }
 
@@ -89,13 +108,26 @@ export async function forkTeamForOrg(
 }
 
 /**
- * Check if user can manage a team (for UI display).
+ * Whether the user can manage a team's roster/players/details (admin or coach).
+ * For UI display of Edit/Add/roster controls.
  */
 export async function canManageTeam(
   teamId: string,
   userId: string,
 ): Promise<boolean> {
   const result = await authorizeTeamMutation(teamId, userId);
+  return result.isAuthorized;
+}
+
+/**
+ * Whether the user can administer a team (delete it) — admin only. Gates the
+ * destructive "Remove Team" affordance (WSM-000121).
+ */
+export async function canAdministerTeam(
+  teamId: string,
+  userId: string,
+): Promise<boolean> {
+  const result = await authorizeTeamAdmin(teamId, userId);
   return result.isAuthorized;
 }
 

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -127,6 +127,21 @@ const refs = {
   getLeagueClaimable: queryRef<{ leagueId: string }, boolean>(
     "sports:getLeagueClaimable",
   ),
+  getOrgMemberRole: queryRef<
+    { orgId: string; userId: string },
+    "coach" | "viewer" | null
+  >("sports:getOrgMemberRole"),
+  listOrgMemberRoles: queryRef<
+    { orgId: string },
+    Array<{ userId: string; role: "coach" | "viewer" }>
+  >("sports:listOrgMemberRoles"),
+  setOrgMemberRole: mutationRef<
+    { orgId: string; userId: string; role: "coach" | "viewer" },
+    null
+  >("sports:setOrgMemberRole"),
+  deleteOrgMemberRole: mutationRef<{ orgId: string; userId: string }, null>(
+    "sports:deleteOrgMemberRole",
+  ),
   listPlayers: queryRef<{ leagueIds: string[] }, PlayerDto[]>("sports:listPlayers"),
   listPlayersByTeam: queryRef<{ teamId: string }, PlayerDto[]>(
     "sports:listPlayersByTeam",
@@ -652,6 +667,35 @@ export async function setLeagueClaimable(
 /** WSM-000109: whether a league's teams can be claimed by coaches. */
 export async function getLeagueClaimable(leagueId: string): Promise<boolean> {
   return queryConvex(refs.getLeagueClaimable, { leagueId });
+}
+
+/** WSM-000121: a member's coach/viewer sub-role (null = viewer default). */
+export async function getOrgMemberRole(
+  orgId: string,
+  userId: string,
+): Promise<"coach" | "viewer" | null> {
+  return queryConvex(refs.getOrgMemberRole, { orgId, userId });
+}
+
+export async function listOrgMemberRoles(
+  orgId: string,
+): Promise<Array<{ userId: string; role: "coach" | "viewer" }>> {
+  return queryConvex(refs.listOrgMemberRoles, { orgId });
+}
+
+export async function setOrgMemberRole(
+  orgId: string,
+  userId: string,
+  role: "coach" | "viewer",
+): Promise<void> {
+  await mutateConvex(refs.setOrgMemberRole, { orgId, userId, role });
+}
+
+export async function deleteOrgMemberRole(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  await mutateConvex(refs.deleteOrgMemberRole, { orgId, userId });
 }
 
 export async function getPlayers(

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -1,6 +1,10 @@
 import { cache } from "react";
 import { clerkClient } from "@clerk/nextjs/server";
-import { getVisibleLeagueContext as getVisibleLeagueContextFromConvex } from "./data-api";
+import {
+  getVisibleLeagueContext as getVisibleLeagueContextFromConvex,
+  getOrgMemberRole,
+} from "./data-api";
+import type { OrgRole } from "./permissions";
 
 export interface OrgContext {
   userId: string;
@@ -110,8 +114,10 @@ export async function requireOrgAdmin(
 }
 
 /**
- * Returns the user's role within a specific Clerk Organization,
- * or null if they are not a member.
+ * Returns the user's raw Clerk role within a specific Organization, or null if
+ * they are not a member. Prefer `resolveOrgRole` for capability decisions — this
+ * is the low-level Clerk read, used where the literal org:admin/org:member value
+ * is needed (e.g. the members admin API).
  */
 export async function getUserRoleInOrg(
   orgId: string,
@@ -126,5 +132,47 @@ export async function getUserRoleInOrg(
   );
   if (!membership) return null;
   return membership.role as "org:admin" | "org:member";
+}
+
+/**
+ * Resolves a user's effective capability role (admin/coach/viewer) in one org
+ * (WSM-000121). Clerk `org:admin` → admin. An `org:member` is split via the
+ * Convex `orgMemberRoles` sub-role, defaulting to viewer when no row exists.
+ * Returns null if the user is not a member of the org.
+ */
+export async function resolveOrgRole(
+  orgId: string,
+  userId: string,
+): Promise<OrgRole | null> {
+  const clerkRole = await getUserRoleInOrg(orgId, userId);
+  if (clerkRole === null) return null;
+  if (clerkRole === "org:admin") return "admin";
+  // org:member — coach unless explicitly stored, else viewer.
+  const subRole = await getOrgMemberRole(orgId, userId).catch(() => null);
+  return subRole === "coach" ? "coach" : "viewer";
+}
+
+const ROLE_RANK: Record<OrgRole, number> = { admin: 3, coach: 2, viewer: 1 };
+
+/**
+ * Resolves the STRONGEST capability role a user holds across several candidate
+ * orgs (e.g. a team's league org and its workspace owner org). Returns null if
+ * the user is a member of none. Used by team-level authorization.
+ */
+export async function resolveBestOrgRole(
+  orgIds: Array<string | null | undefined>,
+  userId: string,
+): Promise<OrgRole | null> {
+  const unique = Array.from(
+    new Set(orgIds.filter((id): id is string => Boolean(id))),
+  );
+  let best: OrgRole | null = null;
+  for (const orgId of unique) {
+    const role = await resolveOrgRole(orgId, userId);
+    if (role && (best === null || ROLE_RANK[role] > ROLE_RANK[best])) {
+      best = role;
+    }
+  }
+  return best;
 }
 

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -1,0 +1,45 @@
+/**
+ * Intra-org capability roles (WSM-000121).
+ *
+ * Three tiers layered on Clerk org membership:
+ *   - admin  — full control: league CRUD, members/invites, visibility,
+ *              roster-lock, team deletion, plus everything a coach can do.
+ *   - coach  — manage players (CRUD), rosters, depth charts, and
+ *              schedules/results. No org/league settings or member management.
+ *   - viewer — read-only. The least-privilege default for new members.
+ *
+ * Clerk owns membership + the admin bit (`org:admin`). The coach/viewer split
+ * for `org:member` users is persisted in Convex (`orgMemberRoles`); a missing
+ * row means viewer. This module is the single source of truth for "what can
+ * this role do" — enforcement sites call these predicates instead of comparing
+ * role strings inline, so the policy lives in one place.
+ */
+export type OrgRole = "admin" | "coach" | "viewer";
+
+export const ORG_ROLES: readonly OrgRole[] = ["admin", "coach", "viewer"];
+
+export function isOrgRole(value: unknown): value is OrgRole {
+  return value === "admin" || value === "coach" || value === "viewer";
+}
+
+/** League/org settings: create/rename/delete league, members, invites,
+ *  visibility toggle, roster lock, team deletion. Admin only. */
+export function canManageOrgSettings(role: OrgRole | null): boolean {
+  return role === "admin";
+}
+
+/** Day-to-day team operations: player CRUD, team edit, roster assignment,
+ *  depth charts, schedules/results. Admin or coach. */
+export function canManageRoster(role: OrgRole | null): boolean {
+  return role === "admin" || role === "coach";
+}
+
+/** Any seat in the org can view. */
+export function canView(role: OrgRole | null): boolean {
+  return role !== null;
+}
+
+/** Human-readable label for a role (for badges/selects). */
+export function roleLabel(role: OrgRole): string {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}


### PR DESCRIPTION
## What
Adds a real three-tier permission model **within an organization** — replacing the binary admin/member system with **admin / coach / viewer**.

## Why
The multi-tenant vision calls for an org admin who sets up an account and grants differentiated access to members. Until now everyone in an org was either a full admin or a "member" who could still edit rosters — there was no read-only seat and no middle tier.

## The model
| Capability | admin | coach | viewer |
|---|:---:|:---:|:---:|
| View leagues/teams/rosters | ✓ | ✓ | ✓ |
| Players (add/edit/delete), roster, depth chart | ✓ | ✓ | — |
| Schedules / record results | ✓ | ✓ | — |
| Player development data | ✓ | ✓ | — |
| Create/rename/delete league | ✓ | — | — |
| Members / invites / join requests | ✓ | — | — |
| League visibility toggle | ✓ | — | — |
| Season roster lock | ✓ | — | — |
| **Delete a team** | ✓ | — | — |

**New members default to viewer** (least privilege); an admin promotes them deliberately.

## How it's stored
Clerk keeps owning membership + the admin bit. The **coach/viewer split for `org:member` users** lives in a new Convex `orgMemberRoles` table — a missing row means viewer. A single `resolveOrgRole()` resolver is the source of truth, and every enforcement site calls capability predicates (`canManageOrgSettings` / `canManageRoster` / `canView`) instead of comparing role strings inline. No Clerk dashboard/custom-role config required, and we can swap to native Clerk roles later without touching a single call site.

## Changes
- **`convex/schema.ts` / `sports.ts`** — `orgMemberRoles` table + `getOrgMemberRole` / `listOrgMemberRoles` / `setOrgMemberRole` / `deleteOrgMemberRole`.
- **`lib/permissions.ts`** (new) — `OrgRole` + capability predicates (single policy definition).
- **`lib/org-context.ts`** — `resolveOrgRole` (Clerk admin→admin; member→sub-role, default viewer) + `resolveBestOrgRole` (strongest role across a team's league/owner orgs).
- **`lib/authorization.ts`** — `authorizeTeamMutation` now grants coach+; new `authorizeTeamAdmin` for team deletion; `canManageTeam` (coach+) + `canAdministerTeam` (admin).
- **Enforcement** — roster, depth-chart reorder, schedule/fixtures, and player-development actions → coach+; roster-lock, team delete, league CRUD/visibility, members/invites → admin.
- **UI** — `RosterBoard`/`DepthChartBoard` gain `canManage`/`canEdit` so viewers are read-only (not just server-rejected); team page splits `canManage` (coach+, edit/players) from `canDelete` (admin, Remove Team); members page becomes a 3-way role selector with capability hints.
- **Members API** — GET returns effective tri-role; PATCH accepts admin/coach/viewer and maps to Clerk role + Convex sub-role (last-admin guard kept); DELETE cleans up the sub-role row.

## Verification
- ✅ `tsc --noEmit`
- ✅ `vitest run` — 356/356 (new `permissions` suite + coach/viewer authorization cases; members/authorization tests updated)
- ✅ `next lint` (no new warnings) · ✅ `next build`
- ✅ Convex deployed to prod (`terrific-aardvark-395`) — additive; `orgMemberRoles.by_orgId_userId` index added, none deleted

## Notes
- Existing members are unaffected at deploy: admins stay admin; current `org:member` users become **viewer** by default until an admin sets them to coach. Worth a heads-up if any members were relying on the old "any member can edit rosters" behavior — promote them to coach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)