### PR TITLE
fix(web): restore react-hooks/set-state-in-effect to error (WSM-000140)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -17,15 +17,6 @@ const eslintConfig = [
     ],
   },
   ...nextCoreWebVitals,
-  {
-    rules: {
-      // New in eslint-config-next 16 (React Compiler era). Flags pre-existing
-      // client-hydration / lazy-init effects (e.g. `setMounted(true)` SSR
-      // guards). Downgraded to `warn` so the Next 16 upgrade lands without
-      // bundling a behavioral refactor of 9 call sites — tracked as follow-up.
-      "react-hooks/set-state-in-effect": "warn",
-    },
-  },
 ];
 
 export default eslintConfig;

--- a/apps/web/src/app/dashboard/_components/command-trigger.tsx
+++ b/apps/web/src/app/dashboard/_components/command-trigger.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { openCommandPalette } from "./command-palette";
+
+// Platform never changes after mount, so the store has nothing to subscribe to.
+const emptySubscribe = () => () => {};
 
 /**
  * Opens the global command palette (WSM-000136 P2). Two looks:
@@ -16,13 +19,14 @@ export function CommandTrigger({
 }: {
   variant?: "bar" | "icon";
 }) {
-  const [isMac, setIsMac] = useState(false);
-  useEffect(() => {
-    setIsMac(
-      typeof navigator !== "undefined" &&
-        navigator.platform.toLowerCase().includes("mac"),
-    );
-  }, []);
+  // Platform is client-only. Read it through useSyncExternalStore (SSR snapshot
+  // is `false`) so the ⌘/Ctrl hint resolves after hydration without a
+  // setState-in-effect.
+  const isMac = useSyncExternalStore(
+    emptySubscribe,
+    () => navigator.platform.toLowerCase().includes("mac"),
+    () => false,
+  );
 
   if (variant === "icon") {
     return (

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -122,6 +122,9 @@ export function NflSyncCard() {
   }, []);
 
   useEffect(() => {
+    // Justified: fetches sync config from the API on mount; setState runs after
+    // the awaited fetch inside loadConfig(), not as a synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadConfig();
   }, [loadConfig]);
 

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -112,6 +112,8 @@ export default function MemberList({ orgId }: { orgId: string }) {
           >
             <div className="flex items-center gap-3">
               {member.imageUrl && (
+                // Clerk-hosted avatar URL; next/image would need a host allowlist.
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={member.imageUrl}
                   alt=""

--- a/apps/web/src/app/local/_components/local-mode-banner.tsx
+++ b/apps/web/src/app/local/_components/local-mode-banner.tsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { Info, X } from "lucide-react";
 
 const DISMISS_KEY = "wsm-local-banner-dismissed";
+const DISMISS_EVENT = "wsm-local-banner-change";
+
+function subscribe(onChange: () => void) {
+  window.addEventListener(DISMISS_EVENT, onChange);
+  return () => window.removeEventListener(DISMISS_EVENT, onChange);
+}
+
+function isDismissed() {
+  return sessionStorage.getItem(DISMISS_KEY) === "1";
+}
 
 /**
  * Persistent (per-session, dismissible) notice that the user is in local mode —
@@ -12,11 +22,11 @@ const DISMISS_KEY = "wsm-local-banner-dismissed";
  * evicted / is per-device) and funnels toward a free account for backup + sharing.
  */
 export function LocalModeBanner() {
-  const [dismissed, setDismissed] = useState(true);
-
-  useEffect(() => {
-    setDismissed(sessionStorage.getItem(DISMISS_KEY) === "1");
-  }, []);
+  // sessionStorage is client-only, so read it via useSyncExternalStore: the SSR
+  // snapshot is `true` (render nothing) and the client snapshot reflects the
+  // stored flag, re-read when the dismiss handler dispatches DISMISS_EVENT. This
+  // avoids a setState-in-effect for the initial hydration read.
+  const dismissed = useSyncExternalStore(subscribe, isDismissed, () => true);
 
   if (dismissed) return null;
 
@@ -38,7 +48,7 @@ export function LocalModeBanner() {
         className="shrink-0 text-muted-foreground hover:text-foreground"
         onClick={() => {
           sessionStorage.setItem(DISMISS_KEY, "1");
-          setDismissed(true);
+          window.dispatchEvent(new Event(DISMISS_EVENT));
         }}
       >
         <X className="h-4 w-4" />

--- a/apps/web/src/app/local/page.tsx
+++ b/apps/web/src/app/local/page.tsx
@@ -50,6 +50,10 @@ export default function LocalHomePage() {
   }, []);
 
   useEffect(() => {
+    // Justified: async load from the client-only IndexedDB provider once it
+    // mounts. The setState calls run after awaits inside reload(), not as a
+    // synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (provider) void reload(provider);
   }, [provider, reload]);
 

--- a/apps/web/src/app/local/schedule/page.tsx
+++ b/apps/web/src/app/local/schedule/page.tsx
@@ -111,12 +111,20 @@ export default function LocalSchedulePage() {
   );
 
   useEffect(() => {
+    // Justified: async load from the client-only IndexedDB provider once it
+    // mounts. The setState calls run after awaits inside reload(), not as a
+    // synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (provider) void reload(provider);
   }, [provider, reload]);
 
   // Re-derive fixtures/standings when the selected season changes.
   useEffect(() => {
+    // Justified: async re-derive from the client-only provider on season change;
+    // setState runs after awaits inside refreshSeason(), not synchronously.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (provider && !loading) void refreshSeason(provider, seasonId);
+    // Intentionally narrowed to seasonId so we don't re-run on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seasonId]);
 

--- a/apps/web/src/app/local/teams/[id]/page.tsx
+++ b/apps/web/src/app/local/teams/[id]/page.tsx
@@ -90,6 +90,10 @@ export default function LocalTeamPage() {
   );
 
   useEffect(() => {
+    // Justified: async load from the client-only IndexedDB provider once it
+    // mounts. The setState calls run after awaits inside load(), not as a
+    // synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (provider) void load(provider);
   }, [provider, load]);
 

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
+
+// Never changes after mount, so the store has nothing to subscribe to.
+const emptySubscribe = () => () => {};
 
 /**
  * Dark/light toggle (WSM-000136 P1). Renders a stable icon until mounted to
@@ -11,8 +14,14 @@ import { Button } from "@/components/ui/button";
  */
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  // `mounted` is false during SSR and the first client render (matching the
+  // server markup), then true — via useSyncExternalStore rather than a
+  // setState-in-effect, so the React Compiler lint guard stays satisfied.
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
 
   const isDark = resolvedTheme !== "light";
 

--- a/apps/web/src/lib/local/use-local-provider.ts
+++ b/apps/web/src/lib/local/use-local-provider.ts
@@ -12,6 +12,11 @@ import { LocalWorkspaceProvider } from "./local-workspace-provider";
 export function useLocalProvider(): LocalWorkspaceProvider | null {
   const [provider, setProvider] = useState<LocalWorkspaceProvider | null>(null);
   useEffect(() => {
+    // Justified: the provider opens IndexedDB (Dexie) in its constructor, which
+    // is browser-only — a useState lazy initializer would run during SSR and
+    // throw. Constructing it once in a mount effect is the correct client-only
+    // pattern, so the setState here is intentional, not a cascading-render bug.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setProvider(new LocalWorkspaceProvider());
   }, []);
   return provider;


### PR DESCRIPTION
## Summary
Fast-follow to the Next.js 16 upgrade (#180), which introduced the React-Compiler-era `react-hooks/set-state-in-effect` rule and downgraded it to `warn` to keep that PR free of a behavioral refactor. This **restores it to `error`** (removes the override in `eslint.config.mjs`, falling back to the `eslint-config-next` preset) and resolves all 9 flagged sites.

### Refactored — `useSyncExternalStore` (eliminates the setState-in-effect entirely)
Client-only values that previously hydrated via `setState` in a mount effect now read through `useSyncExternalStore` with a server snapshot — the canonical hydration-safe pattern, no cascading render:
- **`theme-toggle.tsx`** — `mounted` guard
- **`command-trigger.tsx`** — `isMac` platform hint
- **`local-mode-banner.tsx`** — `dismissed` flag from `sessionStorage` (the dismiss handler now dispatches an event so the store re-reads)

### Justified scoped disables — genuine external-system syncs
These effects asynchronously load from IndexedDB/fetch, gated on a client-only provider; `setState` runs *after* awaits, not synchronously. They correctly belong in an effect, so each gets a one-line-rationale `eslint-disable-next-line`:
- **`use-local-provider.ts`** — `LocalWorkspaceProvider` opens Dexie/IndexedDB in its constructor (browser-only; a `useState` lazy initializer would run during SSR and throw)
- **`local/page.tsx`**, **`local/teams/[id]/page.tsx`**, **`local/schedule/page.tsx`** (×2), **`nfl-sync-card.tsx`**

### Also
`member-list.tsx` `<img>` gets the same scoped `@next/next/no-img-element` disable its two sibling avatar sites (`leagues-accordion`, `team-management`) already carry — so the suite is **0 warnings**, satisfying the AC.

## Verification
- `pnpm --filter @sports-management/web lint` → **0 errors, 0 warnings**
- `pnpm --filter @sports-management/web type-check` → clean
- `pnpm --filter @sports-management/web test:unit` → **445 passed**

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)