### PR TITLE
feat(web): Discover remove / un-add a forked team (WSM-000129)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -43,6 +43,7 @@ void internal.sports.assignPlayerToRoster;
 void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;
 void internal.sports.forkConferenceToWorkspace;
+void internal.sports.unforkTeamFromWorkspace;
 
 // --- Writes MUST NOT be on the public API (each access must be a type error) ---
 // @ts-expect-error createTeam is internal, not public
@@ -63,6 +64,8 @@ void api.sports.setOrgMemberRole;
 void api.sports.forkDivisionToWorkspace;
 // @ts-expect-error forkConferenceToWorkspace is internal, not public
 void api.sports.forkConferenceToWorkspace;
+// @ts-expect-error unforkTeamFromWorkspace is internal, not public
+void api.sports.unforkTeamFromWorkspace;
 
 // --- Public READ queries must remain public (these must exist on api) ---
 void api.sports.listTeams;

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2058,6 +2058,39 @@ export const forkTeamToWorkspace = internalMutationGeneric({
 });
 
 /**
+ * Reverse of forkTeamToWorkspace (WSM-000129): un-add a team by deleting the
+ * org's PRIVATE workspace fork of a reference team. Scans the org's workspace
+ * leagues for the fork whose `sourceTeamId` matches and purges it (roster +
+ * dependents, via purgeTeam). Idempotent — `removed: false` when the org holds
+ * no fork of that source team. Admin authorization is the caller's job (the
+ * /unclaim route resolves the org from the caller's admin memberships, and
+ * forks only ever live in orgs the caller admins).
+ */
+export const unforkTeamFromWorkspace = internalMutationGeneric({
+  args: { orgId: v.string(), sourceTeamId: v.id("teams") },
+  returns: v.object({ removed: v.boolean() }),
+  handler: async (ctx, args) => {
+    const workspaceLeagues = await ctx.db
+      .query("leagues")
+      .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))
+      .collect();
+    for (const league of workspaceLeagues) {
+      const fork = (
+        await ctx.db
+          .query("teams")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", league._id))
+          .collect()
+      ).find((t) => t.sourceTeamId === args.sourceTeamId);
+      if (fork) {
+        await purgeTeam(ctx, fork._id);
+        return { removed: true };
+      }
+    }
+    return { removed: false };
+  },
+});
+
+/**
  * À la carte by division (WSM-000133): fork EVERY team in a reference division
  * into the org's workspace in one idempotent action. Already-forked teams are
  * skipped (no duplicates), so re-running over a partially-added division adds

--- a/apps/web/src/app/api/teams/[id]/unclaim/route.ts
+++ b/apps/web/src/app/api/teams/[id]/unclaim/route.ts
@@ -1,0 +1,50 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { unforkTeamFromWorkspace } from "@/lib/data-api";
+import { handleApiError } from "@/lib/api-error";
+
+/**
+ * Remove a team the caller previously added — the reverse of /claim
+ * (WSM-000129). Deletes the caller's PRIVATE workspace fork of the reference
+ * team (the editable copy + its roster). Resolves the SAME org Discover uses to
+ * mark teams "Added" (active org, else first admin org) so what's shown as added
+ * and what gets removed always agree; never creates an org. The fork only lives
+ * in orgs the caller admins, so this is implicitly admin-scoped. Idempotent —
+ * `removed: false` when no fork is found.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { id: sourceTeamId } = await params;
+
+    let forkOrgId: string | null = orgId ?? null;
+    if (!forkOrgId) {
+      const client = await clerkClient();
+      const memberships = await client.users.getOrganizationMembershipList({
+        userId,
+      });
+      forkOrgId =
+        memberships.data.find((m) => m.role === "org:admin")?.organization.id ??
+        null;
+    }
+
+    if (!forkOrgId) {
+      return NextResponse.json({ message: "Not added", removed: false });
+    }
+
+    const { removed } = await unforkTeamFromWorkspace(forkOrgId, sourceTeamId);
+    return NextResponse.json({
+      message: removed ? "Removed" : "Not added",
+      removed,
+    });
+  } catch (error) {
+    return handleApiError(error, "/api/teams/[id]/unclaim");
+  }
+}

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -16,8 +16,9 @@ import {
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import DeleteConfirm from "@/app/dashboard/_components/delete-confirm";
 import { toast } from "sonner";
-import { Trophy, CheckCircle2, Plus, Layers } from "lucide-react";
+import { Trophy, CheckCircle2, Plus, Layers, X } from "lucide-react";
 
 export interface DiscoverLeague {
   id: string;
@@ -82,6 +83,11 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
   );
   // What's currently being added — a team id, "div:<id>", "conf:<id>", or "all".
   const [busy, setBusy] = useState<string | null>(null);
+  // The team pending removal confirmation (un-add deletes the private fork).
+  const [confirmRemove, setConfirmRemove] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   // Build the conference → division → team hierarchy. Divisions without a
   // conference (or leagues with no conferences at all) fall under a synthetic
@@ -163,6 +169,35 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
       }
     } finally {
       setBusy(null);
+    }
+  }
+
+  // Un-add: open the confirm dialog (removal deletes the private fork + roster).
+  function onRemoveTeam(teamId: string, teamName: string) {
+    setConfirmRemove({ id: teamId, name: teamName });
+  }
+
+  async function doRemoveTeam() {
+    if (!confirmRemove) return;
+    const { id, name } = confirmRemove;
+    setBusy(id);
+    try {
+      const res = await fetch(`/api/teams/${id}/unclaim`, { method: "POST" });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setAdded((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        toast.success(`Removed ${name} from your teams.`);
+        router.refresh();
+      } else {
+        toast.error(body.error ?? `Could not remove ${name}.`);
+      }
+    } finally {
+      setBusy(null);
+      setConfirmRemove(null);
     }
   }
 
@@ -281,6 +316,7 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
                 onAddConference={onAddConference}
                 onAddDivision={onAddDivision}
                 onAddTeam={onAddTeam}
+                onRemoveTeam={onRemoveTeam}
               />
             ))}
             {looseDivisions.length > 0 && (
@@ -294,6 +330,7 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
                     anyBusy={anyBusy}
                     onAddDivision={onAddDivision}
                     onAddTeam={onAddTeam}
+                    onRemoveTeam={onRemoveTeam}
                   />
                 ))}
               </Accordion>
@@ -301,6 +338,14 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
           </div>
         )}
       </CardContent>
+      <DeleteConfirm
+        isOpen={confirmRemove !== null}
+        isDeleting={confirmRemove !== null && busy === confirmRemove.id}
+        title={`Remove ${confirmRemove?.name ?? "team"}?`}
+        message="This deletes your private copy of this team and its roster. The original league is unaffected, and you can add it again later."
+        onConfirm={doRemoveTeam}
+        onCancel={() => setConfirmRemove(null)}
+      />
     </Card>
   );
 }
@@ -332,6 +377,7 @@ function ConferenceSection({
   onAddConference,
   onAddDivision,
   onAddTeam,
+  onRemoveTeam,
 }: {
   conference: ConferenceGroup;
   added: Set<string>;
@@ -340,6 +386,7 @@ function ConferenceSection({
   onAddConference: (conf: ConferenceGroup) => void;
   onAddDivision: (group: DivisionGroup) => void;
   onAddTeam: (teamId: string, teamName: string) => void;
+  onRemoveTeam: (teamId: string, teamName: string) => void;
 }) {
   const allTeams = conference.divisions.flatMap((d) => d.teams);
   const state = addState(allTeams, added);
@@ -379,6 +426,7 @@ function ConferenceSection({
                 anyBusy={anyBusy}
                 onAddDivision={onAddDivision}
                 onAddTeam={onAddTeam}
+                onRemoveTeam={onRemoveTeam}
               />
             ))}
           </Accordion>
@@ -395,6 +443,7 @@ function DivisionSection({
   anyBusy,
   onAddDivision,
   onAddTeam,
+  onRemoveTeam,
 }: {
   group: DivisionGroup;
   added: Set<string>;
@@ -402,6 +451,7 @@ function DivisionSection({
   anyBusy: boolean;
   onAddDivision: (group: DivisionGroup) => void;
   onAddTeam: (teamId: string, teamName: string) => void;
+  onRemoveTeam: (teamId: string, teamName: string) => void;
 }) {
   const state = addState(group.teams, added);
   const remaining = group.teams.filter((t) => !added.has(t.id)).length;
@@ -443,10 +493,26 @@ function DivisionSection({
                   {team.name}
                 </span>
                 {isAdded ? (
-                  <span className="flex shrink-0 items-center gap-1 text-xs text-green-500">
-                    <CheckCircle2 className="h-3.5 w-3.5" />
-                    Added
-                  </span>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <span className="flex items-center gap-1 text-xs text-green-500">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Added
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-muted-foreground hover:text-destructive"
+                      disabled={anyBusy}
+                      onClick={() => onRemoveTeam(team.id, team.name)}
+                      aria-label={`Remove ${team.name}`}
+                    >
+                      {busy === team.id ? (
+                        "…"
+                      ) : (
+                        <X className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
                 ) : (
                   <Button
                     size="sm"

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -117,6 +117,10 @@ const refs = {
     { orgId: string; sourceTeamId: string },
     { teamId: string; leagueId: string; created: boolean }
   >("sports:forkTeamToWorkspace"),
+  unforkTeamFromWorkspace: mutationRef<
+    { orgId: string; sourceTeamId: string },
+    { removed: boolean }
+  >("sports:unforkTeamFromWorkspace"),
   forkDivisionToWorkspace: mutationRef<
     { orgId: string; divisionId: string },
     {
@@ -721,6 +725,18 @@ export async function forkTeamToWorkspace(
   sourceTeamId: string,
 ): Promise<{ teamId: string; leagueId: string; created: boolean }> {
   return mutateConvex(refs.forkTeamToWorkspace, { orgId, sourceTeamId });
+}
+
+/**
+ * WSM-000129: reverse of forkTeamToWorkspace — delete the org's private fork of
+ * a reference team (the team whose sourceTeamId matches, plus its roster). Raw
+ * wrapper — caller MUST resolve an org the user admins first.
+ */
+export async function unforkTeamFromWorkspace(
+  orgId: string,
+  sourceTeamId: string,
+): Promise<{ removed: boolean }> {
+  return mutateConvex(refs.unforkTeamFromWorkspace, { orgId, sourceTeamId });
 }
 
 /**


### PR DESCRIPTION
Closes #247.

## What
Adds the reverse of **Add to my teams** on Discover. A team shown **Added ✓** now has a **Remove** action that deletes the caller's private workspace fork of the reference team (the editable copy + its roster) and reverts the button to **Add**. Removal is confirmed first.

## Changes
- **convex/sports.ts** — new internal mutation `unforkTeamFromWorkspace({ orgId, sourceTeamId }) → { removed }`: scans the org's workspace leagues for the fork whose `sourceTeamId` matches and purges it via the existing `purgeTeam` cascade (roster + dependents). Idempotent.
- **writeMutationsAreInternal.test.ts** — compile-time guard extended: the new mutation must be internal-only.
- **data-api.ts** — `unforkTeamFromWorkspace` ref + wrapper.
- **api/teams/[id]/unclaim/route.ts** (new) — POST resolves the same org Discover uses to mark "Added" (active org → first admin org; never creates one), then removes the fork. Forks only live in admin orgs, so removal is implicitly admin-scoped.
- **discover-leagues.tsx** — Remove (✕) button beside "Added", confirmed via the existing `DeleteConfirm` dialog (warns the private copy + roster are deleted); optimistic un-add + `router.refresh()`.

## Acceptance criteria
- ✅ Un-add from Discover → fork deleted, reverts to "Add"
- ✅ Confirmation before deleting the private copy + roster

## Testing
Full gate green: type-check ✅, **383 tests** ✅, lint ✅ (only pre-existing `<img>` warning), build ✅ (new route + discover page present).

> Backend change → requires a Convex **prod deploy from merged main** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)