### PR TITLE
fix(convex): secure e2eSeed mutations (WSM-000139)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -75,10 +75,30 @@ void api.sports.listPublicLeagues;
 void api.sports.computeStandingsPublic;
 void api.sports.getPlayerDevelopmentPublic;
 
+// --- e2e seed mutations MUST be internal too (WSM-000139) ---
+// Same vuln class as the sports.ts writes above: they create/destroy real
+// rows, so they must never be reachable by an anonymous client. The env gate
+// (CONVEX_ENABLE_E2E_SEED) is defense-in-depth, not the boundary.
+void internal.e2eSeed.createRosterFixture;
+void internal.e2eSeed.resetRosterFixture;
+void internal.e2eSeed.createScheduleFixture;
+// @ts-expect-error createRosterFixture is internal, not public
+void api.e2eSeed.createRosterFixture;
+// @ts-expect-error resetRosterFixture is internal, not public
+void api.e2eSeed.resetRosterFixture;
+// @ts-expect-error createScheduleFixture is internal, not public
+void api.e2eSeed.createScheduleFixture;
+
 describe("sports write mutations are internal (WSM-000096)", () => {
   it("is enforced at compile time (see @ts-expect-error guards above)", () => {
     // Runtime assertion is trivial; the real guard is tsc. The proxy-based
     // `internal` object always returns a reference, so this just documents intent.
     expect(typeof internal.sports.createTeam).not.toBe("undefined");
+  });
+});
+
+describe("e2e seed mutations are internal (WSM-000139)", () => {
+  it("is enforced at compile time (see @ts-expect-error guards above)", () => {
+    expect(typeof internal.e2eSeed.createRosterFixture).not.toBe("undefined");
   });
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -1,6 +1,19 @@
 import { v } from "convex/values";
-import { mutation } from "./_generated/server";
+import { internalMutation } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
+
+/*
+ * e2e seed fixtures (WSM-000139, fast-follow to WSM-000096).
+ *
+ * These mutations create/destroy real rows, so they are `internalMutation` —
+ * NOT callable by an anonymous `ConvexHttpClient` over the public Internet
+ * (anonymous calls get `404 FunctionPathNotFound`). The Playwright harness
+ * (`e2e/helpers/seed-roster.ts`, `seed-schedule.ts`) reaches them with an
+ * admin-keyed client (`CONVEX_ADMIN_KEY`), which is what authorizes internal
+ * calls. `assertSeedEnabled()` is a second, defense-in-depth gate so even a
+ * trusted caller can't seed a deployment where `CONVEX_ENABLE_E2E_SEED` is
+ * unset (e.g. prod). See [[reference_convex_security_model]].
+ */
 
 const FIXTURE_LEAGUE_PREFIX = "E2E:";
 const SEED_ACTOR = "e2e_seed_harness";
@@ -142,7 +155,7 @@ async function deleteFixtureByKey(
   return deleted;
 }
 
-export const createRosterFixture = mutation({
+export const createRosterFixture = internalMutation({
   args: {
     fixtureKey: v.string(),
     clerkOrgId: v.union(v.string(), v.null()),
@@ -239,7 +252,7 @@ export const createRosterFixture = mutation({
   },
 });
 
-export const resetRosterFixture = mutation({
+export const resetRosterFixture = internalMutation({
   args: { fixtureKey: v.string() },
   returns: v.object({ deleted: v.number() }),
   handler: async (ctx, args) => {
@@ -268,7 +281,7 @@ const scheduleFixtureResultValidator = v.object({
   awayTeamName: v.string(),
 });
 
-export const createScheduleFixture = mutation({
+export const createScheduleFixture = internalMutation({
   args: {
     fixtureKey: v.string(),
     clerkOrgId: v.union(v.string(), v.null()),


### PR DESCRIPTION
Closes #261.

## Problem
`apps/web/convex/e2eSeed.ts` exposed three **public** mutations — `createRosterFixture`, `resetRosterFixture`, `createScheduleFixture` — for Playwright e2e seeding. They were gated by a `CONVEX_ENABLE_E2E_SEED` env check (unset in prod), so not wide-open, but they remained the same vuln class as the `sports.ts` writes that #210 (WSM-000096) closed: callable by anyone with the deployment URL.

## Fix
- Convert all three to **`internalMutation`** (Option 1 from the issue). Anonymous `ConvexHttpClient` calls now get `404 FunctionPathNotFound`; only a trusted caller holding `CONVEX_ADMIN_KEY` can invoke them.
- Keep `assertSeedEnabled()` as defense-in-depth.
- The Playwright harness (`e2e/helpers/seed-roster.ts`, `seed-schedule.ts`) is **unchanged** — it already uses an admin-keyed client, which is what authorizes internal calls.
- Extend the compile-time guard `convex/__tests__/writeMutationsAreInternal.test.ts` to cover `internal.e2eSeed.*`, with `@ts-expect-error` on `api.e2eSeed.*`. A regression to public `mutation` re-adds them to the public `api`, the suppressed errors vanish, and `tsc` (CI `type-check`) fails.

## Acceptance criteria
- [x] Anonymous `ConvexHttpClient` cannot invoke the seed mutations against prod (now `internalMutation`).
- [x] Playwright e2e seeding still works against the test deployment (admin-keyed client, unchanged).

## Verification
- `pnpm type-check` (tsc) — passes (the real enforcement point).
- Full convex unit suite — **75 tests pass** (incl. the 6 existing `e2eSeed` tests).
- ESLint on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)