### PR TITLE
feat(web): bento overview dashboard — UI overhaul P4 (WSM-000136)

### DIFF
--- a/apps/web/src/app/dashboard/_components/bento/bento-widgets.tsx
+++ b/apps/web/src/app/dashboard/_components/bento/bento-widgets.tsx
@@ -1,0 +1,159 @@
+import { cn } from "@/lib/utils";
+import {
+  fraction,
+  gaugeDash,
+  heatLevel,
+  percent,
+  sparklinePoints,
+} from "@/lib/bento";
+
+/** A bento tile. */
+export function BentoCard({
+  title,
+  action,
+  className,
+  children,
+}: {
+  title?: string;
+  action?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-xl border border-border bg-card p-5",
+        className,
+      )}
+    >
+      {(title || action) && (
+        <div className="mb-3 flex items-center justify-between gap-2">
+          {title && (
+            <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {title}
+            </h3>
+          )}
+          {action}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+/** Ring gauge showing value/max as a percentage. */
+export function RadialGauge({
+  value,
+  max,
+  caption,
+}: {
+  value: number;
+  max: number;
+  caption: string;
+}) {
+  const size = 104;
+  const stroke = 10;
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const { dash, gap } = gaugeDash(fraction(value, max), c);
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg width={size} height={size} className="-rotate-90">
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            strokeWidth={stroke}
+            stroke="currentColor"
+            className="text-border"
+          />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            strokeDasharray={`${dash} ${gap}`}
+            stroke="currentColor"
+            className="text-foreground"
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="font-mono text-xl font-semibold text-foreground">
+            {percent(value, max)}%
+          </span>
+        </div>
+      </div>
+      <p className="text-center text-xs text-muted-foreground">{caption}</p>
+    </div>
+  );
+}
+
+/** Minimal trend line. */
+export function Sparkline({
+  values,
+  className,
+}: {
+  values: number[];
+  className?: string;
+}) {
+  const w = 260;
+  const h = 52;
+  const pts = sparklinePoints(values, w, h, 4);
+  if (!pts) {
+    return (
+      <div className="flex h-[52px] items-center text-xs text-muted-foreground">
+        No data yet.
+      </div>
+    );
+  }
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      className={cn("h-[52px] w-full text-foreground", className)}
+      role="img"
+      aria-label="Trend"
+    >
+      <polyline
+        points={pts}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+const HEAT_CLASSES = [
+  "bg-muted",
+  "bg-foreground/20",
+  "bg-foreground/40",
+  "bg-foreground/60",
+  "bg-foreground/90",
+] as const;
+
+/** GitHub-style intensity grid; one cell per week. */
+export function WeekHeatmap({ counts }: { counts: number[] }) {
+  if (counts.length === 0) {
+    return <p className="text-xs text-muted-foreground">No games yet.</p>;
+  }
+  const max = Math.max(1, ...counts);
+  return (
+    <div className="flex flex-wrap gap-1">
+      {counts.map((count, i) => (
+        <div
+          key={i}
+          title={`Week ${i + 1}: ${count} game${count === 1 ? "" : "s"}`}
+          className={cn("h-4 w-4 rounded-sm", HEAT_CLASSES[heatLevel(count, max)])}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -7,16 +7,28 @@ import {
   getSeasons,
   getDivisions,
   getLeagues,
+  listFixturesBySeason,
+  getResultByFixture,
+  computeStandings,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
+import { resolveActiveLeague } from "@/lib/active-league";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import {
   Trophy,
   Users,
   UserCircle,
   Calendar,
   Layers,
+  CalendarClock,
 } from "lucide-react";
+import {
+  BentoCard,
+  RadialGauge,
+  Sparkline,
+  WeekHeatmap,
+} from "./_components/bento/bento-widgets";
 
 const statCards = [
   { label: "Leagues", href: "/dashboard/leagues", key: "leagues", icon: Trophy },
@@ -25,6 +37,13 @@ const statCards = [
   { label: "Seasons", href: "/dashboard/seasons", key: "seasons", icon: Calendar },
   { label: "Divisions", href: "/dashboard/divisions", key: "divisions", icon: Layers },
 ] as const;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
 
 export default async function DashboardPage() {
   const { userId } = await auth();
@@ -47,24 +66,123 @@ export default async function DashboardPage() {
     divisions: divisions.length,
   };
 
+  const { activeLeagueId } = await resolveActiveLeague(userId);
+  const activeLeague =
+    leagues.find((l) => l.id === activeLeagueId) ?? leagues[0] ?? null;
+
+  // League-scoped slices for the bento (P4 is league-wide; coach/team tailoring
+  // is a follow-up slice).
+  const leagueTeams = activeLeague
+    ? teams.filter((t) => t.leagueId === activeLeague.id)
+    : [];
+  const leagueTeamIds = new Set(leagueTeams.map((t) => t.id));
+  const leaguePlayers = players.filter((p) => leagueTeamIds.has(p.teamId));
+  const activePlayers = leaguePlayers.filter(
+    (p) => p.status.toLowerCase() === "active",
+  ).length;
+  const rosterCap = leagueTeams.reduce((a, t) => a + (t.rosterLimit ?? 53), 0);
+
+  const leagueSeasons = activeLeague
+    ? seasons.filter((s) => s.leagueId === activeLeague.id)
+    : [];
+  const activeSeason =
+    leagueSeasons.find((s) => s.status === "active") ?? leagueSeasons[0] ?? null;
+
+  // Active-season schedule, results and standings (existing wrappers only).
+  let fixturesTotal = 0;
+  let fixturesFinal = 0;
+  let perWeekGames: number[] = [];
+  let perWeekPoints: number[] = [];
+  let nextKickoff: { label: string; date: string } | null = null;
+  let standings: Awaited<ReturnType<typeof computeStandings>> = [];
+  let feed: {
+    week: number | null;
+    home: string;
+    away: string;
+    homeScore: number;
+    awayScore: number;
+  }[] = [];
+
+  if (activeSeason) {
+    const fixtures = await listFixturesBySeason(activeSeason.id);
+    const results = await Promise.all(
+      fixtures.map((f) => getResultByFixture(f.id)),
+    );
+    const resultByFixture = new Map(
+      fixtures.map((f, i) => [f.id, results[i]] as const),
+    );
+    fixturesTotal = fixtures.length;
+    fixturesFinal = fixtures.filter((f) => f.status === "final").length;
+
+    const maxWeek = Math.max(0, ...fixtures.map((f) => f.week ?? 0));
+    perWeekGames = Array.from(
+      { length: maxWeek },
+      (_, i) =>
+        fixtures.filter((f) => f.week === i + 1 && f.status === "final").length,
+    );
+    perWeekPoints = Array.from({ length: maxWeek }, (_, i) =>
+      fixtures
+        .filter((f) => f.week === i + 1)
+        .reduce((sum, f) => {
+          const r = resultByFixture.get(f.id);
+          return sum + (r ? r.homeScore + r.awayScore : 0);
+        }, 0),
+    );
+
+    const upcoming = fixtures
+      .filter((f) => f.status === "scheduled" && f.scheduledAt)
+      .sort((a, b) => (a.scheduledAt! < b.scheduledAt! ? -1 : 1))[0];
+    if (upcoming) {
+      nextKickoff = {
+        label: `${upcoming.homeTeamName} vs ${upcoming.awayTeamName}`,
+        date: formatDate(upcoming.scheduledAt!),
+      };
+    }
+
+    standings = (await computeStandings(activeSeason.id)).slice(0, 5);
+
+    feed = fixtures
+      .filter((f) => f.status === "final")
+      .map((f) => ({ f, r: resultByFixture.get(f.id) }))
+      .filter((x) => x.r)
+      .sort((a, b) => (b.f.week ?? 0) - (a.f.week ?? 0))
+      .slice(0, 6)
+      .map((x) => ({
+        week: x.f.week,
+        home: x.f.homeTeamName,
+        away: x.f.awayTeamName,
+        homeScore: x.r!.homeScore,
+        awayScore: x.r!.awayScore,
+      }));
+  }
+
   return (
-    <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Overview</h2>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-foreground">Overview</h2>
+        {activeLeague && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Trophy className="h-4 w-4" />
+            <span className="font-medium text-foreground">
+              {activeLeague.name}
+            </span>
+            {activeSeason && <Badge variant="secondary">{activeSeason.name}</Badge>}
+          </div>
+        )}
+      </div>
+
+      {/* Quick-nav stat strip */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         {statCards.map((card) => {
           const Icon = card.icon;
           return (
             <Link key={card.key} href={card.href}>
-              <Card className="transition-shadow hover:shadow-md">
-                <CardContent className="flex items-center gap-4 p-6">
-                  <div className="rounded-lg bg-primary/10 p-2.5">
-                    <Icon className="h-5 w-5 text-primary" />
-                  </div>
+              <Card className="transition-colors hover:border-primary">
+                <CardContent className="flex items-center gap-3 p-4">
+                  <Icon className="h-4 w-4 text-muted-foreground" />
                   <div>
-                    <p className="text-sm font-medium text-muted-foreground">
-                      {card.label}
-                    </p>
-                    <p className="text-2xl font-bold text-foreground">
+                    <p className="text-xs text-muted-foreground">{card.label}</p>
+                    <p className="text-xl font-bold text-foreground">
                       {counts[card.key]}
                     </p>
                   </div>
@@ -74,6 +192,174 @@ export default async function DashboardPage() {
           );
         })}
       </div>
+
+      {leagues.length === 0 ? (
+        <BentoCard className="items-center py-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            No leagues yet. Add teams from{" "}
+            <Link href="/dashboard/discover" className="text-primary hover:underline">
+              Discover
+            </Link>{" "}
+            or{" "}
+            <Link href="/dashboard/import" className="text-primary hover:underline">
+              import
+            </Link>{" "}
+            a roster to get started.
+          </p>
+        </BentoCard>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+          {/* Hero */}
+          <BentoCard title="This league" className="lg:col-span-2">
+            <div className="flex flex-1 flex-col justify-between gap-4">
+              <div>
+                <p className="text-2xl font-semibold text-foreground">
+                  {activeLeague!.name}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {leagueTeams.length} team{leagueTeams.length === 1 ? "" : "s"} ·{" "}
+                  {leaguePlayers.length} player
+                  {leaguePlayers.length === 1 ? "" : "s"} ·{" "}
+                  {activeSeason ? activeSeason.name : "no active season"}
+                </p>
+              </div>
+              {nextKickoff ? (
+                <div className="flex items-center gap-2 rounded-lg border border-border p-3 text-sm">
+                  <CalendarClock className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Next:</span>
+                  <span className="font-medium text-foreground">
+                    {nextKickoff.label}
+                  </span>
+                  <span className="ml-auto font-mono text-muted-foreground">
+                    {nextKickoff.date}
+                  </span>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No upcoming games scheduled.
+                </p>
+              )}
+            </div>
+          </BentoCard>
+
+          {/* Season health gauges */}
+          <BentoCard title="Season health" className="lg:col-span-2">
+            <div className="flex flex-1 items-center justify-around gap-4">
+              <RadialGauge
+                value={activePlayers}
+                max={rosterCap}
+                caption="Roster fill"
+              />
+              <RadialGauge
+                value={fixturesFinal}
+                max={fixturesTotal}
+                caption="Schedule played"
+              />
+            </div>
+          </BentoCard>
+
+          {/* Standings */}
+          <BentoCard
+            title="Standings"
+            className="lg:col-span-2"
+            action={
+              activeSeason ? (
+                <Link
+                  href={`/dashboard/leagues/${activeLeague!.id}/standings`}
+                  className="text-xs text-primary hover:underline"
+                >
+                  View all
+                </Link>
+              ) : undefined
+            }
+          >
+            {standings.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No standings yet — record some game results.
+              </p>
+            ) : (
+              <ul className="space-y-1.5">
+                {standings.map((s) => (
+                  <li
+                    key={s.teamId}
+                    className="flex items-center gap-3 text-sm"
+                  >
+                    <span className="w-5 text-right font-mono text-muted-foreground">
+                      {s.leagueRank}
+                    </span>
+                    <span className="flex-1 truncate font-medium text-foreground">
+                      {s.teamName}
+                    </span>
+                    <span className="font-mono text-muted-foreground">
+                      {s.wins}-{s.losses}
+                      {s.ties ? `-${s.ties}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </BentoCard>
+
+          {/* Activity feed */}
+          <BentoCard title="Recent results" className="lg:col-span-2">
+            {feed.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No games recorded yet.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {feed.map((g, i) => {
+                  const homeWon = g.homeScore > g.awayScore;
+                  const awayWon = g.awayScore > g.homeScore;
+                  return (
+                    <li key={i} className="flex items-center gap-2 text-sm">
+                      {g.week !== null && (
+                        <Badge variant="outline" className="shrink-0">
+                          Wk {g.week}
+                        </Badge>
+                      )}
+                      <span
+                        className={
+                          homeWon
+                            ? "font-semibold text-foreground"
+                            : "text-muted-foreground"
+                        }
+                      >
+                        {g.home}
+                      </span>
+                      <span className="font-mono text-muted-foreground">
+                        {g.homeScore}–{g.awayScore}
+                      </span>
+                      <span
+                        className={
+                          awayWon
+                            ? "font-semibold text-foreground"
+                            : "text-muted-foreground"
+                        }
+                      >
+                        {g.away}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </BentoCard>
+
+          {/* Sparkline */}
+          <BentoCard title="Scoring by week" className="lg:col-span-2">
+            <Sparkline values={perWeekPoints} />
+            <p className="mt-2 text-xs text-muted-foreground">
+              Total points scored each week.
+            </p>
+          </BentoCard>
+
+          {/* Heatmap */}
+          <BentoCard title="Games played by week" className="lg:col-span-2">
+            <WeekHeatmap counts={perWeekGames} />
+          </BentoCard>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/bento.test.ts
+++ b/apps/web/src/lib/__tests__/bento.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  fraction,
+  percent,
+  gaugeDash,
+  sparklinePoints,
+  heatLevel,
+} from "../bento";
+
+describe("fraction / percent", () => {
+  it("clamps to 0..1 and handles max ≤ 0", () => {
+    expect(fraction(5, 10)).toBe(0.5);
+    expect(fraction(20, 10)).toBe(1);
+    expect(fraction(-5, 10)).toBe(0);
+    expect(fraction(5, 0)).toBe(0);
+  });
+  it("rounds to whole percent", () => {
+    expect(percent(1, 3)).toBe(33);
+    expect(percent(2, 3)).toBe(67);
+  });
+});
+
+describe("gaugeDash", () => {
+  it("splits the circumference by fraction", () => {
+    expect(gaugeDash(0.25, 100)).toEqual({ dash: 25, gap: 75 });
+    expect(gaugeDash(0, 100)).toEqual({ dash: 0, gap: 100 });
+    expect(gaugeDash(2, 100)).toEqual({ dash: 100, gap: 0 }); // clamped
+  });
+});
+
+describe("sparklinePoints", () => {
+  it("returns empty for no values", () => {
+    expect(sparklinePoints([], 100, 40)).toBe("");
+  });
+  it("spans the width for a single value", () => {
+    expect(sparklinePoints([5], 100, 40, 2)).toBe("2,20 98,20");
+  });
+  it("maps endpoints to the box corners for a rising series", () => {
+    const pts = sparklinePoints([0, 10], 100, 40, 2).split(" ");
+    expect(pts).toHaveLength(2);
+    // first point at left/bottom, last at right/top (y inverted)
+    expect(pts[0]).toBe("2,38");
+    expect(pts[1]).toBe("98,2");
+  });
+  it("flat series renders mid-height", () => {
+    const pts = sparklinePoints([4, 4, 4], 100, 40, 0);
+    expect(pts).toBe("0,20 50,20 100,20");
+  });
+});
+
+describe("heatLevel", () => {
+  it("buckets counts into 0..4", () => {
+    expect(heatLevel(0, 10)).toBe(0);
+    expect(heatLevel(1, 10)).toBe(1);
+    expect(heatLevel(3, 10)).toBe(2);
+    expect(heatLevel(6, 10)).toBe(3);
+    expect(heatLevel(10, 10)).toBe(4);
+    expect(heatLevel(5, 0)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/bento.ts
+++ b/apps/web/src/lib/bento.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers for the hand-rolled bento dashboard widgets (WSM-000136 P4).
+ * No charting dependency — these turn numbers into SVG geometry / intensity
+ * buckets, kept pure so they're unit-testable and the widgets stay presentational.
+ */
+
+/** Fraction 0..1 of value/max, clamped; 0 when max ≤ 0. */
+export function fraction(value: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(1, value / max));
+}
+
+/** Whole-percent (0..100) of value/max. */
+export function percent(value: number, max: number): number {
+  return Math.round(fraction(value, max) * 100);
+}
+
+/** stroke-dasharray split for a ring gauge: [filled, remaining] of circumference. */
+export function gaugeDash(
+  frac: number,
+  circumference: number,
+): { dash: number; gap: number } {
+  const f = Math.max(0, Math.min(1, frac));
+  const dash = f * circumference;
+  return { dash, gap: circumference - dash };
+}
+
+const round = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * Map a series to an SVG `points` string within a `width`×`height` box. A flat
+ * series renders as a centered horizontal line; a single point spans the width.
+ */
+export function sparklinePoints(
+  values: number[],
+  width: number,
+  height: number,
+  pad = 2,
+): string {
+  if (values.length === 0) return "";
+  const innerH = height - pad * 2;
+  if (values.length === 1) {
+    const y = round(pad + innerH / 2);
+    return `${pad},${y} ${width - pad},${y}`;
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const innerW = width - pad * 2;
+  // A flat series has no range — center it rather than pinning to an edge.
+  if (max === min) {
+    const y = round(pad + innerH / 2);
+    return values
+      .map((_, i) => `${round(pad + (i / (values.length - 1)) * innerW)},${y}`)
+      .join(" ");
+  }
+  const range = max - min;
+  return values
+    .map((v, i) => {
+      const x = pad + (i / (values.length - 1)) * innerW;
+      const y = pad + (1 - (v - min) / range) * innerH;
+      return `${round(x)},${round(y)}`;
+    })
+    .join(" ");
+}
+
+/** Intensity bucket 0..4 for a heatmap cell (GitHub-style). */
+export function heatLevel(count: number, max: number): 0 | 1 | 2 | 3 | 4 {
+  if (count <= 0 || max <= 0) return 0;
+  const r = count / max;
+  if (r > 0.75) return 4;
+  if (r > 0.5) return 3;
+  if (r > 0.25) return 2;
+  return 1;
+}


### PR DESCRIPTION
Refs #255 (P4). The signature **role-aware bento dashboard** — first slice (league-scoped).

## What ships
Replaces the 5-stat overview with a **bento grid**:
- **League hero** — name, team/player counts, active season, next kickoff.
- **Season health** — two ring gauges: **roster fill** (active players / roster cap) and **schedule played** (final / total fixtures).
- **Standings snapshot** — top 5 via `computeStandings`, link to full standings.
- **Recent results** — activity feed of finals (winner bolded).
- **Scoring by week** — sparkline of total points per week.
- **Games by week** — GitHub-style contributions heatmap.

The 5 counts are kept as a **quick-nav strip**. Every widget has a graceful **empty state** (no league / no season / no results).

## How it's built
- Widgets are **hand-rolled SVG** (no charting dependency) driven by **pure helpers** in `bento.ts` (`fraction`/`percent`/`gaugeDash`/`sparklinePoints`/`heatLevel`) — **8 unit tests**. Server-rendered, so the page bundle stays tiny (186 B).
- Data comes **entirely from existing wrappers** (`getTeams`/`getPlayers`/`getSeasons` + `listFixturesBySeason`/`getResultByFixture`/`computeStandings`) — **no new Convex functions, no deploy**.

## Scope note
League-scoped this slice; **coach/team tailoring** (a coach seeing just their team's widgets) is the next P4 slice — flagged, not silently dropped.

## Gate
type-check ✅ · **432 tests** ✅ (+8) · lint ✅ (only pre-existing `<img>`) · build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)