### PR TITLE
feat(web): local workspace data provider — Slice 1 (WSM-000137)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.19.0",
+    "dexie": "^4.4.3",
     "flags": "^4.0.6",
     "geist": "^1.7.0",
     "lucide-react": "^0.577.0",
@@ -61,6 +62,7 @@
     "convex-test": "^0.0.49",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.3.0",
+    "fake-indexeddb": "^6.2.5",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.2"

--- a/apps/web/src/lib/local/__tests__/local-workspace-provider.test.ts
+++ b/apps/web/src/lib/local/__tests__/local-workspace-provider.test.ts
@@ -1,0 +1,222 @@
+// Polyfill IndexedDB for the node test environment (vitest runs in `node`).
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WsmLocalDb } from "../local-db";
+import { LocalWorkspaceProvider } from "../local-workspace-provider";
+import { DuplicateJerseyError } from "../workspace-provider";
+
+let db: WsmLocalDb;
+let provider: LocalWorkspaceProvider;
+// Unique DB name per test so stores never leak across cases.
+let counter = 0;
+
+beforeEach(() => {
+  db = new WsmLocalDb(`wsm-local-test-${counter++}`);
+  provider = new LocalWorkspaceProvider(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+/** Seed a league + team and return both. */
+async function seedTeam(allowDuplicateJerseys = true) {
+  const league = await provider.createLeague({ name: "My League" });
+  const team = await provider.createTeam({
+    name: "Hawks",
+    leagueId: league.id,
+    city: "Austin",
+    stadium: "Nest Field",
+  });
+  if (!allowDuplicateJerseys) {
+    await provider.updateTeam(team.id, { allowDuplicateJerseys: false });
+  }
+  return { league, team };
+}
+
+describe("LocalWorkspaceProvider — leagues", () => {
+  it("creates a league with a generated id and null org", async () => {
+    const league = await provider.createLeague({ name: "My League" });
+    expect(league.id).toMatch(/[0-9a-f-]{36}/);
+    expect(league.orgId).toBeNull();
+    expect(await provider.getLeague(league.id)).toEqual(league);
+    expect(await provider.listLeagues()).toHaveLength(1);
+  });
+});
+
+describe("LocalWorkspaceProvider — teams", () => {
+  it("creates a team with server-matching defaults", async () => {
+    const league = await provider.createLeague({ name: "L" });
+    const team = await provider.createTeam({
+      name: "Hawks",
+      leagueId: league.id,
+      city: "Austin",
+      stadium: "Nest Field",
+    });
+    expect(team).toMatchObject({
+      name: "Hawks",
+      leagueId: league.id,
+      city: "Austin",
+      stadium: "Nest Field",
+      location: "Austin", // seeded from city
+      divisionId: "", // no division yet
+      rosterLimit: 53,
+      allowDuplicateJerseys: true,
+      foundedYear: null,
+      logoUrl: null,
+      teamName: null,
+    });
+  });
+
+  it("lists teams, optionally filtered by league", async () => {
+    const a = await provider.createLeague({ name: "A" });
+    const b = await provider.createLeague({ name: "B" });
+    await provider.createTeam({ name: "T1", leagueId: a.id, city: "x", stadium: "y" });
+    await provider.createTeam({ name: "T2", leagueId: b.id, city: "x", stadium: "y" });
+    expect(await provider.listTeams()).toHaveLength(2);
+    expect(await provider.listTeams(a.id)).toHaveLength(1);
+    expect((await provider.listTeams(a.id))[0].name).toBe("T1");
+  });
+
+  it("updates only the provided fields", async () => {
+    const { team } = await seedTeam();
+    const updated = await provider.updateTeam(team.id, {
+      city: "Dallas",
+      primaryColor: "#1e3a8a",
+    });
+    expect(updated).toMatchObject({
+      name: "Hawks", // untouched
+      city: "Dallas", // changed
+      primaryColor: "#1e3a8a", // changed
+    });
+  });
+
+  it("returns null when updating a missing team", async () => {
+    expect(await provider.updateTeam("nope", { city: "X" })).toBeNull();
+  });
+
+  it("cascade-deletes the roster with the team", async () => {
+    const { team } = await seedTeam();
+    await provider.createPlayer({
+      name: "Pat",
+      teamId: team.id,
+      position: "QB",
+      jerseyNumber: 12,
+      dateOfBirth: null,
+      status: "Active",
+    });
+    await provider.deleteTeam(team.id);
+    expect(await provider.getTeam(team.id)).toBeNull();
+    expect(await provider.listPlayersByTeam(team.id)).toEqual([]);
+  });
+});
+
+describe("LocalWorkspaceProvider — divisions", () => {
+  it("creates, lists, updates and deletes divisions", async () => {
+    const league = await provider.createLeague({ name: "L" });
+    const div = await provider.createDivision({ name: "East", leagueId: league.id });
+    expect(div.conferenceId).toBeNull();
+    expect(await provider.listDivisions(league.id)).toHaveLength(1);
+
+    const renamed = await provider.updateDivision(div.id, { name: "West" });
+    expect(renamed?.name).toBe("West");
+
+    await provider.deleteDivision(div.id);
+    expect(await provider.listDivisions(league.id)).toEqual([]);
+  });
+});
+
+describe("LocalWorkspaceProvider — players & jersey policy", () => {
+  it("creates a player with server-matching defaults", async () => {
+    const { team } = await seedTeam();
+    const player = await provider.createPlayer({
+      name: "Pat Lee",
+      teamId: team.id,
+      position: "QB",
+      jerseyNumber: 12,
+      dateOfBirth: "2003-09-01",
+      status: "Active",
+    });
+    expect(player).toMatchObject({
+      name: "Pat Lee",
+      teamId: team.id,
+      position: "QB",
+      jerseyNumber: 12,
+      status: "Active",
+      positionGroup: null,
+      headshotUrl: null,
+      experienceYears: null,
+    });
+  });
+
+  it("throws creating a player on a missing team", async () => {
+    await expect(
+      provider.createPlayer({
+        name: "X",
+        teamId: "nope",
+        position: "QB",
+        jerseyNumber: 1,
+        dateOfBirth: null,
+        status: "Active",
+      }),
+    ).rejects.toThrow("Team not found");
+  });
+
+  it("allows duplicate jerseys when the team policy permits", async () => {
+    const { team } = await seedTeam(true);
+    await provider.createPlayer({ name: "A", teamId: team.id, position: "QB", jerseyNumber: 7, dateOfBirth: null, status: "Active" });
+    await expect(
+      provider.createPlayer({ name: "B", teamId: team.id, position: "RB", jerseyNumber: 7, dateOfBirth: null, status: "Active" }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("rejects a duplicate active jersey when the policy forbids it", async () => {
+    const { team } = await seedTeam(false);
+    await provider.createPlayer({ name: "A", teamId: team.id, position: "QB", jerseyNumber: 7, dateOfBirth: null, status: "Active" });
+    await expect(
+      provider.createPlayer({ name: "B", teamId: team.id, position: "RB", jerseyNumber: 7, dateOfBirth: null, status: "Active" }),
+    ).rejects.toBeInstanceOf(DuplicateJerseyError);
+  });
+
+  it("ignores inactive wearers and null jerseys under a strict policy", async () => {
+    const { team } = await seedTeam(false);
+    await provider.createPlayer({ name: "A", teamId: team.id, position: "QB", jerseyNumber: 7, dateOfBirth: null, status: "Inactive" });
+    // #7 is free because the existing wearer is inactive.
+    await expect(
+      provider.createPlayer({ name: "B", teamId: team.id, position: "RB", jerseyNumber: 7, dateOfBirth: null, status: "Active" }),
+    ).resolves.toBeTruthy();
+    // null jersey never conflicts.
+    await expect(
+      provider.createPlayer({ name: "C", teamId: team.id, position: "WR", jerseyNumber: null, dateOfBirth: null, status: "Active" }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("does not flag the player being edited as its own duplicate", async () => {
+    const { team } = await seedTeam(false);
+    const p = await provider.createPlayer({ name: "A", teamId: team.id, position: "QB", jerseyNumber: 7, dateOfBirth: null, status: "Active" });
+    const updated = await provider.updatePlayer(p.id, { name: "A. Lee" });
+    expect(updated?.name).toBe("A. Lee");
+    expect(updated?.jerseyNumber).toBe(7);
+  });
+
+  it("deletes a player", async () => {
+    const { team } = await seedTeam();
+    const p = await provider.createPlayer({ name: "A", teamId: team.id, position: "QB", jerseyNumber: 1, dateOfBirth: null, status: "Active" });
+    await provider.deletePlayer(p.id);
+    expect(await provider.getPlayer(p.id)).toBeNull();
+  });
+});
+
+describe("LocalWorkspaceProvider — persistence", () => {
+  it("persists data across a fresh DB handle to the same database", async () => {
+    const league = await provider.createLeague({ name: "Persisted" });
+    const team = await provider.createTeam({ name: "Hawks", leagueId: league.id, city: "Austin", stadium: "Nest" });
+    await provider.createPlayer({ name: "Pat", teamId: team.id, position: "QB", jerseyNumber: 12, dateOfBirth: null, status: "Active" });
+
+    // Simulate a page reload: a brand-new handle/provider over the SAME db name.
+    const reopened = new LocalWorkspaceProvider(new WsmLocalDb(db.name));
+    expect(await reopened.listLeagues()).toHaveLength(1);
+    expect((await reopened.listTeams())[0].name).toBe("Hawks");
+    expect(await reopened.listPlayersByTeam(team.id)).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/local/local-db.ts
+++ b/apps/web/src/lib/local/local-db.ts
@@ -1,0 +1,68 @@
+import Dexie, { type Table } from "dexie";
+import type {
+  DepthChartEntryDto,
+  DivisionDto,
+  FixtureDto,
+  GameResultDto,
+  LeagueDto,
+  PlayerDto,
+  SeasonDto,
+  TeamDto,
+} from "@sports-management/shared-types";
+
+/**
+ * Browser-local workspace store for the free no-login tier (WSM-000137, #258).
+ *
+ * One IndexedDB database holds a single coach's private workspace — the
+ * local-capable entity set from the RFC (§3): leagues, divisions, teams,
+ * players, seasons, schedule (fixtures + results), depth chart. Account-only
+ * concepts (orgs, members, public viewer, Discover forks) have no store here;
+ * their absence is what keeps the local boundary honest.
+ *
+ * Records are stored as the same DTO shapes the rest of the app uses, keyed by a
+ * client-generated UUID string `id` (so a local record is shape-compatible with
+ * a server DTO and migrates cleanly — see RFC §8). Secondary indexes cover the
+ * foreign keys the UI filters by.
+ *
+ * The full store set is declared at v1 even though Slice 1 only writes
+ * leagues/divisions/teams/players — this avoids a schema migration when the
+ * later slices (seasons, schedule, standings) light up.
+ */
+export class WsmLocalDb extends Dexie {
+  leagues!: Table<LeagueDto, string>;
+  divisions!: Table<DivisionDto, string>;
+  teams!: Table<TeamDto, string>;
+  players!: Table<PlayerDto, string>;
+  seasons!: Table<SeasonDto, string>;
+  fixtures!: Table<FixtureDto, string>;
+  gameResults!: Table<GameResultDto, string>;
+  depthChart!: Table<DepthChartEntryDto, string>;
+
+  constructor(name = "wsm-local") {
+    super(name);
+    // First field is the primary key (`id`, client-generated — NOT auto-inc);
+    // the rest are secondary indexes on the foreign keys we query by.
+    this.version(1).stores({
+      leagues: "id, name",
+      divisions: "id, leagueId, conferenceId",
+      teams: "id, leagueId, divisionId",
+      players: "id, teamId, leagueId",
+      seasons: "id, leagueId",
+      fixtures: "id, seasonId, homeTeamId, awayTeamId",
+      gameResults: "id, fixtureId",
+      depthChart: "id, teamId, seasonId, playerId",
+    });
+  }
+}
+
+/**
+ * Process-wide singleton handle to the local DB. Lazily constructed so importing
+ * this module never touches IndexedDB (e.g. on the server, where it's absent).
+ * Tests pass their own name/instance for isolation.
+ */
+let dbSingleton: WsmLocalDb | null = null;
+
+export function getLocalDb(): WsmLocalDb {
+  if (!dbSingleton) dbSingleton = new WsmLocalDb();
+  return dbSingleton;
+}

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -1,0 +1,273 @@
+import type {
+  CreateDivisionInput,
+  CreateLeagueInput,
+  CreatePlayerInput,
+  CreateTeamInput,
+  DivisionDto,
+  LeagueDto,
+  PlayerDto,
+  TeamDto,
+  UpdatePlayerInput,
+  UpdateTeamInput,
+} from "@sports-management/shared-types";
+import { getLocalDb, WsmLocalDb } from "./local-db";
+import {
+  DuplicateJerseyError,
+  type UpdateDivisionInput,
+  type WorkspaceDataProvider,
+} from "./workspace-provider";
+
+/** A team's default roster cap, matching the server's createTeam (53). */
+const DEFAULT_ROSTER_LIMIT = 53;
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * IndexedDB-backed implementation of the workspace contract (WSM-000137 RFC §5),
+ * for the free no-login tier. Everything lives in the browser; ids are generated
+ * client-side. Defaults and the jersey-duplicate policy mirror the server
+ * mutations (createTeam/createPlayer, WSM-000125) so local and synced workspaces
+ * behave identically and a local workspace migrates cleanly (RFC §8).
+ *
+ * Slice 1 scope: leagues, divisions, teams, players.
+ */
+export class LocalWorkspaceProvider implements WorkspaceDataProvider {
+  constructor(private readonly db: WsmLocalDb = getLocalDb()) {}
+
+  // --- Leagues ---
+
+  async createLeague(input: CreateLeagueInput): Promise<LeagueDto> {
+    // Local workspaces have no org — orgId is always null.
+    const league: LeagueDto = { id: newId(), name: input.name, orgId: null };
+    await this.db.leagues.add(league);
+    return league;
+  }
+
+  async getLeague(id: string): Promise<LeagueDto | null> {
+    return (await this.db.leagues.get(id)) ?? null;
+  }
+
+  async listLeagues(): Promise<LeagueDto[]> {
+    return this.db.leagues.toArray();
+  }
+
+  // --- Divisions ---
+
+  async createDivision(input: CreateDivisionInput): Promise<DivisionDto> {
+    const division: DivisionDto = {
+      id: newId(),
+      name: input.name,
+      leagueId: input.leagueId,
+      conferenceId: null,
+    };
+    await this.db.divisions.add(division);
+    return division;
+  }
+
+  async listDivisions(leagueId: string): Promise<DivisionDto[]> {
+    return this.db.divisions.where("leagueId").equals(leagueId).toArray();
+  }
+
+  async updateDivision(
+    id: string,
+    input: UpdateDivisionInput,
+  ): Promise<DivisionDto | null> {
+    const existing = await this.db.divisions.get(id);
+    if (!existing) return null;
+    const updated: DivisionDto = {
+      ...existing,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.conferenceId !== undefined
+        ? { conferenceId: input.conferenceId }
+        : {}),
+    };
+    await this.db.divisions.put(updated);
+    return updated;
+  }
+
+  async deleteDivision(id: string): Promise<void> {
+    await this.db.divisions.delete(id);
+  }
+
+  // --- Teams ---
+
+  async createTeam(input: CreateTeamInput): Promise<TeamDto> {
+    // Defaults mirror the server's createTeam: no division yet (""), location
+    // seeded from city, roster limit 53, duplicate jerseys allowed.
+    const team: TeamDto = {
+      id: newId(),
+      name: input.name,
+      leagueId: input.leagueId,
+      city: input.city,
+      stadium: input.stadium,
+      foundedYear: null,
+      location: input.city,
+      divisionId: "",
+      logoUrl: null,
+      rosterLimit: DEFAULT_ROSTER_LIMIT,
+      teamName: null,
+      primaryColor: null,
+      secondaryColor: null,
+      allowDuplicateJerseys: true,
+    };
+    await this.db.teams.add(team);
+    return team;
+  }
+
+  async getTeam(id: string): Promise<TeamDto | null> {
+    return (await this.db.teams.get(id)) ?? null;
+  }
+
+  async listTeams(leagueId?: string): Promise<TeamDto[]> {
+    if (leagueId === undefined) return this.db.teams.toArray();
+    return this.db.teams.where("leagueId").equals(leagueId).toArray();
+  }
+
+  async updateTeam(
+    id: string,
+    input: UpdateTeamInput,
+  ): Promise<TeamDto | null> {
+    const existing = await this.db.teams.get(id);
+    if (!existing) return null;
+    const updated: TeamDto = {
+      ...existing,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.city !== undefined ? { city: input.city } : {}),
+      ...(input.stadium !== undefined ? { stadium: input.stadium } : {}),
+      ...(input.foundedYear !== undefined
+        ? { foundedYear: input.foundedYear }
+        : {}),
+      ...(input.location !== undefined ? { location: input.location } : {}),
+      ...(input.divisionId !== undefined
+        ? { divisionId: input.divisionId }
+        : {}),
+      ...(input.teamName !== undefined ? { teamName: input.teamName } : {}),
+      ...(input.logoUrl !== undefined ? { logoUrl: input.logoUrl } : {}),
+      ...(input.primaryColor !== undefined
+        ? { primaryColor: input.primaryColor }
+        : {}),
+      ...(input.secondaryColor !== undefined
+        ? { secondaryColor: input.secondaryColor }
+        : {}),
+      ...(input.allowDuplicateJerseys !== undefined
+        ? { allowDuplicateJerseys: input.allowDuplicateJerseys }
+        : {}),
+    };
+    await this.db.teams.put(updated);
+    return updated;
+  }
+
+  async deleteTeam(id: string): Promise<void> {
+    // Cascade to the roster, mirroring the server's purgeTeam.
+    await this.db.transaction("rw", this.db.teams, this.db.players, async () => {
+      await this.db.players.where("teamId").equals(id).delete();
+      await this.db.teams.delete(id);
+    });
+  }
+
+  // --- Players ---
+
+  async createPlayer(input: CreatePlayerInput): Promise<PlayerDto> {
+    const team = await this.db.teams.get(input.teamId);
+    if (!team) throw new Error("Team not found");
+
+    await this.assertJerseyAllowed(
+      team.id,
+      team.allowDuplicateJerseys,
+      input.jerseyNumber ?? null,
+    );
+
+    const player: PlayerDto = {
+      id: newId(),
+      name: input.name,
+      teamId: input.teamId,
+      position: input.position,
+      positionGroup: null,
+      jerseyNumber: input.jerseyNumber ?? null,
+      dateOfBirth: input.dateOfBirth ?? null,
+      status: input.status,
+      headshotUrl: null,
+      experienceYears: null,
+    };
+    await this.db.players.add(player);
+    return player;
+  }
+
+  async getPlayer(id: string): Promise<PlayerDto | null> {
+    return (await this.db.players.get(id)) ?? null;
+  }
+
+  async listPlayersByTeam(teamId: string): Promise<PlayerDto[]> {
+    return this.db.players.where("teamId").equals(teamId).toArray();
+  }
+
+  async updatePlayer(
+    id: string,
+    input: UpdatePlayerInput,
+  ): Promise<PlayerDto | null> {
+    const existing = await this.db.players.get(id);
+    if (!existing) return null;
+
+    const updated: PlayerDto = {
+      ...existing,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.teamId !== undefined ? { teamId: input.teamId } : {}),
+      ...(input.position !== undefined ? { position: input.position } : {}),
+      ...(input.jerseyNumber !== undefined
+        ? { jerseyNumber: input.jerseyNumber }
+        : {}),
+      ...(input.dateOfBirth !== undefined
+        ? { dateOfBirth: input.dateOfBirth }
+        : {}),
+      ...(input.status !== undefined ? { status: input.status } : {}),
+    };
+
+    const team = await this.db.teams.get(updated.teamId);
+    if (team) {
+      await this.assertJerseyAllowed(
+        team.id,
+        team.allowDuplicateJerseys,
+        updated.jerseyNumber,
+        id,
+      );
+    }
+
+    await this.db.players.put(updated);
+    return updated;
+  }
+
+  async deletePlayer(id: string): Promise<void> {
+    await this.db.players.delete(id);
+  }
+
+  /**
+   * Enforce the jersey-duplicate policy (WSM-000125), matching the server's
+   * `jerseyNumberTakenOnTeam`: when the team disallows duplicates, a non-null
+   * number already worn by another ACTIVE player on the team is rejected. The
+   * check keys off existing active wearers and is independent of the incoming
+   * player's own status. `excludePlayerId` skips the player being edited.
+   */
+  private async assertJerseyAllowed(
+    teamId: string,
+    allowDuplicateJerseys: boolean,
+    jerseyNumber: number | null,
+    excludePlayerId?: string,
+  ): Promise<void> {
+    if (allowDuplicateJerseys) return;
+    if (jerseyNumber === null) return;
+
+    const roster = await this.db.players
+      .where("teamId")
+      .equals(teamId)
+      .toArray();
+    const taken = roster.some(
+      (p) =>
+        p.id !== excludePlayerId &&
+        p.jerseyNumber === jerseyNumber &&
+        p.status.toLowerCase() === "active",
+    );
+    if (taken) throw new DuplicateJerseyError(jerseyNumber);
+  }
+}

--- a/apps/web/src/lib/local/workspace-provider.ts
+++ b/apps/web/src/lib/local/workspace-provider.ts
@@ -1,0 +1,79 @@
+import type {
+  CreateDivisionInput,
+  CreateLeagueInput,
+  CreatePlayerInput,
+  CreateTeamInput,
+  DivisionDto,
+  LeagueDto,
+  PlayerDto,
+  TeamDto,
+  UpdatePlayerInput,
+  UpdateTeamInput,
+} from "@sports-management/shared-types";
+
+/** Division fields editable after creation (no server-side equivalent input type). */
+export interface UpdateDivisionInput {
+  name?: string;
+  conferenceId?: string | null;
+}
+
+/**
+ * Transport-agnostic workspace data contract (WSM-000137 RFC §5).
+ *
+ * The local IndexedDB provider and the existing server (Convex) path both aim to
+ * satisfy this single interface, so `/local` pages and `/dashboard` pages can
+ * share presentational components and differ only in which provider they load.
+ *
+ * This is the **local-capable subset** (RFC §3): leagues, divisions, teams,
+ * players. Account-only operations (orgs, members, public viewer, Discover
+ * forks) are deliberately ABSENT — a provider that can't do them simply doesn't
+ * expose them, which is how the boundary is enforced in types rather than at
+ * runtime. Seasons, schedule, and standings join the contract in later slices.
+ */
+export interface WorkspaceDataProvider {
+  // --- Leagues ---
+  createLeague(input: CreateLeagueInput): Promise<LeagueDto>;
+  getLeague(id: string): Promise<LeagueDto | null>;
+  listLeagues(): Promise<LeagueDto[]>;
+
+  // --- Divisions ---
+  createDivision(input: CreateDivisionInput): Promise<DivisionDto>;
+  listDivisions(leagueId: string): Promise<DivisionDto[]>;
+  updateDivision(
+    id: string,
+    input: UpdateDivisionInput,
+  ): Promise<DivisionDto | null>;
+  deleteDivision(id: string): Promise<void>;
+
+  // --- Teams ---
+  createTeam(input: CreateTeamInput): Promise<TeamDto>;
+  getTeam(id: string): Promise<TeamDto | null>;
+  /** All teams, or only those in `leagueId` when provided. */
+  listTeams(leagueId?: string): Promise<TeamDto[]>;
+  updateTeam(id: string, input: UpdateTeamInput): Promise<TeamDto | null>;
+  /** Deletes the team and cascades to its players (mirrors server purgeTeam). */
+  deleteTeam(id: string): Promise<void>;
+
+  // --- Players ---
+  createPlayer(input: CreatePlayerInput): Promise<PlayerDto>;
+  getPlayer(id: string): Promise<PlayerDto | null>;
+  listPlayersByTeam(teamId: string): Promise<PlayerDto[]>;
+  updatePlayer(
+    id: string,
+    input: UpdatePlayerInput,
+  ): Promise<PlayerDto | null>;
+  deletePlayer(id: string): Promise<void>;
+}
+
+/**
+ * Thrown when a jersey number is already worn by an active player on a team whose
+ * `allowDuplicateJerseys` policy is false — mirrors the server's
+ * `duplicate_jersey:<n>` error (WSM-000125) so callers can handle both paths the
+ * same way.
+ */
+export class DuplicateJerseyError extends Error {
+  constructor(public readonly jerseyNumber: number) {
+    super(`duplicate_jersey:${jerseyNumber}`);
+    this.name = "DuplicateJerseyError";
+  }
+}

--- a/docs/research/local-only-tier-rfc.md
+++ b/docs/research/local-only-tier-rfc.md
@@ -5,9 +5,16 @@ model ([org-workspace-data-model-rfc](./org-workspace-data-model-rfc.md)), the i
 (#248), and the "Free for one team, forever" landing promise.
 
 ## Decision log
-- _(unresolved)_ — Storage engine (raw IndexedDB vs Dexie vs localStorage). Recommendation in §6.
-- _(unresolved)_ — Entry path (`/local/**` parallel route vs a global mode flag). Recommendation in §4.
-- _(unresolved)_ — Migration trigger (auto-prompt on first sign-in vs explicit "Import my local data"). Recommendation in §8.
+- **2026-06-15 — Storage engine: Dexie** (§6 resolved). IndexedDB via Dexie, not raw IDB or
+  localStorage. Added `dexie` (dep) + `fake-indexeddb` (dev, for node-env tests).
+- **2026-06-15 — Entry path: `/local/**` parallel client-rendered route** (§4 resolved, Option A).
+  The authed `/dashboard` SSR path is left untouched.
+- **2026-06-15 — Migration trigger: explicit one-click prompt** on first sign-in (§8 resolved), not
+  silent auto-import.
+- **2026-06-15 — Slice 1 shipped.** `WorkspaceDataProvider` contract + `LocalWorkspaceProvider`
+  (leagues/divisions/teams/players) over a versioned Dexie schema, with defaults and the
+  jersey-duplicate policy mirrored from the server. 15 unit tests (CRUD, cascade delete, jersey
+  policy, persistence-across-reopen). No UI yet — Slice 2 adds the `/local` shell.
 
 ## 1. Intent (from product)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       convex:
         specifier: ^1.19.0
         version: 1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      dexie:
+        specifier: ^4.4.3
+        version: 4.4.3
       flags:
         specifier: ^4.0.6
         version: 4.0.6(next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -265,6 +268,9 @@ importers:
       eslint-config-next:
         specifier: ^15.3.0
         version: 15.5.13(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       tailwindcss:
         specifier: ^4.1.0
         version: 4.2.1
@@ -4237,6 +4243,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dexie@4.4.3:
+    resolution: {integrity: sha512-N+3IGQ3HPlyO2YAkntGAwitm42BpBGV86MttzUMiRzWLa4NGh0pltVRcUVF4ybL/OnXjCrr9k7SDPIKkFYP2Lg==}
+
   diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4596,6 +4605,10 @@ packages:
   expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -11852,6 +11865,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  dexie@4.4.3: {}
+
   diff-sequences@27.5.1: {}
 
   dir-glob@3.0.1:
@@ -12481,6 +12496,8 @@ snapshots:
       jest-get-type: 27.5.1
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
+
+  fake-indexeddb@6.2.5: {}
 
   fast-content-type-parse@3.0.0: {}
 


### PR DESCRIPTION
Refs #258. First implementation slice of the free no-login local-only tier (per the merged RFC `docs/research/local-only-tier-rfc.md`).

## What
The **client-side data spine** the RFC's parallel `/local` surface will render against. **No UI yet** — this is the "is the seam real" proof.

- **`workspace-provider.ts`** — transport-agnostic `WorkspaceDataProvider` contract (local-capable subset: leagues / divisions / teams / players) + `DuplicateJerseyError`. Account-only ops are deliberately absent, so the boundary is enforced in types.
- **`local-db.ts`** — Dexie (IndexedDB) schema `wsm-local`; full local-capable store set declared at v1 to avoid a later migration; lazy singleton so importing never touches IndexedDB on the server.
- **`local-workspace-provider.ts`** — IndexedDB implementation, client-generated UUID ids. Team/player **defaults and the jersey-duplicate policy (WSM-000125) mirror the server mutations**, so local and synced workspaces behave identically and migrate cleanly. `deleteTeam` cascades to the roster (mirrors `purgeTeam`).

## Tests
**15 new unit tests** (CRUD, cascade delete, jersey policy incl. inactive-wearer / null-jersey / edit-self cases, and persistence across a fresh DB handle = simulated reload). Polyfills IndexedDB with `fake-indexeddb` since vitest runs in `node`.

Adds `dexie` (dep) + `fake-indexeddb` (dev).

## Gate
type-check ✅ · **398 tests** ✅ (+15) · lint ✅ (only pre-existing `<img>` warning) · build ✅.

Web-only; no Convex change. Decisions confirmed in this turn (Dexie / `/local` route / explicit migration) recorded in the RFC decision log.

## Next
Slice 2 — `/local` shell + "Try it free" CTA + single-team create/edit against this provider (the first user-facing AC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)