### PR TITLE
feat(web): schedule UX — delete fixtures + season-gating CTA (WSM-000127)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -15,6 +15,8 @@ import { canManageRoster } from "@/lib/permissions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
+import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
+import { Button } from "@/components/ui/button";
 
 export default async function LeagueSchedulePage({
   params,
@@ -107,9 +109,14 @@ export default async function LeagueSchedulePage({
 
       {!activeSeason ? (
         <Card>
-          <CardContent className="p-6 text-center text-muted-foreground">
-            No seasons in this league yet. Create a season before scheduling
-            fixtures.
+          <CardContent className="flex flex-col items-center gap-3 p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Scheduling needs a season. Create one to add fixtures and record
+              results.
+            </p>
+            <Button asChild size="sm">
+              <Link href="/dashboard/seasons">Go to Seasons</Link>
+            </Button>
           </CardContent>
         </Card>
       ) : weekKeys.length === 0 ? (
@@ -179,15 +186,23 @@ export default async function LeagueSchedulePage({
                           </td>
                           {isAdmin ? (
                             <td className="px-4 py-2">
-                              <RecordResultDialog
-                                leagueId={leagueId}
-                                fixtureId={fixture.id}
-                                homeTeamName={fixture.homeTeamName}
-                                awayTeamName={fixture.awayTeamName}
-                                initialHomeScore={result?.homeScore ?? null}
-                                initialAwayScore={result?.awayScore ?? null}
-                                triggerLabel={result ? "Edit result" : "Record result"}
-                              />
+                              <div className="flex items-center gap-1">
+                                <RecordResultDialog
+                                  leagueId={leagueId}
+                                  fixtureId={fixture.id}
+                                  homeTeamName={fixture.homeTeamName}
+                                  awayTeamName={fixture.awayTeamName}
+                                  initialHomeScore={result?.homeScore ?? null}
+                                  initialAwayScore={result?.awayScore ?? null}
+                                  triggerLabel={result ? "Edit result" : "Record result"}
+                                />
+                                <DeleteFixtureButton
+                                  leagueId={leagueId}
+                                  fixtureId={fixture.id}
+                                  homeTeamName={fixture.homeTeamName}
+                                  awayTeamName={fixture.awayTeamName}
+                                />
+                              </div>
                             </td>
                           ) : null}
                         </tr>

--- a/apps/web/src/components/schedule/DeleteFixtureButton.tsx
+++ b/apps/web/src/components/schedule/DeleteFixtureButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteFixtureAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+
+export interface DeleteFixtureButtonProps {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+}
+
+export default function DeleteFixtureButton({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+}: DeleteFixtureButtonProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  function remove() {
+    if (
+      !window.confirm(
+        `Delete ${homeTeamName} vs ${awayTeamName}? Any recorded result is removed too. This can't be undone.`,
+      )
+    ) {
+      return;
+    }
+    startTransition(async () => {
+      const res = await deleteFixtureAction({ leagueId, fixtureId });
+      if (res.ok) {
+        toast.success("Fixture deleted.");
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      disabled={pending}
+      onClick={remove}
+      aria-label={`Delete ${homeTeamName} vs ${awayTeamName}`}
+    >
+      <Trash2 className="h-4 w-4 text-destructive" />
+    </Button>
+  );
+}


### PR DESCRIPTION
Closes #245

## Context
The schedule page (`leagues/[id]/schedule`) already supported **add fixture** (`FixtureFormDialog`) and **record result** (`RecordResultDialog`), coach+-gated. This closes the two remaining AC gaps.

## Changes (web-only)
- **No-season is no longer a dead end.** When a league has no season, the page now shows a **"Go to Seasons"** button linking to the Seasons page (season CRUD shipped in #244 / WSM-000126) — satisfying the AC: *"told to create a season first (link to Seasons), not shown a dead end."*
- **Delete fixtures.** The AC requires deleting fixtures but the UI had no control, despite `deleteFixtureAction` already existing. Added a manager-gated `DeleteFixtureButton` per fixture row (removes the fixture and its recorded result, with a confirm), beside *Record result*.

Discoverability is already handled — the league detail page links to Schedule/Standings.

## Verification
- Create fixtures / record results: unchanged, already working.
- No season → "Go to Seasons" CTA.
- Delete fixture → row removed, standings recompute (action revalidates both paths).

Local gate: type-check ✅ · lint ✅ · 351/351 tests ✅ · build ✅. No Convex changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)