### PR TITLE
feat(web): jersey picker + team allow-duplicates policy (WSM-000125)

### DIFF
--- a/apps/web/convex/__tests__/jerseyPolicy.test.ts
+++ b/apps/web/convex/__tests__/jerseyPolicy.test.ts
@@ -1,0 +1,205 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/**
+ * Seed a league with one team. `allowDuplicateJerseys` controls the team's
+ * jersey policy (WSM-000125); leave it undefined to exercise the allow-by-
+ * default path.
+ */
+async function seedTeam(
+  t: ReturnType<typeof convexTest>,
+  allowDuplicateJerseys?: boolean,
+): Promise<Id<"teams">> {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Jersey League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "Div 1",
+      leagueId,
+    });
+    return ctx.db.insert("teams", {
+      name: "Team A",
+      leagueId,
+      divisionId,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Loc",
+      logoUrl: null,
+      rosterLimit: 53,
+      ...(allowDuplicateJerseys !== undefined
+        ? { allowDuplicateJerseys }
+        : {}),
+    });
+  });
+}
+
+describe("jersey policy (WSM-000125)", () => {
+  it("defaults allowDuplicateJerseys to true in the team DTO", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t); // no policy set
+    const dto = await t.query(api.sports.getTeam, { teamId });
+    expect(dto?.allowDuplicateJerseys).toBe(true);
+  });
+
+  it("createTeam returns a team that allows duplicates by default", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await t.run((ctx) =>
+      ctx.db.insert("leagues", {
+        name: "L2",
+        orgId: "org_1",
+        isPublic: false,
+        inviteToken: null,
+      }),
+    );
+    const team = await t.mutation(internal.sports.createTeam, {
+      name: "New Team",
+      leagueId,
+      city: "C",
+      stadium: "S",
+    });
+    expect(team.allowDuplicateJerseys).toBe(true);
+  });
+
+  it("updateTeam persists the allowDuplicateJerseys toggle", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t); // default true
+    const off = await t.mutation(internal.sports.updateTeam, {
+      teamId,
+      allowDuplicateJerseys: false,
+    });
+    expect(off?.allowDuplicateJerseys).toBe(false);
+    const on = await t.mutation(internal.sports.updateTeam, {
+      teamId,
+      allowDuplicateJerseys: true,
+    });
+    expect(on?.allowDuplicateJerseys).toBe(true);
+  });
+
+  it("allows a duplicate jersey when policy is ON (default)", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t, true);
+    await t.mutation(internal.sports.createPlayer, {
+      name: "First",
+      teamId,
+      position: "QB",
+      jerseyNumber: 12,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    // Same number, allowed.
+    const second = await t.mutation(internal.sports.createPlayer, {
+      name: "Second",
+      teamId,
+      position: "WR",
+      jerseyNumber: 12,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    expect(second.jerseyNumber).toBe(12);
+  });
+
+  it("blocks a duplicate jersey on createPlayer when policy is OFF", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t, false);
+    await t.mutation(internal.sports.createPlayer, {
+      name: "First",
+      teamId,
+      position: "QB",
+      jerseyNumber: 7,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    await expect(
+      t.mutation(internal.sports.createPlayer, {
+        name: "Second",
+        teamId,
+        position: "RB",
+        jerseyNumber: 7,
+        dateOfBirth: null,
+        status: "Active",
+      }),
+    ).rejects.toThrow(/duplicate_jersey:7/);
+  });
+
+  it("blocks a duplicate jersey on updatePlayer when policy is OFF", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t, false);
+    await t.mutation(internal.sports.createPlayer, {
+      name: "First",
+      teamId,
+      position: "QB",
+      jerseyNumber: 5,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    const second = await t.mutation(internal.sports.createPlayer, {
+      name: "Second",
+      teamId,
+      position: "RB",
+      jerseyNumber: 22,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    await expect(
+      t.mutation(internal.sports.updatePlayer, {
+        playerId: second.id as Id<"players">,
+        jerseyNumber: 5,
+      }),
+    ).rejects.toThrow(/duplicate_jersey:5/);
+  });
+
+  it("lets a player keep its own number on updatePlayer when policy is OFF", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t, false);
+    const player = await t.mutation(internal.sports.createPlayer, {
+      name: "Solo",
+      teamId,
+      position: "QB",
+      jerseyNumber: 9,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    // Re-saving the same number for the same player must not self-conflict.
+    const updated = await t.mutation(internal.sports.updatePlayer, {
+      playerId: player.id as Id<"players">,
+      jerseyNumber: 9,
+      position: "WR",
+    });
+    expect(updated?.jerseyNumber).toBe(9);
+    expect(updated?.position).toBe("WR");
+  });
+
+  it("ignores non-active players when blocking duplicates", async () => {
+    const t = convexTest(schema, modules);
+    const teamId = await seedTeam(t, false);
+    // An inactive player wearing #4 should not block a new active #4.
+    await t.mutation(internal.sports.createPlayer, {
+      name: "Benched",
+      teamId,
+      position: "QB",
+      jerseyNumber: 4,
+      dateOfBirth: null,
+      status: "Inactive",
+    });
+    const active = await t.mutation(internal.sports.createPlayer, {
+      name: "Starter",
+      teamId,
+      position: "QB",
+      jerseyNumber: 4,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    expect(active.jerseyNumber).toBe(4);
+  });
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -54,6 +54,11 @@ export default defineSchema({
     // Org workspace (WSM-000114): a workspace team's link to the reference team
     // it was forked from. Ratings + provenance resolve through it.
     sourceTeamId: v.optional(v.id("teams")),
+    // Jersey policy (WSM-000125): when false, the player create/update mutations
+    // block a jersey number that's already on another active player. When true
+    // or undefined, duplicates are allowed (the historical default) — the UI
+    // still surfaces an inline duplicate alert.
+    allowDuplicateJerseys: v.optional(v.boolean()),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_divisionId", ["divisionId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -59,6 +59,7 @@ function toTeamDto(doc: {
   teamName?: string | null;
   primaryColor?: string | null;
   secondaryColor?: string | null;
+  allowDuplicateJerseys?: boolean;
 }) {
   return {
     id: doc._id,
@@ -74,6 +75,8 @@ function toTeamDto(doc: {
     teamName: doc.teamName ?? null,
     primaryColor: doc.primaryColor ?? null,
     secondaryColor: doc.secondaryColor ?? null,
+    // Default true preserves the historical allow-by-default behavior.
+    allowDuplicateJerseys: doc.allowDuplicateJerseys ?? true,
   };
 }
 
@@ -468,6 +471,7 @@ export const listTeams = queryGeneric({
       teamName: v.union(v.string(), v.null()),
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
+      allowDuplicateJerseys: v.boolean(),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -500,6 +504,7 @@ export const listTeamsByLeague = queryGeneric({
       teamName: v.union(v.string(), v.null()),
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
+      allowDuplicateJerseys: v.boolean(),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -528,6 +533,7 @@ export const getTeam = queryGeneric({
       teamName: v.union(v.string(), v.null()),
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
+      allowDuplicateJerseys: v.boolean(),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1062,6 +1068,7 @@ export const upsertTeam = internalMutationGeneric({
       teamName: v.union(v.string(), v.null()),
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
+      allowDuplicateJerseys: v.boolean(),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     created: v.boolean(),
@@ -1123,6 +1130,7 @@ export const upsertTeam = internalMutationGeneric({
         teamName: null,
         primaryColor: null,
         secondaryColor: null,
+        allowDuplicateJerseys: true,
       },
       created: true,
     };
@@ -1232,6 +1240,7 @@ export const createTeam = internalMutationGeneric({
     teamName: v.union(v.string(), v.null()),
     primaryColor: v.union(v.string(), v.null()),
     secondaryColor: v.union(v.string(), v.null()),
+    allowDuplicateJerseys: v.boolean(),
     rosterLimit: v.union(v.number(), v.null()),
   }),
   handler: async (ctx, args) => {
@@ -1260,6 +1269,7 @@ export const createTeam = internalMutationGeneric({
       teamName: null,
       primaryColor: null,
       secondaryColor: null,
+      allowDuplicateJerseys: true,
     };
   },
 });
@@ -1277,6 +1287,7 @@ export const updateTeam = internalMutationGeneric({
     logoUrl: v.optional(v.union(v.string(), v.null())),
     primaryColor: v.optional(v.union(v.string(), v.null())),
     secondaryColor: v.optional(v.union(v.string(), v.null())),
+    allowDuplicateJerseys: v.optional(v.boolean()),
   },
   returns: v.union(
     v.object({
@@ -1292,6 +1303,7 @@ export const updateTeam = internalMutationGeneric({
       teamName: v.union(v.string(), v.null()),
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
+      allowDuplicateJerseys: v.boolean(),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1315,6 +1327,9 @@ export const updateTeam = internalMutationGeneric({
       ...(args.secondaryColor !== undefined
         ? { secondaryColor: args.secondaryColor }
         : {}),
+      ...(args.allowDuplicateJerseys !== undefined
+        ? { allowDuplicateJerseys: args.allowDuplicateJerseys }
+        : {}),
     };
     await ctx.db.patch(args.teamId, patch);
 
@@ -1324,6 +1339,32 @@ export const updateTeam = internalMutationGeneric({
     });
   },
 });
+
+/*
+ * Jersey policy enforcement (WSM-000125). When a team's `allowDuplicateJerseys`
+ * is false (it defaults to true / undefined), the player create/update mutations
+ * reject a jersey number already worn by another ACTIVE player on the same team.
+ * Returns true if the number is taken (and should be blocked). A null jersey is
+ * never a conflict. `excludePlayerId` skips the player being edited.
+ */
+async function jerseyNumberTakenOnTeam(
+  ctx: MutationCtx,
+  teamId: Id<"teams">,
+  jerseyNumber: number | null,
+  excludePlayerId?: Id<"players">,
+): Promise<boolean> {
+  if (jerseyNumber === null) return false;
+  const roster = await ctx.db
+    .query("players")
+    .withIndex("by_teamId", (q) => q.eq("teamId", teamId))
+    .collect();
+  return roster.some(
+    (p) =>
+      p._id !== excludePlayerId &&
+      p.jerseyNumber === jerseyNumber &&
+      p.status.toLowerCase() === "active",
+  );
+}
 
 export const createPlayer = internalMutationGeneric({
   args: {
@@ -1350,6 +1391,18 @@ export const createPlayer = internalMutationGeneric({
     const team = await ctx.db.get(args.teamId);
     if (!team) {
       throw new Error("Team not found");
+    }
+
+    const allowDuplicates = team.allowDuplicateJerseys ?? true;
+    if (
+      !allowDuplicates &&
+      (await jerseyNumberTakenOnTeam(
+        ctx as MutationCtx,
+        args.teamId,
+        args.jerseyNumber,
+      ))
+    ) {
+      throw new Error(`duplicate_jersey:${args.jerseyNumber}`);
     }
 
     const playerId = await ctx.db.insert("players", {
@@ -1405,12 +1458,35 @@ export const updatePlayer = internalMutationGeneric({
     if (!existing) return null;
 
     let leagueId = existing.leagueId;
+    const targetTeamId = args.teamId ?? existing.teamId;
+    const targetTeam = await ctx.db.get(targetTeamId);
     if (args.teamId !== undefined) {
-      const team = await ctx.db.get(args.teamId);
-      if (!team) {
+      if (!targetTeam) {
         throw new Error("Team not found");
       }
-      leagueId = team.leagueId;
+      leagueId = targetTeam.leagueId;
+    }
+
+    // Jersey policy (WSM-000125): re-check on any jersey or team change.
+    if (
+      (args.jerseyNumber !== undefined || args.teamId !== undefined) &&
+      targetTeam &&
+      !(targetTeam.allowDuplicateJerseys ?? true)
+    ) {
+      const targetJersey =
+        args.jerseyNumber !== undefined
+          ? args.jerseyNumber
+          : existing.jerseyNumber;
+      if (
+        await jerseyNumberTakenOnTeam(
+          ctx as MutationCtx,
+          targetTeamId,
+          targetJersey,
+          existing._id,
+        )
+      ) {
+        throw new Error(`duplicate_jersey:${targetJersey}`);
+      }
     }
 
     const patch = {

--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -59,6 +59,9 @@ const POSITION_OPTIONS = [
   "ATH",
 ];
 
+// Jersey numbers 0–99 (WSM-000125). Picker, not free text.
+const JERSEY_OPTIONS = Array.from({ length: 100 }, (_, n) => n);
+
 interface PlayerFormProps {
   mode: "create" | "edit";
   teamId: string;
@@ -66,6 +69,9 @@ interface PlayerFormProps {
   /** Jersey numbers already on the roster (excluding this player) — for the
       duplicate warning (WSM-000119). Duplicates are allowed (e.g. college). */
   existingJerseyNumbers?: number[];
+  /** Team policy (WSM-000125): when false, a duplicate is blocked server-side,
+      so the inline alert is an error rather than a soft warning. */
+  allowDuplicateJerseys?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
@@ -76,6 +82,7 @@ export default function PlayerForm({
   teamId,
   player,
   existingJerseyNumbers = [],
+  allowDuplicateJerseys = true,
   open,
   onOpenChange,
   onSuccess,
@@ -110,7 +117,10 @@ export default function PlayerForm({
         status,
       };
 
-      if (jerseyTaken) {
+      // When duplicates are allowed, a clash is a soft warning (saved anyway).
+      // When blocked, we still attempt the save — the server returns a 409 that
+      // surfaces below — so we don't pre-empt with a misleading toast.
+      if (jerseyTaken && allowDuplicateJerseys) {
         toast.warning(
           `#${jerseyNumber} is already used on this roster — saved anyway.`,
         );
@@ -210,19 +220,36 @@ export default function PlayerForm({
 
           <div className="space-y-2">
             <Label htmlFor="player-jersey">Jersey Number</Label>
-            <Input
-              id="player-jersey"
-              type="number"
-              min={0}
-              max={99}
-              value={jerseyNumber}
-              onChange={(e) => setJerseyNumber(e.target.value)}
-              aria-invalid={jerseyTaken}
-            />
+            <Select
+              value={jerseyNumber === "" ? "none" : jerseyNumber}
+              onValueChange={(val) =>
+                setJerseyNumber(val === "none" ? "" : val)
+              }
+            >
+              <SelectTrigger id="player-jersey" aria-invalid={jerseyTaken}>
+                <SelectValue placeholder="Select a number" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                {JERSEY_OPTIONS.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             {jerseyTaken && (
-              <p className="text-xs text-yellow-600 dark:text-yellow-500">
-                #{jerseyNumber} is already on this roster — allowed, but it&rsquo;s
-                a duplicate.
+              <p
+                role="alert"
+                className={
+                  allowDuplicateJerseys
+                    ? "text-xs text-yellow-600 dark:text-yellow-500"
+                    : "text-xs text-destructive"
+                }
+              >
+                {allowDuplicateJerseys
+                  ? `#${jerseyNumber} is already on this roster — allowed, but it’s a duplicate.`
+                  : `#${jerseyNumber} is already on this roster. This team blocks duplicate numbers — pick another.`}
               </p>
             )}
           </div>

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -46,6 +46,9 @@ export default function TeamEditForm({
   const [secondaryColor, setSecondaryColor] = useState(
     team.secondaryColor ?? "#64748b",
   );
+  const [allowDuplicateJerseys, setAllowDuplicateJerseys] = useState(
+    team.allowDuplicateJerseys,
+  );
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -65,6 +68,7 @@ export default function TeamEditForm({
         logoUrl: logoUrl.trim() || null,
         primaryColor: useColors ? primaryColor : null,
         secondaryColor: useColors ? secondaryColor : null,
+        allowDuplicateJerseys,
       };
 
       const parsed = UpdateTeamInputSchema.safeParse(data);
@@ -226,6 +230,22 @@ export default function TeamEditForm({
                 </div>
               </div>
             ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <input
+                type="checkbox"
+                checked={allowDuplicateJerseys}
+                onChange={(e) => setAllowDuplicateJerseys(e.target.checked)}
+              />
+              Allow duplicate jersey numbers
+            </label>
+            <p className="text-xs text-muted-foreground">
+              {allowDuplicateJerseys
+                ? "Players may share a number — duplicates are flagged but allowed."
+                : "Saving a number already on the roster is blocked."}
+            </p>
           </div>
 
           <div className="flex justify-end gap-3 pt-2">

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -428,6 +428,7 @@ export default function TeamManagement({
         existingJerseyNumbers={players
           .map((p) => p.jerseyNumber)
           .filter((n): n is number => n != null)}
+        allowDuplicateJerseys={team.allowDuplicateJerseys}
         open={modal.type === "addPlayer"}
         onOpenChange={(open) => !open && setModal({ type: "none" })}
         onSuccess={handleSuccess}
@@ -442,6 +443,7 @@ export default function TeamManagement({
             .filter((p) => p.id !== modal.player.id)
             .map((p) => p.jerseyNumber)
             .filter((n): n is number => n != null)}
+          allowDuplicateJerseys={team.allowDuplicateJerseys}
           open
           onOpenChange={(open) => !open && setModal({ type: "none" })}
           onSuccess={handleSuccess}

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -44,6 +44,17 @@ export function classifyError(error: unknown): ClassifiedError {
 
   const message = error instanceof Error ? error.message : String(error);
 
+  // Jersey policy (WSM-000125): the player create/update mutations throw
+  // `duplicate_jersey:<n>` when a team disallows duplicates and the chosen
+  // number is already worn. Surface a clear 409 the form can show inline.
+  const jerseyMatch = message.match(/duplicate_jersey:(\d+)/);
+  if (jerseyMatch) {
+    return {
+      statusCode: 409,
+      userMessage: `Jersey #${jerseyMatch[1]} is already taken on this roster. This team blocks duplicate numbers.`,
+    };
+  }
+
   if (SF_CONNECTION_PATTERNS.some((p) => message.includes(p))) {
     return { statusCode: 503, userMessage: "Service temporarily unavailable" };
   }

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -44,6 +44,7 @@ export const TeamDtoSchema = z.object({
   teamName: z.string().nullable(),
   primaryColor: z.string().nullable(),
   secondaryColor: z.string().nullable(),
+  allowDuplicateJerseys: z.boolean(),
 }) satisfies z.ZodType<TeamDto>;
 
 export const PlayerDtoSchema = z.object({
@@ -152,6 +153,7 @@ export const UpdateTeamInputSchema = z.object({
   logoUrl: z.string().url("Enter a valid URL").nullable().optional(),
   primaryColor: hexColor.nullable().optional(),
   secondaryColor: hexColor.nullable().optional(),
+  allowDuplicateJerseys: z.boolean().optional(),
 }) satisfies z.ZodType<UpdateTeamInput>;
 
 // --- Import schema ---

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -33,6 +33,12 @@ export interface TeamDto {
   /** Optional brand colors (hex, e.g. "#1e3a8a"). */
   primaryColor: string | null;
   secondaryColor: string | null;
+  /**
+   * Jersey policy (WSM-000125): when false, the server blocks duplicate jersey
+   * numbers on the roster. When true (the default), duplicates are allowed and
+   * only surfaced as an inline alert.
+   */
+  allowDuplicateJerseys: boolean;
 }
 
 export interface PlayerDto {
@@ -146,6 +152,7 @@ export interface UpdateTeamInput {
   logoUrl?: string | null;
   primaryColor?: string | null;
   secondaryColor?: string | null;
+  allowDuplicateJerseys?: boolean;
 }
 
 // --- Import types ---


### PR DESCRIPTION
## Story
Closes #243 — [WSM-000125] Jersey number picker + team-level allow-duplicates setting.

Jersey numbers are chosen from a 0–99 picker (select) with an inline duplicate alert, plus a per-team `allowDuplicateJerseys` policy that controls whether duplicate numbers are blocked server-side.

## Acceptance
1. ✅ Add/Edit Player form: jersey number is a 0–99 `<select>` picker (with a "None" option), not free text.
2. ✅ Selecting a number already on the roster shows a clear inline duplicate alert (soft warning when duplicates allowed; error styling when blocked).
3. ✅ Team admins can toggle "Allow duplicate jersey numbers" in team settings. When OFF, saving a duplicate is blocked server-side (409 with a clear message). When ON (default), duplicates are allowed (alert only — preserves current behavior).

## Changes
- **schema** (`apps/web/convex/schema.ts`): `teams.allowDuplicateJerseys: v.optional(v.boolean())`. Undefined = allow (historical default).
- **convex** (`apps/web/convex/sports.ts`): `toTeamDto` coalesces `?? true`; all 6 team return-validators + inline DTO returns include `allowDuplicateJerseys`; `updateTeam` accepts the toggle; new `jerseyNumberTakenOnTeam` helper; `createPlayer`/`updatePlayer` enforce the policy for active players (throw `duplicate_jersey:<n>`).
- **shared-types / api-contracts**: `allowDuplicateJerseys` added to `TeamDto`/`TeamDtoSchema` (boolean) and `UpdateTeamInput`/`UpdateTeamInputSchema` (optional boolean).
- **api-error**: `duplicate_jersey:<n>` classified as a 409 with a clear inline message.
- **UI**: jersey 0–99 select picker + inline alert (`player-form.tsx`); team settings toggle (`team-edit-form.tsx`); policy threaded from `team-management.tsx`.
- **tests**: `apps/web/convex/__tests__/jerseyPolicy.test.ts` — blocked when OFF (create + update), allowed when ON, DTO default, self-edit not blocked, non-active ignored.

## Gate
- `turbo type-check` ✅ (includes the `writeMutationsAreInternal` compile-time guard — all new/changed writes remain `internalMutation`)
- `turbo lint` ✅ (no new warnings)
- web `vitest run` ✅ 364 tests (8 new)
- `turbo build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)