### PR TITLE
feat(web): leagues active-league accordion + division CRUD (WSM-000132)

### DIFF
--- a/apps/web/convex/__tests__/divisionCrud.test.ts
+++ b/apps/web/convex/__tests__/divisionCrud.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "L",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "East",
+      leagueId,
+    });
+    return { leagueId, divisionId };
+  });
+}
+
+async function addTeam(
+  t: ReturnType<typeof convexTest>,
+  leagueId: Id<"leagues">,
+  divisionId: Id<"divisions">,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("teams", {
+      name: "Team",
+      leagueId,
+      divisionId,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Loc",
+      logoUrl: null,
+      rosterLimit: 53,
+    }),
+  );
+}
+
+describe("division CRUD (WSM-000132 / WSM-000128)", () => {
+  it("updateDivision renames", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionId } = await seedLeague(t);
+    const dto = await t.mutation(internal.sports.updateDivision, {
+      divisionId,
+      name: "West",
+    });
+    expect(dto?.name).toBe("West");
+  });
+
+  it("deleteDivision refuses a non-empty division", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, divisionId } = await seedLeague(t);
+    await addTeam(t, leagueId, divisionId);
+
+    const res = await t.mutation(internal.sports.deleteDivision, {
+      divisionId,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.teamCount).toBe(1);
+
+    const stillThere = await t.run((ctx) => ctx.db.get(divisionId));
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("deleteDivision removes an empty division", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionId } = await seedLeague(t);
+    const res = await t.mutation(internal.sports.deleteDivision, {
+      divisionId,
+    });
+    expect(res.ok).toBe(true);
+    const gone = await t.run((ctx) => ctx.db.get(divisionId));
+    expect(gone).toBeNull();
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -35,6 +35,8 @@ void internal.sports.clearSeasonPlayerAttributes;
 void internal.sports.ingestMaddenRatingsBatch;
 void internal.sports.ingestPlayerAttributesBatch;
 void internal.sports.setOrgMemberRole;
+void internal.sports.updateDivision;
+void internal.sports.deleteDivision;
 void internal.sports.setLeaguePublic;
 void internal.sports.recordGameResult;
 void internal.sports.assignPlayerToRoster;

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -989,6 +989,41 @@ export const upsertDivision = internalMutationGeneric({
   },
 });
 
+/** Rename a division by id (WSM-000132 / WSM-000128). */
+export const updateDivision = internalMutationGeneric({
+  args: { divisionId: v.id("divisions"), name: v.string() },
+  returns: v.union(
+    v.object({ id: v.string(), name: v.string(), leagueId: v.string() }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.divisionId);
+    if (!existing) return null;
+    await ctx.db.patch(args.divisionId, { name: args.name });
+    return toDivisionDto({ ...existing, name: args.name });
+  },
+});
+
+/**
+ * Delete an empty division (WSM-000132 / WSM-000128). Refuses when teams still
+ * reference it — they must be moved or removed first — so no team is orphaned.
+ */
+export const deleteDivision = internalMutationGeneric({
+  args: { divisionId: v.id("divisions") },
+  returns: v.object({ ok: v.boolean(), teamCount: v.number() }),
+  handler: async (ctx, args) => {
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_divisionId", (q) => q.eq("divisionId", args.divisionId))
+      .collect();
+    if (teams.length > 0) {
+      return { ok: false, teamCount: teams.length };
+    }
+    await ctx.db.delete(args.divisionId);
+    return { ok: true, teamCount: 0 };
+  },
+});
+
 export const upsertTeam = internalMutationGeneric({
   args: {
     name: v.string(),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-accordion": "^1.2.13",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/web/src/app/dashboard/leagues/division-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/division-actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import {
+  createDivision,
+  updateDivision as updateDivisionMutation,
+  deleteDivision as deleteDivisionMutation,
+  getDivisionLeagueId,
+  getLeagueOrgId,
+} from "@/lib/data-api";
+import { getUserRoleInOrg } from "@/lib/org-context";
+
+type Result<T = unknown> = ({ ok: true } & T) | { ok: false; error: string };
+
+/** Org-admin gate for a division's league. Mirrors leagues/actions.ts. */
+async function requireLeagueAdmin(
+  leagueId: string | null,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!leagueId) return { ok: false, error: "This can't be edited." };
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "This league can't be edited." };
+  const role = await getUserRoleInOrg(orgId, userId);
+  if (role !== "org:admin") return { ok: false, error: "not_admin" };
+  return { ok: true };
+}
+
+export async function createDivisionAction(
+  leagueId: string,
+  name: string,
+): Promise<Result<{ id: string }>> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "Division name is required." };
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+  try {
+    const { dto } = await createDivision({ name: trimmed, leagueId });
+    revalidatePath("/dashboard/leagues");
+    return { ok: true, id: dto.id };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not create division.",
+    };
+  }
+}
+
+export async function renameDivisionAction(
+  divisionId: string,
+  name: string,
+): Promise<Result> {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, error: "Division name is required." };
+  const leagueId = await getDivisionLeagueId(divisionId);
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+  try {
+    await updateDivisionMutation({ divisionId, name: trimmed });
+    revalidatePath("/dashboard/leagues");
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not rename division.",
+    };
+  }
+}
+
+export async function deleteDivisionAction(
+  divisionId: string,
+): Promise<Result> {
+  const leagueId = await getDivisionLeagueId(divisionId);
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+  const res = await deleteDivisionMutation(divisionId);
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: `Move or remove its ${res.teamCount} team${
+        res.teamCount === 1 ? "" : "s"
+      } first.`,
+    };
+  }
+  revalidatePath("/dashboard/leagues");
+  return { ok: true };
+}

--- a/apps/web/src/app/dashboard/leagues/division-controls.tsx
+++ b/apps/web/src/app/dashboard/leagues/division-controls.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Plus, Trash2, Pencil } from "lucide-react";
+import {
+  createDivisionAction,
+  renameDivisionAction,
+  deleteDivisionAction,
+} from "./division-actions";
+
+const inputClass =
+  "rounded-md border border-input bg-background px-2 py-1 text-sm text-foreground";
+
+function errorText(error: string): string {
+  return error === "not_admin" ? "Only league admins can do that." : error;
+}
+
+export function CreateDivisionButton({ leagueId }: { leagueId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    const res = await createDivisionAction(leagueId, trimmed);
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`Added ${trimmed}.`);
+      setName("");
+      setOpen(false);
+      router.refresh();
+    } else {
+      toast.error(errorText(res.error));
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Plus className="mr-1 h-4 w-4" />
+        New division
+      </Button>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") setOpen(false);
+        }}
+        placeholder="Division name"
+        className={inputClass}
+      />
+      <Button size="sm" disabled={busy} onClick={submit}>
+        {busy ? "…" : "Add"}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => setOpen(false)}>
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+export function DivisionRowActions({
+  divisionId,
+  currentName,
+}: {
+  divisionId: string;
+  currentName: string;
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(currentName);
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === currentName) {
+      setEditing(false);
+      return;
+    }
+    setBusy(true);
+    const res = await renameDivisionAction(divisionId, trimmed);
+    setBusy(false);
+    if (res.ok) {
+      toast.success("Division renamed.");
+      setEditing(false);
+      router.refresh();
+    } else {
+      toast.error(errorText(res.error));
+    }
+  }
+
+  async function remove() {
+    if (!window.confirm(`Delete division "${currentName}"?`)) return;
+    setBusy(true);
+    const res = await deleteDivisionAction(divisionId);
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`Deleted ${currentName}.`);
+      router.refresh();
+    } else {
+      toast.error(errorText(res.error));
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") save();
+            if (e.key === "Escape") setEditing(false);
+          }}
+          className={inputClass}
+        />
+        <Button size="sm" disabled={busy} onClick={save}>
+          {busy ? "…" : "Save"}
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => setEditing(true)}
+        aria-label={`Rename ${currentName}`}
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={busy}
+        onClick={remove}
+        aria-label={`Delete ${currentName}`}
+      >
+        <Trash2 className="h-4 w-4 text-destructive" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Link from "next/link";
+import { Users } from "lucide-react";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { CreateDivisionButton, DivisionRowActions } from "./division-controls";
+
+export interface AccordionDivision {
+  id: string;
+  name: string;
+  teams: Array<{ id: string; name: string; city: string | null }>;
+}
+
+export function LeaguesAccordion({
+  leagueId,
+  isAdmin,
+  divisions,
+}: {
+  leagueId: string;
+  isAdmin: boolean;
+  divisions: AccordionDivision[];
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium text-muted-foreground">
+          Divisions
+        </h3>
+        {isAdmin ? <CreateDivisionButton leagueId={leagueId} /> : null}
+      </div>
+
+      {divisions.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          No divisions yet.
+          {isAdmin ? " Add one to start organizing teams." : ""}
+        </p>
+      ) : (
+        <Accordion type="multiple" className="rounded-md border border-border">
+          {divisions.map((division) => (
+            <AccordionItem
+              key={division.id}
+              value={division.id}
+              className="px-3 last:border-b-0"
+            >
+              <div className="flex items-center gap-2">
+                <AccordionTrigger className="flex-1">
+                  <span className="flex items-center gap-2">
+                    {division.name}
+                    <Badge variant="outline" className="text-xs">
+                      {division.teams.length} team
+                      {division.teams.length !== 1 ? "s" : ""}
+                    </Badge>
+                  </span>
+                </AccordionTrigger>
+                {isAdmin ? (
+                  <DivisionRowActions
+                    divisionId={division.id}
+                    currentName={division.name}
+                  />
+                ) : null}
+              </div>
+              <AccordionContent>
+                {division.teams.length === 0 ? (
+                  <div className="flex items-center justify-between gap-2 px-1 py-1">
+                    <span className="text-sm text-muted-foreground">
+                      No teams in this division.
+                    </span>
+                    <Link
+                      href="/dashboard/discover"
+                      className="text-sm text-primary hover:underline"
+                    >
+                      Add teams &rarr;
+                    </Link>
+                  </div>
+                ) : (
+                  <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {division.teams.map((team) => (
+                      <li key={team.id}>
+                        <Link
+                          href={`/dashboard/teams/${team.id}?from=leagues`}
+                          className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-muted"
+                        >
+                          <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          <span className="truncate font-medium text-foreground">
+                            {team.name}
+                          </span>
+                          {team.city ? (
+                            <span className="truncate text-muted-foreground">
+                              &mdash; {team.city}
+                            </span>
+                          ) : null}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -1,143 +1,112 @@
-import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getLeagues, getDivisions, getTeams } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { getDivisions, getTeams, getLeagueOrgId } from "@/lib/data-api";
+import { resolveActiveLeague } from "@/lib/active-league";
+import { getUserRoleInOrg } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
-import { Trophy, Layers, Users } from "lucide-react";
-import { CreateLeagueButton, DeleteLeagueButton } from "./leagues-actions";
+import { Trophy } from "lucide-react";
+import { LeagueSwitcher } from "../_components/league-switcher";
+import {
+  CreateLeagueButton,
+  DeleteLeagueButton,
+  RenameLeagueForm,
+} from "./leagues-actions";
+import { LeaguesAccordion, type AccordionDivision } from "./leagues-accordion";
 
 export default async function LeaguesPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  const orgContext = await resolveOrgContext(userId);
-  const ids = orgContext.visibleLeagueIds;
+  const { leagues, activeLeagueId, orgContext } =
+    await resolveActiveLeague(userId);
 
-  const [leagues, divisions, teams] = await Promise.all([
-    getLeagues(ids),
-    getDivisions(ids),
-    getTeams(ids),
-  ]);
-
-  const divisionsByLeague = new Map<string, typeof divisions>();
-  for (const div of divisions) {
-    const existing = divisionsByLeague.get(div.leagueId) ?? [];
-    existing.push(div);
-    divisionsByLeague.set(div.leagueId, existing);
-  }
-
-  const teamsByDivision = new Map<string, typeof teams>();
-  for (const team of teams) {
-    const existing = teamsByDivision.get(team.divisionId) ?? [];
-    existing.push(team);
-    teamsByDivision.set(team.divisionId, existing);
-  }
-
-  return (
-    <div>
-      <div className="mb-6 flex items-center justify-between gap-2">
-        <h2 className="text-lg font-semibold text-foreground">Leagues</h2>
-        <CreateLeagueButton />
-      </div>
-
-      {leagues.length === 0 ? (
+  if (leagues.length === 0) {
+    return (
+      <div>
+        <div className="mb-6 flex items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold text-foreground">Leagues</h2>
+          <CreateLeagueButton />
+        </div>
         <EmptyState
           icon={Trophy}
           title="No leagues yet"
           description="Create a league, or add teams from Discover, to get started."
         />
-      ) : (
-        <div className="space-y-6">
-          {leagues.map((league) => {
-            const leagueDivisions = divisionsByLeague.get(league.id) ?? [];
+      </div>
+    );
+  }
 
-            return (
-              <Card key={league.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <Trophy className="h-5 w-5 shrink-0 text-primary" />
-                      <CardTitle className="truncate">
-                        <Link
-                          href={`/dashboard/leagues/${league.id}`}
-                          className="hover:underline"
-                        >
-                          {league.name}
-                        </Link>
-                      </CardTitle>
-                      <Badge variant="secondary" className="shrink-0">
-                        {leagueDivisions.length} division
-                        {leagueDivisions.length !== 1 ? "s" : ""}
-                      </Badge>
-                    </div>
-                    <DeleteLeagueButton
-                      leagueId={league.id}
-                      leagueName={league.name}
-                    />
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  {leagueDivisions.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      No divisions in this league.
-                    </p>
-                  ) : (
-                    <div className="space-y-4">
-                      {leagueDivisions.map((division) => {
-                        const divTeams =
-                          teamsByDivision.get(division.id) ?? [];
+  const activeLeague =
+    leagues.find((l) => l.id === activeLeagueId) ?? leagues[0];
 
-                        return (
-                          <div key={division.id}>
-                            <div className="mb-2 flex items-center gap-2">
-                              <Layers className="h-4 w-4 text-muted-foreground" />
-                              <span className="text-sm font-medium text-foreground">
-                                {division.name}
-                              </span>
-                              <Badge variant="outline" className="text-xs">
-                                {divTeams.length} team
-                                {divTeams.length !== 1 ? "s" : ""}
-                              </Badge>
-                            </div>
-                            {divTeams.length > 0 ? (
-                              <div className="ml-6 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                                {divTeams.map((team) => (
-                                  <Link
-                                    key={team.id}
-                                    href={`/dashboard/teams/${team.id}?from=leagues`}
-                                    className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-card"
-                                  >
-                                    <Users className="h-3.5 w-3.5 text-muted-foreground" />
-                                    <span className="font-medium text-foreground">
-                                      {team.name}
-                                    </span>
-                                    {team.city && (
-                                      <span className="text-muted-foreground">
-                                        &mdash; {team.city}
-                                      </span>
-                                    )}
-                                  </Link>
-                                ))}
-                              </div>
-                            ) : (
-                              <p className="ml-6 text-sm text-muted-foreground">
-                                No teams in this division.
-                              </p>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })}
+  // Org-admin of the active league sees CRUD controls (members/coaches don't).
+  const orgId = await getLeagueOrgId(activeLeague.id);
+  const role = orgId ? await getUserRoleInOrg(orgId, userId) : null;
+  const isAdmin = role === "org:admin";
+
+  const [divisions, teams] = await Promise.all([
+    getDivisions([activeLeague.id]),
+    getTeams([activeLeague.id]),
+  ]);
+
+  const teamsByDivision = new Map<string, AccordionDivision["teams"]>();
+  for (const team of teams) {
+    const arr = teamsByDivision.get(team.divisionId) ?? [];
+    arr.push({ id: team.id, name: team.name, city: team.city ?? null });
+    teamsByDivision.set(team.divisionId, arr);
+  }
+
+  const accordionDivisions: AccordionDivision[] = divisions.map((d) => ({
+    id: d.id,
+    name: d.name,
+    teams: teamsByDivision.get(d.id) ?? [],
+  }));
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold text-foreground">Leagues</h2>
+          <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
         </div>
-      )}
+        <CreateLeagueButton />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-3">
+              <Trophy className="h-5 w-5 shrink-0 text-primary" />
+              <CardTitle className="truncate">{activeLeague.name}</CardTitle>
+              <Badge variant="secondary" className="shrink-0">
+                {divisions.length} division
+                {divisions.length !== 1 ? "s" : ""}
+              </Badge>
+            </div>
+            {isAdmin ? (
+              <div className="flex items-center gap-1">
+                <RenameLeagueForm
+                  leagueId={activeLeague.id}
+                  currentName={activeLeague.name}
+                />
+                <DeleteLeagueButton
+                  leagueId={activeLeague.id}
+                  leagueName={activeLeague.name}
+                />
+              </div>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <LeaguesAccordion
+            leagueId={activeLeague.id}
+            isAdmin={isAdmin}
+            divisions={accordionDivisions}
+          />
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -86,6 +86,8 @@
 
   --animate-in: enter 0.2s ease-out;
   --animate-out: exit 0.2s ease-in;
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
 
   @keyframes enter {
     from {
@@ -98,6 +100,24 @@
     to {
       opacity: 0;
       transform: translateY(2px) scale(0.97);
+    }
+  }
+
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
+  }
+
+  @keyframes accordion-up {
+    from {
+      height: var(--radix-accordion-content-height);
+    }
+    to {
+      height: 0;
     }
   }
 }

--- a/apps/web/src/components/ui/accordion.tsx
+++ b/apps/web/src/components/ui/accordion.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b border-border", className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between gap-2 py-3 text-sm font-medium text-foreground transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-3 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -194,6 +194,14 @@ const refs = {
     { name: string; leagueId: string },
     { dto: DivisionDto; created: boolean }
   >("sports:upsertDivision"),
+  updateDivision: mutationRef<
+    { divisionId: string; name: string },
+    DivisionDto | null
+  >("sports:updateDivision"),
+  deleteDivision: mutationRef<
+    { divisionId: string },
+    { ok: boolean; teamCount: number }
+  >("sports:deleteDivision"),
   upsertTeam: mutationRef<
     {
       name: string;
@@ -610,6 +618,36 @@ export async function getDivision(
   if (!division) throw new Error("Division not found");
   requireLeagueAccessLocal(division.leagueId, orgContext);
   return division;
+}
+
+export async function createDivision(input: {
+  name: string;
+  leagueId: string;
+}): Promise<{ dto: DivisionDto; created: boolean }> {
+  return mutateConvex(refs.upsertDivision, input);
+}
+
+export async function updateDivision(input: {
+  divisionId: string;
+  name: string;
+}): Promise<DivisionDto> {
+  const dto = await mutateConvex(refs.updateDivision, input);
+  if (!dto) throw new Error("Division not found");
+  return dto;
+}
+
+export async function deleteDivision(
+  divisionId: string,
+): Promise<{ ok: boolean; teamCount: number }> {
+  return mutateConvex(refs.deleteDivision, { divisionId });
+}
+
+/** Resolve a division's league for authorization, without an org-access gate. */
+export async function getDivisionLeagueId(
+  divisionId: string,
+): Promise<string | null> {
+  const division = await queryConvex(refs.getDivision, { divisionId });
+  return division?.leagueId ?? null;
 }
 
 export async function getTeams(visibleLeagueIds: string[]): Promise<TeamDto[]> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.13
+        version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1988,6 +1991,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-accessible-icon@1.1.7':
     resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
     peerDependencies:
@@ -2003,6 +2009,19 @@ packages:
 
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.13':
+    resolution: {integrity: sha512-xITxBB2p5m5tAe7M0F95kb4uAh7jSIKGlExMEm93HlW+XxZHV2eXFbPWLktd4JhRiwcnXNbO7iekcrbZy6ZCvA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2092,6 +2111,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collapsible@1.1.13':
+    resolution: {integrity: sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -2105,8 +2137,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.9':
+    resolution: {integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2136,6 +2190,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -2151,6 +2214,15 @@ packages:
 
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2234,6 +2306,15 @@ packages:
 
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2371,6 +2452,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
@@ -2386,6 +2480,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2519,6 +2626,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
     peerDependencies:
@@ -2628,8 +2744,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2657,6 +2791,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -9423,6 +9566,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9443,6 +9588,23 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-accordion@1.2.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collapsible': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -9526,6 +9688,22 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-collapsible@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
@@ -9538,7 +9716,25 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -9559,6 +9755,12 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -9587,6 +9789,12 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -9671,6 +9879,13 @@ snapshots:
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -9847,6 +10062,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
@@ -9859,6 +10083,15 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -10007,6 +10240,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.2.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -10133,9 +10373,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -10155,6 +10410,12 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:


### PR DESCRIPTION
Closes #250

## Problem
`/dashboard/leagues` rendered **every** visible league fully expanded (divisions + team grids) — noisy and overflow-prone on mobile.

## What
Redesigned around the **active league** with an accordion drill-down and inline CRUD.

- **Active-league focus.** Uses `resolveActiveLeague` + the existing `LeagueSwitcher` to show one league at a time with a way to switch — instead of every visible league.
- **Accordion drill-down.** Standard shadcn Accordion (new `@radix-ui/react-accordion` dep + `ui/accordion.tsx` + accordion keyframes in `globals.css`): divisions are collapsed rows that expand to reveal their teams. Teams link to their detail page (where remove already lives, WSM-000120). No nested wall of cards → scannable on mobile.
- **CRUD at each level (admin):** league rename/delete in the header (existing components); **division create / rename / delete** inline. Adds `updateDivision` + `deleteDivision` `internalMutation`s — `deleteDivision` **refuses a non-empty division** so no team is orphaned (this also delivers the core of #246 / WSM-000128) — plus org-admin-gated server actions.

## Tests
`divisionCrud.test.ts`: rename, delete-blocks-non-empty (with team-count), delete-empty. New mutations added to the `writeMutationsAreInternal` compile-time guard.

Local gate: type-check ✅ · lint ✅ · 354/354 tests ✅ · build ✅

## Notes
- Team **add** stays in Discover (linked from empty divisions) — that's #251.
- Largely delivers #246 (division CRUD) as a side effect; can close/trim that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)