### PR TITLE
feat(web): SPRT ratings for workspace teams (WSM-000123)

### DIFF
--- a/apps/web/convex/__tests__/workspaceSprt.test.ts
+++ b/apps/web/convex/__tests__/workspaceSprt.test.ts
@@ -1,0 +1,152 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/*
+ * Seed a public reference league (active season + one rated player) and an org
+ * workspace that forked it — a workspace league/team/player linked back via
+ * sourceLeagueId / sourceTeamId / sourcePlayerId, with NO seasons or attributes
+ * of its own. This is the shape forkTeamToWorkspace produces.
+ */
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const refLeagueId = await ctx.db.insert("leagues", {
+      name: "NFL",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+      claimable: true,
+    });
+    const refSeasonId = await ctx.db.insert("seasons", {
+      name: "2025",
+      leagueId: refLeagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const refTeamId = await ctx.db.insert("teams", {
+      name: "Bills",
+      leagueId: refLeagueId,
+      divisionId: null,
+      city: "Buffalo",
+      stadium: "Highmark",
+      foundedYear: null,
+      location: "Buffalo",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const refPlayerId = await ctx.db.insert("players", {
+      name: "Josh Allen",
+      leagueId: refLeagueId,
+      teamId: refTeamId,
+      position: "QB",
+      positionGroup: "QB",
+      jerseyNumber: 17,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    await ctx.db.insert("playerAttributes", {
+      playerId: refPlayerId,
+      seasonId: refSeasonId,
+      positionGroup: "QB",
+      attributesJson: JSON.stringify({ THP: 99, SAC: 92 }),
+      pffSourceJson: null,
+      maddenSourceJson: null,
+      pffWeight: 1,
+      maddenWeight: 0,
+      weightedOverall: 94,
+      ingestedAt: "2025-09-01",
+    });
+
+    // Workspace fork — no seasons, no attributes of its own.
+    const wsLeagueId = await ctx.db.insert("leagues", {
+      name: "NFL",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+      sourceLeagueId: refLeagueId,
+    });
+    const wsTeamId = await ctx.db.insert("teams", {
+      name: "Bills",
+      leagueId: wsLeagueId,
+      divisionId: null,
+      city: "Buffalo",
+      stadium: "Highmark",
+      foundedYear: null,
+      location: "Buffalo",
+      logoUrl: null,
+      rosterLimit: 53,
+      ownerOrgId: "org_1",
+      sourceTeamId: refTeamId,
+    });
+    const wsPlayerId = await ctx.db.insert("players", {
+      name: "Josh Allen",
+      leagueId: wsLeagueId,
+      teamId: wsTeamId,
+      position: "QB",
+      positionGroup: "QB",
+      jerseyNumber: 17,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+      sourcePlayerId: refPlayerId,
+    });
+
+    return { refTeamId, refPlayerId, wsTeamId, wsPlayerId };
+  });
+}
+
+const asTeam = (id: string) => id as Id<"teams">;
+const asPlayer = (id: string) => id as Id<"players">;
+
+describe("workspace SPRT resolution (WSM-000122)", () => {
+  it("resolves team snapshots for a forked team via the source season", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const snapshots = await t.query(api.sports.getTeamAttributeSnapshots, {
+      teamId: asTeam(s.wsTeamId),
+    });
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({
+      playerId: s.wsPlayerId, // keyed by the workspace player, not the source
+      weightedOverall: 94,
+    });
+    expect(snapshots[0].attributes).toEqual({ THP: 99, SAC: 92 });
+  });
+
+  it("resolves a single forked player's snapshot via the source season", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const rating = await t.query(api.sports.getPlayerSeasonAttributes, {
+      playerId: asPlayer(s.wsPlayerId),
+    });
+
+    expect(rating).toMatchObject({ weightedOverall: 94, positionGroup: "QB" });
+    expect(rating?.attributes).toEqual({ THP: 99, SAC: 92 });
+  });
+
+  it("still resolves native (non-forked) teams from their own season", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+
+    const snapshots = await t.query(api.sports.getTeamAttributeSnapshots, {
+      teamId: asTeam(s.refTeamId),
+    });
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({
+      playerId: s.refPlayerId,
+      weightedOverall: 94,
+    });
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,7 +1,7 @@
 import { mutationGeneric, queryGeneric } from "convex/server";
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
-import type { MutationCtx } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { writeAuditLog } from "./lib/auditLog";
 import { computeStandingsPure } from "./lib/standings";
@@ -2609,10 +2609,47 @@ export const getSeasonAttributesByPosition = queryGeneric({
  * breakdown. Point read via by_playerId_seasonId. Access control lives
  * in the data-api layer, matching getPlayer.
  */
+/*
+ * The season whose attributes represent a league's "current" SPRT ratings —
+ * the active season, else whichever exists first. Matches the convention the
+ * dashboard pages used to apply caller-side; centralized here so workspace
+ * forks (whose own league has no seasons) resolve against their SOURCE league.
+ */
+async function currentSeasonId(
+  ctx: QueryCtx,
+  leagueId: Id<"leagues">,
+): Promise<Id<"seasons"> | null> {
+  const seasons = await ctx.db
+    .query("seasons")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+    .collect();
+  const chosen =
+    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  return chosen ? chosen._id : null;
+}
+
+/*
+ * The league whose seasons + players carry a team's SPRT attributes. A forked
+ * workspace team (WSM-000122) holds no attributes of its own — they live on the
+ * source reference team's players/season — so resolve through `sourceTeamId`.
+ */
+async function attributeLeagueId(
+  ctx: QueryCtx,
+  team: { leagueId: Id<"leagues">; sourceTeamId?: Id<"teams"> },
+): Promise<Id<"leagues">> {
+  if (team.sourceTeamId) {
+    const source = await ctx.db.get(team.sourceTeamId);
+    if (source) return source.leagueId;
+  }
+  return team.leagueId;
+}
+
 export const getPlayerSeasonAttributes = queryGeneric({
   args: {
     playerId: v.id("players"),
-    seasonId: v.id("seasons"),
+    // Optional + ignored now that the season is self-resolved (WSM-000122) —
+    // kept so a previously-deployed web passing it still validates.
+    seasonId: v.optional(v.id("seasons")),
   },
   returns: v.union(
     v.object({
@@ -2623,11 +2660,22 @@ export const getPlayerSeasonAttributes = queryGeneric({
     v.null(),
   ),
   handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) return null;
+    // Workspace fork: attributes live on the source player, keyed by the source
+    // league's current season — so resolve both from the source (WSM-000122).
+    const attrPlayer = player.sourcePlayerId
+      ? ((await ctx.db.get(player.sourcePlayerId)) ?? player)
+      : player;
+    const seasonId = await currentSeasonId(ctx as QueryCtx, attrPlayer.leagueId);
+    if (!seasonId) return null;
     const candidates = await ctx.db
       .query("playerAttributes")
-      .withIndex("by_playerId_seasonId", (q) => q.eq("playerId", args.playerId))
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", attrPlayer._id),
+      )
       .collect();
-    const row = candidates.find((r) => r.seasonId === args.seasonId);
+    const row = candidates.find((r) => r.seasonId === seasonId);
     if (!row) return null;
     return {
       weightedOverall: row.weightedOverall,
@@ -2640,7 +2688,8 @@ export const getPlayerSeasonAttributes = queryGeneric({
 export const getTeamAttributeSnapshots = queryGeneric({
   args: {
     teamId: v.id("teams"),
-    seasonId: v.id("seasons"),
+    // Optional + ignored now that the season is self-resolved (WSM-000122).
+    seasonId: v.optional(v.id("seasons")),
   },
   returns: v.array(
     v.object({
@@ -2650,6 +2699,18 @@ export const getTeamAttributeSnapshots = queryGeneric({
     }),
   ),
   handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) return [];
+
+    // For a forked team this is the source reference league's current season;
+    // for a native team, its own. Both source players' attributes are keyed by
+    // this season (WSM-000122).
+    const seasonId = await currentSeasonId(
+      ctx as QueryCtx,
+      await attributeLeagueId(ctx as QueryCtx, team),
+    );
+    if (!seasonId) return [];
+
     const players = await ctx.db
       .query("players")
       .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
@@ -2657,12 +2718,15 @@ export const getTeamAttributeSnapshots = queryGeneric({
 
     const snapshots = [];
     for (const player of players) {
+      const attrPlayerId = player.sourcePlayerId ?? player._id;
       // Leading-field index form — see ingestPlayerAttributes for why.
       const candidates = await ctx.db
         .query("playerAttributes")
-        .withIndex("by_playerId_seasonId", (q) => q.eq("playerId", player._id))
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", attrPlayerId),
+        )
         .collect();
-      const row = candidates.find((r) => r.seasonId === args.seasonId);
+      const row = candidates.find((r) => r.seasonId === seasonId);
       if (!row) continue;
       snapshots.push({
         playerId: player._id as string,

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 import {
   getPlayer,
   getTeam,
-  getSeasons,
   getPlayerSeasonAttributes,
   getPlayerMaddenRating,
 } from "@/lib/data-api";
@@ -58,23 +57,18 @@ export default async function PlayerProfilePage({
   const age = player.dateOfBirth ? ageFrom(player.dateOfBirth) : null;
   const attributesEnabled = await playerAttributesV1();
 
-  // SPRT rating breakdown (WSM-000093) — the player's snapshot for the
-  // league's active season, when Phase 2 is on. Never blocks the page.
+  // SPRT rating breakdown (WSM-000093) — the player's current-season snapshot
+  // when Phase 2 is on. The season is resolved server-side, including workspace
+  // forks that read their source player/season (WSM-000122). Never blocks the
+  // page.
   let rating: {
     weightedOverall: number | null;
     attributes: Record<string, number>;
   } | null = null;
   if (attributesEnabled && team) {
-    const seasons = await getSeasons([team.leagueId]).catch(() => []);
-    const activeSeason =
-      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
-    if (activeSeason) {
-      rating = await getPlayerSeasonAttributes(
-        playerId,
-        activeSeason.id,
-        orgContext,
-      ).catch(() => null);
-    }
+    rating = await getPlayerSeasonAttributes(playerId, orgContext).catch(
+      () => null,
+    );
   }
   const components = rating ? orderedComponents(rating.attributes) : [];
 

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 import {
   getTeam,
   getPlayersByTeam,
-  getSeasons,
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
   getLeagueClaimable,
@@ -55,23 +54,16 @@ export default async function TeamDetailPage({
     offerFork = await getLeagueClaimable(team.leagueId).catch(() => false);
   }
 
-  // WSM-000090: attribute snapshots feed the Madden stat columns.
-  // Phase 2-gated; resolved against the league's active season, same
-  // rule as the depth-chart page. Failure here must never take down
-  // the roster — columns simply don't render.
+  // WSM-000090: attribute snapshots feed the SPRT stat columns. Phase 2-gated;
+  // the season is resolved server-side — including workspace forks, which read
+  // their source league's current season (WSM-000122). Failure here must never
+  // take down the roster — columns simply don't render.
   let snapshots: ReadonlyMap<string, PlayerSnapshot> = new Map();
   let maddenOveralls: ReadonlyMap<string, number> = new Map();
   if (await playerAttributesV1()) {
-    const seasons = await getSeasons([team.leagueId]).catch(() => []);
-    const activeSeason =
-      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
-    if (activeSeason) {
-      snapshots = await getTeamAttributeSnapshots(
-        id,
-        activeSeason.id,
-        orgContext,
-      ).catch(() => new Map());
-    }
+    snapshots = await getTeamAttributeSnapshots(id, orgContext).catch(
+      () => new Map(),
+    );
     // WSM-000095: Madden overall per player, shown beside SPRT. Season-agnostic.
     maddenOveralls = await getTeamMaddenOveralls(id, orgContext).catch(
       () => new Map(),

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -300,7 +300,7 @@ const refs = {
     }>
   >("sports:getSeasonAttributesByPosition"),
   getPlayerSeasonAttributes: queryRef<
-    { playerId: string; seasonId: string },
+    { playerId: string },
     {
       weightedOverall: number | null;
       attributes: Record<string, number>;
@@ -308,7 +308,7 @@ const refs = {
     } | null
   >("sports:getPlayerSeasonAttributes"),
   getTeamAttributeSnapshots: queryRef<
-    { teamId: string; seasonId: string },
+    { teamId: string },
     Array<{
       playerId: string;
       weightedOverall: number | null;
@@ -745,10 +745,11 @@ export async function getPlayersByTeam(
   return queryConvex(refs.listPlayersByTeam, { teamId });
 }
 
-/** WSM-000093: one player's SPRT snapshot for the profile breakdown. */
+/** WSM-000093: one player's SPRT snapshot for the profile breakdown. The
+ *  season is resolved server-side (the source season for workspace forks),
+ *  so callers no longer pass one (WSM-000122). */
 export async function getPlayerSeasonAttributes(
   playerId: string,
-  seasonId: string,
   orgContext: OrgContext,
 ): Promise<{
   weightedOverall: number | null;
@@ -759,23 +760,20 @@ export async function getPlayerSeasonAttributes(
   if (!player) return null;
   const teamLeagueId = await getTeamLeagueId(player.teamId);
   requireLeagueAccessLocal(teamLeagueId, orgContext);
-  return queryConvex(refs.getPlayerSeasonAttributes, { playerId, seasonId });
+  return queryConvex(refs.getPlayerSeasonAttributes, { playerId });
 }
 
-/** WSM-000090: playerId → snapshot map for the roster stat columns. */
+/** WSM-000090: playerId → snapshot map for the roster stat columns. Season
+ *  resolved server-side, including workspace forks (WSM-000122). */
 export async function getTeamAttributeSnapshots(
   teamId: string,
-  seasonId: string,
   orgContext: OrgContext,
 ): Promise<
   Map<string, { weightedOverall: number | null; attributes: Record<string, number> }>
 > {
   const teamLeagueId = await getTeamLeagueId(teamId);
   requireLeagueAccessLocal(teamLeagueId, orgContext);
-  const rows = await queryConvex(refs.getTeamAttributeSnapshots, {
-    teamId,
-    seasonId,
-  });
+  const rows = await queryConvex(refs.getTeamAttributeSnapshots, { teamId });
   return new Map(
     rows.map((r) => [
       r.playerId,


### PR DESCRIPTION
## What
Forked workspace teams now show **SPRT ratings**, not just Madden.

## Why
After the fork refactor, Madden resolved through `sourcePlayerId` (works), but **SPRT** is season-keyed — and a workspace league has no seasons of its own. So the roster's SPRT (OVR) column and the player profile's rating breakdown came up blank for every forked team. Most visible functional gap left in workspaces.

## Fix
Make the two SPRT reads resolve through the fork and self-resolve the season:
- **`getTeamAttributeSnapshots(teamId)`** — resolves each player via `sourcePlayerId` and reads the **source league's current season** (active, else first). Native teams use their own league/season (unchanged).
- **`getPlayerSeasonAttributes(playerId)`** — resolves the source player and its league's current season.

The season is resolved server-side now, so callers stop passing one — the team and player pages drop their workspace-empty `getSeasons` lookups (net simpler). `getPlayerDevelopment` (the career chart) already resolved via `sourcePlayerId`, so it's untouched.

## Deploy-order safety
Both queries keep `seasonId` as an **optional, ignored** arg so the currently-live web (which still passes it) keeps validating. Convex is deployed; new web simply omits it.

## Tests
New convex-test (`workspaceSprt.test.ts`): forked team snapshots + single forked player resolve through the source season (keyed by the workspace player id), and native teams still resolve from their own season.

## Verification
- ✅ `tsc --noEmit` · ✅ `vitest run` — 362/362 · ✅ `next lint` (no new warnings) · ✅ `next build`
- ✅ Convex deployed to prod (`terrific-aardvark-395`) — backward-compatible; no indexes changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)