### PR TITLE
feat(web): CSV/JSON seed into local workspace — Slice 4 (WSM-000137)

### DIFF
--- a/apps/web/src/app/local/import/page.tsx
+++ b/apps/web/src/app/local/import/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import { csvToLeagueImport } from "@/lib/csv-import";
+import { useLocalProvider } from "@/lib/local/use-local-provider";
+import {
+  importLeagueIntoLocal,
+  type LeagueImportPayload,
+  type LocalImportResult,
+} from "@/lib/local/local-import";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  ArrowLeft,
+  Upload,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
+
+interface Preview {
+  leagueName: string;
+  divisions: number;
+  teams: number;
+  players: number;
+}
+
+type State =
+  | { step: "idle" }
+  | { step: "invalid"; fileName: string; errors: string[] }
+  | { step: "preview"; fileName: string; preview: Preview; payload: LeagueImportPayload }
+  | { step: "importing"; fileName: string }
+  | { step: "done"; result: LocalImportResult };
+
+function previewOf(payload: LeagueImportPayload): Preview {
+  let teams = 0;
+  let players = 0;
+  for (const d of payload.divisions) {
+    teams += d.teams.length;
+    for (const t of d.teams) players += t.players.length;
+  }
+  return {
+    leagueName: payload.league.name,
+    divisions: payload.divisions.length,
+    teams,
+    players,
+  };
+}
+
+export default function LocalImportPage() {
+  const provider = useLocalProvider();
+  const [state, setState] = useState<State>({ step: "idle" });
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback((file: File) => {
+    const isCsv =
+      file.name.toLowerCase().endsWith(".csv") || file.type === "text/csv";
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result as string;
+      let raw: unknown;
+
+      if (isCsv) {
+        const { payload, rowErrors } = csvToLeagueImport(text);
+        if (rowErrors.length > 0 || payload === null) {
+          setState({
+            step: "invalid",
+            fileName: file.name,
+            errors:
+              rowErrors.length > 0
+                ? rowErrors
+                : ["Could not read any rows from the CSV file."],
+          });
+          return;
+        }
+        raw = payload;
+      } else {
+        try {
+          raw = JSON.parse(text);
+        } catch {
+          setState({
+            step: "invalid",
+            fileName: file.name,
+            errors: ["File is not valid JSON."],
+          });
+          return;
+        }
+      }
+
+      const parsed = LeagueImportSchema.safeParse(raw);
+      if (!parsed.success) {
+        setState({
+          step: "invalid",
+          fileName: file.name,
+          errors: parsed.error.issues.map(
+            (i) => `${i.path.join(".") || "(root)"}: ${i.message}`,
+          ),
+        });
+        return;
+      }
+
+      setState({
+        step: "preview",
+        fileName: file.name,
+        preview: previewOf(parsed.data),
+        payload: parsed.data,
+      });
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const onInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFile(file);
+    },
+    [handleFile],
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (file) handleFile(file);
+    },
+    [handleFile],
+  );
+
+  async function onImport() {
+    if (state.step !== "preview" || !provider) return;
+    const { fileName, payload } = state;
+    setState({ step: "importing", fileName });
+    try {
+      const result = await importLeagueIntoLocal(provider, payload);
+      setState({ step: "done", result });
+      toast.success("Imported into your local workspace.");
+    } catch {
+      toast.error("Import failed.");
+      setState({ step: "idle" });
+    }
+  }
+
+  function reset() {
+    setState({ step: "idle" });
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/local"
+          className="mb-2 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Workspace
+        </Link>
+        <h1 className="text-xl font-semibold text-foreground">Import</h1>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Seed your local workspace from a CSV or JSON file — the same format the
+          full importer uses. CSV is one row per player with a header row
+          (league, division, team, city, stadium, playerName, position,
+          jerseyNumber, …). Existing teams and players are matched by name.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Upload a file</CardTitle>
+          <CardDescription>
+            Everything imports into this browser only — no account needed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            onDrop={onDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => inputRef.current?.click()}
+            className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-border p-8 transition-colors hover:border-primary hover:bg-card"
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+            }}
+            aria-label="Upload import file"
+          >
+            <Upload className="mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Drop a <code>.csv</code> or <code>.json</code> file here or click to
+              browse
+            </p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".json,application/json,.csv,text/csv"
+              onChange={onInput}
+              className="hidden"
+              aria-label="Choose import file"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {state.step === "invalid" && (
+        <Card className="border-destructive/30">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base text-destructive">
+              <AlertCircle className="h-5 w-5" />
+              Couldn&rsquo;t read {state.fileName}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div role="alert" className="space-y-1">
+              {state.errors.slice(0, 8).map((err, i) => (
+                <p key={i} className="text-sm text-destructive">
+                  {err}
+                </p>
+              ))}
+            </div>
+            <Button variant="outline" className="mt-4" onClick={reset}>
+              Try another file
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {state.step === "preview" && (
+        <Card className="border-primary/30">
+          <CardHeader>
+            <CardTitle className="text-base">Ready to import</CardTitle>
+            <CardDescription>{state.fileName}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Stat label="League" value={state.preview.leagueName} />
+              <Stat label="Divisions" value={state.preview.divisions} />
+              <Stat label="Teams" value={state.preview.teams} />
+              <Stat label="Players" value={state.preview.players} />
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={onImport} disabled={!provider}>
+                Import into my workspace
+              </Button>
+              <Button variant="outline" onClick={reset}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {state.step === "importing" && (
+        <Card>
+          <CardContent className="flex items-center gap-3 py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" />
+            <p className="text-sm text-muted-foreground">Importing…</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {state.step === "done" && (
+        <Card className="border-green-500/30">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base text-green-500">
+              <CheckCircle2 className="h-5 w-5" />
+              Import complete
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="mb-4 text-sm text-muted-foreground">
+              Added {state.result.created.divisions} division(s),{" "}
+              {state.result.created.teams} team(s), and{" "}
+              {state.result.created.players} player(s).
+            </p>
+            <div className="flex gap-2">
+              <Button asChild>
+                <Link href="/local">Go to workspace</Link>
+              </Button>
+              <Button variant="outline" onClick={reset}>
+                Import another
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-md bg-card p-3 text-center">
+      <p className="truncate text-2xl font-bold">{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/local/page.tsx
+++ b/apps/web/src/app/local/page.tsx
@@ -22,7 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Users, ChevronRight, CalendarDays, Trash2 } from "lucide-react";
+import { Users, ChevronRight, CalendarDays, Trash2, Upload } from "lucide-react";
 
 export default function LocalHomePage() {
   const provider = useLocalProvider();
@@ -108,12 +108,20 @@ export default function LocalHomePage() {
             required. Everything persists across reloads.
           </p>
         </div>
-        <Button asChild variant="outline" size="sm">
-          <Link href="/local/schedule">
-            <CalendarDays className="mr-1.5 h-4 w-4" />
-            Schedule &amp; standings
-          </Link>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/local/import">
+              <Upload className="mr-1.5 h-4 w-4" />
+              Import
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/local/schedule">
+              <CalendarDays className="mr-1.5 h-4 w-4" />
+              Schedule &amp; standings
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {/* Teams */}

--- a/apps/web/src/lib/local/__tests__/local-import.test.ts
+++ b/apps/web/src/lib/local/__tests__/local-import.test.ts
@@ -1,0 +1,87 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import { csvToLeagueImport } from "../../csv-import";
+import { WsmLocalDb } from "../local-db";
+import { LocalWorkspaceProvider } from "../local-workspace-provider";
+import { importLeagueIntoLocal } from "../local-import";
+
+let db: WsmLocalDb;
+let provider: LocalWorkspaceProvider;
+let counter = 0;
+
+beforeEach(() => {
+  db = new WsmLocalDb(`wsm-local-import-test-${counter++}`);
+  provider = new LocalWorkspaceProvider(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+const HEADER =
+  "league,division,team,city,stadium,teamLogoUrl,playerName,position,jerseyNumber,dateOfBirth,status,headshotUrl,experienceYears";
+
+const CSV = [
+  HEADER,
+  "Metro,East,Hawks,Austin,Nest Field,,Pat Lee,QB,12,,Active,,",
+  "Metro,East,Hawks,Austin,Nest Field,,Sam Roe,RB,28,,Active,,",
+  "Metro,West,Bears,Dallas,Den Stadium,,Jo Fox,WR,80,,Active,,",
+].join("\n");
+
+/** CSV → validated LeagueImportPayload, exactly as the UI produces it. */
+function payloadFromCsv(csv: string) {
+  const { payload } = csvToLeagueImport(csv);
+  return LeagueImportSchema.parse(payload);
+}
+
+describe("importLeagueIntoLocal", () => {
+  it("seeds divisions, teams and players into the local league", async () => {
+    const result = await importLeagueIntoLocal(provider, payloadFromCsv(CSV));
+    expect(result.created).toEqual({ divisions: 2, teams: 2, players: 3 });
+
+    const leagues = await provider.listLeagues();
+    expect(leagues).toHaveLength(1);
+    const leagueId = leagues[0].id;
+
+    const divisions = await provider.listDivisions(leagueId);
+    expect(divisions.map((d) => d.name).sort()).toEqual(["East", "West"]);
+
+    const teams = await provider.listTeams(leagueId);
+    expect(teams).toHaveLength(2);
+
+    const hawks = teams.find((t) => t.name === "Hawks")!;
+    const east = divisions.find((d) => d.name === "East")!;
+    // Team is placed in its imported division.
+    expect(hawks.divisionId).toBe(east.id);
+    expect(await provider.listPlayersByTeam(hawks.id)).toHaveLength(2);
+  });
+
+  it("is idempotent — re-importing the same payload adds nothing", async () => {
+    await importLeagueIntoLocal(provider, payloadFromCsv(CSV));
+    const second = await importLeagueIntoLocal(provider, payloadFromCsv(CSV));
+    expect(second.created).toEqual({ divisions: 0, teams: 0, players: 0 });
+
+    const leagueId = (await provider.listLeagues())[0].id;
+    expect(await provider.listTeams(leagueId)).toHaveLength(2);
+    expect(await provider.listDivisions(leagueId)).toHaveLength(2);
+  });
+
+  it("merges into an existing local workspace, adding only new records", async () => {
+    // Pre-seed one team by hand.
+    const league = (await provider.listLeagues())[0]
+      ? (await provider.listLeagues())[0]
+      : await provider.createLeague({ name: "My Program" });
+    await provider.createTeam({
+      name: "Hawks",
+      leagueId: league.id,
+      city: "Austin",
+      stadium: "Nest Field",
+    });
+
+    const result = await importLeagueIntoLocal(provider, payloadFromCsv(CSV));
+    // Hawks already existed → only Bears is a new team; both divisions are new.
+    expect(result.created.teams).toBe(1);
+    expect(result.created.divisions).toBe(2);
+  });
+});

--- a/apps/web/src/lib/local/local-import.ts
+++ b/apps/web/src/lib/local/local-import.ts
@@ -1,0 +1,96 @@
+import { LeagueImportSchema } from "@sports-management/api-contracts";
+import { ensureLocalWorkspace } from "./local-workspace";
+import type { WorkspaceDataProvider } from "./workspace-provider";
+
+/** The validated nested import payload (same shape the server importer accepts). */
+export type LeagueImportPayload = ReturnType<(typeof LeagueImportSchema)["parse"]>;
+
+export interface LocalImportResult {
+  created: { divisions: number; teams: number; players: number };
+}
+
+/**
+ * Seed the browser-local workspace from a validated `LeagueImportPayload` — the
+ * SAME shape `csvToLeagueImport` (#248) produces and the server importer accepts
+ * (RFC §9). Instead of POSTing to `/api/cli/import`, it writes into the local
+ * provider, so one payload shape serves server import, local seed, and (Slice 6)
+ * local→server migration.
+ *
+ * Merge semantics mirror the server importer: matched by name and reused.
+ * Divisions and teams dedupe by name within the single local league; players
+ * dedupe by name within a team. A player that can't be created (e.g. a strict
+ * jersey-policy conflict) is skipped rather than aborting the whole import.
+ */
+export async function importLeagueIntoLocal(
+  provider: WorkspaceDataProvider,
+  payload: LeagueImportPayload,
+): Promise<LocalImportResult> {
+  const league = await ensureLocalWorkspace(provider);
+
+  const divByName = new Map(
+    (await provider.listDivisions(league.id)).map((d) => [d.name, d]),
+  );
+  const teamByName = new Map(
+    (await provider.listTeams(league.id)).map((t) => [t.name, t]),
+  );
+
+  let divisions = 0;
+  let teams = 0;
+  let players = 0;
+
+  for (const div of payload.divisions) {
+    let division = divByName.get(div.name);
+    if (!division) {
+      division = await provider.createDivision({
+        name: div.name,
+        leagueId: league.id,
+      });
+      divByName.set(div.name, division);
+      divisions += 1;
+    }
+
+    for (const team of div.teams) {
+      let teamDto = teamByName.get(team.name);
+      if (!teamDto) {
+        teamDto = await provider.createTeam({
+          name: team.name,
+          leagueId: league.id,
+          city: team.city,
+          stadium: team.stadium,
+        });
+        teamByName.set(team.name, teamDto);
+        teams += 1;
+      }
+      // Place the team in its division and refresh its details (idempotent).
+      await provider.updateTeam(teamDto.id, {
+        divisionId: division.id,
+        city: team.city,
+        stadium: team.stadium,
+        logoUrl: team.logoUrl ?? null,
+      });
+
+      const existingNames = new Set(
+        (await provider.listPlayersByTeam(teamDto.id)).map((p) => p.name),
+      );
+      for (const player of team.players) {
+        if (existingNames.has(player.name)) continue;
+        try {
+          await provider.createPlayer({
+            name: player.name,
+            teamId: teamDto.id,
+            position: player.position,
+            jerseyNumber: player.jerseyNumber ?? null,
+            dateOfBirth: player.dateOfBirth ?? null,
+            status: player.status ?? "Active",
+          });
+          existingNames.add(player.name);
+          players += 1;
+        } catch {
+          // Skip a player that can't be created; don't abort the import.
+        }
+      }
+    }
+  }
+
+  return { created: { divisions, teams, players } };
+}

--- a/docs/research/local-only-tier-rfc.md
+++ b/docs/research/local-only-tier-rfc.md
@@ -23,6 +23,11 @@ model ([org-workspace-data-model-rfc](./org-workspace-data-model-rfc.md)), the i
   local and synced standings cannot drift — the §11 risk is closed by sharing the one function, not
   porting it. Division create/assign UI added. `/local/schedule` page (season picker, fixtures,
   result entry, standings table). 9 new unit tests incl. an end-to-end standings computation.
+- **2026-06-15 — Slice 4 shipped.** CSV/JSON seed into local: `importLeagueIntoLocal` writes a
+  validated `LeagueImportPayload` (the SAME shape `csvToLeagueImport` #248 produces) into the local
+  provider, merging by name. `/local/import` page reuses the #248 drop-zone + `LeagueImportSchema`.
+  3 unit tests through the full CSV→payload→local chain (seed, idempotent re-import, merge). One
+  payload shape now serves server import + local seed; Slice 6 adds the third use (local→server).
 
 ## 1. Intent (from product)
 


### PR DESCRIPTION
Refs #258. Fourth slice of the free no-login local-only tier — seed the local workspace from a file, **reusing the #248 import pipeline end to end**.

## What ships
- **`importLeagueIntoLocal`** — writes a validated `LeagueImportPayload` (the **same shape** `csvToLeagueImport` produces and the server importer accepts) into the local provider. Merge-by-name mirrors the server importer: divisions/teams dedupe by name within the single local league, players dedupe by name per team; a player that can't be created (e.g. strict jersey policy) is skipped, not fatal.
- **`/local/import`** — reuses the #248 drop-zone + `csvToLeagueImport` + `LeagueImportSchema` validation (CSV and JSON), with a preview-counts → import → result-summary flow.
- **`/local` home** — an Import link beside Schedule.

One payload shape now serves **server import + local seed**; Slice 6 adds the third use (local→server migration).

## Tests
**3 new** (410 total) through the full **CSV → payload → local** chain: seed counts, idempotent re-import (adds nothing), and merge into an existing workspace (only new records created).

## Gate
type-check ✅ · **410 tests** ✅ (+3) · lint ✅ (only pre-existing `<img>`) · build ✅ — `/local/import` route compiles.

Web-only; no Convex change.

## Test on prod
`/local/import` → drop a `.csv` (one row per player, header row) or `.json` → preview → "Import into my workspace" → teams/divisions/players appear in `/local` and standings work in `/local/schedule`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)