### PR TITLE
test(web): exhaustive compile-time guard for public Convex writes (WSM-000096)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -75,6 +75,82 @@ void api.sports.listPublicLeagues;
 void api.sports.computeStandingsPublic;
 void api.sports.getPlayerDevelopmentPublic;
 
+/*
+ * EXHAUSTIVE backstop (WSM-000096 hardening).
+ *
+ * The per-name lists above protect only the writes someone remembered to add.
+ * This catches the rest: every sports.ts write is an `internalMutation`, so it
+ * never appears on the public `api.sports` object — therefore `api.sports` must
+ * expose ONLY read queries. `AllowedPublicSportsReads` enumerates them; if a
+ * future write is registered as a public `mutation`, its name joins
+ * `keyof typeof api.sports`, falls outside the allow-list, and
+ * `LeakedPublicSportsWrites` becomes a non-`never` union that fails the
+ * assignment below at compile time (tsc names the leaked function). This is the
+ * exact regression that wrote 1,637 unauthenticated rows to prod — now it can't
+ * merge undetected.
+ *
+ * Adding a genuinely-public READ query? Add its name here — a deliberate,
+ * security-reviewed act — to keep the backstop green.
+ */
+type AllowedPublicSportsReads =
+  | "computeDivisionStandings"
+  | "computeStandings"
+  | "computeStandingsPublic"
+  | "getDepthChartByTeamSeason"
+  | "getDivision"
+  | "getFixture"
+  | "getLeague"
+  | "getLeagueByInviteToken"
+  | "getLeagueByName"
+  | "getLeagueClaimable"
+  | "getLeagueForOrg"
+  | "getLeagueOrgId"
+  | "getLeagueVisibility"
+  | "getOrgForkedSourceTeamIds"
+  | "getOrgMemberRole"
+  | "getPlayer"
+  | "getPlayerDevelopment"
+  | "getPlayerDevelopmentPublic"
+  | "getPlayerMaddenRating"
+  | "getPlayerSeasonAttributes"
+  | "getResultByFixture"
+  | "getRosterAssignmentHistory"
+  | "getRosterBySeasonTeam"
+  | "getSeason"
+  | "getSeasonAttributesByPosition"
+  | "getSyncConfig"
+  | "getTeam"
+  | "getTeamAttributeSnapshots"
+  | "getTeamLeagueId"
+  | "getTeamMaddenOveralls"
+  | "getTeamOwnerOrgId"
+  | "getTeamRosterLimitStatus"
+  | "getVisibleLeagueContext"
+  | "healthSummary"
+  | "listConferences"
+  | "listDivisions"
+  | "listFixturesBySeason"
+  | "listLeagues"
+  | "listOrgMemberRoles"
+  | "listPlayers"
+  | "listPlayersByTeam"
+  | "listPublicLeagues"
+  | "listSeasons"
+  | "listTeams"
+  | "listTeamsByLeague";
+
+type LeakedPublicSportsWrites = Exclude<
+  keyof typeof api.sports,
+  AllowedPublicSportsReads
+>;
+
+// If any write leaks onto the public API, the right-hand `true` is no longer
+// assignable to the (now non-`never`) leaked-name union and tsc fails here.
+const _noLeakedPublicSportsWrites: LeakedPublicSportsWrites extends never
+  ? true
+  : LeakedPublicSportsWrites = true;
+void _noLeakedPublicSportsWrites;
+
 // --- e2e seed mutations MUST be internal too (WSM-000139) ---
 // Same vuln class as the sports.ts writes above: they create/destroy real
 // rows, so they must never be reachable by an anonymous client. The env gate


### PR DESCRIPTION
## Summary
Closes the security gap from #210. Investigation found the **code side was already done** — every `sports.ts` write is an `internalMutation` (anonymous `ConvexHttpClient` calls return `FunctionPathNotFound`, satisfying AC1), public reads stay public (AC3), and **`CONVEX_ADMIN_KEY` is now set in Vercel Production** (encrypted, ~3 days ago), so trusted server-action/ingest writes authenticate via the admin-keyed client (AC2). `getConvexClient()` is fail-closed: it throws if the key is missing in a non-local deploy.

What was missing was **recurrence prevention**. The existing guard hand-listed ~25 of the 44 internal writes, so a *new* write accidentally registered as a public `mutation` could merge undetected — the exact failure mode that wrote 1,637 unauthenticated rows to prod during WSM-000095.

## Change
A self-maintaining, exhaustive backstop in `writeMutationsAreInternal.test.ts`:
- Every write is `internalMutation`, so it never appears on the public `api.sports` object.
- Therefore `keyof typeof api.sports` must be a **subset of an explicit read-query allow-list**.
- Any write leaked to public `mutation` joins that keyset, falls outside the allow-list, and breaks a compile-time assignment — `tsc` fails and **names the offending function**.
- New writes are caught automatically; nobody has to remember to add them. Adding a genuinely-public *read* is a deliberate one-line allow-list edit (a security-reviewed act).

## Verification
- `pnpm --filter @sports-management/web type-check` → clean (proves `keyof api.sports` resolves to literal names and the allow-list is exactly complete)
- **Negative test**: temporarily dropping `listTeamsByLeague` from the allow-list fails type-check with `Type 'true' is not assignable to type '"listTeamsByLeague"'` — proving the backstop is not a no-op. Restored, green.
- `pnpm lint` 0/0, `pnpm test:unit` 445 passed.

## Note on AC2
`CONVEX_ADMIN_KEY` presence in prod is confirmed via `vercel env ls`; a fully authenticated prod-write smoke needs a signed-in session (not autonomously runnable), but the fail-closed client + the app operating normally make this low-risk.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)