### PR TITLE
fix(web): make players and divisions list rows selectable (WSM-000135)

### DIFF
--- a/apps/web/src/app/dashboard/divisions/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/[id]/page.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { getDivision, getTeams, getLeague } from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { EmptyState } from "@/components/empty-state";
+import { Users } from "lucide-react";
+
+export default async function DivisionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const division = await getDivision(id, orgContext).catch(() => null);
+  if (!division) notFound();
+
+  const [league, allTeams] = await Promise.all([
+    getLeague(division.leagueId, orgContext).catch(() => null),
+    getTeams([division.leagueId]),
+  ]);
+  const teams = allTeams.filter((t) => t.divisionId === id);
+
+  return (
+    <div>
+      <Link
+        href="/dashboard/divisions"
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Divisions
+      </Link>
+
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold text-foreground">{division.name}</h2>
+        {league && (
+          <p className="mt-1 text-sm text-muted-foreground">{league.name}</p>
+        )}
+      </div>
+
+      {teams.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="No teams in this division"
+          description="Teams assigned to this division will appear here."
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {teams.map((team) => (
+            <Link
+              key={team.id}
+              href={`/dashboard/teams/${team.id}?from=divisions`}
+              className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-card"
+            >
+              <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 truncate font-medium text-foreground">
+                {team.name}
+              </span>
+              {team.city && (
+                <span className="shrink-0 text-muted-foreground">
+                  &mdash; {team.city}
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/divisions/divisions-table.tsx
+++ b/apps/web/src/app/dashboard/divisions/divisions-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import type { DivisionDto } from "@sports-management/shared-types";
 import { DataTable, type Column } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
@@ -22,6 +23,8 @@ interface DivisionsTableProps {
 }
 
 export function DivisionsTable({ divisions }: DivisionsTableProps) {
+  const router = useRouter();
+
   if (divisions.length === 0) {
     return (
       <EmptyState
@@ -38,6 +41,7 @@ export function DivisionsTable({ divisions }: DivisionsTableProps) {
       columns={columns}
       searchPlaceholder="Search divisions..."
       searchKeys={["name", "leagueName"]}
+      onRowClick={(d) => router.push(`/dashboard/divisions/${d.id}`)}
     />
   );
 }

--- a/apps/web/src/app/dashboard/players/players-table.tsx
+++ b/apps/web/src/app/dashboard/players/players-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import type { PlayerDto } from "@sports-management/shared-types";
 import { DataTable, type Column } from "@/components/data-table";
 import { StatusBadge } from "@/components/status-badge";
@@ -28,6 +29,8 @@ interface PlayersTableProps {
 }
 
 export function PlayersTable({ players }: PlayersTableProps) {
+  const router = useRouter();
+
   if (players.length === 0) {
     return (
       <EmptyState
@@ -44,6 +47,7 @@ export function PlayersTable({ players }: PlayersTableProps) {
       columns={columns}
       searchPlaceholder="Search players..."
       searchKeys={["name", "position", "status"]}
+      onRowClick={(p) => router.push(`/dashboard/players/${p.id}`)}
     />
   );
 }

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -33,7 +33,9 @@ export default async function TeamDetailPage({
   const back =
     from === "leagues"
       ? { href: "/dashboard/leagues", label: "Back to Leagues" }
-      : { href: "/dashboard/teams", label: "Back to Teams" };
+      : from === "divisions"
+        ? { href: "/dashboard/divisions", label: "Back to Divisions" }
+        : { href: "/dashboard/teams", label: "Back to Teams" };
   const orgContext = await resolveOrgContext(userId);
 
   // canManage = admin or coach (roster/players/edit); canDelete = admin only


### PR DESCRIPTION
## What
Fixes two reports: you couldn't select/click rows on the **Players** page or the **Divisions** page.

## Cause
Both list tables rendered the shared `DataTable` **without an `onRowClick`**, so rows had no navigation (every other roster table passes one).

## Fix
- **Players:** row click → player profile (`/dashboard/players/[id]`).
- **Divisions:** row click → a **new minimal division detail page** that lists the division's teams. No division detail route existed, so a click had nowhere to go — this adds one (`/dashboard/divisions/[id]`). Team links carry `?from=divisions`, and the team page back-link now reads "Back to Divisions".

Mobile-friendly (truncating team names, wrapping). The division detail page is an interim step toward the divisions/accordion work in #246 / #250.

## Verification
- ✅ `tsc` · ✅ `next lint` (no new warnings) · ✅ `vitest` 347 · ✅ `next build`
- No Convex changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)