### PR TITLE
feat(web): consistent page headers — UI overhaul P3 (WSM-000136)

### DIFF
--- a/apps/web/src/app/dashboard/_components/page-header.tsx
+++ b/apps/web/src/app/dashboard/_components/page-header.tsx
@@ -1,0 +1,26 @@
+/**
+ * Consistent page header for dashboard list pages (WSM-000136 P3). Title, an
+ * optional context description, and an optional right-aligned action — so the
+ * top of every page reads the same and gains a calm one-line subtitle.
+ */
+export function PageHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/divisions/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getDivisions, getLeagues } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
 import { DivisionsTable } from "./divisions-table";
+import { PageHeader } from "../_components/page-header";
 
 export default async function DivisionsPage() {
   const { userId } = await auth();
@@ -26,7 +27,7 @@ export default async function DivisionsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Divisions</h2>
+      <PageHeader title="Divisions" description="Divisions that group teams in the active league." />
       <DivisionsTable divisions={divisionsWithLeague} />
     </div>
   );

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -14,6 +14,7 @@ import {
   RenameLeagueForm,
 } from "./leagues-actions";
 import { LeaguesAccordion, type AccordionDivision } from "./leagues-accordion";
+import { PageHeader } from "../_components/page-header";
 
 export default async function LeaguesPage() {
   const { userId } = await auth();
@@ -25,10 +26,7 @@ export default async function LeaguesPage() {
   if (leagues.length === 0) {
     return (
       <div>
-        <div className="mb-6 flex items-center justify-between gap-2">
-          <h2 className="text-lg font-semibold text-foreground">Leagues</h2>
-          <CreateLeagueButton />
-        </div>
+        <PageHeader title="Leagues" action={<CreateLeagueButton />} />
         <EmptyState
           icon={Trophy}
           title="No leagues yet"

--- a/apps/web/src/app/dashboard/players/page.tsx
+++ b/apps/web/src/app/dashboard/players/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getPlayers } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
 import { PlayersTable } from "./players-table";
+import { PageHeader } from "../_components/page-header";
 
 export default async function PlayersPage() {
   const { userId } = await auth();
@@ -14,7 +15,7 @@ export default async function PlayersPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Players</h2>
+      <PageHeader title="Players" description="All players on rosters in the active league." />
       <PlayersTable players={players} />
     </div>
   );

--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from "@/components/empty-state";
 import { Calendar, Trophy } from "lucide-react";
 import { formatDate } from "@/lib/format";
 import { CreateSeasonButton, SeasonRowActions } from "./season-actions";
+import { PageHeader } from "../_components/page-header";
 
 export default async function SeasonsPage() {
   const { userId } = await auth();
@@ -30,7 +31,7 @@ export default async function SeasonsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Seasons</h2>
+      <PageHeader title="Seasons" description="Seasons and their schedules across your leagues." />
 
       {leagues.length === 0 ? (
         <EmptyState

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getTeams } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
+import { PageHeader } from "../_components/page-header";
 
 export default async function TeamsPage() {
   const { userId } = await auth();
@@ -14,7 +15,7 @@ export default async function TeamsPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-semibold text-foreground">Teams</h2>
+      <PageHeader title="Teams" description="Every team in the active league." />
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {teams.map((team) => (
           <Link


### PR DESCRIPTION
Refs #255 (P3). A focused density-polish slice — consistent page headers.

## What ships
- A shared **`PageHeader`** (title + optional context description + optional right-aligned action).
- Applied across the high-traffic list pages — **teams, players, seasons, divisions, and the leagues empty state** — replacing ad-hoc per-page `<h2>` headers. Each now carries a calm one-line subtitle.
- The leagues **main** header (with its inline league switcher) is intentionally left as-is.

Presentational only — no logic change, no new deps. Closes out the discrete P3 work; further per-page density tweaks are ongoing refinement.

## Gate
type-check ✅ · **443 tests** ✅ · lint ✅ (only pre-existing `<img>`) · build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)