### PR TITLE
feat(web): hierarchical Discover add-by-division/conference (WSM-000133)

### DIFF
--- a/apps/web/convex/__tests__/forkHierarchy.test.ts
+++ b/apps/web/convex/__tests__/forkHierarchy.test.ts
@@ -1,0 +1,249 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ORG = "org_coach";
+
+/**
+ * Seed a forkable reference league (public + claimable) with a conference
+ * containing two divisions, each with two teams (and one player apiece). Returns
+ * the ids the fork tests need.
+ */
+async function seedReferenceLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Reference League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+      claimable: true,
+    });
+    const conferenceId = await ctx.db.insert("conferences", {
+      name: "Conference A",
+      leagueId,
+    });
+    const divisionIds: Id<"divisions">[] = [];
+    const teamIds: Id<"teams">[] = [];
+    for (let d = 0; d < 2; d++) {
+      const divisionId = await ctx.db.insert("divisions", {
+        name: `Division ${d}`,
+        leagueId,
+        conferenceId,
+      });
+      divisionIds.push(divisionId);
+      for (let i = 0; i < 2; i++) {
+        const teamId = await ctx.db.insert("teams", {
+          name: `Team ${d}-${i}`,
+          leagueId,
+          divisionId,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Loc",
+          logoUrl: null,
+          rosterLimit: 53,
+        });
+        teamIds.push(teamId);
+        await ctx.db.insert("players", {
+          name: `Player ${d}-${i}`,
+          leagueId,
+          teamId,
+          position: "QB",
+          positionGroup: null,
+          jerseyNumber: 1,
+          dateOfBirth: null,
+          status: "active",
+          headshotUrl: null,
+        });
+      }
+    }
+    return { leagueId, conferenceId, divisionIds, teamIds };
+  });
+}
+
+async function workspaceTeamCount(
+  t: ReturnType<typeof convexTest>,
+  orgId: string,
+): Promise<number> {
+  return t.run(async (ctx: MutationCtx) => {
+    const leagues = await ctx.db
+      .query("leagues")
+      .withIndex("by_orgId", (q) => q.eq("orgId", orgId))
+      .collect();
+    let count = 0;
+    for (const l of leagues) {
+      const teams = await ctx.db
+        .query("teams")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", l._id))
+        .collect();
+      count += teams.length;
+    }
+    return count;
+  });
+}
+
+describe("hierarchical Discover fork (WSM-000133)", () => {
+  it("forks every team in a division in one action", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionIds } = await seedReferenceLeague(t);
+
+    const res = await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+
+    expect(res.totalTeams).toBe(2);
+    expect(res.forkedTeams).toBe(2);
+    expect(res.alreadyForked).toBe(0);
+    expect(await workspaceTeamCount(t, ORG)).toBe(2);
+  });
+
+  it("mirrors the conference + division hierarchy into the workspace", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionIds } = await seedReferenceLeague(t);
+
+    await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+
+    await t.run(async (ctx) => {
+      const league = (
+        await ctx.db
+          .query("leagues")
+          .withIndex("by_orgId", (q) => q.eq("orgId", ORG))
+          .collect()
+      )[0];
+      const conferences = await ctx.db
+        .query("conferences")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", league._id))
+        .collect();
+      expect(conferences).toHaveLength(1);
+      expect(conferences[0].name).toBe("Conference A");
+      expect(conferences[0].sourceConferenceId).toBeTruthy();
+
+      const divisions = await ctx.db
+        .query("divisions")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", league._id))
+        .collect();
+      expect(divisions).toHaveLength(1);
+      expect(divisions[0].conferenceId).toBe(conferences[0]._id);
+    });
+  });
+
+  it("is idempotent — re-running a division fork adds nothing new", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionIds } = await seedReferenceLeague(t);
+
+    await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+    const second = await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+
+    expect(second.forkedTeams).toBe(0);
+    expect(second.alreadyForked).toBe(2);
+    expect(await workspaceTeamCount(t, ORG)).toBe(2);
+  });
+
+  it("partial: a division fork adds only the teams not already forked", async () => {
+    const t = convexTest(schema, modules);
+    const { divisionIds, teamIds } = await seedReferenceLeague(t);
+
+    // Pre-fork ONE team in division 0 individually.
+    await t.mutation(internal.sports.forkTeamToWorkspace, {
+      orgId: ORG,
+      sourceTeamId: teamIds[0],
+    });
+    expect(await workspaceTeamCount(t, ORG)).toBe(1);
+
+    const res = await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+
+    expect(res.totalTeams).toBe(2);
+    expect(res.forkedTeams).toBe(1); // only the remaining team
+    expect(res.alreadyForked).toBe(1);
+    expect(await workspaceTeamCount(t, ORG)).toBe(2);
+  });
+
+  it("conference fork cascades over all divisions/teams under it", async () => {
+    const t = convexTest(schema, modules);
+    const { conferenceId } = await seedReferenceLeague(t);
+
+    const res = await t.mutation(internal.sports.forkConferenceToWorkspace, {
+      orgId: ORG,
+      conferenceId,
+    });
+
+    expect(res.totalTeams).toBe(4);
+    expect(res.forkedTeams).toBe(4);
+    expect(res.alreadyForked).toBe(0);
+    expect(await workspaceTeamCount(t, ORG)).toBe(4);
+  });
+
+  it("conference fork is idempotent and reports partials", async () => {
+    const t = convexTest(schema, modules);
+    const { conferenceId, divisionIds } = await seedReferenceLeague(t);
+
+    // Add one division first, then the whole conference.
+    await t.mutation(internal.sports.forkDivisionToWorkspace, {
+      orgId: ORG,
+      divisionId: divisionIds[0],
+    });
+    const res = await t.mutation(internal.sports.forkConferenceToWorkspace, {
+      orgId: ORG,
+      conferenceId,
+    });
+
+    expect(res.totalTeams).toBe(4);
+    expect(res.forkedTeams).toBe(2); // the other division's teams
+    expect(res.alreadyForked).toBe(2);
+    expect(await workspaceTeamCount(t, ORG)).toBe(4);
+  });
+
+  it("refuses to fork a non-forkable (private) league's division", async () => {
+    const t = convexTest(schema, modules);
+    const divisionId = await t.run(async (ctx) => {
+      const leagueId = await ctx.db.insert("leagues", {
+        name: "Private",
+        orgId: "org_other",
+        isPublic: false,
+        inviteToken: null,
+      });
+      const divisionId = await ctx.db.insert("divisions", {
+        name: "Div",
+        leagueId,
+      });
+      await ctx.db.insert("teams", {
+        name: "T",
+        leagueId,
+        divisionId,
+        city: "C",
+        stadium: "S",
+        foundedYear: null,
+        location: "L",
+        logoUrl: null,
+        rosterLimit: null,
+      });
+      return divisionId;
+    });
+
+    await expect(
+      t.mutation(internal.sports.forkDivisionToWorkspace, {
+        orgId: ORG,
+        divisionId,
+      }),
+    ).rejects.toThrow(/not forkable/);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -40,6 +40,9 @@ void internal.sports.deleteDivision;
 void internal.sports.setLeaguePublic;
 void internal.sports.recordGameResult;
 void internal.sports.assignPlayerToRoster;
+void internal.sports.forkTeamToWorkspace;
+void internal.sports.forkDivisionToWorkspace;
+void internal.sports.forkConferenceToWorkspace;
 
 // --- Writes MUST NOT be on the public API (each access must be a type error) ---
 // @ts-expect-error createTeam is internal, not public
@@ -56,9 +59,14 @@ void api.sports.clearSeasonPlayerAttributes;
 void api.sports.ingestMaddenRatingsBatch;
 // @ts-expect-error setOrgMemberRole is internal, not public
 void api.sports.setOrgMemberRole;
+// @ts-expect-error forkDivisionToWorkspace is internal, not public
+void api.sports.forkDivisionToWorkspace;
+// @ts-expect-error forkConferenceToWorkspace is internal, not public
+void api.sports.forkConferenceToWorkspace;
 
 // --- Public READ queries must remain public (these must exist on api) ---
 void api.sports.listTeams;
+void api.sports.listConferences;
 void api.sports.getPlayer;
 void api.sports.listPublicLeagues;
 void api.sports.computeStandingsPublic;

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -23,12 +23,31 @@ export default defineSchema({
     .index("by_isPublic", ["isPublic"])
     .index("by_inviteToken", ["inviteToken"]),
 
-  divisions: defineTable({
+  /*
+   * Hierarchy level above divisions (WSM-000133). A reference league can group
+   * its divisions under conferences (e.g. NFL's AFC/NFC). Optional: leagues with
+   * a flat division list simply have no conference rows. Mirrors `divisions`
+   * (leagueId + name), plus `sourceConferenceId` so a workspace fork can point
+   * back at the reference conference it mirrored.
+   */
+  conferences: defineTable({
     name: v.string(),
     leagueId: v.id("leagues"),
+    sourceConferenceId: v.optional(v.id("conferences")),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_leagueId_name", ["leagueId", "name"]),
+
+  divisions: defineTable({
+    name: v.string(),
+    leagueId: v.id("leagues"),
+    // Optional parent conference (WSM-000133). Absent = the division sits
+    // directly under the league (flat hierarchy, backward-compatible).
+    conferenceId: v.optional(v.id("conferences")),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_leagueId_name", ["leagueId", "name"])
+    .index("by_conferenceId", ["conferenceId"]),
 
   teams: defineTable({
     name: v.string(),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -33,7 +33,7 @@ function toLeagueDto(doc: {
   };
 }
 
-function toDivisionDto(doc: {
+function toConferenceDto(doc: {
   _id: string;
   name: string;
   leagueId: string;
@@ -42,6 +42,20 @@ function toDivisionDto(doc: {
     id: doc._id,
     name: doc.name,
     leagueId: doc.leagueId,
+  };
+}
+
+function toDivisionDto(doc: {
+  _id: string;
+  name: string;
+  leagueId: string;
+  conferenceId?: string | null;
+}) {
+  return {
+    id: doc._id,
+    name: doc.name,
+    leagueId: doc.leagueId,
+    conferenceId: doc.conferenceId ?? null,
   };
 }
 
@@ -421,6 +435,7 @@ export const listDivisions = queryGeneric({
       id: v.string(),
       name: v.string(),
       leagueId: v.string(),
+      conferenceId: v.union(v.string(), v.null()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -443,12 +458,36 @@ export const getDivision = queryGeneric({
       id: v.string(),
       name: v.string(),
       leagueId: v.string(),
+      conferenceId: v.union(v.string(), v.null()),
     }),
     v.null(),
   ),
   handler: async (ctx, args) => {
     const doc = await ctx.db.get(args.divisionId);
     return doc ? toDivisionDto(doc) : null;
+  },
+});
+
+/** Conferences for one or more leagues (WSM-000133). */
+export const listConferences = queryGeneric({
+  args: { leagueIds: v.array(v.id("leagues")) },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const docs = await Promise.all(
+      args.leagueIds.map((leagueId) =>
+        ctx.db
+          .query("conferences")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+          .collect(),
+      ),
+    );
+    return sortByName(uniqueById(docs.flat().map(toConferenceDto)));
   },
 });
 
@@ -974,12 +1013,14 @@ export const upsertDivision = internalMutationGeneric({
   args: {
     name: v.string(),
     leagueId: v.id("leagues"),
+    conferenceId: v.optional(v.id("conferences")),
   },
   returns: v.object({
     dto: v.object({
       id: v.string(),
       name: v.string(),
       leagueId: v.string(),
+      conferenceId: v.union(v.string(), v.null()),
     }),
     created: v.boolean(),
   }),
@@ -996,9 +1037,18 @@ export const upsertDivision = internalMutationGeneric({
       return { dto: toDivisionDto(existing), created: false };
     }
 
-    const divisionId = await ctx.db.insert("divisions", args);
+    const divisionId = await ctx.db.insert("divisions", {
+      name: args.name,
+      leagueId: args.leagueId,
+      ...(args.conferenceId ? { conferenceId: args.conferenceId } : {}),
+    });
     return {
-      dto: { id: divisionId, name: args.name, leagueId: args.leagueId },
+      dto: {
+        id: divisionId,
+        name: args.name,
+        leagueId: args.leagueId,
+        conferenceId: args.conferenceId ?? null,
+      },
       created: true,
     };
   },
@@ -1008,7 +1058,12 @@ export const upsertDivision = internalMutationGeneric({
 export const updateDivision = internalMutationGeneric({
   args: { divisionId: v.id("divisions"), name: v.string() },
   returns: v.union(
-    v.object({ id: v.string(), name: v.string(), leagueId: v.string() }),
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      leagueId: v.string(),
+      conferenceId: v.union(v.string(), v.null()),
+    }),
     v.null(),
   ),
   handler: async (ctx, args) => {
@@ -1728,6 +1783,174 @@ export const setLeagueInviteToken = internalMutationGeneric({
  * provenance resolve back to the reference. This replaces the shared-edit
  * claimTeam path under the private-only workspace model (RFC §11).
  */
+/**
+ * Get-or-create the org's PRIVATE workspace league mirroring `refLeague`.
+ * Shared by the single-team and batch (division/conference) fork paths so the
+ * idempotent "one workspace league per reference league per org" rule holds.
+ */
+async function ensureWorkspaceLeague(
+  ctx: MutationCtx,
+  orgId: string,
+  refLeague: { _id: Id<"leagues">; name: string },
+): Promise<Id<"leagues">> {
+  const existing =
+    (
+      await ctx.db
+        .query("leagues")
+        .withIndex("by_orgId", (q) => q.eq("orgId", orgId))
+        .collect()
+    ).find((l) => l.sourceLeagueId === refLeague._id) ?? null;
+  if (existing) return existing._id;
+  return ctx.db.insert("leagues", {
+    name: refLeague.name,
+    orgId,
+    isPublic: false,
+    inviteToken: null,
+    sourceLeagueId: refLeague._id,
+  });
+}
+
+/**
+ * Mirror a reference conference into the workspace (by name), get-or-create.
+ * Returns the workspace conference id, or null when the reference team/division
+ * has no conference. Keeps the workspace hierarchy parallel to the reference.
+ */
+async function ensureWorkspaceConference(
+  ctx: MutationCtx,
+  workspaceLeagueId: Id<"leagues">,
+  refConferenceId: Id<"conferences"> | null | undefined,
+): Promise<Id<"conferences"> | null> {
+  if (!refConferenceId) return null;
+  const refConf = await ctx.db.get(refConferenceId);
+  if (!refConf) return null;
+  const existingConf =
+    (
+      await ctx.db
+        .query("conferences")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", workspaceLeagueId))
+        .collect()
+    ).find((c) => c.name === refConf.name) ?? null;
+  if (existingConf) return existingConf._id;
+  return ctx.db.insert("conferences", {
+    name: refConf.name,
+    leagueId: workspaceLeagueId,
+    sourceConferenceId: refConf._id,
+  });
+}
+
+/**
+ * Mirror a reference division into the workspace (by name), get-or-create,
+ * carrying its conference link. Returns null when the team has no division.
+ */
+async function ensureWorkspaceDivision(
+  ctx: MutationCtx,
+  workspaceLeagueId: Id<"leagues">,
+  refDivisionId: Id<"divisions"> | null | undefined,
+): Promise<Id<"divisions"> | null> {
+  if (!refDivisionId) return null;
+  const refDiv = await ctx.db.get(refDivisionId);
+  if (!refDiv) return null;
+  const existingDiv =
+    (
+      await ctx.db
+        .query("divisions")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", workspaceLeagueId))
+        .collect()
+    ).find((d) => d.name === refDiv.name) ?? null;
+  if (existingDiv) return existingDiv._id;
+  const workspaceConferenceId = await ensureWorkspaceConference(
+    ctx,
+    workspaceLeagueId,
+    refDiv.conferenceId,
+  );
+  return ctx.db.insert("divisions", {
+    name: refDiv.name,
+    leagueId: workspaceLeagueId,
+    ...(workspaceConferenceId ? { conferenceId: workspaceConferenceId } : {}),
+  });
+}
+
+/**
+ * Fork a single reference team (+ roster) into an already-resolved workspace
+ * league. Idempotent per (workspace league, source team). The reference league
+ * forkability check is the CALLER's responsibility. Returns the workspace team
+ * id and whether it was newly created (false = already forked).
+ */
+async function forkOneTeamInto(
+  ctx: MutationCtx,
+  orgId: string,
+  workspaceLeagueId: Id<"leagues">,
+  sourceTeamId: Id<"teams">,
+): Promise<{ teamId: Id<"teams">; created: boolean }> {
+  const refTeam = await ctx.db.get(sourceTeamId);
+  if (!refTeam) throw new Error("Source team not found");
+
+  const existing =
+    (
+      await ctx.db
+        .query("teams")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", workspaceLeagueId))
+        .collect()
+    ).find((t) => t.sourceTeamId === sourceTeamId) ?? null;
+  if (existing) return { teamId: existing._id, created: false };
+
+  const workspaceDivisionId = await ensureWorkspaceDivision(
+    ctx,
+    workspaceLeagueId,
+    refTeam.divisionId,
+  );
+
+  const newTeamId = await ctx.db.insert("teams", {
+    name: refTeam.name,
+    leagueId: workspaceLeagueId,
+    divisionId: workspaceDivisionId,
+    city: refTeam.city,
+    stadium: refTeam.stadium,
+    foundedYear: refTeam.foundedYear,
+    location: refTeam.location,
+    logoUrl: refTeam.logoUrl,
+    rosterLimit: refTeam.rosterLimit,
+    ownerOrgId: orgId,
+    sourceTeamId: sourceTeamId,
+  });
+
+  const refPlayers = await ctx.db
+    .query("players")
+    .withIndex("by_teamId", (q) => q.eq("teamId", sourceTeamId))
+    .collect();
+  for (const p of refPlayers) {
+    await ctx.db.insert("players", {
+      name: p.name,
+      leagueId: workspaceLeagueId,
+      teamId: newTeamId,
+      position: p.position,
+      positionGroup: p.positionGroup,
+      jerseyNumber: p.jerseyNumber,
+      dateOfBirth: p.dateOfBirth,
+      status: p.status,
+      headshotUrl: p.headshotUrl,
+      experienceYears: p.experienceYears,
+      sourcePlayerId: p._id,
+    });
+  }
+
+  return { teamId: newTeamId, created: true };
+}
+
+/** Reference league a team can be forked from, or throw if not forkable. */
+async function requireForkableLeague(
+  ctx: MutationCtx,
+  refLeagueId: Id<"leagues">,
+): Promise<{ _id: Id<"leagues">; name: string }> {
+  const refLeague = await ctx.db.get(refLeagueId);
+  // Forkable = a public reference league we've marked claimable (the curated
+  // "discovery data we allow"). Workspace leagues (private) aren't forkable.
+  if (!refLeague || !refLeague.isPublic || !refLeague.claimable) {
+    throw new Error("Team is not forkable");
+  }
+  return { _id: refLeague._id, name: refLeague.name };
+}
+
 export const forkTeamToWorkspace = internalMutationGeneric({
   args: { orgId: v.string(), sourceTeamId: v.id("teams") },
   returns: v.object({
@@ -1738,112 +1961,134 @@ export const forkTeamToWorkspace = internalMutationGeneric({
   handler: async (ctx, args) => {
     const refTeam = await ctx.db.get(args.sourceTeamId);
     if (!refTeam) throw new Error("Source team not found");
-    const refLeague = await ctx.db.get(refTeam.leagueId);
-    // Forkable = a public reference league we've marked claimable (the curated
-    // "discovery data we allow"). Workspace leagues (private) aren't forkable.
-    if (!refLeague || !refLeague.isPublic || !refLeague.claimable) {
-      throw new Error("Team is not forkable");
-    }
+    const refLeague = await requireForkableLeague(ctx, refTeam.leagueId);
+    const workspaceLeagueId = await ensureWorkspaceLeague(
+      ctx,
+      args.orgId,
+      refLeague,
+    );
+    const { teamId, created } = await forkOneTeamInto(
+      ctx,
+      args.orgId,
+      workspaceLeagueId,
+      args.sourceTeamId,
+    );
+    return {
+      teamId: teamId as string,
+      leagueId: workspaceLeagueId as string,
+      created,
+    };
+  },
+});
 
-    // Get-or-create the org's workspace league for this reference league.
-    let workspaceLeague =
-      (
-        await ctx.db
-          .query("leagues")
-          .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))
-          .collect()
-      ).find((l) => l.sourceLeagueId === refLeague._id) ?? null;
-    if (!workspaceLeague) {
-      const id = await ctx.db.insert("leagues", {
-        name: refLeague.name,
-        orgId: args.orgId,
-        isPublic: false,
-        inviteToken: null,
-        sourceLeagueId: refLeague._id,
-      });
-      workspaceLeague = await ctx.db.get(id);
-    }
-    const workspaceLeagueId = workspaceLeague!._id;
+/**
+ * À la carte by division (WSM-000133): fork EVERY team in a reference division
+ * into the org's workspace in one idempotent action. Already-forked teams are
+ * skipped (no duplicates), so re-running over a partially-added division adds
+ * only the remaining teams. Returns per-division counts the UI uses to render
+ * added/partial/all state.
+ */
+export const forkDivisionToWorkspace = internalMutationGeneric({
+  args: { orgId: v.string(), divisionId: v.id("divisions") },
+  returns: v.object({
+    leagueId: v.string(),
+    totalTeams: v.number(),
+    forkedTeams: v.number(),
+    alreadyForked: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const refDiv = await ctx.db.get(args.divisionId);
+    if (!refDiv) throw new Error("Source division not found");
+    const refLeague = await requireForkableLeague(ctx, refDiv.leagueId);
+    const workspaceLeagueId = await ensureWorkspaceLeague(
+      ctx,
+      args.orgId,
+      refLeague,
+    );
 
-    // Idempotent: already forked this team into the workspace?
-    const existing =
-      (
-        await ctx.db
-          .query("teams")
-          .withIndex("by_leagueId", (q) =>
-            q.eq("leagueId", workspaceLeagueId),
-          )
-          .collect()
-      ).find((t) => t.sourceTeamId === args.sourceTeamId) ?? null;
-    if (existing) {
-      return {
-        teamId: existing._id as string,
-        leagueId: workspaceLeagueId as string,
-        created: false,
-      };
-    }
-
-    // Mirror the team's division into the workspace (by name).
-    let workspaceDivisionId: Id<"divisions"> | null = null;
-    if (refTeam.divisionId) {
-      const refDiv = await ctx.db.get(refTeam.divisionId);
-      if (refDiv) {
-        const existingDiv =
-          (
-            await ctx.db
-              .query("divisions")
-              .withIndex("by_leagueId", (q) =>
-                q.eq("leagueId", workspaceLeagueId),
-              )
-              .collect()
-          ).find((d) => d.name === refDiv.name) ?? null;
-        workspaceDivisionId = existingDiv
-          ? existingDiv._id
-          : await ctx.db.insert("divisions", {
-              name: refDiv.name,
-              leagueId: workspaceLeagueId,
-            });
-      }
-    }
-
-    const newTeamId = await ctx.db.insert("teams", {
-      name: refTeam.name,
-      leagueId: workspaceLeagueId,
-      divisionId: workspaceDivisionId,
-      city: refTeam.city,
-      stadium: refTeam.stadium,
-      foundedYear: refTeam.foundedYear,
-      location: refTeam.location,
-      logoUrl: refTeam.logoUrl,
-      rosterLimit: refTeam.rosterLimit,
-      ownerOrgId: args.orgId,
-      sourceTeamId: args.sourceTeamId,
-    });
-
-    const refPlayers = await ctx.db
-      .query("players")
-      .withIndex("by_teamId", (q) => q.eq("teamId", args.sourceTeamId))
+    const refTeams = await ctx.db
+      .query("teams")
+      .withIndex("by_divisionId", (q) => q.eq("divisionId", args.divisionId))
       .collect();
-    for (const p of refPlayers) {
-      await ctx.db.insert("players", {
-        name: p.name,
-        leagueId: workspaceLeagueId,
-        teamId: newTeamId,
-        position: p.position,
-        positionGroup: p.positionGroup,
-        jerseyNumber: p.jerseyNumber,
-        dateOfBirth: p.dateOfBirth,
-        status: p.status,
-        headshotUrl: p.headshotUrl,
-        experienceYears: p.experienceYears,
-        sourcePlayerId: p._id,
-      });
+
+    let forkedTeams = 0;
+    let alreadyForked = 0;
+    for (const t of refTeams) {
+      const { created } = await forkOneTeamInto(
+        ctx,
+        args.orgId,
+        workspaceLeagueId,
+        t._id,
+      );
+      if (created) forkedTeams += 1;
+      else alreadyForked += 1;
     }
 
     return {
-      teamId: newTeamId as string,
       leagueId: workspaceLeagueId as string,
-      created: true,
+      totalTeams: refTeams.length,
+      forkedTeams,
+      alreadyForked,
+    };
+  },
+});
+
+/**
+ * À la carte by conference (WSM-000133, optimal AC): fork every team in every
+ * division under a reference conference. Idempotent — already-forked teams are
+ * skipped. Returns aggregate counts across all the conference's divisions.
+ */
+export const forkConferenceToWorkspace = internalMutationGeneric({
+  args: { orgId: v.string(), conferenceId: v.id("conferences") },
+  returns: v.object({
+    leagueId: v.string(),
+    totalTeams: v.number(),
+    forkedTeams: v.number(),
+    alreadyForked: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const refConf = await ctx.db.get(args.conferenceId);
+    if (!refConf) throw new Error("Source conference not found");
+    const refLeague = await requireForkableLeague(ctx, refConf.leagueId);
+    const workspaceLeagueId = await ensureWorkspaceLeague(
+      ctx,
+      args.orgId,
+      refLeague,
+    );
+
+    const divisions = await ctx.db
+      .query("divisions")
+      .withIndex("by_conferenceId", (q) =>
+        q.eq("conferenceId", args.conferenceId),
+      )
+      .collect();
+
+    let totalTeams = 0;
+    let forkedTeams = 0;
+    let alreadyForked = 0;
+    for (const div of divisions) {
+      const refTeams = await ctx.db
+        .query("teams")
+        .withIndex("by_divisionId", (q) => q.eq("divisionId", div._id))
+        .collect();
+      totalTeams += refTeams.length;
+      for (const t of refTeams) {
+        const { created } = await forkOneTeamInto(
+          ctx,
+          args.orgId,
+          workspaceLeagueId,
+          t._id,
+        );
+        if (created) forkedTeams += 1;
+        else alreadyForked += 1;
+      }
+    }
+
+    return {
+      leagueId: workspaceLeagueId as string,
+      totalTeams,
+      forkedTeams,
+      alreadyForked,
     };
   },
 });

--- a/apps/web/src/app/api/conferences/[id]/fork/route.ts
+++ b/apps/web/src/app/api/conferences/[id]/fork/route.ts
@@ -1,18 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { forkTeamToWorkspace } from "@/lib/data-api";
+import { forkConferenceToWorkspace } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 import { resolveForkTargetOrg } from "@/lib/fork-target-org";
 
 /**
- * Add a team to the caller's org — forking it into their PRIVATE workspace
- * (WSM-000110/111/115). Resolves an org the user admins, never making them set
- * one up first:
- *   1. the active org, if they admin it; else
- *   2. any org they already admin; else
- *   3. a freshly created org (they become its admin) — org-on-claim onboarding.
- * Then forks the reference team (+ roster) into that org's workspace and returns
- * the workspace team to redirect to (the editable copy).
+ * Add a whole conference to the caller's workspace (WSM-000133, optimal AC) —
+ * fork every team in every division under the reference conference, in one
+ * idempotent action. Org resolution + idempotency mirror the division route.
  */
 export async function POST(
   request: NextRequest,
@@ -24,9 +19,9 @@ export async function POST(
   }
 
   try {
-    const { id: teamId } = await params;
+    const { id: conferenceId } = await params;
     const body = await request.json().catch(() => ({}));
-    const teamName =
+    const orgName =
       typeof body?.teamName === "string" && body.teamName.trim()
         ? body.teamName.trim()
         : "My Team";
@@ -35,30 +30,26 @@ export async function POST(
       userId,
       orgId,
       orgRole,
-      newOrgName: teamName,
+      newOrgName: orgName,
     });
 
-    // targetOrgId is always an org this user admins (active/found/just-created),
-    // so fork directly into it. Fork = a private editable copy of the team.
-    const {
-      teamId: workspaceTeamId,
-      leagueId,
-      created,
-    } = await forkTeamToWorkspace(targetOrgId, teamId);
+    const { leagueId, totalTeams, forkedTeams, alreadyForked } =
+      await forkConferenceToWorkspace(targetOrgId, conferenceId);
 
     return NextResponse.json({
       message: "Added",
-      teamId: workspaceTeamId,
       leagueId,
       orgId: targetOrgId,
       createdOrg,
-      created,
+      totalTeams,
+      forkedTeams,
+      alreadyForked,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     if (msg.includes("not forkable")) {
       return NextResponse.json({ error: msg }, { status: 409 });
     }
-    return handleApiError(error, "/api/teams/[id]/claim");
+    return handleApiError(error, "/api/conferences/[id]/fork");
   }
 }

--- a/apps/web/src/app/api/divisions/[id]/fork/route.ts
+++ b/apps/web/src/app/api/divisions/[id]/fork/route.ts
@@ -1,18 +1,15 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { forkTeamToWorkspace } from "@/lib/data-api";
+import { forkDivisionToWorkspace } from "@/lib/data-api";
 import { handleApiError } from "@/lib/api-error";
 import { resolveForkTargetOrg } from "@/lib/fork-target-org";
 
 /**
- * Add a team to the caller's org — forking it into their PRIVATE workspace
- * (WSM-000110/111/115). Resolves an org the user admins, never making them set
- * one up first:
- *   1. the active org, if they admin it; else
- *   2. any org they already admin; else
- *   3. a freshly created org (they become its admin) — org-on-claim onboarding.
- * Then forks the reference team (+ roster) into that org's workspace and returns
- * the workspace team to redirect to (the editable copy).
+ * Add a whole division to the caller's workspace (WSM-000133) — fork EVERY team
+ * in the reference division into their PRIVATE workspace in one idempotent
+ * action. Resolves the target org exactly like per-team claim (active admin org,
+ * else any admin org, else org-on-claim). Already-forked teams are skipped, so
+ * re-running over a partially-added division adds only the remaining teams.
  */
 export async function POST(
   request: NextRequest,
@@ -24,9 +21,9 @@ export async function POST(
   }
 
   try {
-    const { id: teamId } = await params;
+    const { id: divisionId } = await params;
     const body = await request.json().catch(() => ({}));
-    const teamName =
+    const orgName =
       typeof body?.teamName === "string" && body.teamName.trim()
         ? body.teamName.trim()
         : "My Team";
@@ -35,30 +32,26 @@ export async function POST(
       userId,
       orgId,
       orgRole,
-      newOrgName: teamName,
+      newOrgName: orgName,
     });
 
-    // targetOrgId is always an org this user admins (active/found/just-created),
-    // so fork directly into it. Fork = a private editable copy of the team.
-    const {
-      teamId: workspaceTeamId,
-      leagueId,
-      created,
-    } = await forkTeamToWorkspace(targetOrgId, teamId);
+    const { leagueId, totalTeams, forkedTeams, alreadyForked } =
+      await forkDivisionToWorkspace(targetOrgId, divisionId);
 
     return NextResponse.json({
       message: "Added",
-      teamId: workspaceTeamId,
       leagueId,
       orgId: targetOrgId,
       createdOrg,
-      created,
+      totalTeams,
+      forkedTeams,
+      alreadyForked,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     if (msg.includes("not forkable")) {
       return NextResponse.json({ error: msg }, { status: 409 });
     }
-    return handleApiError(error, "/api/teams/[id]/claim");
+    return handleApiError(error, "/api/divisions/[id]/fork");
   }
 }

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -8,18 +8,48 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
-import { Trophy, CheckCircle2, Plus } from "lucide-react";
+import { Trophy, CheckCircle2, Plus, Layers } from "lucide-react";
 
 export interface DiscoverLeague {
   id: string;
   name: string;
   /** Whether teams in this (reference) league can be forked into a workspace. */
   forkable: boolean;
-  divisions: { id: string; name: string }[];
+  /** Top-tier grouping (WSM-000133), where the league has one. */
+  conferences: { id: string; name: string }[];
+  divisions: { id: string; name: string; conferenceId: string | null }[];
   teams: { id: string; name: string; divisionId: string; added: boolean }[];
+}
+
+interface DivisionGroup {
+  id: string;
+  name: string;
+  teams: DiscoverLeague["teams"];
+}
+
+interface ConferenceGroup {
+  id: string;
+  name: string;
+  divisions: DivisionGroup[];
+}
+
+/** Aggregate added/total over a list of teams → "all" | "partial" | "none". */
+type AddState = "all" | "partial" | "none";
+function addState(teams: { id: string }[], added: Set<string>): AddState {
+  if (teams.length === 0) return "none";
+  const have = teams.filter((t) => added.has(t.id)).length;
+  if (have === 0) return "none";
+  if (have === teams.length) return "all";
+  return "partial";
 }
 
 export default function DiscoverLeagues({
@@ -45,45 +75,89 @@ export default function DiscoverLeagues({
 
 function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
   const router = useRouter();
-  const { divisions, teams } = league;
+  const { conferences, divisions, teams } = league;
   // Local "added" overlay so the UI updates without a full refetch.
   const [added, setAdded] = useState<Set<string>>(
     () => new Set(teams.filter((t) => t.added).map((t) => t.id)),
   );
+  // What's currently being added — a team id, "div:<id>", "conf:<id>", or "all".
   const [busy, setBusy] = useState<string | null>(null);
-  const [bulk, setBulk] = useState(false);
 
-  const groups = useMemo(() => {
-    const byDivision = new Map<string, typeof teams>();
+  // Build the conference → division → team hierarchy. Divisions without a
+  // conference (or leagues with no conferences at all) fall under a synthetic
+  // "Divisions" group so the tree stays uniform.
+  const { conferenceGroups, looseDivisions } = useMemo(() => {
+    const teamsByDivision = new Map<string, DiscoverLeague["teams"]>();
     for (const team of teams) {
-      const list = byDivision.get(team.divisionId) ?? [];
+      const list = teamsByDivision.get(team.divisionId) ?? [];
       list.push(team);
-      byDivision.set(team.divisionId, list);
+      teamsByDivision.set(team.divisionId, list);
     }
-    const named = divisions
-      .map((d) => ({ id: d.id, name: d.name, teams: byDivision.get(d.id) ?? [] }))
-      .filter((g) => g.teams.length > 0);
-    const known = new Set(divisions.map((d) => d.id));
-    const other = teams.filter((t) => !known.has(t.divisionId));
-    if (other.length) named.push({ id: "__other", name: "Other", teams: other });
-    return named;
-  }, [divisions, teams]);
 
-  async function addTeam(teamId: string, teamName: string): Promise<boolean> {
-    const res = await fetch(`/api/teams/${teamId}/claim`, { method: "POST" });
+    const knownDivisionIds = new Set(divisions.map((d) => d.id));
+    const toDivisionGroup = (d: {
+      id: string;
+      name: string;
+    }): DivisionGroup => ({
+      id: d.id,
+      name: d.name,
+      teams: teamsByDivision.get(d.id) ?? [],
+    });
+
+    const divisionsByConference = new Map<string, DivisionGroup[]>();
+    const loose: DivisionGroup[] = [];
+    for (const d of divisions) {
+      const group = toDivisionGroup(d);
+      if (group.teams.length === 0) continue;
+      if (d.conferenceId) {
+        const list = divisionsByConference.get(d.conferenceId) ?? [];
+        list.push(group);
+        divisionsByConference.set(d.conferenceId, list);
+      } else {
+        loose.push(group);
+      }
+    }
+
+    // Teams whose division isn't in the divisions list → "Other".
+    const orphanTeams = teams.filter((t) => !knownDivisionIds.has(t.divisionId));
+    if (orphanTeams.length) {
+      loose.push({ id: "__other", name: "Other", teams: orphanTeams });
+    }
+
+    const confGroups: ConferenceGroup[] = conferences
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        divisions: divisionsByConference.get(c.id) ?? [],
+      }))
+      .filter((c) => c.divisions.length > 0);
+
+    return { conferenceGroups: confGroups, looseDivisions: loose };
+  }, [conferences, divisions, teams]);
+
+  async function postFork(
+    url: string,
+    teamIds: string[],
+    label: string,
+  ): Promise<boolean> {
+    const res = await fetch(url, { method: "POST" });
     const body = await res.json().catch(() => ({}));
     if (res.ok) {
-      setAdded((prev) => new Set(prev).add(teamId));
+      setAdded((prev) => {
+        const next = new Set(prev);
+        for (const id of teamIds) next.add(id);
+        return next;
+      });
       return true;
     }
-    toast.error(body.error ?? `Could not add ${teamName}.`);
+    toast.error(body.error ?? `Could not add ${label}.`);
     return false;
   }
 
-  async function onAddOne(teamId: string, teamName: string) {
+  async function onAddTeam(teamId: string, teamName: string) {
     setBusy(teamId);
     try {
-      if (await addTeam(teamId, teamName)) {
+      if (await postFork(`/api/teams/${teamId}/claim`, [teamId], teamName)) {
         toast.success(`Added ${teamName} to your teams.`);
         router.refresh();
       }
@@ -92,22 +166,82 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
     }
   }
 
+  async function onAddDivision(group: DivisionGroup) {
+    const remaining = group.teams.filter((t) => !added.has(t.id));
+    if (remaining.length === 0) return;
+    // The "Other" bucket isn't a real division — fall back to per-team forks.
+    setBusy(`div:${group.id}`);
+    try {
+      let ok: boolean;
+      if (group.id === "__other") {
+        ok = true;
+        for (const t of remaining) {
+          ok =
+            (await postFork(`/api/teams/${t.id}/claim`, [t.id], t.name)) && ok;
+        }
+      } else {
+        ok = await postFork(
+          `/api/divisions/${group.id}/fork`,
+          remaining.map((t) => t.id),
+          group.name,
+        );
+      }
+      if (ok) {
+        toast.success(
+          `Added ${remaining.length} team${
+            remaining.length === 1 ? "" : "s"
+          } from ${group.name}.`,
+        );
+        router.refresh();
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onAddConference(conf: ConferenceGroup) {
+    const teamIds = conf.divisions.flatMap((d) => d.teams.map((t) => t.id));
+    const remaining = teamIds.filter((id) => !added.has(id));
+    if (remaining.length === 0) return;
+    setBusy(`conf:${conf.id}`);
+    try {
+      if (
+        await postFork(
+          `/api/conferences/${conf.id}/fork`,
+          remaining,
+          conf.name,
+        )
+      ) {
+        toast.success(
+          `Added ${remaining.length} team${
+            remaining.length === 1 ? "" : "s"
+          } from ${conf.name}.`,
+        );
+        router.refresh();
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function onAddAll() {
-    setBulk(true);
+    const remaining = league.teams.filter((t) => !added.has(t.id));
+    if (remaining.length === 0) return;
+    setBusy("all");
     try {
       let n = 0;
-      for (const t of league.teams) {
-        if (added.has(t.id)) continue;
-        if (await addTeam(t.id, t.name)) n += 1;
+      for (const t of remaining) {
+        if (await postFork(`/api/teams/${t.id}/claim`, [t.id], t.name)) n += 1;
       }
       if (n) toast.success(`Added ${n} team${n === 1 ? "" : "s"} to your teams.`);
       router.refresh();
     } finally {
-      setBulk(false);
+      setBusy(null);
     }
   }
 
-  const remaining = league.teams.filter((t) => !added.has(t.id)).length;
+  const remainingAll = league.teams.filter((t) => !added.has(t.id)).length;
+  const anyBusy = busy !== null;
 
   return (
     <Card>
@@ -118,9 +252,14 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
             <CardTitle className="text-base">{league.name}</CardTitle>
             <Badge variant="outline">Public</Badge>
           </div>
-          {league.forkable && remaining > 0 && (
-            <Button size="sm" variant="outline" disabled={bulk} onClick={onAddAll}>
-              {bulk ? "Adding…" : `Add all (${remaining})`}
+          {league.forkable && remainingAll > 0 && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={anyBusy}
+              onClick={onAddAll}
+            >
+              {busy === "all" ? "Adding…" : `Add all (${remainingAll})`}
             </Button>
           )}
         </div>
@@ -131,49 +270,200 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
             This league isn&rsquo;t available to add yet.
           </p>
         ) : (
-          <div className="space-y-4">
-            {groups.map((group) => (
-              <div key={group.id}>
-                <p className="mb-2 text-sm font-medium text-foreground">
-                  {group.name}
-                </p>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                  {group.teams.map((team) => {
-                    const isAdded = added.has(team.id);
-                    return (
-                      <div
-                        key={team.id}
-                        className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm"
-                      >
-                        <span className="truncate font-medium text-foreground">
-                          {team.name}
-                        </span>
-                        {isAdded ? (
-                          <span className="flex shrink-0 items-center gap-1 text-xs text-green-500">
-                            <CheckCircle2 className="h-3.5 w-3.5" />
-                            Added
-                          </span>
-                        ) : (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="h-7 shrink-0 px-2"
-                            disabled={busy === team.id || bulk}
-                            onClick={() => onAddOne(team.id, team.name)}
-                          >
-                            <Plus className="mr-1 h-3.5 w-3.5" />
-                            {busy === team.id ? "…" : "Add"}
-                          </Button>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
+          <div className="space-y-2">
+            {conferenceGroups.map((conf) => (
+              <ConferenceSection
+                key={conf.id}
+                conference={conf}
+                added={added}
+                busy={busy}
+                anyBusy={anyBusy}
+                onAddConference={onAddConference}
+                onAddDivision={onAddDivision}
+                onAddTeam={onAddTeam}
+              />
             ))}
+            {looseDivisions.length > 0 && (
+              <Accordion type="multiple" className="w-full">
+                {looseDivisions.map((group) => (
+                  <DivisionSection
+                    key={group.id}
+                    group={group}
+                    added={added}
+                    busy={busy}
+                    anyBusy={anyBusy}
+                    onAddDivision={onAddDivision}
+                    onAddTeam={onAddTeam}
+                  />
+                ))}
+              </Accordion>
+            )}
           </div>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function StateBadge({ state }: { state: AddState }) {
+  if (state === "all") {
+    return (
+      <span className="flex shrink-0 items-center gap-1 text-xs text-green-500">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        All added
+      </span>
+    );
+  }
+  if (state === "partial") {
+    return (
+      <Badge variant="secondary" className="shrink-0 text-xs">
+        Partial
+      </Badge>
+    );
+  }
+  return null;
+}
+
+function ConferenceSection({
+  conference,
+  added,
+  busy,
+  anyBusy,
+  onAddConference,
+  onAddDivision,
+  onAddTeam,
+}: {
+  conference: ConferenceGroup;
+  added: Set<string>;
+  busy: string | null;
+  anyBusy: boolean;
+  onAddConference: (conf: ConferenceGroup) => void;
+  onAddDivision: (group: DivisionGroup) => void;
+  onAddTeam: (teamId: string, teamName: string) => void;
+}) {
+  const allTeams = conference.divisions.flatMap((d) => d.teams);
+  const state = addState(allTeams, added);
+  const remaining = allTeams.filter((t) => !added.has(t.id)).length;
+  return (
+    <Accordion type="multiple" className="w-full">
+      <AccordionItem value={conference.id}>
+        <AccordionTrigger>
+          <span className="flex flex-1 items-center gap-2">
+            <Layers className="h-4 w-4 text-primary" />
+            <span className="font-semibold">{conference.name}</span>
+            <StateBadge state={state} />
+          </span>
+        </AccordionTrigger>
+        <AccordionContent>
+          <div className="mb-3 flex justify-end">
+            {state === "all" ? null : (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={anyBusy}
+                onClick={() => onAddConference(conference)}
+              >
+                {busy === `conf:${conference.id}`
+                  ? "Adding…"
+                  : `Add conference (${remaining})`}
+              </Button>
+            )}
+          </div>
+          <Accordion type="multiple" className="w-full pl-2">
+            {conference.divisions.map((group) => (
+              <DivisionSection
+                key={group.id}
+                group={group}
+                added={added}
+                busy={busy}
+                anyBusy={anyBusy}
+                onAddDivision={onAddDivision}
+                onAddTeam={onAddTeam}
+              />
+            ))}
+          </Accordion>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}
+
+function DivisionSection({
+  group,
+  added,
+  busy,
+  anyBusy,
+  onAddDivision,
+  onAddTeam,
+}: {
+  group: DivisionGroup;
+  added: Set<string>;
+  busy: string | null;
+  anyBusy: boolean;
+  onAddDivision: (group: DivisionGroup) => void;
+  onAddTeam: (teamId: string, teamName: string) => void;
+}) {
+  const state = addState(group.teams, added);
+  const remaining = group.teams.filter((t) => !added.has(t.id)).length;
+  return (
+    <AccordionItem value={group.id}>
+      <AccordionTrigger>
+        <span className="flex flex-1 items-center gap-2">
+          <span className="font-medium">{group.name}</span>
+          <span className="text-xs text-muted-foreground">
+            ({group.teams.length})
+          </span>
+          <StateBadge state={state} />
+        </span>
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="mb-3 flex justify-end">
+          {state === "all" ? null : (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={anyBusy}
+              onClick={() => onAddDivision(group)}
+            >
+              {busy === `div:${group.id}`
+                ? "Adding…"
+                : `Add division (${remaining})`}
+            </Button>
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {group.teams.map((team) => {
+            const isAdded = added.has(team.id);
+            return (
+              <div
+                key={team.id}
+                className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm"
+              >
+                <span className="truncate font-medium text-foreground">
+                  {team.name}
+                </span>
+                {isAdded ? (
+                  <span className="flex shrink-0 items-center gap-1 text-xs text-green-500">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    Added
+                  </span>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 shrink-0 px-2"
+                    disabled={anyBusy}
+                    onClick={() => onAddTeam(team.id, team.name)}
+                  >
+                    <Plus className="mr-1 h-3.5 w-3.5" />
+                    {busy === team.id ? "…" : "Add"}
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
   );
 }

--- a/apps/web/src/app/dashboard/discover/page.tsx
+++ b/apps/web/src/app/dashboard/discover/page.tsx
@@ -31,13 +31,16 @@ export default async function DiscoverPage() {
   ]);
   const forked = new Set(forkedIds);
 
-  // Discover is a catalog of reference leagues you fork teams from (WSM-000117).
+  // Discover is a catalog of reference leagues you fork teams from
+  // (WSM-000117). WSM-000133 surfaces the conference → division → team hierarchy
+  // so coaches can add whole groups, not just individual teams.
   const leagues: DiscoverLeague[] = await Promise.all(
     publicLeagues.map(async (league) => {
-      const [{ teams, divisions }, forkable] = await Promise.all([
+      const [{ teams, divisions, conferences }, forkable] = await Promise.all([
         getPublicLeagueImportTree(league.id).catch(() => ({
           teams: [],
           divisions: [],
+          conferences: [],
         })),
         getLeagueClaimable(league.id).catch(() => false),
       ]);
@@ -45,7 +48,12 @@ export default async function DiscoverPage() {
         id: league.id,
         name: league.name,
         forkable,
-        divisions: divisions.map((d) => ({ id: d.id, name: d.name })),
+        conferences: conferences.map((c) => ({ id: c.id, name: c.name })),
+        divisions: divisions.map((d) => ({
+          id: d.id,
+          name: d.name,
+          conferenceId: d.conferenceId,
+        })),
         teams: teams.map((t) => ({
           id: t.id,
           name: t.name,

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -1,5 +1,6 @@
 import { makeFunctionReference } from "convex/server";
 import type {
+  ConferenceDto,
   CreatePlayerInput,
   CreateTeamInput,
   DepthChartEntryDto,
@@ -98,6 +99,9 @@ const refs = {
   getDivision: queryRef<{ divisionId: string }, DivisionDto | null>(
     "sports:getDivision",
   ),
+  listConferences: queryRef<{ leagueIds: string[] }, ConferenceDto[]>(
+    "sports:listConferences",
+  ),
   listTeams: queryRef<{ leagueIds: string[] }, TeamDto[]>("sports:listTeams"),
   listTeamsByLeague: queryRef<{ leagueId: string }, TeamDto[]>(
     "sports:listTeamsByLeague",
@@ -113,6 +117,24 @@ const refs = {
     { orgId: string; sourceTeamId: string },
     { teamId: string; leagueId: string; created: boolean }
   >("sports:forkTeamToWorkspace"),
+  forkDivisionToWorkspace: mutationRef<
+    { orgId: string; divisionId: string },
+    {
+      leagueId: string;
+      totalTeams: number;
+      forkedTeams: number;
+      alreadyForked: number;
+    }
+  >("sports:forkDivisionToWorkspace"),
+  forkConferenceToWorkspace: mutationRef<
+    { orgId: string; conferenceId: string },
+    {
+      leagueId: string;
+      totalTeams: number;
+      forkedTeams: number;
+      alreadyForked: number;
+    }
+  >("sports:forkConferenceToWorkspace"),
   getOrgForkedSourceTeamIds: queryRef<{ orgId: string }, string[]>(
     "sports:getOrgForkedSourceTeamIds",
   ),
@@ -512,18 +534,22 @@ export async function getPublicLeagues(): Promise<LeagueDto[]> {
 }
 
 /**
- * Teams + divisions for a PUBLIC league's à la carte import tree (WSM-000100).
- * The league id must come from getPublicLeagues — public leagues are browseable
- * for import, so there's no org-access gate here.
+ * Teams + divisions + conferences for a PUBLIC league's à la carte import tree
+ * (WSM-000100 / WSM-000133). The league id must come from getPublicLeagues —
+ * public leagues are browseable for import, so there's no org-access gate here.
+ * Conferences (where present) form the top tier of the discover hierarchy.
  */
-export async function getPublicLeagueImportTree(
-  leagueId: string,
-): Promise<{ teams: TeamDto[]; divisions: DivisionDto[] }> {
-  const [teams, divisions] = await Promise.all([
+export async function getPublicLeagueImportTree(leagueId: string): Promise<{
+  teams: TeamDto[];
+  divisions: DivisionDto[];
+  conferences: ConferenceDto[];
+}> {
+  const [teams, divisions, conferences] = await Promise.all([
     queryConvex(refs.listTeamsByLeague, { leagueId }),
     queryConvex(refs.listDivisions, { leagueIds: [leagueId] }),
+    queryConvex(refs.listConferences, { leagueIds: [leagueId] }),
   ]);
-  return { teams, divisions };
+  return { teams, divisions, conferences };
 }
 
 export async function getLeagueByInviteToken(
@@ -695,6 +721,38 @@ export async function forkTeamToWorkspace(
   sourceTeamId: string,
 ): Promise<{ teamId: string; leagueId: string; created: boolean }> {
   return mutateConvex(refs.forkTeamToWorkspace, { orgId, sourceTeamId });
+}
+
+/**
+ * WSM-000133: fork EVERY team in a reference division into the org's workspace
+ * in one idempotent batch. Raw wrapper — caller MUST verify org admin first.
+ */
+export async function forkDivisionToWorkspace(
+  orgId: string,
+  divisionId: string,
+): Promise<{
+  leagueId: string;
+  totalTeams: number;
+  forkedTeams: number;
+  alreadyForked: number;
+}> {
+  return mutateConvex(refs.forkDivisionToWorkspace, { orgId, divisionId });
+}
+
+/**
+ * WSM-000133: fork every team under a reference conference (all its divisions)
+ * into the org's workspace, idempotently. Raw wrapper — verify org admin first.
+ */
+export async function forkConferenceToWorkspace(
+  orgId: string,
+  conferenceId: string,
+): Promise<{
+  leagueId: string;
+  totalTeams: number;
+  forkedTeams: number;
+  alreadyForked: number;
+}> {
+  return mutateConvex(refs.forkConferenceToWorkspace, { orgId, conferenceId });
 }
 
 /** WSM-000117: reference team ids the org has already forked (for Discover). */

--- a/apps/web/src/lib/fork-target-org.ts
+++ b/apps/web/src/lib/fork-target-org.ts
@@ -1,0 +1,40 @@
+import { clerkClient } from "@clerk/nextjs/server";
+
+/**
+ * Resolve the org a fork should land in (WSM-000110/111/115/133), never making
+ * the coach set one up first:
+ *   1. the active org, if they admin it; else
+ *   2. any org they already admin; else
+ *   3. a freshly created org (they become its admin) — org-on-claim onboarding.
+ * Returns the target org id and whether one was created. Shared by the per-team
+ * claim route and the batch division/conference fork routes so org resolution
+ * (and the org-on-claim path) stays identical across à la carte granularities.
+ */
+export async function resolveForkTargetOrg(params: {
+  userId: string;
+  orgId: string | null | undefined;
+  orgRole: string | null | undefined;
+  newOrgName: string;
+}): Promise<{ targetOrgId: string; createdOrg: boolean }> {
+  const { userId, orgId, orgRole, newOrgName } = params;
+
+  if (orgId && orgRole === "org:admin") {
+    return { targetOrgId: orgId, createdOrg: false };
+  }
+
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
+  const adminMembership = memberships.data.find((m) => m.role === "org:admin");
+  if (adminMembership) {
+    return { targetOrgId: adminMembership.organization.id, createdOrg: false };
+  }
+
+  // Org-on-claim: stand up the coach's organization behind the scenes.
+  const org = await client.organizations.createOrganization({
+    name: newOrgName,
+    createdBy: userId,
+  });
+  return { targetOrgId: org.id, createdOrg: true };
+}

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type {
   ApiResponse,
   LeagueDto,
+  ConferenceDto,
   DivisionDto,
   TeamDto,
   PlayerDto,
@@ -24,10 +25,17 @@ export const LeagueDtoSchema = z.object({
   orgId: z.string().nullable(),
 }) satisfies z.ZodType<LeagueDto>;
 
+export const ConferenceDtoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  leagueId: z.string(),
+}) satisfies z.ZodType<ConferenceDto>;
+
 export const DivisionDtoSchema = z.object({
   id: z.string(),
   name: z.string(),
   leagueId: z.string(),
+  conferenceId: z.string().nullable(),
 }) satisfies z.ZodType<DivisionDto>;
 
 export const TeamDtoSchema = z.object({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -11,10 +11,18 @@ export interface LeagueDto {
   orgId: string | null;
 }
 
+export interface ConferenceDto {
+  id: string;
+  name: string;
+  leagueId: string;
+}
+
 export interface DivisionDto {
   id: string;
   name: string;
   leagueId: string;
+  /** Parent conference (WSM-000133), or null when the division is top-level. */
+  conferenceId: string | null;
 }
 
 export interface TeamDto {


### PR DESCRIPTION
Closes #251 — [WSM-000133] Discover: hierarchical à la carte (add by division/conference, not just per team)

## What
Discover now drills down a real **conference → division → team** hierarchy as an expandable tree (shadcn `Accordion`) instead of a flat list, and lets a coach fork whole groups in one idempotent action.

## Acceptance criteria
1. ✅ Hierarchical drill-down — teams nested under division (and conference where present) as an expandable tree.
2. ✅ Add a whole division — `forkDivisionToWorkspace` forks every team in the division in one idempotent action; row reflects added/partial/all.
3. ✅ Add a whole conference (optimal) — `forkConferenceToWorkspace` cascades over all divisions/teams.
4. ✅ Mixed/partial state — partial indicator + add-only-remaining (idempotent batch skips already-forked teams).

## Changes
- **Schema**: new `conferences` table (`leagueId`, `name`, `sourceConferenceId`) + `divisions.conferenceId` (optional) + `by_conferenceId` index.
- **Convex** (`sports.ts`): `listConferences` query; `forkDivisionToWorkspace` / `forkConferenceToWorkspace` internal batch mutations; `forkTeamToWorkspace` refactored over shared helpers that mirror the conference hierarchy into the workspace; division DTO/validators carry `conferenceId`.
- **DTOs**: `ConferenceDto` + `ConferenceDtoSchema`; `conferenceId` on `DivisionDto` / `DivisionDtoSchema`.
- **Web**: import tree includes conferences; new `/api/divisions/[id]/fork` and `/api/conferences/[id]/fork` routes (shared `resolveForkTargetOrg` org-resolution helper, also adopted by the existing claim route); accordion tree UI with Add division / Add conference + added/partial/all badges; per-team add preserved.
- **Tests**: `forkHierarchy.test.ts` (whole-division/conference forks, idempotency, partial state, forkability guard); `writeMutationsAreInternal` guard extended.

## Gate
- `@sports-management/api-contracts` build ✅
- `web type-check` ✅
- `web lint` ✅ (only pre-existing unrelated warning)
- `web test` — 53 files / 363 tests ✅
- `web build` ✅ (new routes present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)