### PR TITLE
chore(web): gitignore Convex ai-files tooling docs (WSM-000138)

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -4,3 +4,7 @@ test-results/
 *.tsbuildinfo
 
 .env.local
+
+# Convex ai-files install (local tooling guidance, not source)
+/AGENTS.md
+/CLAUDE.md


### PR DESCRIPTION
## What
Ignore `apps/web/AGENTS.md` and `apps/web/CLAUDE.md` — generated locally by `convex ai-files install` as agent guidance, not source. Anchored patterns (`/AGENTS.md`, `/CLAUDE.md`) scope to `apps/web/` only, so the tracked root `CLAUDE.md` is unaffected.

## Why
They were showing as persistent untracked noise after the Convex tooling install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)