### PR TITLE
feat(web): ⌘K command palette + context breadcrumb — UI overhaul P2 (WSM-000136)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "convex": "^1.19.0",
     "dexie": "^4.4.3",
     "flags": "^4.0.6",

--- a/apps/web/src/app/dashboard/_components/breadcrumbs.tsx
+++ b/apps/web/src/app/dashboard/_components/breadcrumbs.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import { breadcrumbsForPath } from "@/lib/breadcrumbs";
+
+/**
+ * Slim context breadcrumb above the page content (WSM-000136 P2). Hidden at the
+ * dashboard root (a lone "Dashboard" crumb adds nothing).
+ */
+export function Breadcrumbs() {
+  const pathname = usePathname();
+  const crumbs = breadcrumbsForPath(pathname);
+  if (crumbs.length <= 1) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="mb-4 flex items-center gap-1 text-sm text-muted-foreground"
+    >
+      {crumbs.map((crumb, i) => {
+        const isLast = i === crumbs.length - 1;
+        return (
+          <span key={crumb.href} className="flex items-center gap-1">
+            {i > 0 && <ChevronRight className="h-3.5 w-3.5 opacity-50" />}
+            {isLast ? (
+              <span className="font-medium text-foreground">{crumb.label}</span>
+            ) : (
+              <Link href={crumb.href} className="hover:text-foreground">
+                {crumb.label}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/command-palette.tsx
+++ b/apps/web/src/app/dashboard/_components/command-palette.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  LayoutDashboard,
+  Trophy,
+  Compass,
+  Users,
+  UserCircle,
+  Calendar,
+  Layers,
+  Upload,
+  CreditCard,
+  Shield,
+} from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+/** Window event that any trigger button dispatches to open the single palette. */
+export const COMMAND_PALETTE_EVENT = "command-palette:open";
+
+export function openCommandPalette() {
+  window.dispatchEvent(new Event(COMMAND_PALETTE_EVENT));
+}
+
+const NAV = [
+  { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
+  { href: "/dashboard/leagues", label: "Leagues", icon: Trophy },
+  { href: "/dashboard/discover", label: "Discover", icon: Compass },
+  { href: "/dashboard/teams", label: "Teams", icon: Users },
+  { href: "/dashboard/players", label: "Players", icon: UserCircle },
+  { href: "/dashboard/seasons", label: "Seasons", icon: Calendar },
+  { href: "/dashboard/divisions", label: "Divisions", icon: Layers },
+  { href: "/dashboard/import", label: "Import", icon: Upload },
+  { href: "/dashboard/roles", label: "Roles & permissions", icon: Shield },
+  { href: "/dashboard/billing", label: "Billing", icon: CreditCard },
+];
+
+interface LeagueOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Global ⌘K command palette (WSM-000136 P2). Mounted ONCE in the dashboard
+ * layout; opens on ⌘K / Ctrl+K or a `command-palette:open` window event (so
+ * header buttons can trigger the same instance). Jumps to nav destinations and
+ * the user's leagues.
+ */
+export function CommandPalette({ leagues }: { leagues: LeagueOption[] }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    const onOpen = () => setOpen(true);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener(COMMAND_PALETTE_EVENT, onOpen);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener(COMMAND_PALETTE_EVENT, onOpen);
+    };
+  }, []);
+
+  const go = (href: string) => {
+    setOpen(false);
+    router.push(href);
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Command palette"
+      description="Jump to a page or league"
+    >
+      <CommandInput placeholder="Search pages and leagues…" />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Navigate">
+          {NAV.map((item) => (
+            <CommandItem
+              key={item.href}
+              value={`go ${item.label}`}
+              onSelect={() => go(item.href)}
+            >
+              <item.icon />
+              {item.label}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        {leagues.length > 0 && (
+          <CommandGroup heading="Leagues">
+            {leagues.map((league) => (
+              <CommandItem
+                key={league.id}
+                value={`league ${league.name}`}
+                onSelect={() => go(`/dashboard/leagues/${league.id}`)}
+              >
+                <Trophy />
+                {league.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/command-trigger.tsx
+++ b/apps/web/src/app/dashboard/_components/command-trigger.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { openCommandPalette } from "./command-palette";
+
+/**
+ * Opens the global command palette (WSM-000136 P2). Two looks:
+ *  - `variant="bar"` (default): a Vercel-style "Search…  ⌘K" bar for the desktop
+ *    header (the ⌘/Ctrl hint resolves per-platform after mount).
+ *  - `variant="icon"`: a compact search icon button for the mobile header.
+ */
+export function CommandTrigger({
+  variant = "bar",
+}: {
+  variant?: "bar" | "icon";
+}) {
+  const [isMac, setIsMac] = useState(false);
+  useEffect(() => {
+    setIsMac(
+      typeof navigator !== "undefined" &&
+        navigator.platform.toLowerCase().includes("mac"),
+    );
+  }, []);
+
+  if (variant === "icon") {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Search"
+        onClick={openCommandPalette}
+      >
+        <Search className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={openCommandPalette}
+      className="text-muted-foreground w-56 justify-between gap-2 font-normal"
+    >
+      <span className="flex items-center gap-2">
+        <Search className="h-4 w-4" />
+        Search…
+      </span>
+      <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium select-none">
+        {isMac ? "⌘" : "Ctrl"} K
+      </kbd>
+    </Button>
+  );
+}

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import Sidebar from "./sidebar";
 import { LeagueSwitcher } from "./league-switcher";
+import { CommandTrigger } from "./command-trigger";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 interface LeagueOption {
@@ -41,6 +42,7 @@ export default function MobileHeader({
         <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
       )}
       <div className="flex items-center gap-1">
+        <CommandTrigger variant="icon" />
         <ThemeToggle />
         <UserButton />
       </div>

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -4,6 +4,9 @@ import Sidebar from "./_components/sidebar";
 import MobileHeader from "./_components/mobile-header";
 import { LeagueSwitcher } from "./_components/league-switcher";
 import { MigrateLocalPrompt } from "./_components/migrate-local-prompt";
+import { CommandPalette } from "./_components/command-palette";
+import { CommandTrigger } from "./_components/command-trigger";
+import { Breadcrumbs } from "./_components/breadcrumbs";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { resolveActiveLeague } from "@/lib/active-league";
 
@@ -37,14 +40,20 @@ export default async function DashboardLayout({
 
         {/* Desktop header — the league switcher is the focus anchor (WSM-000103) */}
         <header className="hidden items-center justify-between border-b border-border px-8 py-4 lg:flex">
-          <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
+          <div className="flex items-center gap-3">
+            <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
+            <CommandTrigger />
+          </div>
           <div className="flex items-center gap-2">
             <ThemeToggle />
             <UserButton />
           </div>
         </header>
 
+        <CommandPalette leagues={leagues} />
+
         <main id="main-content" className="flex-1 p-4 sm:p-6 lg:p-8">
+          <Breadcrumbs />
           <MigrateLocalPrompt />
           {children}
         </main>

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/apps/web/src/lib/__tests__/breadcrumbs.test.ts
+++ b/apps/web/src/lib/__tests__/breadcrumbs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { breadcrumbsForPath } from "../breadcrumbs";
+
+describe("breadcrumbsForPath", () => {
+  it("returns a single crumb at the dashboard root", () => {
+    expect(breadcrumbsForPath("/dashboard")).toEqual([
+      { label: "Dashboard", href: "/dashboard" },
+    ]);
+  });
+
+  it("labels known sections", () => {
+    expect(breadcrumbsForPath("/dashboard/teams")).toEqual([
+      { label: "Dashboard", href: "/dashboard" },
+      { label: "Teams", href: "/dashboard/teams" },
+    ]);
+  });
+
+  it("skips dynamic id segments but keeps them in later hrefs", () => {
+    const crumbs = breadcrumbsForPath("/dashboard/leagues/abc123XYZ/members");
+    expect(crumbs.map((c) => c.label)).toEqual([
+      "Dashboard",
+      "Leagues",
+      "Members",
+    ]);
+    // The id is invisible as a label but preserved in the Members link.
+    expect(crumbs.at(-1)!.href).toBe("/dashboard/leagues/abc123XYZ/members");
+  });
+
+  it("ignores unknown trailing segments (e.g. a bare league id)", () => {
+    expect(breadcrumbsForPath("/dashboard/leagues/abc123").map((c) => c.label)).toEqual([
+      "Dashboard",
+      "Leagues",
+    ]);
+  });
+
+  it("handles a deep nested path", () => {
+    expect(
+      breadcrumbsForPath("/dashboard/teams/t1/roster").map((c) => c.label),
+    ).toEqual(["Dashboard", "Teams", "Roster"]);
+  });
+});

--- a/apps/web/src/lib/breadcrumbs.ts
+++ b/apps/web/src/lib/breadcrumbs.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure pathname → breadcrumb trail (WSM-000136 P2).
+ *
+ * Builds a crumb for each KNOWN route segment, accumulating the href across all
+ * segments (so dynamic `[id]` segments stay in the links but contribute no
+ * visible crumb — we don't have entity names client-side here). The last crumb
+ * is the current page.
+ */
+export interface Crumb {
+  label: string;
+  href: string;
+}
+
+const SEGMENT_LABELS: Record<string, string> = {
+  dashboard: "Dashboard",
+  leagues: "Leagues",
+  teams: "Teams",
+  players: "Players",
+  seasons: "Seasons",
+  divisions: "Divisions",
+  discover: "Discover",
+  import: "Import",
+  billing: "Billing",
+  roles: "Roles",
+  members: "Members",
+  roster: "Roster",
+  standings: "Standings",
+  schedule: "Schedule",
+  format: "Format",
+  requests: "Requests",
+  development: "Development",
+  "depth-chart": "Depth chart",
+};
+
+export function breadcrumbsForPath(pathname: string): Crumb[] {
+  const segments = pathname.split("/").filter(Boolean);
+  const crumbs: Crumb[] = [];
+  let href = "";
+  for (const segment of segments) {
+    href += `/${segment}`;
+    const label = SEGMENT_LABELS[segment];
+    if (label) crumbs.push({ label, href });
+  }
+  return crumbs;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       convex:
         specifier: ^1.19.0
         version: 1.35.1(@clerk/clerk-react@5.61.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -3972,6 +3975,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -11639,6 +11648,18 @@ snapshots:
       wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   co@4.6.0: {}
 


### PR DESCRIPTION
Refs #255 (P2). Second phase of the UI-overhaul epic — the first net-new "Vercel feel" shell features.

## What ships
- **⌘K command palette** (`cmdk`): a shadcn `command` primitive + a global palette mounted **once** in the dashboard layout. Jumps to every nav destination and the user's leagues. Opened by **⌘K / Ctrl+K** or a **"Search… ⌘K"** bar in the desktop header / a **search icon** in the mobile header — triggers are decoupled from the dialog via a window event so one instance serves all of them.
- **Context breadcrumb**: a slim trail above page content, derived from the pathname by a **pure `breadcrumbsForPath`** (known segments are labelled; dynamic `[id]` segments stay in the hrefs but show no crumb). Hidden at the dashboard root.

## Tests
**5 new** (424 total) for `breadcrumbsForPath` (root, known sections, id-skipping with href preserved, deep nested paths).

## Gate
type-check ✅ · **424 tests** ✅ (+5) · lint ✅ (only pre-existing `<img>`) · build ✅.

Web-only; no Convex change. Sidebar/mobile drawer were already professional (left as-is). The RFC's "status dot" is deferred — no meaningful signal to show yet; I didn't want decorative noise.

## Test on prod
Anywhere in `/dashboard` press **⌘K** (or click the search bar) → palette opens → type to filter pages/leagues → Enter jumps. Navigate into a league/team → the breadcrumb trail appears above the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)