### PR TITLE
feat(web): account-only boundary chips in local mode — Slice 5 (WSM-000137)

### DIFF
--- a/apps/web/src/app/local/_components/account-only.tsx
+++ b/apps/web/src/app/local/_components/account-only.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { Lock } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+/**
+ * Marks a capability that inherently needs a server (org sharing, multi-user
+ * roles, public viewer links, Discover forks, cloud backup) as account-only —
+ * the "clearly marked" half of AC #2 (RFC §7). Rendered as a dashed upgrade chip
+ * linking to sign-up, so the boundary doubles as the upgrade funnel rather than
+ * a dead end. Local-capable features are simply present in the shell; these are
+ * the ones intentionally not.
+ */
+export function AccountOnly({
+  feature,
+  description,
+}: {
+  feature: string;
+  description?: string;
+}) {
+  return (
+    <Link
+      href="/sign-up"
+      className="group flex items-center justify-between gap-3 rounded-md border border-dashed border-border px-3 py-2.5 transition-colors hover:border-primary hover:bg-card"
+    >
+      <span>
+        <span className="block text-sm font-medium text-foreground">
+          {feature}
+        </span>
+        {description && (
+          <span className="block text-xs text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+      <Badge
+        variant="outline"
+        className="shrink-0 gap-1 text-muted-foreground group-hover:text-primary"
+      >
+        <Lock className="h-3 w-3" />
+        Free account
+      </Badge>
+    </Link>
+  );
+}

--- a/apps/web/src/app/local/page.tsx
+++ b/apps/web/src/app/local/page.tsx
@@ -9,6 +9,7 @@ import type {
   TeamDto,
 } from "@sports-management/shared-types";
 import { useLocalProvider } from "@/lib/local/use-local-provider";
+import { AccountOnly } from "./_components/account-only";
 import { ensureLocalWorkspace } from "@/lib/local/local-workspace";
 import type { LocalWorkspaceProvider } from "@/lib/local/local-workspace-provider";
 import {
@@ -254,6 +255,40 @@ export default function LocalHomePage() {
               {savingDiv ? "Adding…" : "Add"}
             </Button>
           </form>
+        </CardContent>
+      </Card>
+
+      {/* Account-only boundary (AC #2) */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Unlock more with a free account
+          </CardTitle>
+          <CardDescription>
+            Local mode keeps everything in this browser. A free account adds the
+            things that need a server — and your local workspace comes with you.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <AccountOnly
+            feature="Back up & sync across devices"
+            description="Saved to the cloud, not just this browser."
+          />
+          <AccountOnly
+            feature="Share a public schedule & standings link"
+            description="A read-only link for players and parents."
+          />
+          <AccountOnly
+            feature="Invite coaches and assign roles"
+            description="Multiple people, with permissions."
+          />
+          <AccountOnly
+            feature="Discover & add reference teams"
+            description="Fork curated leagues into your workspace."
+          />
+          <Button asChild className="mt-2">
+            <Link href="/sign-up">Create a free account</Link>
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/docs/research/local-only-tier-rfc.md
+++ b/docs/research/local-only-tier-rfc.md
@@ -28,6 +28,11 @@ model ([org-workspace-data-model-rfc](./org-workspace-data-model-rfc.md)), the i
   provider, merging by name. `/local/import` page reuses the #248 drop-zone + `LeagueImportSchema`.
   3 unit tests through the full CSV→payload→local chain (seed, idempotent re-import, merge). One
   payload shape now serves server import + local seed; Slice 6 adds the third use (local→server).
+- **2026-06-15 — Slice 5 shipped (AC #2 met).** The boundary: account-only features are already
+  absent from the `/local` route tree (hidden); this slice adds the "clearly marked" half — an
+  `<AccountOnly>` upgrade chip and an "Unlock with a free account" panel listing the server-only
+  capabilities (cloud backup, public link, roles, Discover) as dashed chips linking to sign-up, so
+  the boundary doubles as the upgrade funnel. Presentational; no new tests.
 
 ## 1. Intent (from product)
 


### PR DESCRIPTION
Refs #258. Fifth slice of the free no-login local-only tier — **meets AC #2** (clear boundary).

## What ships
Account-only features (org sharing, multi-user roles, public viewer links, Discover forks, cloud backup) are already **absent** from the `/local` route tree — *hidden*. This adds the **"clearly marked"** half:
- **`<AccountOnly>`** — a reusable dashed upgrade chip (lock badge "Free account") linking to `/sign-up`, so the boundary doubles as the upgrade funnel rather than a dead end.
- **`/local` home** — an "Unlock more with a free account" panel listing the server-only capabilities as chips + a create-account CTA.

## Tests
Presentational; no new logic → no new tests. Full suite stays green (**410**).

## Gate
type-check ✅ · 410 tests ✅ · lint ✅ (only pre-existing `<img>`) · build ✅.

Web-only; no Convex change.

## AC status for #258
- ✅ AC #1 — use with no account, persists (Slices 2–3)
- ✅ AC #2 — clear boundary (this slice)
- ⏳ AC #3 — upgrade-without-data-loss migration (Slice 6, next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)