### PR TITLE
fix(web): mobile responsiveness — keyboard zoom + overflow (WSM-000085)

### DIFF
--- a/apps/web/e2e/tests/mobile-input-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-input-zoom.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, devices } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withRosterFixture,
+  getTestOrgId,
+  type RosterFixtureResult,
+} from "../helpers/seed-roster";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+/*
+ * WSM-000085: iOS Safari auto-zooms the page when you focus a form control
+ * whose font-size is below 16px. A `@media (pointer: coarse)` rule in
+ * globals.css bumps inputs/selects/textareas to 16px on touch devices to stop
+ * that. Emulating a real iPhone gives us a coarse primary pointer, so the rule
+ * applies — assert our controls render at >= 16px.
+ */
+test.use({ ...devices["iPhone 13"] });
+
+test.describe.serial("Mobile — no input auto-zoom on focus (WSM-000085)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withRosterFixture({
+      fixtureKey: "mobile-input-zoom",
+      clerkOrgId: orgId,
+      teamName: "E2E Mobile Zoom Team",
+      rosterLimit: 53,
+      seedActivePlayers: 3,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    await signInTestUser(page);
+  });
+
+  test("roster search input renders at >= 16px (no iOS zoom)", async ({
+    page,
+  }) => {
+    await page.goto(`/dashboard/teams/${fixture!.teamId}`);
+    await page.waitForLoadState("networkidle");
+
+    const search = page.getByPlaceholder("Search players...");
+    await expect(search).toBeVisible();
+
+    const fontSizePx = await search.evaluate(
+      (el) => parseFloat(getComputedStyle(el).fontSize),
+    );
+    expect(
+      fontSizePx,
+      `focused inputs below 16px trigger iOS auto-zoom (got ${fontSizePx}px)`,
+    ).toBeGreaterThanOrEqual(16);
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invitation-list.tsx
@@ -39,10 +39,12 @@ export default function InvitationList({ orgId }: { orgId: string }) {
         {invitations.map((inv) => (
           <li
             key={inv.id}
-            className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm"
+            className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm"
           >
-            <span className="text-foreground">{inv.emailAddress}</span>
-            <div className="flex items-center gap-2">
+            <span className="min-w-0 truncate text-foreground">
+              {inv.emailAddress}
+            </span>
+            <div className="flex shrink-0 items-center gap-2">
               <Badge variant={inv.status === "pending" ? "secondary" : "outline"}>
                 {inv.status}
               </Badge>

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
@@ -41,8 +41,11 @@ export default function InviteForm({ orgId }: { orgId: string }) {
   return (
     <div>
       <h3 className="mb-3 text-sm font-semibold text-foreground">Invite Member</h3>
-      <form onSubmit={handleSubmit} className="flex items-end gap-3">
-        <div className="flex-1">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3 sm:flex-row sm:items-end"
+      >
+        <div className="min-w-0 flex-1">
           <Label htmlFor="invite-email">Email address</Label>
           <Input
             id="invite-email"
@@ -53,7 +56,7 @@ export default function InviteForm({ orgId }: { orgId: string }) {
             required
           />
         </div>
-        <Button type="submit" disabled={submitting}>
+        <Button type="submit" disabled={submitting} className="shrink-0">
           {submitting ? "Sending..." : "Send Invite"}
         </Button>
       </form>

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-link-section.tsx
@@ -63,8 +63,8 @@ export default function InviteLinkSection({ orgId }: { orgId: string }) {
     <div>
       <h3 className="mb-3 text-sm font-semibold text-foreground">Invite Link</h3>
       {linkUrl ? (
-        <div className="flex items-center gap-2">
-          <code className="flex-1 rounded bg-card px-3 py-2 text-sm text-foreground">
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="min-w-0 flex-1 break-all rounded bg-card px-3 py-2 text-sm text-foreground">
             {linkUrl}
           </code>
           <Button size="sm" variant="outline" onClick={handleCopy}>

--- a/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
@@ -33,17 +33,18 @@ export default function LeaguePublicToggle({
 
   return (
     <div className="flex flex-col gap-2 border-2 border-border bg-card p-4">
-      <div className="flex items-center justify-between gap-4">
-        <div>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
           <p className="text-sm font-semibold text-foreground">
             Public viewer
           </p>
           <p className="text-xs text-muted-foreground">
             When on, anyone can view player development charts at{" "}
-            <code className="font-mono">/leagues/{leagueId}/...</code>
+            <code className="break-all font-mono">/leagues/{leagueId}/...</code>
           </p>
         </div>
         <Button
+          className="shrink-0"
           variant={isPublic ? "destructive" : "default"}
           onClick={handleToggle}
           disabled={pending}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function LeagueDetailPage({
                 leagueId={id}
                 initialIsPublic={visibility?.isPublic ?? false}
               />
-              <div className="flex gap-4">
+              <div className="flex flex-wrap gap-x-4 gap-y-2">
                 <Link
                   href={`/dashboard/leagues/${id}/members`}
                   className="inline-flex items-center gap-1 text-sm text-primary hover:underline"

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -222,10 +222,12 @@ export default function TeamManagement({
     <>
       <Card className="mb-8">
         <CardContent className="pt-6">
-          <div className="flex items-start justify-between">
-            <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <h2 className="min-w-0 break-words text-2xl font-bold text-foreground">
+              {team.name}
+            </h2>
             {(canManage || canDelete) && (
-              <div className="flex gap-2">
+              <div className="flex shrink-0 flex-wrap gap-2">
                 {canManage && (
                   <Button
                     variant="outline"

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -173,3 +173,20 @@ h1, h2, h3, h4, h5, h6 {
 .skip-to-content:focus {
   top: 0;
 }
+
+/*
+ * Prevent iOS Safari from auto-zooming the page when a form control is focused
+ * (WSM-000085). Safari zooms whenever the focused field's font-size is < 16px,
+ * and our controls use text-sm (14px). Bump them to 16px on touch devices only
+ * — `pointer: coarse` targets phones/tablets and leaves mouse-driven desktops
+ * untouched. `!important` is needed to beat the per-component Tailwind text-*
+ * utilities. We intentionally do NOT pin maximum-scale on the viewport, which
+ * would suppress the zoom but also disable pinch-to-zoom (an a11y regression).
+ */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
+}


### PR DESCRIPTION
Fixes found while driving the production app from a phone.

## 1. iOS keyboard auto-zoom
Safari zooms the whole page whenever a focused form control has `font-size < 16px` — ours use `text-sm` (14px). Added a `@media (pointer: coarse)` rule forcing `input`/`select`/`textarea` to 16px on touch devices. Desktops are untouched, and pinch-zoom stays enabled (we deliberately did **not** pin `maximum-scale`, which would be an a11y regression). Added an iPhone-emulation e2e asserting our inputs render ≥16px.

## 2. Horizontal page overflow (league-detail + team pages)
Caused by long unbreakable Convex IDs / invite tokens in `<code>` blocks and non-wrapping flex rows:
- **League page:** nav-links row wraps; invite-link token + public-toggle league-id get `break-all` + `min-w-0`; invite form stacks on mobile; pending-invitation emails truncate.
- **Team page:** the header (name + Edit/Remove Team) wraps instead of pushing **Remove Team** off the right edge (per screenshot).

## Verification
- ✅ `tsc` · ✅ `next lint` (no new warnings) · ✅ `vitest` 347 · ✅ `next build`
- e2e (`mobile-input-zoom.spec.ts`) runs against a deployment (not in CI); not run locally here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)