### PR TITLE
feat(web): 44px touch targets on import flow (WSM-000085)

### DIFF
--- a/apps/web/e2e/tests/mobile-import.spec.ts
+++ b/apps/web/e2e/tests/mobile-import.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, devices } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+/*
+ * WSM-000085 (AC3): the Import flow must be fully tappable on a phone — the
+ * file picker, the preview card's action buttons, and the result card's reset
+ * button all need a >= 44px touch target. Buttons hit that via
+ * `pointer-coarse:min-h-11` in ui/button.tsx, which only resolves under a
+ * coarse primary pointer — so we emulate a real iPhone (setViewportSize alone
+ * keeps a fine pointer and would not exercise the rule).
+ *
+ * The preview step is pure client state (FileReader -> setState), so uploading
+ * a valid payload reaches it without any backend; we never click "Start
+ * Import" (that would POST to /api/cli/import).
+ */
+test.use({ ...devices["iPhone 13"] });
+
+const MIN_TOUCH_PX = 44;
+
+// Minimal payload that satisfies LeagueImportSchema (league + >=1 division
+// with >=1 team). Players omitted — the schema defaults them to [].
+const VALID_IMPORT = JSON.stringify({
+  league: { name: "E2E Mobile Import League" },
+  divisions: [
+    {
+      name: "East",
+      teams: [
+        { name: "Test Team", city: "Testville", stadium: "Test Field" },
+      ],
+    },
+  ],
+});
+
+test.describe("Mobile — import flow touch targets (WSM-000085)", () => {
+  test.beforeAll(() => {
+    test.skip(
+      !process.env.E2E_CLERK_USER_ID || !process.env.CLERK_SECRET_KEY,
+      "E2E_CLERK_USER_ID / CLERK_SECRET_KEY not set",
+    );
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    await signInTestUser(page);
+    await page.goto("/dashboard/import");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("dropzone is a large, tappable target", async ({ page }) => {
+    const dropzone = page.getByLabel("Upload import file");
+    await expect(dropzone).toBeVisible();
+    const box = await dropzone.boundingBox();
+    expect(box).not.toBeNull();
+    // The dropzone is a generous p-8 region, well above the minimum.
+    expect(box!.height).toBeGreaterThanOrEqual(MIN_TOUCH_PX);
+  });
+
+  test("preview action buttons meet the 44px touch target", async ({
+    page,
+  }) => {
+    await page.getByLabel("Choose import file").setInputFiles({
+      name: "league.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(VALID_IMPORT),
+    });
+
+    // Preview card renders client-side once the file parses.
+    const startImport = page.getByRole("button", { name: "Start Import" });
+    await expect(startImport).toBeVisible();
+
+    for (const name of ["Start Import", "Cancel"]) {
+      const box = await page.getByRole("button", { name }).boundingBox();
+      expect(box, `${name} button has no box`).not.toBeNull();
+      expect(
+        box!.height,
+        `${name} button is ${box!.height}px tall (< ${MIN_TOUCH_PX}px touch target)`,
+      ).toBeGreaterThanOrEqual(MIN_TOUCH_PX);
+    }
+  });
+});

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,7 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
+  // WSM-000085 (AC3): `pointer-coarse:min-h-11` enforces a 44px minimum touch
+  // target on phones/tablets while leaving mouse-driven desktops at the denser
+  // h-8/h-9 heights — same coarse-pointer strategy as the 16px input rule in
+  // globals.css. Icon buttons additionally get min-w-11 for a square 44px hit area.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 pointer-coarse:min-h-11",
   {
     variants: {
       variant: {
@@ -22,7 +26,7 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        icon: "h-9 w-9 pointer-coarse:min-w-11",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
Closes the final open acceptance criterion of the mobile-responsive dashboard (#185, **AC3** — Import flow tappable with 44px minimum touch targets). The rest of #185 (drawer nav, table overflow, depth-chart touch, mobile e2e specs, iOS-zoom rule) already shipped across prior `WSM-000085` PRs; this was the one remaining gap.

### Problem
The shared `Button` was `h-9` (36px) with no coarse-pointer bump, so the Import preview/result action buttons fell below the 44px touch-target minimum on phones. The Import page also had zero e2e coverage.

### Changes
- **`button.tsx`** — `pointer-coarse:min-h-11` on the base + `pointer-coarse:min-w-11` on the icon size. Enforces a 44px minimum touch target on phones/tablets while leaving mouse-driven desktops at the denser `h-8`/`h-9` heights — the same `@media (pointer: coarse)` strategy already used for the 16px input rule in `globals.css`. Also lifts the 36px mobile-header icon buttons.
- **`mobile-import.spec.ts`** (new) — emulates iPhone 13 (required for the coarse-pointer rule to resolve; `setViewportSize` alone keeps a fine pointer), uploads a minimal valid `LeagueImportSchema` payload to reach the preview client-side, and asserts the dropzone + "Start Import"/"Cancel" buttons are ≥44px. Env-gated skip like the sibling mobile specs.

### Verification
- `pnpm type-check` ✅
- `pnpm lint` ✅
- New e2e spec runs under the web app's Playwright config (`apps/web/e2e`), gated on `E2E_CLERK_USER_ID` / `CLERK_SECRET_KEY`.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)