### PR TITLE
feat(web): division CRUD controls (WSM-000128)

### DIFF
--- a/apps/web/convex/__tests__/divisionCrud.test.ts
+++ b/apps/web/convex/__tests__/divisionCrud.test.ts
@@ -54,19 +54,25 @@ describe("division CRUD (WSM-000132 / WSM-000128)", () => {
     expect(dto?.name).toBe("West");
   });
 
-  it("deleteDivision refuses a non-empty division", async () => {
+  it("deleteDivision reassigns teams to no division, then deletes (WSM-000128)", async () => {
     const t = convexTest(schema, modules);
     const { leagueId, divisionId } = await seedLeague(t);
-    await addTeam(t, leagueId, divisionId);
+    const teamId = await addTeam(t, leagueId, divisionId);
 
     const res = await t.mutation(internal.sports.deleteDivision, {
       divisionId,
     });
-    expect(res.ok).toBe(false);
+    expect(res.ok).toBe(true);
     expect(res.teamCount).toBe(1);
 
-    const stillThere = await t.run((ctx) => ctx.db.get(divisionId));
-    expect(stillThere).not.toBeNull();
+    // Division is gone...
+    const gone = await t.run((ctx) => ctx.db.get(divisionId));
+    expect(gone).toBeNull();
+
+    // ...but its team survives, reassigned to "no division".
+    const team = await t.run((ctx) => ctx.db.get(teamId));
+    expect(team).not.toBeNull();
+    expect(team?.divisionId).toBeNull();
   });
 
   it("deleteDivision removes an empty division", async () => {

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1086,17 +1086,20 @@ export const updateDivision = internalMutationGeneric({
  */
 export const deleteDivision = internalMutationGeneric({
   args: { divisionId: v.id("divisions") },
+  // `teamCount` is the number of teams reassigned to "no division" (WSM-000128).
   returns: v.object({ ok: v.boolean(), teamCount: v.number() }),
   handler: async (ctx, args) => {
     const teams = await ctx.db
       .query("teams")
       .withIndex("by_divisionId", (q) => q.eq("divisionId", args.divisionId))
       .collect();
-    if (teams.length > 0) {
-      return { ok: false, teamCount: teams.length };
+    // Reassign teams to "no division" rather than orphaning or deleting them,
+    // then drop the division.
+    for (const team of teams) {
+      await ctx.db.patch(team._id, { divisionId: null });
     }
     await ctx.db.delete(args.divisionId);
-    return { ok: true, teamCount: 0 };
+    return { ok: true, teamCount: teams.length };
   },
 });
 

--- a/apps/web/src/app/dashboard/divisions/divisions-table.tsx
+++ b/apps/web/src/app/dashboard/divisions/divisions-table.tsx
@@ -5,8 +5,15 @@ import type { DivisionDto } from "@sports-management/shared-types";
 import { DataTable, type Column } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
 import { Layers } from "lucide-react";
+import {
+  CreateDivisionButton,
+  DivisionRowActions,
+} from "../leagues/division-controls";
 
-type DivisionWithLeague = DivisionDto & { leagueName: string } & Record<string, unknown>;
+type DivisionWithLeague = DivisionDto & {
+  leagueName: string;
+  teamCount: number;
+} & Record<string, unknown>;
 
 const columns: Column<DivisionWithLeague>[] = [
   { key: "name", header: "Name", sortable: true },
@@ -16,32 +23,73 @@ const columns: Column<DivisionWithLeague>[] = [
     sortable: true,
     render: (d) => d.leagueName,
   },
+  {
+    key: "teamCount",
+    header: "Teams",
+    sortable: true,
+    render: (d) => d.teamCount,
+  },
 ];
 
 interface DivisionsTableProps {
   divisions: DivisionWithLeague[];
+  isAdmin: boolean;
+  activeLeagueId: string | null;
 }
 
-export function DivisionsTable({ divisions }: DivisionsTableProps) {
+export function DivisionsTable({
+  divisions,
+  isAdmin,
+  activeLeagueId,
+}: DivisionsTableProps) {
   const router = useRouter();
 
   if (divisions.length === 0) {
     return (
-      <EmptyState
-        icon={Layers}
-        title="No divisions found"
-        description="Divisions will appear here once created in the system."
-      />
+      <div className="space-y-4">
+        {isAdmin && activeLeagueId ? (
+          <div className="flex justify-end">
+            <CreateDivisionButton leagueId={activeLeagueId} />
+          </div>
+        ) : null}
+        <EmptyState
+          icon={Layers}
+          title="No divisions found"
+          description={
+            isAdmin && activeLeagueId
+              ? "Create a division to start grouping teams."
+              : "Divisions will appear here once created in the system."
+          }
+        />
+      </div>
     );
   }
 
   return (
-    <DataTable
-      data={divisions}
-      columns={columns}
-      searchPlaceholder="Search divisions..."
-      searchKeys={["name", "leagueName"]}
-      onRowClick={(d) => router.push(`/dashboard/divisions/${d.id}`)}
-    />
+    <div className="space-y-4">
+      {isAdmin && activeLeagueId ? (
+        <div className="flex justify-end">
+          <CreateDivisionButton leagueId={activeLeagueId} />
+        </div>
+      ) : null}
+      <DataTable
+        data={divisions}
+        columns={columns}
+        searchPlaceholder="Search divisions..."
+        searchKeys={["name", "leagueName"]}
+        onRowClick={(d) => router.push(`/dashboard/divisions/${d.id}`)}
+        actions={
+          isAdmin
+            ? (d) => (
+                <DivisionRowActions
+                  divisionId={d.id}
+                  currentName={d.name}
+                  teamCount={d.teamCount}
+                />
+              )
+            : undefined
+        }
+      />
+    </div>
   );
 }

--- a/apps/web/src/app/dashboard/divisions/page.tsx
+++ b/apps/web/src/app/dashboard/divisions/page.tsx
@@ -1,7 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getDivisions, getLeagues } from "@/lib/data-api";
+import {
+  getDivisions,
+  getLeagues,
+  getTeams,
+  getLeagueOrgId,
+} from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
+import { getUserRoleInOrg } from "@/lib/org-context";
 import { DivisionsTable } from "./divisions-table";
 import { PageHeader } from "../_components/page-header";
 
@@ -13,22 +19,39 @@ export default async function DivisionsPage() {
   const { activeLeagueId } = await resolveActiveLeague(userId);
   const ids = activeLeagueId ? [activeLeagueId] : [];
 
-  const [divisions, leagues] = await Promise.all([
+  const [divisions, leagues, teams] = await Promise.all([
     getDivisions(ids),
     getLeagues(ids),
+    getTeams(ids),
   ]);
 
+  // Org-admin of the active league sees CRUD controls (members/coaches don't).
+  const orgId = activeLeagueId ? await getLeagueOrgId(activeLeagueId) : null;
+  const role = orgId ? await getUserRoleInOrg(orgId, userId) : null;
+  const isAdmin = role === "org:admin";
+
   const leagueMap = new Map(leagues.map((l) => [l.id, l.name]));
+
+  // Teams per division, to warn before a delete reassigns them (WSM-000128).
+  const teamCounts = teams.reduce<Record<string, number>>((acc, team) => {
+    if (team.divisionId) acc[team.divisionId] = (acc[team.divisionId] ?? 0) + 1;
+    return acc;
+  }, {});
 
   const divisionsWithLeague = divisions.map((d) => ({
     ...d,
     leagueName: leagueMap.get(d.leagueId) ?? "\u2014",
+    teamCount: teamCounts[d.id] ?? 0,
   }));
 
   return (
     <div>
       <PageHeader title="Divisions" description="Divisions that group teams in the active league." />
-      <DivisionsTable divisions={divisionsWithLeague} />
+      <DivisionsTable
+        divisions={divisionsWithLeague}
+        isAdmin={isAdmin}
+        activeLeagueId={activeLeagueId}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/leagues/division-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/division-actions.ts
@@ -13,6 +13,12 @@ import { getUserRoleInOrg } from "@/lib/org-context";
 
 type Result<T = unknown> = ({ ok: true } & T) | { ok: false; error: string };
 
+/** Pages that render division controls and must refresh after a mutation. */
+function revalidateDivisionViews(): void {
+  revalidatePath("/dashboard/leagues");
+  revalidatePath("/dashboard/divisions");
+}
+
 /** Org-admin gate for a division's league. Mirrors leagues/actions.ts. */
 async function requireLeagueAdmin(
   leagueId: string | null,
@@ -37,7 +43,7 @@ export async function createDivisionAction(
   if (!gate.ok) return gate;
   try {
     const { dto } = await createDivision({ name: trimmed, leagueId });
-    revalidatePath("/dashboard/leagues");
+    revalidateDivisionViews();
     return { ok: true, id: dto.id };
   } catch (err) {
     return {
@@ -58,7 +64,7 @@ export async function renameDivisionAction(
   if (!gate.ok) return gate;
   try {
     await updateDivisionMutation({ divisionId, name: trimmed });
-    revalidatePath("/dashboard/leagues");
+    revalidateDivisionViews();
     return { ok: true };
   } catch (err) {
     return {
@@ -70,19 +76,19 @@ export async function renameDivisionAction(
 
 export async function deleteDivisionAction(
   divisionId: string,
-): Promise<Result> {
+): Promise<Result<{ teamCount: number }>> {
   const leagueId = await getDivisionLeagueId(divisionId);
   const gate = await requireLeagueAdmin(leagueId);
   if (!gate.ok) return gate;
-  const res = await deleteDivisionMutation(divisionId);
-  if (!res.ok) {
+  try {
+    // Teams in the division are reassigned to "no division", not deleted.
+    const { teamCount } = await deleteDivisionMutation(divisionId);
+    revalidateDivisionViews();
+    return { ok: true, teamCount };
+  } catch (err) {
     return {
       ok: false,
-      error: `Move or remove its ${res.teamCount} team${
-        res.teamCount === 1 ? "" : "s"
-      } first.`,
+      error: err instanceof Error ? err.message : "Could not delete division.",
     };
   }
-  revalidatePath("/dashboard/leagues");
-  return { ok: true };
 }

--- a/apps/web/src/app/dashboard/leagues/division-controls.tsx
+++ b/apps/web/src/app/dashboard/leagues/division-controls.tsx
@@ -74,9 +74,12 @@ export function CreateDivisionButton({ leagueId }: { leagueId: string }) {
 export function DivisionRowActions({
   divisionId,
   currentName,
+  teamCount = 0,
 }: {
   divisionId: string;
   currentName: string;
+  /** Teams currently in this division; they're moved to No Division on delete. */
+  teamCount?: number;
 }) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
@@ -102,12 +105,24 @@ export function DivisionRowActions({
   }
 
   async function remove() {
-    if (!window.confirm(`Delete division "${currentName}"?`)) return;
+    const warning =
+      teamCount > 0
+        ? `Delete division "${currentName}"? Its ${teamCount} team${
+            teamCount === 1 ? "" : "s"
+          } will be moved to No Division.`
+        : `Delete division "${currentName}"?`;
+    if (!window.confirm(warning)) return;
     setBusy(true);
     const res = await deleteDivisionAction(divisionId);
     setBusy(false);
     if (res.ok) {
-      toast.success(`Deleted ${currentName}.`);
+      toast.success(
+        res.teamCount > 0
+          ? `Deleted ${currentName}. Moved ${res.teamCount} team${
+              res.teamCount === 1 ? "" : "s"
+            } to No Division.`
+          : `Deleted ${currentName}.`,
+      );
       router.refresh();
     } else {
       toast.error(errorText(res.error));

--- a/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-accordion.tsx
@@ -68,6 +68,7 @@ export function LeaguesAccordion({
                   <DivisionRowActions
                     divisionId={division.id}
                     currentName={division.name}
+                    teamCount={division.teams.length}
                   />
                 ) : null}
               </div>


### PR DESCRIPTION
Closes #246.

## Summary
Adds admin division management to the dashboard and changes the delete guard to match the issue's "reassign, don't orphan" requirement.

## What changed
- **`/dashboard/divisions` page** — was a read-only table. Now (for org-admins of the active league) it shows a **New division** button and per-row **rename/delete** controls, plus a **Teams** column with per-division counts. Non-admins still see the read-only view. The backend mutations and server actions already existed (built for the leagues page); this wires them onto the dedicated page and has the actions revalidate `/dashboard/divisions` too.
- **Delete guard (the real behavior change)** — `deleteDivision` previously *hard-blocked* a division that still had teams (`{ ok: false, teamCount }`). Per the issue it now **reassigns those teams to "no division"** (`divisionId: null`) and then deletes, returning `{ ok: true, teamCount }` (count reassigned). The delete confirm warns "_its N teams will be moved to No Division_" and the success toast reports the count. Applied on both the divisions page and the leagues accordion.

## Acceptance criteria
- [x] **Manage divisions** — admin can add / rename / delete a division; changes persist and teams can be assigned (team form already supports `divisionId`).
- [x] **Delete guard** — deleting a division with teams warns the admin and reassigns its teams to "no division" rather than orphaning/deleting them.

## Verification
- `pnpm type-check` — passes.
- Full web unit suite — **444 tests pass** (incl. the rewritten `divisionCrud.test.ts`, which now asserts teams are reassigned to `divisionId: null` and survive the delete).
- ESLint on all changed files — clean.

## Files
- `convex/sports.ts` — `deleteDivision` reassigns teams then deletes
- `convex/__tests__/divisionCrud.test.ts` — reassignment test
- `dashboard/leagues/division-actions.ts` — revalidate divisions page; delete returns `teamCount`
- `dashboard/leagues/division-controls.tsx` — `teamCount` prop + reassignment warning
- `dashboard/leagues/leagues-accordion.tsx` — pass `teamCount`
- `dashboard/divisions/page.tsx` — fetch teams, compute counts, admin-gate
- `dashboard/divisions/divisions-table.tsx` — render controls + Teams column

🤖 Generated with [Claude Code](https://claude.com/claude-code)