### PR TITLE
feat(web): team identity — name/mascot, logo, colors (WSM-000134)

### DIFF
--- a/apps/web/convex/__tests__/teamIdentity.test.ts
+++ b/apps/web/convex/__tests__/teamIdentity.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedTeam(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "L",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", { name: "D", leagueId });
+    return ctx.db.insert("teams", {
+      name: "Allatoona",
+      leagueId,
+      divisionId,
+      city: "Acworth",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Acworth",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+  });
+}
+
+describe("team identity (WSM-000134)", () => {
+  it("persists teamName, logoUrl, and colors via updateTeam", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t);
+
+    const dto = await t.mutation(internal.sports.updateTeam, {
+      teamId,
+      teamName: "Buccaneers",
+      logoUrl: "https://example.com/logo.png",
+      primaryColor: "#1e3a8a",
+      secondaryColor: "#fbbf24",
+    });
+
+    expect(dto?.name).toBe("Allatoona");
+    expect(dto?.teamName).toBe("Buccaneers");
+    expect(dto?.logoUrl).toBe("https://example.com/logo.png");
+    expect(dto?.primaryColor).toBe("#1e3a8a");
+    expect(dto?.secondaryColor).toBe("#fbbf24");
+  });
+
+  it("defaults identity fields to null and can clear them", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t);
+
+    // Defaults null on a fresh team.
+    const before = await t.run((ctx) => ctx.db.get(teamId));
+    expect(before?.teamName ?? null).toBeNull();
+
+    // Set then clear.
+    await t.mutation(internal.sports.updateTeam, {
+      teamId,
+      teamName: "Bucs",
+      primaryColor: "#1e3a8a",
+    });
+    const cleared = await t.mutation(internal.sports.updateTeam, {
+      teamId,
+      teamName: null,
+      primaryColor: null,
+      secondaryColor: null,
+    });
+    expect(cleared?.teamName).toBeNull();
+    expect(cleared?.primaryColor).toBeNull();
+  });
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -40,6 +40,13 @@ export default defineSchema({
     location: v.string(),
     logoUrl: v.union(v.string(), v.null()),
     rosterLimit: v.union(v.number(), v.null()),
+    // Team identity (WSM-000134): the team's own name/mascot, distinct from the
+    // school name in `name` (e.g. school "Allatoona", teamName "Buccaneers"),
+    // plus optional brand colors (hex). All optional; absent = fall back to
+    // `name` and a neutral theme.
+    teamName: v.optional(v.union(v.string(), v.null())),
+    primaryColor: v.optional(v.union(v.string(), v.null())),
+    secondaryColor: v.optional(v.union(v.string(), v.null())),
     // Hybrid fork model (WSM-000109): the Clerk org that CLAIMED this team in a
     // claimable league. null/undefined = unclaimed. An admin of this org can
     // edit the team + its roster even though the league itself is shared.

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -56,6 +56,9 @@ function toTeamDto(doc: {
   divisionId: string | null;
   logoUrl: string | null;
   rosterLimit?: number | null;
+  teamName?: string | null;
+  primaryColor?: string | null;
+  secondaryColor?: string | null;
 }) {
   return {
     id: doc._id,
@@ -68,6 +71,9 @@ function toTeamDto(doc: {
     divisionId: doc.divisionId ?? "",
     logoUrl: doc.logoUrl ?? null,
     rosterLimit: doc.rosterLimit ?? null,
+    teamName: doc.teamName ?? null,
+    primaryColor: doc.primaryColor ?? null,
+    secondaryColor: doc.secondaryColor ?? null,
   };
 }
 
@@ -459,6 +465,9 @@ export const listTeams = queryGeneric({
       location: v.string(),
       divisionId: v.string(),
       logoUrl: v.union(v.string(), v.null()),
+      teamName: v.union(v.string(), v.null()),
+      primaryColor: v.union(v.string(), v.null()),
+      secondaryColor: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -488,6 +497,9 @@ export const listTeamsByLeague = queryGeneric({
       location: v.string(),
       divisionId: v.string(),
       logoUrl: v.union(v.string(), v.null()),
+      teamName: v.union(v.string(), v.null()),
+      primaryColor: v.union(v.string(), v.null()),
+      secondaryColor: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -513,6 +525,9 @@ export const getTeam = queryGeneric({
       location: v.string(),
       divisionId: v.string(),
       logoUrl: v.union(v.string(), v.null()),
+      teamName: v.union(v.string(), v.null()),
+      primaryColor: v.union(v.string(), v.null()),
+      secondaryColor: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1044,6 +1059,9 @@ export const upsertTeam = internalMutationGeneric({
       location: v.string(),
       divisionId: v.string(),
       logoUrl: v.union(v.string(), v.null()),
+      teamName: v.union(v.string(), v.null()),
+      primaryColor: v.union(v.string(), v.null()),
+      secondaryColor: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     created: v.boolean(),
@@ -1102,6 +1120,9 @@ export const upsertTeam = internalMutationGeneric({
         divisionId: args.divisionId ?? "",
         logoUrl: args.logoUrl,
         rosterLimit: 53,
+        teamName: null,
+        primaryColor: null,
+        secondaryColor: null,
       },
       created: true,
     };
@@ -1208,6 +1229,9 @@ export const createTeam = internalMutationGeneric({
     location: v.string(),
     divisionId: v.string(),
     logoUrl: v.union(v.string(), v.null()),
+    teamName: v.union(v.string(), v.null()),
+    primaryColor: v.union(v.string(), v.null()),
+    secondaryColor: v.union(v.string(), v.null()),
     rosterLimit: v.union(v.number(), v.null()),
   }),
   handler: async (ctx, args) => {
@@ -1233,6 +1257,9 @@ export const createTeam = internalMutationGeneric({
       divisionId: "",
       logoUrl: null,
       rosterLimit: 53,
+      teamName: null,
+      primaryColor: null,
+      secondaryColor: null,
     };
   },
 });
@@ -1246,6 +1273,10 @@ export const updateTeam = internalMutationGeneric({
     foundedYear: v.optional(v.union(v.number(), v.null())),
     location: v.optional(v.string()),
     divisionId: v.optional(v.id("divisions")),
+    teamName: v.optional(v.union(v.string(), v.null())),
+    logoUrl: v.optional(v.union(v.string(), v.null())),
+    primaryColor: v.optional(v.union(v.string(), v.null())),
+    secondaryColor: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.union(
     v.object({
@@ -1258,6 +1289,9 @@ export const updateTeam = internalMutationGeneric({
       location: v.string(),
       divisionId: v.string(),
       logoUrl: v.union(v.string(), v.null()),
+      teamName: v.union(v.string(), v.null()),
+      primaryColor: v.union(v.string(), v.null()),
+      secondaryColor: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1273,6 +1307,14 @@ export const updateTeam = internalMutationGeneric({
       ...(args.foundedYear !== undefined ? { foundedYear: args.foundedYear } : {}),
       ...(args.location !== undefined ? { location: args.location } : {}),
       ...(args.divisionId !== undefined ? { divisionId: args.divisionId } : {}),
+      ...(args.teamName !== undefined ? { teamName: args.teamName } : {}),
+      ...(args.logoUrl !== undefined ? { logoUrl: args.logoUrl } : {}),
+      ...(args.primaryColor !== undefined
+        ? { primaryColor: args.primaryColor }
+        : {}),
+      ...(args.secondaryColor !== undefined
+        ? { secondaryColor: args.secondaryColor }
+        : {}),
     };
     await ctx.db.patch(args.teamId, patch);
 

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -29,12 +29,23 @@ export default function TeamEditForm({
   onSuccess,
 }: TeamEditFormProps) {
   const [name, setName] = useState(team.name);
+  const [teamName, setTeamName] = useState(team.teamName ?? "");
   const [city, setCity] = useState(team.city);
   const [stadium, setStadium] = useState(team.stadium);
   const [foundedYear, setFoundedYear] = useState(
     team.foundedYear?.toString() ?? "",
   );
   const [location, setLocation] = useState(team.location);
+  const [logoUrl, setLogoUrl] = useState(team.logoUrl ?? "");
+  const [useColors, setUseColors] = useState(
+    team.primaryColor != null || team.secondaryColor != null,
+  );
+  const [primaryColor, setPrimaryColor] = useState(
+    team.primaryColor ?? "#1e293b",
+  );
+  const [secondaryColor, setSecondaryColor] = useState(
+    team.secondaryColor ?? "#64748b",
+  );
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -50,6 +61,10 @@ export default function TeamEditForm({
         stadium,
         foundedYear: foundedYear ? Number(foundedYear) : null,
         location,
+        teamName: teamName.trim() || null,
+        logoUrl: logoUrl.trim() || null,
+        primaryColor: useColors ? primaryColor : null,
+        secondaryColor: useColors ? secondaryColor : null,
       };
 
       const parsed = UpdateTeamInputSchema.safeParse(data);
@@ -98,13 +113,28 @@ export default function TeamEditForm({
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="team-name">Name</Label>
+            <Label htmlFor="team-name">School / Organization name</Label>
             <Input
               id="team-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="team-teamname">Team name / mascot</Label>
+            <Input
+              id="team-teamname"
+              type="text"
+              value={teamName}
+              placeholder="e.g. Buccaneers (optional)"
+              onChange={(e) => setTeamName(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Shown as &ldquo;{name || "School"}
+              {teamName.trim() ? ` — ${teamName.trim()}` : ""}&rdquo;.
+            </p>
           </div>
 
           <div className="space-y-2">
@@ -145,6 +175,57 @@ export default function TeamEditForm({
               value={location}
               onChange={(e) => setLocation(e.target.value)}
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="team-logo">Logo URL</Label>
+            <Input
+              id="team-logo"
+              type="url"
+              inputMode="url"
+              value={logoUrl}
+              placeholder="https://… (optional)"
+              onChange={(e) => setLogoUrl(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <input
+                type="checkbox"
+                checked={useColors}
+                onChange={(e) => setUseColors(e.target.checked)}
+              />
+              Custom team colors
+            </label>
+            {useColors ? (
+              <div className="flex flex-wrap gap-4 pt-1">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="team-primary" className="text-xs">
+                    Primary
+                  </Label>
+                  <input
+                    id="team-primary"
+                    type="color"
+                    value={primaryColor}
+                    onChange={(e) => setPrimaryColor(e.target.value)}
+                    className="h-8 w-12 cursor-pointer rounded border border-input bg-background"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="team-secondary" className="text-xs">
+                    Secondary
+                  </Label>
+                  <input
+                    id="team-secondary"
+                    type="color"
+                    value={secondaryColor}
+                    onChange={(e) => setSecondaryColor(e.target.value)}
+                    className="h-8 w-12 cursor-pointer rounded border border-input bg-background"
+                  />
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="flex justify-end gap-3 pt-2">

--- a/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
@@ -14,7 +14,13 @@ import { CreateDivisionButton, DivisionRowActions } from "./division-controls";
 export interface AccordionDivision {
   id: string;
   name: string;
-  teams: Array<{ id: string; name: string; city: string | null }>;
+  teams: Array<{
+    id: string;
+    name: string;
+    teamName: string | null;
+    city: string | null;
+    logoUrl: string | null;
+  }>;
 }
 
 export function LeaguesAccordion({
@@ -86,11 +92,24 @@ export function LeaguesAccordion({
                           href={`/dashboard/teams/${team.id}?from=leagues`}
                           className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm transition-colors hover:bg-muted"
                         >
-                          <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          {team.logoUrl ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={team.logoUrl}
+                              alt=""
+                              className="h-5 w-5 shrink-0 rounded bg-muted object-contain"
+                            />
+                          ) : (
+                            <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          )}
                           <span className="truncate font-medium text-foreground">
                             {team.name}
                           </span>
-                          {team.city ? (
+                          {team.teamName ? (
+                            <span className="truncate text-muted-foreground">
+                              &mdash; {team.teamName}
+                            </span>
+                          ) : team.city ? (
                             <span className="truncate text-muted-foreground">
                               &mdash; {team.city}
                             </span>

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -54,7 +54,13 @@ export default async function LeaguesPage() {
   const teamsByDivision = new Map<string, AccordionDivision["teams"]>();
   for (const team of teams) {
     const arr = teamsByDivision.get(team.divisionId) ?? [];
-    arr.push({ id: team.id, name: team.name, city: team.city ?? null });
+    arr.push({
+      id: team.id,
+      name: team.name,
+      teamName: team.teamName ?? null,
+      city: team.city ?? null,
+      logoUrl: team.logoUrl ?? null,
+    });
     teamsByDivision.set(team.divisionId, arr);
   }
 

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -18,7 +18,7 @@ import {
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { UserCircle, Pencil, Trash2 } from "lucide-react";
+import { UserCircle, Pencil, Trash2, Shield } from "lucide-react";
 import { toast } from "sonner";
 
 interface TeamManagementProps {
@@ -223,9 +223,55 @@ export default function TeamManagement({
       <Card className="mb-8">
         <CardContent className="pt-6">
           <div className="flex flex-wrap items-start justify-between gap-2">
-            <h2 className="min-w-0 break-words text-2xl font-bold text-foreground">
-              {team.name}
-            </h2>
+            <div className="flex min-w-0 items-center gap-3">
+              {team.logoUrl ? (
+                // Arbitrary user-pasted host; next/image would need an allowlist.
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={team.logoUrl}
+                  alt={`${team.name} logo`}
+                  className="h-12 w-12 shrink-0 rounded-md bg-muted object-contain"
+                />
+              ) : (
+                <div
+                  className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-muted"
+                  style={
+                    team.primaryColor
+                      ? { backgroundColor: team.primaryColor }
+                      : undefined
+                  }
+                >
+                  <Shield className="h-6 w-6 text-muted-foreground" />
+                </div>
+              )}
+              <div className="min-w-0">
+                <h2 className="min-w-0 break-words text-2xl font-bold text-foreground">
+                  {team.name}
+                  {team.teamName ? (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      &mdash; {team.teamName}
+                    </span>
+                  ) : null}
+                </h2>
+                {team.primaryColor || team.secondaryColor ? (
+                  <div className="mt-1 flex gap-1" aria-hidden>
+                    {team.primaryColor ? (
+                      <span
+                        className="h-2 w-8 rounded-full"
+                        style={{ backgroundColor: team.primaryColor }}
+                      />
+                    ) : null}
+                    {team.secondaryColor ? (
+                      <span
+                        className="h-2 w-8 rounded-full"
+                        style={{ backgroundColor: team.secondaryColor }}
+                      />
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            </div>
             {(canManage || canDelete) && (
               <div className="flex shrink-0 flex-wrap gap-2">
                 {canManage && (

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -41,6 +41,9 @@ export const TeamDtoSchema = z.object({
   divisionId: z.string(),
   logoUrl: z.string().nullable(),
   rosterLimit: z.number().nullable(),
+  teamName: z.string().nullable(),
+  primaryColor: z.string().nullable(),
+  secondaryColor: z.string().nullable(),
 }) satisfies z.ZodType<TeamDto>;
 
 export const PlayerDtoSchema = z.object({
@@ -134,6 +137,10 @@ export const UpdatePlayerInputSchema = z.object({
   status: z.string().min(1).optional(),
 }) satisfies z.ZodType<UpdatePlayerInput>;
 
+const hexColor = z
+  .string()
+  .regex(/^#[0-9a-fA-F]{6}$/, "Use a hex color like #1e3a8a");
+
 export const UpdateTeamInputSchema = z.object({
   name: z.string().min(1).optional(),
   city: z.string().min(1).optional(),
@@ -141,6 +148,10 @@ export const UpdateTeamInputSchema = z.object({
   foundedYear: z.number().nullable().optional(),
   location: z.string().min(1).optional(),
   divisionId: z.string().min(1).optional(),
+  teamName: z.string().max(100).nullable().optional(),
+  logoUrl: z.string().url("Enter a valid URL").nullable().optional(),
+  primaryColor: hexColor.nullable().optional(),
+  secondaryColor: hexColor.nullable().optional(),
 }) satisfies z.ZodType<UpdateTeamInput>;
 
 // --- Import schema ---

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -28,6 +28,11 @@ export interface TeamDto {
   divisionId: string;
   logoUrl: string | null;
   rosterLimit: number | null;
+  /** Team's own name/mascot, distinct from the school name in `name`. */
+  teamName: string | null;
+  /** Optional brand colors (hex, e.g. "#1e3a8a"). */
+  primaryColor: string | null;
+  secondaryColor: string | null;
 }
 
 export interface PlayerDto {
@@ -137,6 +142,10 @@ export interface UpdateTeamInput {
   foundedYear?: number | null;
   location?: string;
   divisionId?: string;
+  teamName?: string | null;
+  logoUrl?: string | null;
+  primaryColor?: string | null;
+  secondaryColor?: string | null;
 }
 
 // --- Import types ---


### PR DESCRIPTION
Closes #252

## Problem
`teams.name` doubled as the school name, `logoUrl` was only set via seed/import, and there were no brand colors — so a team's pages couldn't reflect its real identity (e.g. school "Allatoona", team "Buccaneers").

## Data model (additive, backward-compatible)
- `teams` gains optional **`teamName`** (mascot), **`primaryColor`**, **`secondaryColor`**.
- `updateTeam` now also accepts `teamName`, `logoUrl`, `primaryColor`, `secondaryColor`.
- `toTeamDto` + all 6 team return-validators + `TeamDto`/`UpdateTeamInput` (shared-types) + `TeamDtoSchema`/`UpdateTeamInputSchema` (api-contracts, with **hex-color** + **URL** validation) carry the new fields.

## UI
- **TeamEditForm:** team name/mascot field, logo URL, and a "custom team colors" toggle with primary/secondary color pickers.
- **Team page header:** logo (or a neutral shield placeholder), "School — Team Name", and a color-swatch accent.
- **Leagues accordion cards:** show the logo + mascot when set.

## Defaults / a11y
Absent branding falls back to the school name + placeholder (no broken image). Logo is **URL-paste**; file upload (Vercel Blob) is a follow-up per the issue.

## Tests
`teamIdentity.test.ts` — persist + clear identity fields. Gate: type-check ✅ · lint ✅ · 356/356 tests ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)