### PR TITLE
fix(convex): make sports write mutations internal-only (WSM-000096)

### DIFF
--- a/apps/web/convex/__tests__/deleteLeagueBatch.test.ts
+++ b/apps/web/convex/__tests__/deleteLeagueBatch.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 
 const modules = import.meta.glob("../**/*.*s");
 
@@ -142,9 +142,9 @@ describe("deleteLeagueBatch", () => {
     const t = convexTest(schema, modules);
     const { leagueId } = await seedLeague(t, 1);
     // First drain it, then call again — second call sees no league.
-    await t.mutation(api.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
-    await t.mutation(api.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
-    const again = await t.mutation(api.sports.deleteLeagueBatch, {
+    await t.mutation(internal.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
+    await t.mutation(internal.sports.deleteLeagueBatch, { leagueId, maxTeams: 5 });
+    const again = await t.mutation(internal.sports.deleteLeagueBatch, {
       leagueId,
       maxTeams: 5,
     });
@@ -161,7 +161,7 @@ describe("deleteLeagueBatch", () => {
     let done = false;
     let guard = 0;
     while (!done && guard++ < 50) {
-      const res = await t.mutation(api.sports.deleteLeagueBatch, {
+      const res = await t.mutation(internal.sports.deleteLeagueBatch, {
         leagueId,
         maxTeams: 2,
       });
@@ -193,13 +193,13 @@ describe("deleteLeagueBatch", () => {
     const t = convexTest(schema, modules);
     const { leagueId } = await seedLeague(t, 3);
 
-    const first = await t.mutation(api.sports.deleteLeagueBatch, {
+    const first = await t.mutation(internal.sports.deleteLeagueBatch, {
       leagueId,
       maxTeams: 10,
     });
     expect(first).toEqual({ done: false, teamsDeleted: 3 });
 
-    const second = await t.mutation(api.sports.deleteLeagueBatch, {
+    const second = await t.mutation(internal.sports.deleteLeagueBatch, {
       leagueId,
       maxTeams: 10,
     });

--- a/apps/web/convex/__tests__/depthChart.test.ts
+++ b/apps/web/convex/__tests__/depthChart.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 
 const modules = import.meta.glob("../**/*.*s");
 
@@ -97,7 +97,7 @@ describe("reorderDepthChart", () => {
     const t = convexTest(schema, modules);
     const seed = await seedBaseline(t);
 
-    const result = await t.mutation(api.sports.reorderDepthChart, {
+    const result = await t.mutation(internal.sports.reorderDepthChart, {
       teamId: seed.teamA,
       seasonId: seed.season,
       positionSlot: "QB",
@@ -112,13 +112,13 @@ describe("reorderDepthChart", () => {
     const t = convexTest(schema, modules);
     const seed = await seedBaseline(t);
 
-    await t.mutation(api.sports.reorderDepthChart, {
+    await t.mutation(internal.sports.reorderDepthChart, {
       teamId: seed.teamA,
       seasonId: seed.season,
       positionSlot: "QB",
       playerIds: [seed.p1, seed.p2, seed.p3],
     });
-    await t.mutation(api.sports.reorderDepthChart, {
+    await t.mutation(internal.sports.reorderDepthChart, {
       teamId: seed.teamA,
       seasonId: seed.season,
       positionSlot: "QB",
@@ -138,13 +138,13 @@ describe("reorderDepthChart", () => {
     const t = convexTest(schema, modules);
     const seed = await seedBaseline(t);
 
-    await t.mutation(api.sports.setRosterLocked, {
+    await t.mutation(internal.sports.setRosterLocked, {
       seasonId: seed.season,
       locked: true,
     });
 
     await expect(
-      t.mutation(api.sports.reorderDepthChart, {
+      t.mutation(internal.sports.reorderDepthChart, {
         teamId: seed.teamA,
         seasonId: seed.season,
         positionSlot: "QB",
@@ -158,7 +158,7 @@ describe("reorderDepthChart", () => {
     const seed = await seedBaseline(t);
 
     await expect(
-      t.mutation(api.sports.reorderDepthChart, {
+      t.mutation(internal.sports.reorderDepthChart, {
         teamId: seed.teamA,
         seasonId: seed.season,
         positionSlot: "QB",
@@ -173,13 +173,13 @@ describe("setRosterLocked", () => {
     const t = convexTest(schema, modules);
     const seed = await seedBaseline(t);
 
-    const locked = await t.mutation(api.sports.setRosterLocked, {
+    const locked = await t.mutation(internal.sports.setRosterLocked, {
       seasonId: seed.season,
       locked: true,
     });
     expect(locked.rosterLocked).toBe(true);
 
-    const unlocked = await t.mutation(api.sports.setRosterLocked, {
+    const unlocked = await t.mutation(internal.sports.setRosterLocked, {
       seasonId: seed.season,
       locked: false,
     });

--- a/apps/web/convex/__tests__/rosterAssignments.test.ts
+++ b/apps/web/convex/__tests__/rosterAssignments.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 
 const modules = import.meta.glob("../**/*.*s");
@@ -78,7 +78,7 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const first = await t.mutation(api.sports.assignPlayerToRoster, {
+    const first = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
@@ -88,7 +88,7 @@ describe("assignPlayerToRoster", () => {
     expect(first.depthRank).toBe(1);
     expect(first.status).toBe("active");
 
-    const second = await t.mutation(api.sports.assignPlayerToRoster, {
+    const second = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -102,7 +102,7 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
@@ -123,13 +123,13 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    await t.mutation(api.sports.setRosterLocked, {
+    await t.mutation(internal.sports.setRosterLocked, {
       seasonId: seed1.season,
       locked: true,
     });
 
     await expect(
-      t.mutation(api.sports.assignPlayerToRoster, {
+      t.mutation(internal.sports.assignPlayerToRoster, {
         seasonId: seed1.season,
         teamId: seed1.teamA,
         playerId: seed1.qb1,
@@ -143,14 +143,14 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t, 2);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -159,7 +159,7 @@ describe("assignPlayerToRoster", () => {
     });
 
     await expect(
-      t.mutation(api.sports.assignPlayerToRoster, {
+      t.mutation(internal.sports.assignPlayerToRoster, {
         seasonId: seed1.season,
         teamId: seed1.teamA,
         playerId: seed1.qb3,
@@ -173,14 +173,14 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t, null);
 
-    const r1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const r1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    const r2 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const r2 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -195,7 +195,7 @@ describe("assignPlayerToRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
@@ -204,7 +204,7 @@ describe("assignPlayerToRoster", () => {
     });
 
     await expect(
-      t.mutation(api.sports.assignPlayerToRoster, {
+      t.mutation(internal.sports.assignPlayerToRoster, {
         seasonId: seed1.season,
         teamId: seed1.teamA,
         playerId: seed1.qb1,
@@ -219,7 +219,7 @@ describe("assignPlayerToRoster", () => {
     const seed1 = await seed(t);
 
     await expect(
-      t.mutation(api.sports.assignPlayerToRoster, {
+      t.mutation(internal.sports.assignPlayerToRoster, {
         seasonId: seed1.season,
         teamId: seed1.teamA,
         playerId: seed1.qbB,
@@ -235,21 +235,21 @@ describe("removePlayerFromRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    const a2 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a2 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb3,
@@ -257,7 +257,7 @@ describe("removePlayerFromRoster", () => {
       actorUserId: ACTOR,
     });
 
-    await t.mutation(api.sports.removePlayerFromRoster, {
+    await t.mutation(internal.sports.removePlayerFromRoster, {
       assignmentId: asAssignmentId(a1.id),
       actorUserId: ACTOR,
     });
@@ -279,21 +279,21 @@ describe("removePlayerFromRoster", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a.id),
       newStatus: "ir",
       actorUserId: ACTOR,
     });
 
     await expect(
-      t.mutation(api.sports.removePlayerFromRoster, {
+      t.mutation(internal.sports.removePlayerFromRoster, {
         assignmentId: asAssignmentId(a.id),
         actorUserId: ACTOR,
       }),
@@ -306,14 +306,14 @@ describe("updateRosterStatus", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    const a2 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a2 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -321,7 +321,7 @@ describe("updateRosterStatus", () => {
       actorUserId: ACTOR,
     });
 
-    const updated = await t.mutation(api.sports.updateRosterStatus, {
+    const updated = await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a1.id),
       newStatus: "ir",
       actorUserId: ACTOR,
@@ -339,7 +339,7 @@ describe("updateRosterStatus", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
@@ -348,7 +348,7 @@ describe("updateRosterStatus", () => {
     });
 
     await expect(
-      t.mutation(api.sports.updateRosterStatus, {
+      t.mutation(internal.sports.updateRosterStatus, {
         assignmentId: asAssignmentId(a.id),
         newStatus: "bogus",
         actorUserId: ACTOR,
@@ -360,14 +360,14 @@ describe("updateRosterStatus", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t, 2);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -375,14 +375,14 @@ describe("updateRosterStatus", () => {
       actorUserId: ACTOR,
     });
 
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a1.id),
       newStatus: "ir",
       actorUserId: ACTOR,
     });
 
     // With rosterLimit 2 and one remaining active, we can reactivate a1.
-    const back = await t.mutation(api.sports.updateRosterStatus, {
+    const back = await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a1.id),
       newStatus: "active",
       actorUserId: ACTOR,
@@ -395,14 +395,14 @@ describe("updateRosterStatus", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t, 2);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb2,
@@ -410,14 +410,14 @@ describe("updateRosterStatus", () => {
       actorUserId: ACTOR,
     });
 
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a1.id),
       newStatus: "ir",
       actorUserId: ACTOR,
     });
 
     // Fill the freed slot with qb3.
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb3,
@@ -426,7 +426,7 @@ describe("updateRosterStatus", () => {
     });
 
     await expect(
-      t.mutation(api.sports.updateRosterStatus, {
+      t.mutation(internal.sports.updateRosterStatus, {
         assignmentId: asAssignmentId(a1.id),
         newStatus: "active",
         actorUserId: ACTOR,
@@ -438,14 +438,14 @@ describe("updateRosterStatus", () => {
     const t = convexTest(schema, modules);
     const seed1 = await seed(t);
 
-    const a = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: seed1.season,
       teamId: seed1.teamA,
       playerId: seed1.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: asAssignmentId(a.id),
       newStatus: "suspended",
       actorUserId: ACTOR,

--- a/apps/web/convex/__tests__/rosterQueries.test.ts
+++ b/apps/web/convex/__tests__/rosterQueries.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 
 const modules = import.meta.glob("../**/*.*s");
@@ -83,21 +83,21 @@ describe("getRosterBySeasonTeam", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb2,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.rb1,
@@ -123,21 +123,21 @@ describe("getRosterBySeasonTeam", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb2,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: a1.id as Id<"rosterAssignments">,
       newStatus: "ir",
       actorUserId: ACTOR,
@@ -158,7 +158,7 @@ describe("getRosterBySeasonTeam", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.otherSeason,
       teamId: s.team,
       playerId: s.qb1,
@@ -196,7 +196,7 @@ describe("getTeamRosterLimitStatus", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t, 2);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
@@ -220,7 +220,7 @@ describe("getTeamRosterLimitStatus", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t, null);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
@@ -244,14 +244,14 @@ describe("getTeamRosterLimitStatus", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t, 5);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: a1.id as Id<"rosterAssignments">,
       newStatus: "ir",
       actorUserId: ACTOR,
@@ -272,14 +272,14 @@ describe("getRosterAssignmentHistory", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb2,
@@ -303,21 +303,21 @@ describe("getRosterAssignmentHistory", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    const a1 = await t.mutation(api.sports.assignPlayerToRoster, {
+    const a1 = await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb2,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.updateRosterStatus, {
+    await t.mutation(internal.sports.updateRosterStatus, {
       assignmentId: a1.id as Id<"rosterAssignments">,
       newStatus: "ir",
       actorUserId: ACTOR,
@@ -337,14 +337,14 @@ describe("getRosterAssignmentHistory", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb1,
       positionSlot: "QB",
       actorUserId: ACTOR,
     });
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.season,
       teamId: s.team,
       playerId: s.qb2,
@@ -366,7 +366,7 @@ describe("getRosterAssignmentHistory", () => {
     const t = convexTest(schema, modules);
     const s = await seed(t);
 
-    await t.mutation(api.sports.assignPlayerToRoster, {
+    await t.mutation(internal.sports.assignPlayerToRoster, {
       seasonId: s.otherSeason,
       teamId: s.team,
       playerId: s.qb1,

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { api, internal } from "../_generated/api";
+
+/*
+ * Security regression guard (WSM-000096).
+ *
+ * All sports.ts WRITE mutations must be registered as `internalMutation` /
+ * `internalMutationGeneric` so they are NOT callable by an anonymous
+ * `ConvexHttpClient` over the public Internet — only by trusted server code
+ * holding the deploy/admin key (data-api.ts, ingest scripts).
+ *
+ * Enforcement is COMPILE-TIME via tsc (which CI runs as `type-check`; vitest is
+ * not in CI). The `internal.sports.*` accesses must type-check (proves they are
+ * internal), and the `api.sports.*` write accesses are `@ts-expect-error` — if
+ * any write is reverted to a public `mutation`, it reappears on the typed `api`
+ * object, the suppressed error disappears, and tsc fails on the now-unused
+ * `@ts-expect-error`. Public READ queries must remain on `api`.
+ */
+
+// --- Writes MUST be internal (these references must exist) ---
+void internal.sports.createTeam;
+void internal.sports.updateTeam;
+void internal.sports.deleteTeam;
+void internal.sports.createPlayer;
+void internal.sports.deletePlayer;
+void internal.sports.upsertPlayer;
+void internal.sports.deleteLeague;
+void internal.sports.deleteLeagueBatch;
+void internal.sports.upsertSeason;
+void internal.sports.clearSeasonPlayerAttributes;
+void internal.sports.ingestMaddenRatingsBatch;
+void internal.sports.ingestPlayerAttributesBatch;
+void internal.sports.setOrgMemberRole;
+void internal.sports.setLeaguePublic;
+void internal.sports.recordGameResult;
+void internal.sports.assignPlayerToRoster;
+
+// --- Writes MUST NOT be on the public API (each access must be a type error) ---
+// @ts-expect-error createTeam is internal, not public
+void api.sports.createTeam;
+// @ts-expect-error deleteTeam is internal, not public
+void api.sports.deleteTeam;
+// @ts-expect-error deletePlayer is internal, not public
+void api.sports.deletePlayer;
+// @ts-expect-error deleteLeague is internal, not public
+void api.sports.deleteLeague;
+// @ts-expect-error clearSeasonPlayerAttributes is internal, not public
+void api.sports.clearSeasonPlayerAttributes;
+// @ts-expect-error ingestMaddenRatingsBatch is internal, not public
+void api.sports.ingestMaddenRatingsBatch;
+// @ts-expect-error setOrgMemberRole is internal, not public
+void api.sports.setOrgMemberRole;
+
+// --- Public READ queries must remain public (these must exist on api) ---
+void api.sports.listTeams;
+void api.sports.getPlayer;
+void api.sports.listPublicLeagues;
+void api.sports.computeStandingsPublic;
+void api.sports.getPlayerDevelopmentPublic;
+
+describe("sports write mutations are internal (WSM-000096)", () => {
+  it("is enforced at compile time (see @ts-expect-error guards above)", () => {
+    // Runtime assertion is trivial; the real guard is tsc. The proxy-based
+    // `internal` object always returns a reference, so this just documents intent.
+    expect(typeof internal.sports.createTeam).not.toBe("undefined");
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,6 +1,6 @@
-import { mutationGeneric, queryGeneric } from "convex/server";
+import { internalMutationGeneric, queryGeneric } from "convex/server";
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { writeAuditLog } from "./lib/auditLog";
@@ -711,7 +711,7 @@ export const healthSummary = queryGeneric({
   },
 });
 
-export const upsertLeague = mutationGeneric({
+export const upsertLeague = internalMutationGeneric({
   args: {
     name: v.string(),
     orgId: v.union(v.string(), v.null()),
@@ -753,7 +753,7 @@ export const upsertLeague = mutationGeneric({
 });
 
 /** Create a new org-owned league (WSM-000118). Name unique within the org. */
-export const createLeague = mutationGeneric({
+export const createLeague = internalMutationGeneric({
   args: { name: v.string(), orgId: v.string() },
   returns: v.object({ id: v.string(), name: v.string() }),
   handler: async (ctx, args) => {
@@ -777,7 +777,7 @@ export const createLeague = mutationGeneric({
 });
 
 /** Rename a league (WSM-000118). Auth enforced in the calling server action. */
-export const renameLeague = mutationGeneric({
+export const renameLeague = internalMutationGeneric({
   args: { leagueId: v.id("leagues"), name: v.string() },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -806,7 +806,7 @@ export const renameLeague = mutationGeneric({
  * log, assignments) and deletes the league itself. The caller loops until
  * `done`. Idempotent and resumable — a partial delete just continues next call.
  */
-export const deleteLeagueBatch = mutationGeneric({
+export const deleteLeagueBatch = internalMutationGeneric({
   args: { leagueId: v.id("leagues"), maxTeams: v.optional(v.number()) },
   returns: v.object({ done: v.boolean(), teamsDeleted: v.number() }),
   handler: async (ctx, args) => {
@@ -888,7 +888,7 @@ export const deleteLeagueBatch = mutationGeneric({
  * leagues; a very large one can exceed mutation limits — exactly why the
  * batched path exists.
  */
-export const deleteLeague = mutationGeneric({
+export const deleteLeague = internalMutationGeneric({
   args: { leagueId: v.id("leagues") },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -955,7 +955,7 @@ export const deleteLeague = mutationGeneric({
   },
 });
 
-export const upsertDivision = mutationGeneric({
+export const upsertDivision = internalMutationGeneric({
   args: {
     name: v.string(),
     leagueId: v.id("leagues"),
@@ -989,7 +989,7 @@ export const upsertDivision = mutationGeneric({
   },
 });
 
-export const upsertTeam = mutationGeneric({
+export const upsertTeam = internalMutationGeneric({
   args: {
     name: v.string(),
     city: v.string(),
@@ -1073,7 +1073,7 @@ export const upsertTeam = mutationGeneric({
   },
 });
 
-export const upsertPlayer = mutationGeneric({
+export const upsertPlayer = internalMutationGeneric({
   args: {
     name: v.string(),
     leagueId: v.id("leagues"),
@@ -1156,7 +1156,7 @@ export const upsertPlayer = mutationGeneric({
   },
 });
 
-export const createTeam = mutationGeneric({
+export const createTeam = internalMutationGeneric({
   args: {
     name: v.string(),
     leagueId: v.id("leagues"),
@@ -1202,7 +1202,7 @@ export const createTeam = mutationGeneric({
   },
 });
 
-export const updateTeam = mutationGeneric({
+export const updateTeam = internalMutationGeneric({
   args: {
     teamId: v.id("teams"),
     name: v.optional(v.string()),
@@ -1248,7 +1248,7 @@ export const updateTeam = mutationGeneric({
   },
 });
 
-export const createPlayer = mutationGeneric({
+export const createPlayer = internalMutationGeneric({
   args: {
     name: v.string(),
     teamId: v.id("teams"),
@@ -1298,7 +1298,7 @@ export const createPlayer = mutationGeneric({
   },
 });
 
-export const updatePlayer = mutationGeneric({
+export const updatePlayer = internalMutationGeneric({
   args: {
     playerId: v.id("players"),
     name: v.optional(v.string()),
@@ -1354,7 +1354,7 @@ export const updatePlayer = mutationGeneric({
   },
 });
 
-export const deletePlayer = mutationGeneric({
+export const deletePlayer = internalMutationGeneric({
   args: { playerId: v.id("players") },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -1443,7 +1443,7 @@ async function purgeTeam(ctx: MutationCtx, teamId: Id<"teams">): Promise<void> {
   await ctx.db.delete(teamId);
 }
 
-export const deleteTeam = mutationGeneric({
+export const deleteTeam = internalMutationGeneric({
   args: { teamId: v.id("teams") },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -1452,7 +1452,7 @@ export const deleteTeam = mutationGeneric({
   },
 });
 
-export const upsertSeason = mutationGeneric({
+export const upsertSeason = internalMutationGeneric({
   args: {
     name: v.string(),
     leagueId: v.id("leagues"),
@@ -1517,7 +1517,7 @@ export const upsertSeason = mutationGeneric({
   },
 });
 
-export const setLeagueInviteToken = mutationGeneric({
+export const setLeagueInviteToken = internalMutationGeneric({
   args: {
     leagueId: v.id("leagues"),
     token: v.union(v.string(), v.null()),
@@ -1539,7 +1539,7 @@ export const setLeagueInviteToken = mutationGeneric({
  * provenance resolve back to the reference. This replaces the shared-edit
  * claimTeam path under the private-only workspace model (RFC §11).
  */
-export const forkTeamToWorkspace = mutationGeneric({
+export const forkTeamToWorkspace = internalMutationGeneric({
   args: { orgId: v.string(), sourceTeamId: v.id("teams") },
   returns: v.object({
     teamId: v.string(),
@@ -1659,7 +1659,7 @@ export const forkTeamToWorkspace = mutationGeneric({
   },
 });
 
-export const setSyncEnabled = mutationGeneric({
+export const setSyncEnabled = internalMutationGeneric({
   args: { enabled: v.boolean() },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -1683,7 +1683,7 @@ export const setSyncEnabled = mutationGeneric({
   },
 });
 
-export const writeSyncReport = mutationGeneric({
+export const writeSyncReport = internalMutationGeneric({
   args: {
     reportJson: v.string(),
   },
@@ -1751,7 +1751,7 @@ export const getDepthChartByTeamSeason = query({
   },
 });
 
-export const reorderDepthChart = mutation({
+export const reorderDepthChart = internalMutation({
   args: {
     teamId: v.id("teams"),
     seasonId: v.id("seasons"),
@@ -1817,7 +1817,7 @@ export const reorderDepthChart = mutation({
   },
 });
 
-export const setRosterLocked = mutation({
+export const setRosterLocked = internalMutation({
   args: {
     seasonId: v.id("seasons"),
     locked: v.boolean(),
@@ -1836,7 +1836,7 @@ export const setRosterLocked = mutation({
   },
 });
 
-export const assignPlayerToRoster = mutation({
+export const assignPlayerToRoster = internalMutation({
   args: {
     seasonId: v.id("seasons"),
     teamId: v.id("teams"),
@@ -1959,7 +1959,7 @@ async function compactSlotRanks(
   );
 }
 
-export const removePlayerFromRoster = mutation({
+export const removePlayerFromRoster = internalMutation({
   args: {
     assignmentId: v.id("rosterAssignments"),
     actorUserId: v.string(),
@@ -2001,7 +2001,7 @@ export const removePlayerFromRoster = mutation({
   },
 });
 
-export const updateRosterStatus = mutation({
+export const updateRosterStatus = internalMutation({
   args: {
     assignmentId: v.id("rosterAssignments"),
     newStatus: v.string(),
@@ -2206,7 +2206,7 @@ export const getRosterAssignmentHistory = query({
  *   weightedOverall — already computed at the wrapper layer (null if
  *                     neither source carried an "OVR"/"overall" attribute).
  */
-export const ingestPlayerAttributes = mutationGeneric({
+export const ingestPlayerAttributes = internalMutationGeneric({
   args: {
     playerId: v.id("players"),
     seasonId: v.id("seasons"),
@@ -2274,7 +2274,7 @@ export const ingestPlayerAttributes = mutationGeneric({
  * so players without a computed rating fall back to "no snapshot" (em
  * dash) rather than showing leftover values. Idempotent.
  */
-export const clearSeasonPlayerAttributes = mutationGeneric({
+export const clearSeasonPlayerAttributes = internalMutationGeneric({
   args: { seasonId: v.id("seasons") },
   returns: v.object({ deleted: v.number() }),
   handler: async (ctx, args) => {
@@ -2289,7 +2289,7 @@ export const clearSeasonPlayerAttributes = mutationGeneric({
   },
 });
 
-export const ingestPlayerAttributesBatch = mutationGeneric({
+export const ingestPlayerAttributesBatch = internalMutationGeneric({
   args: {
     seasonId: v.id("seasons"),
     rows: v.array(
@@ -2628,7 +2628,7 @@ export const getTeamAttributeSnapshots = queryGeneric({
  * Madden ratings (WSM-000095) — ingest + reads. One row per player; the
  * ingest upserts by playerId so a re-run refreshes in place.
  */
-export const ingestMaddenRatingsBatch = mutationGeneric({
+export const ingestMaddenRatingsBatch = internalMutationGeneric({
   args: {
     rows: v.array(
       v.object({
@@ -2737,7 +2737,7 @@ export const getLeagueVisibility = queryGeneric({
   },
 });
 
-export const setLeaguePublic = mutationGeneric({
+export const setLeaguePublic = internalMutationGeneric({
   args: {
     leagueId: v.id("leagues"),
     isPublic: v.boolean(),
@@ -2803,7 +2803,7 @@ export const listOrgMemberRoles = queryGeneric({
   },
 });
 
-export const setOrgMemberRole = mutationGeneric({
+export const setOrgMemberRole = internalMutationGeneric({
   args: {
     orgId: v.string(),
     userId: v.string(),
@@ -2829,7 +2829,7 @@ export const setOrgMemberRole = mutationGeneric({
   },
 });
 
-export const deleteOrgMemberRole = mutationGeneric({
+export const deleteOrgMemberRole = internalMutationGeneric({
   args: { orgId: v.string(), userId: v.string() },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -2844,7 +2844,7 @@ export const deleteOrgMemberRole = mutationGeneric({
 });
 
 /** Mark a (public template) league's teams claimable by coaches (WSM-000109). */
-export const setLeagueClaimable = mutationGeneric({
+export const setLeagueClaimable = internalMutationGeneric({
   args: {
     leagueId: v.id("leagues"),
     claimable: v.boolean(),
@@ -2942,7 +2942,7 @@ const fixtureDtoValidator = v.object({
   createdBy: v.string(),
 });
 
-export const createFixture = mutationGeneric({
+export const createFixture = internalMutationGeneric({
   args: {
     seasonId: v.id("seasons"),
     homeTeamId: v.id("teams"),
@@ -3001,7 +3001,7 @@ export const createFixture = mutationGeneric({
   },
 });
 
-export const updateFixture = mutationGeneric({
+export const updateFixture = internalMutationGeneric({
   args: {
     fixtureId: v.id("fixtures"),
     scheduledAt: v.optional(v.union(v.string(), v.null())),
@@ -3043,7 +3043,7 @@ export const updateFixture = mutationGeneric({
   },
 });
 
-export const deleteFixture = mutationGeneric({
+export const deleteFixture = internalMutationGeneric({
   args: { fixtureId: v.id("fixtures") },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -3140,7 +3140,7 @@ const gameResultDtoValidator = v.object({
   recordedBy: v.string(),
 });
 
-export const recordGameResult = mutationGeneric({
+export const recordGameResult = internalMutationGeneric({
   args: {
     fixtureId: v.id("fixtures"),
     homeScore: v.number(),

--- a/apps/web/scripts/backfill-sprt-career.mts
+++ b/apps/web/scripts/backfill-sprt-career.mts
@@ -64,9 +64,12 @@ type IngestRow = {
 async function main() {
   const client = new ConvexHttpClient(CONVEX_URL!);
   const adminKey = process.env.CONVEX_ADMIN_KEY;
-  if (adminKey) {
-    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  if (!adminKey) {
+    throw new Error(
+      "CONVEX_ADMIN_KEY is required: sports write mutations are internal (WSM-000096) and reject unauthenticated calls.",
+    );
   }
+  (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
   const q = (name: string, args: unknown) =>
     client.query(name as never, args as never) as Promise<unknown>;
   const m = (name: string, args: unknown) =>

--- a/apps/web/scripts/ingest-madden-ratings.mts
+++ b/apps/web/scripts/ingest-madden-ratings.mts
@@ -141,9 +141,12 @@ async function main() {
 
   const client = new ConvexHttpClient(CONVEX_URL!);
   const adminKey = process.env.CONVEX_ADMIN_KEY;
-  if (adminKey) {
-    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  if (!adminKey) {
+    throw new Error(
+      "CONVEX_ADMIN_KEY is required: sports write mutations are internal (WSM-000096) and reject unauthenticated calls.",
+    );
   }
+  (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
   const q = (name: string, args: unknown) =>
     client.query(name as never, args as never) as Promise<unknown>;
   const m = (name: string, args: unknown) =>

--- a/apps/web/scripts/ingest-sprt-ratings.mts
+++ b/apps/web/scripts/ingest-sprt-ratings.mts
@@ -56,9 +56,12 @@ async function main() {
 
   const client = new ConvexHttpClient(CONVEX_URL);
   const adminKey = process.env.CONVEX_ADMIN_KEY;
-  if (adminKey) {
-    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  if (!adminKey) {
+    throw new Error(
+      "CONVEX_ADMIN_KEY is required: sports write mutations are internal (WSM-000096) and reject unauthenticated calls.",
+    );
   }
+  (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
   const teams = (await client.query("sports:listTeamsByLeague" as never, { leagueId: LEAGUE_ID } as never)) as { id: string }[];
 
   const rows: { playerId: string; positionGroup: string; attributesJson: string; weightedOverall: number | null }[] = [];

--- a/apps/web/scripts/seed-ghsa-cobb.mts
+++ b/apps/web/scripts/seed-ghsa-cobb.mts
@@ -64,9 +64,12 @@ async function main() {
 
   const client = new ConvexHttpClient(CONVEX_URL!);
   const adminKey = process.env.CONVEX_ADMIN_KEY;
-  if (adminKey) {
-    (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
+  if (!adminKey) {
+    throw new Error(
+      "CONVEX_ADMIN_KEY is required: sports write mutations are internal (WSM-000096) and reject unauthenticated calls.",
+    );
   }
+  (client as unknown as { setAdminAuth: (k: string) => void }).setAdminAuth(adminKey);
   const m = (name: string, args: unknown) =>
     client.mutation(name as never, args as never) as Promise<unknown>;
 


### PR DESCRIPTION
Closes #210

## Problem
All 36 write mutations in `convex/sports.ts` were **public** (`mutation` / `mutationGeneric`) — callable by anyone with the deployment URL, bypassing the Next.js authorization in `data-api.ts`. Includes destructive ops (`clearSeasonPlayerAttributes`, `deletePlayer`, `deleteLeagueBatch`, `ingest*Batch`). Surfaced in WSM-000095 when the Madden ingest wrote **1,637 prod rows with an empty admin key** because the mutation was public.

## Fix
- **Convert all 36 writes → `internalMutation` / `internalMutationGeneric`.** 44 read queries stay public. Trusted callers (`data-api.ts`, ingest scripts) use the **admin-keyed** `ConvexHttpClient` with untyped `makeFunctionReference` strings, so they keep working unchanged; anonymous clients get `FunctionPathNotFound` (404).
- **Harden ingest scripts** to *require* `CONVEX_ADMIN_KEY` (throw instead of silently running unauthenticated — the exact WSM-000095 bug).
- **Update convex tests** to call writes via `internal.sports.*`.
- **`writeMutationsAreInternal.test.ts`** — a compile-time guard (tsc, which CI runs) that fails the build if any write is reverted to a public `mutation`.

## Verification (dev deployment `laudable-reindeer-759`)
| Anonymous call | Result |
|---|---|
| `createTeam`, `clearSeasonPlayerAttributes`, `deletePlayer`, `deleteLeagueBatch`, `ingestMaddenRatingsBatch` (writes) | ✅ **404 FunctionPathNotFound** — rejected |
| `listPublicLeagues`, `computeStandingsPublic` (reads) | ✅ still resolve |

Local gate: type-check ✅ · lint ✅ · 348/348 unit tests ✅ · build ✅

## ⚠️ Prod cutover prerequisite
Convex deploy-from-main will make prod writes internal. Prod `CONVEX_ADMIN_KEY` **must be a valid admin/deploy key** or all prod writes break. (Current prod reads work via the admin client, which strongly implies the key is already valid — but confirm before deploying.) Deploy order is not fragile: admin-authed calls work against both old and new function visibility.

## Out of scope (follow-up)
`e2eSeed.ts` mutations are also public but gated by `CONVEX_ENABLE_E2E_SEED` (unset in prod), so not wide-open. Will file a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)