### PR TITLE
feat(web): theme toggle + de-retro cleanup — UI overhaul P1 (WSM-000136)

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -17,8 +17,5 @@
     "ui": "@/components/ui",
     "lib": "@/lib",
     "hooks": "@/hooks"
-  },
-  "registries": {
-    "@8bitcn": "https://www.8bitcn.com/r/{name}.json"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "geist": "^1.7.0",
     "lucide-react": "^0.577.0",
     "next": "^15.3.0",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import Sidebar from "./sidebar";
 import { LeagueSwitcher } from "./league-switcher";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 interface LeagueOption {
   id: string;
@@ -39,7 +40,10 @@ export default function MobileHeader({
       ) : (
         <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
       )}
-      <UserButton />
+      <div className="flex items-center gap-1">
+        <ThemeToggle />
+        <UserButton />
+      </div>
     </header>
   );
 }

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import Sidebar from "./_components/sidebar";
 import MobileHeader from "./_components/mobile-header";
 import { LeagueSwitcher } from "./_components/league-switcher";
 import { MigrateLocalPrompt } from "./_components/migrate-local-prompt";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { resolveActiveLeague } from "@/lib/active-league";
 
 export default async function DashboardLayout({
@@ -37,7 +38,10 @@ export default async function DashboardLayout({
         {/* Desktop header — the league switcher is the focus anchor (WSM-000103) */}
         <header className="hidden items-center justify-between border-b border-border px-8 py-4 lg:flex">
           <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
-          <UserButton />
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <UserButton />
+          </div>
         </header>
 
         <main id="main-content" className="flex-1 p-4 sm:p-6 lg:p-8">

--- a/apps/web/src/app/dev/ui/page.tsx
+++ b/apps/web/src/app/dev/ui/page.tsx
@@ -34,6 +34,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 function Section({
   title,
@@ -56,13 +57,17 @@ export default function UiKitchenSinkPage() {
   return (
     <div className="min-h-screen px-6 py-10 font-sans">
       <div className="mx-auto max-w-4xl space-y-12">
-        <header className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            Design system — professional theme
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            WSM-000136 · standard shadcn/ui · dark-first.
-          </p>
+        <header className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+              Design system — professional theme
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              WSM-000136 · standard shadcn/ui · dark-first. Toggle to review the
+              light theme →
+            </p>
+          </div>
+          <ThemeToggle />
         </header>
 
         <Section title="Buttons">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "sonner";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
 export const dynamic = "force-dynamic";
@@ -61,18 +62,26 @@ export default function RootLayout({
 }) {
   return (
     <ClerkProvider>
-      {/* dark-first (WSM-000136); light theme retained for a future toggle. */}
+      {/* dark-first (WSM-000136); next-themes sets the class, light via toggle. */}
       <html
         lang="en"
-        className={`dark ${GeistSans.variable} ${GeistMono.variable} ${pixelifySans.variable}`}
+        suppressHydrationWarning
+        className={`${GeistSans.variable} ${GeistMono.variable} ${pixelifySans.variable}`}
       >
         <body className="bg-background text-foreground font-sans antialiased">
           <script
             type="application/ld+json"
             dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
           />
-          {children}
-          <Toaster position="bottom-right" richColors closeButton />
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="dark"
+            enableSystem={false}
+            disableTransitionOnChange
+          >
+            {children}
+            <Toaster position="bottom-right" richColors closeButton />
+          </ThemeProvider>
           <Analytics />
           <SpeedInsights />
         </body>

--- a/apps/web/src/app/local/layout.tsx
+++ b/apps/web/src/app/local/layout.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { LocalModeBanner } from "./_components/local-mode-banner";
 
 /**
@@ -19,9 +20,12 @@ export default function LocalLayout({
         <Link href="/local" className="text-sm font-semibold text-foreground">
           sprtsmng <span className="text-muted-foreground">· local</span>
         </Link>
-        <Button asChild size="sm">
-          <Link href="/sign-up">Create a free account</Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Button asChild size="sm">
+            <Link href="/sign-up">Create a free account</Link>
+          </Button>
+        </div>
       </header>
       <LocalModeBanner />
       <main className="mx-auto max-w-4xl px-4 py-8">{children}</main>

--- a/apps/web/src/components/marketing/header.tsx
+++ b/apps/web/src/components/marketing/header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Monogram } from "./monogram";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 interface HeaderProps {
   isSignedIn: boolean;
@@ -35,6 +36,7 @@ export function MarketingHeader({ isSignedIn }: HeaderProps) {
         </nav>
 
         <div className="flex items-center gap-3">
+          <ThemeToggle />
           {isSignedIn ? (
             <Button asChild size="sm">
               <Link href="/dashboard">Go to Dashboard</Link>

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+/**
+ * App theme provider (WSM-000136 P1). Wraps next-themes so the `dark`/`light`
+ * class is applied to <html>. Dark is the default and design target; light is
+ * retained and reachable via the toggle. System preference is disabled so the
+ * default is deterministic (and visual-regression snapshots stay dark).
+ */
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Dark/light toggle (WSM-000136 P1). Renders a stable icon until mounted to
+ * avoid a hydration mismatch (the resolved theme is only known client-side).
+ */
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const isDark = resolvedTheme !== "light";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      title="Toggle theme"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {mounted && !isDark ? (
+        <Moon className="h-4 w-4" />
+      ) : (
+        <Sun className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       next:
         specifier: ^15.3.0
         version: 15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5926,6 +5929,12 @@ packages:
 
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.5.13:
     resolution: {integrity: sha512-n0AXf6vlTwGuM93Z++POtjMsRuQ9pT5v2URPciXKUQIl/EB2WjXF0YiIUxaa9AEMFaMpZlaG3KPK6i4UVnx9eQ==}
@@ -14004,6 +14013,11 @@ snapshots:
   neo-async@2.6.2: {}
 
   nerf-dart@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   next@15.5.13(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
Refs #255 (P1). First phase of the UI-overhaul epic. Per the pre-P1 audit (RFC §11), the "8bit migration" was already done, so **P1 is the light/dark toggle + trivial cleanup**, not a re-theme.

## What ships
- **`next-themes` ThemeProvider** — dark default, system disabled (so the default is deterministic and visual snapshots stay dark). The root layout no longer hardcodes the `dark` class; next-themes sets it (`suppressHydrationWarning`).
- **`ThemeToggle`** (sun/moon, hydration-safe) in the **dashboard desktop + mobile headers, the marketing header, and the `/local` shell header**.
- Removed the stale **`@8bitcn`** registry line from `components.json`.
- **`/dev/ui`** kitchen sink gains the toggle to review both themes.

## Deliberately out of scope (keeps the 4 visual baselines stable)
Left the already-monochrome oklch token ramp and `PixelLineChart` untouched — the chart restyle belongs to P4. Light tokens already existed in `globals.css`; this just makes them reachable. Only *how* the theme class is applied changed (dark stays the rendered default), so the Playwright visual baselines should hold.

## Gate
type-check ✅ · **419 tests** ✅ · lint ✅ (only pre-existing `<img>`) · build ✅.

Web-only; no Convex change.

## Test on prod
Any header (landing, `/local`, dashboard) → click the sun/moon → flips to light and back; preference persists across reloads. `/dev/ui` shows the full primitive set in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)