### PR TITLE
fix(web): batch league deletion to stay within Convex limits (WSM-000122)

### DIFF
--- a/apps/web/convex/__tests__/deleteLeagueBatch.test.ts
+++ b/apps/web/convex/__tests__/deleteLeagueBatch.test.ts
@@ -1,0 +1,213 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/**
+ * Seed a league with `teamCount` teams, each carrying a few players plus
+ * depth-chart entries and roster assignments, a division, a season, and a
+ * fixture + game result — enough to exercise every branch of the cascade.
+ */
+async function seedLeague(
+  t: ReturnType<typeof convexTest>,
+  teamCount: number,
+  playersPerTeam = 3,
+) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Batch League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "Div 1",
+      leagueId,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+
+    const teamIds = [];
+    for (let i = 0; i < teamCount; i++) {
+      const teamId = await ctx.db.insert("teams", {
+        name: `Team ${i}`,
+        leagueId,
+        divisionId,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Loc",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+      teamIds.push(teamId);
+      for (let p = 0; p < playersPerTeam; p++) {
+        const playerId = await ctx.db.insert("players", {
+          name: `P${i}-${p}`,
+          leagueId,
+          teamId,
+          position: "QB",
+          positionGroup: null,
+          jerseyNumber: null,
+          dateOfBirth: null,
+          status: "active",
+          headshotUrl: null,
+        });
+        await ctx.db.insert("maddenRatings", {
+          playerId,
+          overall: 80,
+          position: "QB",
+          attributesJson: "{}",
+          portraitUrl: null,
+          teamLogoUrl: null,
+          ingestedAt: "2026-01-01",
+        });
+        await ctx.db.insert("rosterAssignments", {
+          seasonId,
+          teamId,
+          playerId,
+          leagueId,
+          depthRank: p + 1,
+          positionSlot: "QB",
+          status: "active",
+          assignedAt: "2026-01-01",
+          assignedBy: "actor",
+        });
+        await ctx.db.insert("depthChartEntries", {
+          teamId,
+          seasonId,
+          playerId,
+          positionSlot: "QB",
+          sortOrder: p,
+          updatedAt: "2026-01-01",
+        });
+      }
+    }
+
+    // A fixture between the first two teams, with a result.
+    if (teamIds.length >= 2) {
+      const fixtureId = await ctx.db.insert("fixtures", {
+        seasonId,
+        homeTeamId: teamIds[0],
+        awayTeamId: teamIds[1],
+        scheduledAt: null,
+        week: 1,
+        venue: null,
+        status: "final",
+        createdAt: "2026-01-01",
+        createdBy: "actor",
+      });
+      await ctx.db.insert("gameResults", {
+        fixtureId,
+        homeScore: 21,
+        awayScore: 17,
+        playerStatsJson: null,
+        recordedAt: "2026-01-01",
+        recordedBy: "actor",
+      });
+    }
+
+    return { leagueId };
+  });
+}
+
+async function countAll(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ({
+    leagues: (await ctx.db.query("leagues").collect()).length,
+    teams: (await ctx.db.query("teams").collect()).length,
+    players: (await ctx.db.query("players").collect()).length,
+    divisions: (await ctx.db.query("divisions").collect()).length,
+    seasons: (await ctx.db.query("seasons").collect()).length,
+    fixtures: (await ctx.db.query("fixtures").collect()).length,
+    gameResults: (await ctx.db.query("gameResults").collect()).length,
+    maddenRatings: (await ctx.db.query("maddenRatings").collect()).length,
+    rosterAssignments: (await ctx.db.query("rosterAssignments").collect())
+      .length,
+    depthChartEntries: (await ctx.db.query("depthChartEntries").collect())
+      .length,
+  }));
+}
+
+describe("deleteLeagueBatch", () => {
+  it("returns done for a missing league (idempotent)", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId } = await seedLeague(t, 1);
+    // First drain it, then call again — second call sees no league.
+    await t.mutation(api.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
+    await t.mutation(api.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
+    const again = await t.mutation(api.sports.deleteLeagueBatch, {
+      leagueId,
+      maxTeams: 5,
+    });
+    expect(again).toEqual({ done: true, teamsDeleted: 0 });
+  });
+
+  it("deletes teams in bounded batches, finishing on the sweep call", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId } = await seedLeague(t, 5);
+
+    // maxTeams: 2 → batches of 2, 2, 1, then a final sweep that deletes the
+    // league. Loop until done, asserting batch sizes never exceed the cap.
+    const teamsPerBatch: number[] = [];
+    let done = false;
+    let guard = 0;
+    while (!done && guard++ < 50) {
+      const res = await t.mutation(api.sports.deleteLeagueBatch, {
+        leagueId,
+        maxTeams: 2,
+      });
+      teamsPerBatch.push(res.teamsDeleted);
+      expect(res.teamsDeleted).toBeLessThanOrEqual(2);
+      done = res.done;
+    }
+
+    expect(done).toBe(true);
+    // 5 teams over batches of ≤2, then a 0-team sweep that completes.
+    expect(teamsPerBatch).toEqual([2, 2, 1, 0]);
+
+    const counts = await countAll(t);
+    expect(counts).toEqual({
+      leagues: 0,
+      teams: 0,
+      players: 0,
+      divisions: 0,
+      seasons: 0,
+      fixtures: 0,
+      gameResults: 0,
+      maddenRatings: 0,
+      rosterAssignments: 0,
+      depthChartEntries: 0,
+    });
+  });
+
+  it("clears a league in one call when maxTeams covers every team", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId } = await seedLeague(t, 3);
+
+    const first = await t.mutation(api.sports.deleteLeagueBatch, {
+      leagueId,
+      maxTeams: 10,
+    });
+    expect(first).toEqual({ done: false, teamsDeleted: 3 });
+
+    const second = await t.mutation(api.sports.deleteLeagueBatch, {
+      leagueId,
+      maxTeams: 10,
+    });
+    expect(second).toEqual({ done: true, teamsDeleted: 0 });
+
+    const counts = await countAll(t);
+    expect(counts.leagues).toBe(0);
+    expect(counts.players).toBe(0);
+    expect(counts.maddenRatings).toBe(0);
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -796,13 +796,36 @@ export const renameLeague = mutationGeneric({
  * attributes, depth-chart entries, players, teams, divisions. Auth enforced in
  * the calling server action (org:admin of the league's org).
  */
-export const deleteLeague = mutationGeneric({
-  args: { leagueId: v.id("leagues") },
-  returns: v.null(),
+/*
+ * Delete a league in bounded batches (WSM-000122). A forked NFL league carries
+ * ~2,900 players plus their attributes/ratings/assignments — far more than a
+ * single Convex mutation can read/write in one transaction. So each call purges
+ * up to `maxTeams` teams (each via the bounded `purgeTeam` cascade) and reports
+ * whether more remain; once no teams are left it sweeps the league-level rows
+ * (subscriptions, seasons + their fixtures/results/attributes, divisions, audit
+ * log, assignments) and deletes the league itself. The caller loops until
+ * `done`. Idempotent and resumable — a partial delete just continues next call.
+ */
+export const deleteLeagueBatch = mutationGeneric({
+  args: { leagueId: v.id("leagues"), maxTeams: v.optional(v.number()) },
+  returns: v.object({ done: v.boolean(), teamsDeleted: v.number() }),
   handler: async (ctx, args) => {
     const league = await ctx.db.get(args.leagueId);
-    if (!league) return null;
+    if (!league) return { done: true, teamsDeleted: 0 };
 
+    const limit = Math.max(1, Math.min(args.maxTeams ?? 3, 25));
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .take(limit);
+
+    // Still have teams: purge this batch and ask the caller to come back.
+    if (teams.length > 0) {
+      for (const team of teams) await purgeTeam(ctx as MutationCtx, team._id);
+      return { done: false, teamsDeleted: teams.length };
+    }
+
+    // No teams left — sweep the (now small) league-level rows and the league.
     for (const s of await ctx.db
       .query("leagueSubscriptions")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
@@ -810,16 +833,12 @@ export const deleteLeague = mutationGeneric({
       await ctx.db.delete(s._id);
     for (const a of await ctx.db
       .query("rosterAuditLog")
-      .withIndex("by_leagueId_createdAt", (q) =>
-        q.eq("leagueId", args.leagueId),
-      )
+      .withIndex("by_leagueId_createdAt", (q) => q.eq("leagueId", args.leagueId))
       .collect())
       await ctx.db.delete(a._id);
     for (const r of await ctx.db
       .query("rosterAssignments")
-      .withIndex("by_leagueId_seasonId", (q) =>
-        q.eq("leagueId", args.leagueId),
-      )
+      .withIndex("by_leagueId_seasonId", (q) => q.eq("leagueId", args.leagueId))
       .collect())
       await ctx.db.delete(r._id);
 
@@ -850,23 +869,81 @@ export const deleteLeague = mutationGeneric({
       await ctx.db.delete(season._id);
     }
 
+    for (const d of await ctx.db
+      .query("divisions")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(d._id);
+
+    await ctx.db.delete(args.leagueId);
+    return { done: true, teamsDeleted: 0 };
+  },
+});
+
+/*
+ * @deprecated Single-shot league delete kept for deploy-order compatibility
+ * (the previously-shipped web calls `sports:deleteLeague`). New web loops
+ * `deleteLeagueBatch` instead, which is safe for large forked leagues. Remove
+ * this once the WSM-000122 web release is live everywhere. Fine for small
+ * leagues; a very large one can exceed mutation limits — exactly why the
+ * batched path exists.
+ */
+export const deleteLeague = mutationGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) return null;
+
     const teams = await ctx.db
       .query("teams")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
       .collect();
-    for (const team of teams) {
-      for (const dce of await ctx.db
-        .query("depthChartEntries")
-        .withIndex("by_team_season", (q) => q.eq("teamId", team._id))
-        .collect())
-        await ctx.db.delete(dce._id);
-    }
-    for (const p of await ctx.db
-      .query("players")
+    for (const team of teams) await purgeTeam(ctx as MutationCtx, team._id);
+
+    for (const s of await ctx.db
+      .query("leagueSubscriptions")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
       .collect())
-      await ctx.db.delete(p._id);
-    for (const t of teams) await ctx.db.delete(t._id);
+      await ctx.db.delete(s._id);
+    for (const a of await ctx.db
+      .query("rosterAuditLog")
+      .withIndex("by_leagueId_createdAt", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(a._id);
+    for (const r of await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_leagueId_seasonId", (q) => q.eq("leagueId", args.leagueId))
+      .collect())
+      await ctx.db.delete(r._id);
+
+    const seasons = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    for (const season of seasons) {
+      const fixtures = await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", season._id))
+        .collect();
+      for (const f of fixtures) {
+        for (const gr of await ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+          .collect())
+          await ctx.db.delete(gr._id);
+        await ctx.db.delete(f._id);
+      }
+      for (const pa of await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_seasonId_positionGroup", (q) =>
+          q.eq("seasonId", season._id),
+        )
+        .collect())
+        await ctx.db.delete(pa._id);
+      await ctx.db.delete(season._id);
+    }
+
     for (const d of await ctx.db
       .query("divisions")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
@@ -1295,71 +1372,82 @@ export const deletePlayer = mutationGeneric({
  * Scoped to one team, so it stays comfortably inside mutation limits (unlike a
  * whole forked-NFL league delete). Idempotent: a missing team is a no-op.
  */
+/*
+ * Cascade-delete one team and everything that references it: players (and
+ * their playerAttributes / maddenRatings / rosterAssignments), depth-chart
+ * entries across all seasons, roster audit log, and fixtures (home or away)
+ * with their gameResults. One team is bounded (~a roster's worth of rows), so
+ * this stays well inside Convex mutation limits — which is why whole-league
+ * deletion batches over teams rather than purging everything in one shot.
+ * Idempotent: a missing team is a no-op.
+ */
+async function purgeTeam(ctx: MutationCtx, teamId: Id<"teams">): Promise<void> {
+  const team = await ctx.db.get(teamId);
+  if (!team) return;
+
+  const players = await ctx.db
+    .query("players")
+    .withIndex("by_teamId", (q) => q.eq("teamId", teamId))
+    .collect();
+  for (const player of players) {
+    const attributes = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) => q.eq("playerId", player._id))
+      .collect();
+    for (const row of attributes) await ctx.db.delete(row._id);
+
+    const madden = await ctx.db
+      .query("maddenRatings")
+      .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+      .collect();
+    for (const row of madden) await ctx.db.delete(row._id);
+
+    const assignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
+      .collect();
+    for (const row of assignments) await ctx.db.delete(row._id);
+
+    await ctx.db.delete(player._id);
+  }
+
+  const depthEntries = await ctx.db
+    .query("depthChartEntries")
+    .withIndex("by_team_season", (q) => q.eq("teamId", teamId))
+    .collect();
+  for (const row of depthEntries) await ctx.db.delete(row._id);
+
+  const auditRows = await ctx.db
+    .query("rosterAuditLog")
+    .withIndex("by_teamId_createdAt", (q) => q.eq("teamId", teamId))
+    .collect();
+  for (const row of auditRows) await ctx.db.delete(row._id);
+
+  const homeFixtures = await ctx.db
+    .query("fixtures")
+    .withIndex("by_homeTeamId", (q) => q.eq("homeTeamId", teamId))
+    .collect();
+  const awayFixtures = await ctx.db
+    .query("fixtures")
+    .withIndex("by_awayTeamId", (q) => q.eq("awayTeamId", teamId))
+    .collect();
+  for (const fixture of [...homeFixtures, ...awayFixtures]) {
+    const results = await ctx.db
+      .query("gameResults")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", fixture._id))
+      .collect();
+    for (const row of results) await ctx.db.delete(row._id);
+    await ctx.db.delete(fixture._id);
+  }
+
+  await ctx.db.delete(teamId);
+}
+
 export const deleteTeam = mutationGeneric({
   args: { teamId: v.id("teams") },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const team = await ctx.db.get(args.teamId);
-    if (!team) return null;
-
-    const players = await ctx.db
-      .query("players")
-      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
-      .collect();
-    for (const player of players) {
-      const attributes = await ctx.db
-        .query("playerAttributes")
-        .withIndex("by_playerId_seasonId", (q) =>
-          q.eq("playerId", player._id),
-        )
-        .collect();
-      for (const row of attributes) await ctx.db.delete(row._id);
-
-      const madden = await ctx.db
-        .query("maddenRatings")
-        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
-        .collect();
-      for (const row of madden) await ctx.db.delete(row._id);
-
-      const assignments = await ctx.db
-        .query("rosterAssignments")
-        .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
-        .collect();
-      for (const row of assignments) await ctx.db.delete(row._id);
-
-      await ctx.db.delete(player._id);
-    }
-
-    const depthEntries = await ctx.db
-      .query("depthChartEntries")
-      .withIndex("by_team_season", (q) => q.eq("teamId", args.teamId))
-      .collect();
-    for (const row of depthEntries) await ctx.db.delete(row._id);
-
-    const auditRows = await ctx.db
-      .query("rosterAuditLog")
-      .withIndex("by_teamId_createdAt", (q) => q.eq("teamId", args.teamId))
-      .collect();
-    for (const row of auditRows) await ctx.db.delete(row._id);
-
-    const homeFixtures = await ctx.db
-      .query("fixtures")
-      .withIndex("by_homeTeamId", (q) => q.eq("homeTeamId", args.teamId))
-      .collect();
-    const awayFixtures = await ctx.db
-      .query("fixtures")
-      .withIndex("by_awayTeamId", (q) => q.eq("awayTeamId", args.teamId))
-      .collect();
-    for (const fixture of [...homeFixtures, ...awayFixtures]) {
-      const results = await ctx.db
-        .query("gameResults")
-        .withIndex("by_fixtureId", (q) => q.eq("fixtureId", fixture._id))
-        .collect();
-      for (const row of results) await ctx.db.delete(row._id);
-      await ctx.db.delete(fixture._id);
-    }
-
-    await ctx.db.delete(args.teamId);
+    await purgeTeam(ctx as MutationCtx, args.teamId);
     return null;
   },
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -174,7 +174,10 @@ const refs = {
   renameLeague: mutationRef<{ leagueId: string; name: string }, null>(
     "sports:renameLeague",
   ),
-  deleteLeague: mutationRef<{ leagueId: string }, null>("sports:deleteLeague"),
+  deleteLeagueBatch: mutationRef<
+    { leagueId: string; maxTeams?: number },
+    { done: boolean; teamsDeleted: number }
+  >("sports:deleteLeagueBatch"),
   clearSeasonPlayerAttributes: mutationRef<
     { seasonId: string },
     { deleted: number }
@@ -551,8 +554,24 @@ export async function renameLeague(
   await mutateConvex(refs.renameLeague, { leagueId, name });
 }
 
+/**
+ * Delete a league, batching the cascade over teams so a large forked league
+ * (NFL ~2,900 players) stays inside Convex mutation limits (WSM-000122). Loops
+ * until the backend reports `done`; a generous iteration cap guards against an
+ * unexpected non-terminating response.
+ */
 export async function deleteLeague(leagueId: string): Promise<void> {
-  await mutateConvex(refs.deleteLeague, { leagueId });
+  // ~10 teams/batch keeps each transaction comfortably bounded (a forked
+  // 32-team league finishes in ~4 round trips); the cap (400) covers leagues
+  // far larger than anything real before it would ever trip.
+  for (let i = 0; i < 400; i++) {
+    const { done } = await mutateConvex(refs.deleteLeagueBatch, {
+      leagueId,
+      maxTeams: 10,
+    });
+    if (done) return;
+  }
+  throw new Error("deleteLeague did not complete within the batch limit");
 }
 
 export async function getLeagues(visibleLeagueIds: string[]): Promise<LeagueDto[]> {


### PR DESCRIPTION
## What
Makes **league deletion safe for large leagues** by batching the cascade over teams instead of doing it all in one Convex mutation.

## Why
`deleteLeague` purged the entire league — every team, player, attribute, rating, assignment, depth-chart entry, fixture, and result — in a single transaction. A forked NFL league (~2,900 players plus their assignments/depth charts) blows past Convex's per-transaction read/write limits and throws **mid-delete**, leaving the league half-gone. The #235 "Delete league" button can now reach this.

## How
- Extract the per-team cascade into a shared **`purgeTeam`** helper (also used by `deleteTeam`).
- Add **`deleteLeagueBatch(leagueId, maxTeams)`**: purges up to `maxTeams` teams per call and returns `{ done, teamsDeleted }`. Once no teams remain it sweeps the (now small) league-level rows — subscriptions, seasons + their fixtures/results/attributes, divisions, audit log, assignments — and deletes the league.
- The data-api **`deleteLeague` wrapper loops** `deleteLeagueBatch` (~10 teams/batch) until `done`, with a generous safety cap (400 iterations). Each transaction stays bounded; the delete is **idempotent and resumable** — a partial delete just continues next call.

## Also fixed
An orphan the old single-shot cascade missed: per-player **`maddenRatings`** are now removed (`purgeTeam` deletes them).

## Deploy-order safety
The original **`deleteLeague` mutation is kept (deprecated)** and now delegates to `purgeTeam` — the currently-live web (from #235) still calls `sports:deleteLeague`, so removing it would 500 league deletes until this web release ships. Both functions are deployed to prod now. The deprecated single-shot can be deleted in a follow-up once this release is everywhere.

## Tests
New `convex-test` suite (`deleteLeagueBatch.test.ts`) asserting:
- batch sizes never exceed `maxTeams`;
- the loop completes on a final 0-team sweep call (`[2, 2, 1, 0]` for 5 teams at `maxTeams: 2`);
- **full cascade cleanup** — every dependent table ends at 0 (no orphans);
- idempotency on a missing league.

## Verification
- ✅ `tsc --noEmit` · ✅ `vitest run` — 359/359 · ✅ `next lint` (no new warnings) · ✅ `next build`
- ✅ Convex deployed to prod (`terrific-aardvark-395`) — both `deleteLeague` + `deleteLeagueBatch` present; no indexes deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)