### PR TITLE
fix(convex): secure data migration mutations (WSM-000079)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -89,6 +89,21 @@ void api.e2eSeed.resetRosterFixture;
 // @ts-expect-error createScheduleFixture is internal, not public
 void api.e2eSeed.createScheduleFixture;
 
+// --- Data migrations MUST be internal too (WSM-000079) ---
+// Backfills/migrations write rows; they're run manually with an admin/deploy
+// key (`npx convex run migrations/... --prod`), never from the public API.
+void internal.migrations["20260422_seasonsRosterLocked"]
+  .backfillSeasonsRosterLocked;
+void internal.migrations["20260428_playersPositionGroup"]
+  .backfillPlayersPositionGroup;
+void internal.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster;
+// @ts-expect-error backfillSeasonsRosterLocked is internal, not public
+void api.migrations["20260422_seasonsRosterLocked"].backfillSeasonsRosterLocked;
+// @ts-expect-error backfillPlayersPositionGroup is internal, not public
+void api.migrations["20260428_playersPositionGroup"].backfillPlayersPositionGroup;
+// @ts-expect-error migrateDepthChartToRoster is internal, not public
+void api.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster;
+
 describe("sports write mutations are internal (WSM-000096)", () => {
   it("is enforced at compile time (see @ts-expect-error guards above)", () => {
     // Runtime assertion is trivial; the real guard is tsc. The proxy-based
@@ -100,5 +115,14 @@ describe("sports write mutations are internal (WSM-000096)", () => {
 describe("e2e seed mutations are internal (WSM-000139)", () => {
   it("is enforced at compile time (see @ts-expect-error guards above)", () => {
     expect(typeof internal.e2eSeed.createRosterFixture).not.toBe("undefined");
+  });
+});
+
+describe("data migrations are internal (WSM-000079)", () => {
+  it("is enforced at compile time (see @ts-expect-error guards above)", () => {
+    expect(
+      typeof internal.migrations["20260428_depthChartToRoster"]
+        .migrateDepthChartToRoster,
+    ).not.toBe("undefined");
   });
 });

--- a/apps/web/convex/migrations/20260422_seasonsRosterLocked.ts
+++ b/apps/web/convex/migrations/20260422_seasonsRosterLocked.ts
@@ -1,7 +1,10 @@
-import { mutationGeneric } from "convex/server";
+import { internalMutationGeneric } from "convex/server";
 import { v } from "convex/values";
 
-export const backfillSeasonsRosterLocked = mutationGeneric({
+// Internal-only: migrations write data and must not be anonymously callable
+// over the public Internet (WSM-000079 follow-up; see WSM-000096). Run with an
+// admin/deploy key: `npx convex run migrations/... --prod`.
+export const backfillSeasonsRosterLocked = internalMutationGeneric({
   args: {},
   returns: v.object({
     scanned: v.number(),

--- a/apps/web/convex/migrations/20260428_depthChartToRoster.ts
+++ b/apps/web/convex/migrations/20260428_depthChartToRoster.ts
@@ -1,8 +1,11 @@
 import { v } from "convex/values";
-import { mutation } from "../_generated/server";
+import { internalMutation } from "../_generated/server";
 import { writeAuditLog } from "../lib/auditLog";
 
-export const migrateDepthChartToRoster = mutation({
+// Internal-only: migrations write data and must not be anonymously callable
+// over the public Internet (WSM-000079 follow-up; see WSM-000096). Run with an
+// admin/deploy key: `npx convex run migrations/... --prod`.
+export const migrateDepthChartToRoster = internalMutation({
   args: { actorUserId: v.string() },
   returns: v.object({
     scanned: v.number(),

--- a/apps/web/convex/migrations/20260428_playersPositionGroup.ts
+++ b/apps/web/convex/migrations/20260428_playersPositionGroup.ts
@@ -1,8 +1,11 @@
-import { mutationGeneric } from "convex/server";
+import { internalMutationGeneric } from "convex/server";
 import { v } from "convex/values";
 import { derivePositionGroup } from "../../src/lib/position-group";
 
-export const backfillPlayersPositionGroup = mutationGeneric({
+// Internal-only: migrations write data and must not be anonymously callable
+// over the public Internet (WSM-000079 follow-up; see WSM-000096). Run with an
+// admin/deploy key: `npx convex run migrations/... --prod`.
+export const backfillPlayersPositionGroup = internalMutationGeneric({
   args: {},
   returns: v.object({
     scanned: v.number(),


### PR DESCRIPTION
Fast-follow surfaced during the #178 (WSM-000079) cutover review.

## Problem
All three Convex data migrations were **public** mutations — anonymously callable against the prod deployment URL, the same vuln class closed for `sports.ts` (#210) and `e2eSeed.ts` (#261):

- `migrations/20260422_seasonsRosterLocked.ts` → `backfillSeasonsRosterLocked` (`mutationGeneric`)
- `migrations/20260428_playersPositionGroup.ts` → `backfillPlayersPositionGroup` (`mutationGeneric`)
- `migrations/20260428_depthChartToRoster.ts` → `migrateDepthChartToRoster` (`mutation`)

Each writes data (the depth-chart migration inserts `rosterAssignments` rows **and** audit-log entries). Risk is low today because prod's source tables are empty, but it's a latent public write on production.

## Fix
- Convert all three to internal (`internalMutationGeneric` / `internalMutation`). Anonymous `ConvexHttpClient` calls now get `404 FunctionPathNotFound`.
- Migrations are run manually with an admin/deploy key (`npx convex run migrations/... --prod`), which still authorizes internal calls — **the run workflow is unchanged.**
- Extend the `writeMutationsAreInternal` compile-time guard to cover `internal.migrations.*`, with `@ts-expect-error` on the `api.migrations.*` accesses. A regression to public re-adds them to the public `api`, the suppressed errors vanish, and `tsc` (CI `type-check`) fails.

## Verification
- `pnpm type-check` — passes (the enforcement point).
- Convex unit suite — **76 tests pass**. `depthChartToRoster.test.ts` invokes the migration via convex-test `anyApi`, which is visibility-agnostic, so it's unaffected.
- ESLint on changed files — clean.

## Note
This does not change #178's status (the Phase 0/1 flags are already `on` in prod and the migration source tables are empty). It just closes the security gap found while reviewing that cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)