### PR TITLE
feat(web): P1 professional theme tokens + /dev/ui kitchen sink (WSM-000136)

### DIFF
--- a/apps/web/src/app/dev/ui/page.tsx
+++ b/apps/web/src/app/dev/ui/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/*
+ * WSM-000136 P1 — Professional theme kitchen sink.
+ *
+ * Renders the base shadcn `ui/*` primitives inside `.theme-pro` (monochrome
+ * dark) so the new design language can be reviewed in isolation, without
+ * touching the live 8bit-themed pages. Dev-only; not linked from nav.
+ */
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export default function UiKitchenSinkPage() {
+  return (
+    <div className="theme-pro min-h-screen px-6 py-10 font-sans">
+      <div className="mx-auto max-w-4xl space-y-12">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Design system — professional theme
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            WSM-000136 P1 · monochrome, dark-first · base shadcn/ui primitives
+            scoped to <code className="font-mono">.theme-pro</code>.
+          </p>
+        </header>
+
+        <Section title="Buttons">
+          <div className="flex flex-wrap items-center gap-3">
+            <Button>Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="link">Link</Button>
+            <Button variant="destructive">Destructive</Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button size="sm">Small</Button>
+            <Button>Default</Button>
+            <Button size="lg">Large</Button>
+            <Button disabled>Disabled</Button>
+          </div>
+        </Section>
+
+        <Section title="Badges (status uses semantic color only)">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge>Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="outline">Outline</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+          </div>
+        </Section>
+
+        <Section title="Form controls">
+          <div className="grid max-w-md gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="ks-name">Team name</Label>
+              <Input id="ks-name" placeholder="Allatoona Buccaneers" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="ks-div">Division</Label>
+              <Select>
+                <SelectTrigger id="ks-div">
+                  <SelectValue placeholder="Select a division" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="4a">Class 4A</SelectItem>
+                  <SelectItem value="5a">Class 5A</SelectItem>
+                  <SelectItem value="6a">Class 6A</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </Section>
+
+        <Section title="Card">
+          <Card className="max-w-md">
+            <CardHeader>
+              <CardTitle>Cobb County Football</CardTitle>
+              <CardDescription>16 schools · 3 divisions</CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Hairline borders, soft corners, monochrome surface. Emphasis comes
+              from contrast and weight, not hue.
+            </CardContent>
+          </Card>
+        </Section>
+
+        <Section title="Table">
+          <Card>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Team</TableHead>
+                  <TableHead>Division</TableHead>
+                  <TableHead className="text-right">SPRT</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[
+                  ["Allatoona", "Class 6A", 88],
+                  ["Harrison", "Class 6A", 84],
+                  ["Kennesaw Mountain", "Class 5A", 81],
+                ].map(([team, div, ovr]) => (
+                  <TableRow key={team as string}>
+                    <TableCell className="font-medium">{team}</TableCell>
+                    <TableCell className="text-muted-foreground">{div}</TableCell>
+                    <TableCell className="text-right font-mono">{ovr}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        </Section>
+
+        <Section title="Skeleton & separator">
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-72" />
+            <Separator />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -109,6 +109,61 @@
 }
 
 /*
+ * `.theme-pro` — WSM-000136 P1: the professional dark "Vercel/Convex" theme,
+ * scoped to a subtree (the /dev/ui kitchen sink for now) so it can be developed
+ * and reviewed WITHOUT recoloring the 55 live 8bit pages mid-overhaul. Overrides
+ * the same shadcn `--color-*` vars by cascade, so any base `ui/*` primitive
+ * rendered inside picks it up automatically. Monochrome: white/gray on
+ * near-black; color reserved for semantic status. Later phases migrate pages
+ * into this theme and finally flip it global (RFC §7 P6).
+ */
+.theme-pro {
+  --color-background: #0a0a0a;
+  --color-foreground: #ededed;
+  --color-card: #0f0f0f;
+  --color-card-foreground: #ededed;
+  --color-popover: #111111;
+  --color-popover-foreground: #ededed;
+
+  /* Monochrome "primary" = near-white surface, near-black text (Vercel CTA). */
+  --color-primary: #ededed;
+  --color-primary-foreground: #0a0a0a;
+  --color-secondary: #1a1a1a;
+  --color-secondary-foreground: #ededed;
+  --color-muted: #1a1a1a;
+  --color-muted-foreground: #a1a1a1;
+  --color-accent: #1f1f1f; /* subtle hover/active surface */
+  --color-accent-foreground: #ededed;
+  --color-destructive: #e5484d; /* semantic only */
+  --color-destructive-foreground: #ffffff;
+
+  --color-border: #262626; /* hairline */
+  --color-input: #262626;
+  --color-ring: #ededed;
+
+  /* Soft, modern corners (the 8bit theme pins these to 0). */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
+
+  /* Drop the pixel display font — headings use the grotesk body sans. */
+  --font-display: var(--font-sans);
+
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
+.theme-pro h1,
+.theme-pro h2,
+.theme-pro h3,
+.theme-pro h4,
+.theme-pro h5,
+.theme-pro h6 {
+  letter-spacing: -0.01em; /* tighter, professional */
+}
+
+/*
  * Headings — Pixel display font.
  *
  * Maps every h1-h6 to --font-display so any page-level heading picks up


### PR DESCRIPTION
First shippable slice of the UI overhaul epic (#255).

## What
- A scoped **`.theme-pro`** token set in `globals.css`: **monochrome, dark-first**, hairline borders (`#262626`), soft corners, grotesk headings (drops the pixel display font). It overrides the shadcn `--color-*` vars **by cascade**, so any base `ui/*` primitive rendered inside `.theme-pro` adopts the new look with zero per-component changes.
- A dev-only **`/dev/ui`** kitchen-sink route rendering the base shadcn primitives (buttons, badges, inputs, select, card, table, skeleton, separator) in the new theme for review.

## Why scoped (not global)
Under Tailwind v4 the existing `--color-*` tokens *are* the shadcn tokens, and the 8bitcn components read the same ones — so flipping them globally would recolor all **55** live 8bit pages into a half-migrated state. Scoping to a subtree lets us build/review the new language now and migrate pages incrementally (RFC §7 P3), then flip global + delete 8bit (P6).

## Decisions honored (RFC §9)
Monochrome + status-only · dark-first (light retained) · shadcn baseline (extend, don't fork) · full 8bit replacement (later phase).

## Verify
- ✅ `tsc` · ✅ `next lint` (clean) · ✅ `vitest` 347 · ✅ `next build` (`/dev/ui` compiles)
- No live page or existing component changed; no Convex changes.
- Preview the look at `/dev/ui` on the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)