### PR TITLE
feat(web): roles & permissions docs page (WSM-000131)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/page.tsx
@@ -37,9 +37,17 @@ export default async function MembersPage({
         &larr; Back to {league.name}
       </Link>
 
-      <h2 className="mb-6 text-lg font-semibold text-foreground">
-        Members — {league.name}
-      </h2>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-foreground">
+          Members — {league.name}
+        </h2>
+        <Link
+          href="/dashboard/roles"
+          className="text-sm text-primary hover:underline"
+        >
+          Roles &amp; permissions →
+        </Link>
+      </div>
 
       <MemberList orgId={league.orgId} />
     </div>

--- a/apps/web/src/app/dashboard/roles/page.tsx
+++ b/apps/web/src/app/dashboard/roles/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import { Check, Minus, ArrowLeft } from "lucide-react";
+import { ORG_ROLES, roleLabel } from "@/lib/permissions";
+import {
+  capabilityGrid,
+  ROLE_SUMMARIES,
+} from "@/lib/roles-matrix";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export const metadata = {
+  title: "Roles & permissions",
+};
+
+export default function RolesPage() {
+  const grid = capabilityGrid();
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link
+          href="/dashboard"
+          className="mb-2 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Dashboard
+        </Link>
+        <h1 className="text-xl font-semibold text-foreground">
+          Roles &amp; permissions
+        </h1>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Everyone in your organization has one of three roles. This is exactly
+          what each can do — use it to decide who to assign which role.
+        </p>
+      </div>
+
+      {/* Role summaries */}
+      <div className="grid gap-3 sm:grid-cols-3">
+        {ROLE_SUMMARIES.map((s) => (
+          <Card key={s.role}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">{roleLabel(s.role)}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{s.blurb}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Capability matrix */}
+      <div className="rounded-md border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="min-w-56">Capability</TableHead>
+              {ORG_ROLES.map((role) => (
+                <TableHead key={role} className="text-center">
+                  {roleLabel(role)}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {grid.map((row) => (
+              <TableRow key={row.label}>
+                <TableCell>
+                  <span className="font-medium text-foreground">
+                    {row.label}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {row.detail}
+                  </span>
+                </TableCell>
+                {ORG_ROLES.map((role) => (
+                  <TableCell key={role} className="text-center">
+                    {row.allowed[role] ? (
+                      <Check
+                        className="mx-auto h-4 w-4 text-green-500"
+                        aria-label="Allowed"
+                      />
+                    ) : (
+                      <Minus
+                        className="mx-auto h-4 w-4 text-muted-foreground/40"
+                        aria-label="Not allowed"
+                      />
+                    )}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* New-member default */}
+      <Card className="border-primary/30">
+        <CardContent className="py-4 text-sm text-muted-foreground">
+          New members join as <strong className="text-foreground">Viewer</strong>{" "}
+          — the least-privilege default. Only an{" "}
+          <strong className="text-foreground">Admin</strong> can promote someone
+          to Coach or Admin, from the league&rsquo;s Members page.
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/roles-matrix.test.ts
+++ b/apps/web/src/lib/__tests__/roles-matrix.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { capabilityGrid, ROLE_SUMMARIES } from "../roles-matrix";
+import { ORG_ROLES } from "../permissions";
+
+describe("capabilityGrid", () => {
+  const grid = capabilityGrid();
+  const row = (label: string) => grid.find((r) => r.label === label)!;
+
+  it("covers every capability for all three roles", () => {
+    expect(grid.length).toBeGreaterThanOrEqual(10);
+    for (const r of grid) {
+      expect(Object.keys(r.allowed).sort()).toEqual([...ORG_ROLES].sort());
+    }
+  });
+
+  it("viewer can only view", () => {
+    expect(row("View everything").allowed.viewer).toBe(true);
+    // Every non-view capability is denied to viewer.
+    const nonView = grid.filter((r) => r.label !== "View everything");
+    expect(nonView.every((r) => r.allowed.viewer === false)).toBe(true);
+  });
+
+  it("coach manages the roster but not org settings", () => {
+    expect(row("Manage players").allowed.coach).toBe(true);
+    expect(row("Manage schedules & results").allowed.coach).toBe(true);
+    // Org-settings capabilities are admin-only.
+    expect(row("Manage members & invites").allowed.coach).toBe(false);
+    expect(row("Delete teams").allowed.coach).toBe(false);
+    expect(row("Change league visibility").allowed.coach).toBe(false);
+  });
+
+  it("admin can do everything", () => {
+    expect(grid.every((r) => r.allowed.admin === true)).toBe(true);
+  });
+
+  it("documents a summary for each role", () => {
+    expect(ROLE_SUMMARIES.map((s) => s.role).sort()).toEqual(
+      [...ORG_ROLES].sort(),
+    );
+  });
+});

--- a/apps/web/src/lib/roles-matrix.ts
+++ b/apps/web/src/lib/roles-matrix.ts
@@ -1,0 +1,119 @@
+import {
+  canManageOrgSettings,
+  canManageRoster,
+  canView,
+  ORG_ROLES,
+  type OrgRole,
+} from "./permissions";
+
+/**
+ * The roles & permissions reference (WSM-000131, #249).
+ *
+ * Each capability is gated by the SAME predicate that enforces it in
+ * `permissions.ts` — the grid is computed by calling that predicate per role, so
+ * the docs matrix can't drift from the policy. Add a capability here by pointing
+ * it at the predicate that guards it; the ✓/✗ columns follow automatically.
+ */
+export interface RoleCapability {
+  label: string;
+  detail: string;
+  gate: (role: OrgRole) => boolean;
+}
+
+export const ROLE_CAPABILITIES: readonly RoleCapability[] = [
+  {
+    label: "View everything",
+    detail: "Leagues, teams, rosters, depth charts, schedules & standings.",
+    gate: canView,
+  },
+  {
+    label: "Manage players",
+    detail: "Add, edit and remove players.",
+    gate: canManageRoster,
+  },
+  {
+    label: "Manage rosters & depth charts",
+    detail: "Assign players to a roster and order depth charts.",
+    gate: canManageRoster,
+  },
+  {
+    label: "Edit team details",
+    detail: "Names, colors, venue and the jersey policy.",
+    gate: canManageRoster,
+  },
+  {
+    label: "Manage schedules & results",
+    detail: "Create fixtures and enter game results.",
+    gate: canManageRoster,
+  },
+  {
+    label: "Create, rename & delete leagues",
+    detail: "Full league CRUD.",
+    gate: canManageOrgSettings,
+  },
+  {
+    label: "Manage members & invites",
+    detail: "Invite people and assign their role.",
+    gate: canManageOrgSettings,
+  },
+  {
+    label: "Change league visibility",
+    detail: "Toggle the public viewer link on or off.",
+    gate: canManageOrgSettings,
+  },
+  {
+    label: "Lock / unlock rosters",
+    detail: "Freeze a season's rosters against edits.",
+    gate: canManageOrgSettings,
+  },
+  {
+    label: "Delete teams",
+    detail: "Permanently remove a team and its roster.",
+    gate: canManageOrgSettings,
+  },
+] as const;
+
+export interface RoleSummary {
+  role: OrgRole;
+  blurb: string;
+}
+
+export const ROLE_SUMMARIES: readonly RoleSummary[] = [
+  {
+    role: "admin",
+    blurb:
+      "Full control — league CRUD, members & invites, visibility, roster lock and team deletion, plus everything a coach can do.",
+  },
+  {
+    role: "coach",
+    blurb:
+      "Day-to-day team operations — players, rosters, depth charts and schedules/results. No org or league settings.",
+  },
+  {
+    role: "viewer",
+    blurb:
+      "Read-only access to the whole workspace. The least-privilege default for every new member.",
+  },
+] as const;
+
+/** A capability row with a resolved ✓/✗ per role, in ORG_ROLES order. */
+export interface CapabilityRow {
+  label: string;
+  detail: string;
+  allowed: Record<OrgRole, boolean>;
+}
+
+/** Compute the full matrix by evaluating each capability's gate per role. */
+export function capabilityGrid(): CapabilityRow[] {
+  return ROLE_CAPABILITIES.map((cap) => ({
+    label: cap.label,
+    detail: cap.detail,
+    allowed: ORG_ROLES.reduce(
+      (acc, role) => {
+        acc[role] = cap.gate(role);
+        return acc;
+      },
+      {} as Record<OrgRole, boolean>,
+    ),
+  }));
+}


### PR DESCRIPTION
Closes #249. A docs page explaining the three intra-org roles (admin / coach / viewer) and exactly what each can do.

## What ships
- **`/dashboard/roles`** — role summary cards + a ✓/✗ **capability matrix** (view; players/rosters/depth charts; schedules & results; league CRUD; members & invites; visibility; roster lock; team deletion) + a note that new members default to **Viewer** and only an admin can promote.
- **Members page** links to it ("Roles & permissions →").

## Can't drift from policy
`roles-matrix.ts` defines each capability with the **same predicate that enforces it** in `permissions.ts` (`canView` / `canManageRoster` / `canManageOrgSettings`). The grid is computed by evaluating those predicates per role — so the matrix is literally derived from the source of truth, not hand-maintained.

## Tests
**5 new** (419 total) asserting the grid matches the policy: viewer is view-only, coach manages the roster but not org settings, admin can do everything, and every role has a summary.

## Gate
type-check ✅ · **419 tests** ✅ (+5) · lint ✅ (only pre-existing `<img>`) · build ✅ — `/dashboard/roles` route present.

Web-only; no Convex change.

## AC coverage
- ✅ Capability matrix for admin/coach/viewer across all listed capabilities
- ✅ States new members default to viewer; only an admin can promote
- ✅ Linked from the league members page

🤖 Generated with [Claude Code](https://claude.com/claude-code)