### PR TITLE
feat(web): compact injury/inactive roster status indicator (WSM-000098)

### DIFF
--- a/apps/web/e2e/tests/team-detail.spec.ts
+++ b/apps/web/e2e/tests/team-detail.spec.ts
@@ -63,4 +63,31 @@ test.describe("Team Detail Page", () => {
     await page.getByRole("link", { name: /Back to Teams/ }).click();
     await expect(page).toHaveURL("/dashboard/teams");
   });
+
+  // WSM-000098: the wide Status column was replaced by a compact per-row
+  // indicator. Non-active players get an icon + popover; active players stay
+  // clean.
+  test("non-active player shows a status indicator, active player does not", async ({
+    page,
+  }) => {
+    const tbody = page.locator("tbody");
+
+    // Micah Parsons is seeded as "Injured" → indicator with an accessible label.
+    const parsonsRow = tbody.locator("tr", { hasText: PLAYERS.PARSONS.name });
+    const indicator = parsonsRow.getByRole("button", {
+      name: /Status: Injured/i,
+    });
+    await expect(indicator).toBeVisible();
+
+    // Opening it reveals the designation in a dismissable popover.
+    await indicator.click();
+    await expect(page.getByText("Injured")).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    // Dak Prescott is "Active" → no indicator in his row.
+    const prescottRow = tbody.locator("tr", { hasText: PLAYERS.PRESCOTT.name });
+    await expect(
+      prescottRow.getByRole("button", { name: /Status:/i }),
+    ).toHaveCount(0);
+  });
 });

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -8,6 +8,7 @@ import TeamEditForm from "../../_components/team-edit-form";
 import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
 import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
+import { RosterStatusIndicator } from "@/components/roster/RosterStatusIndicator";
 import { orderByDepth } from "@/lib/roster/depth-order";
 import { abbreviateName } from "@/lib/position-group";
 import {
@@ -138,7 +139,10 @@ export default function TeamManagement({
         header: "Player",
         sortable: true,
         render: (p) => (
-          <span className="font-medium">{abbreviateName(p.name)}</span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="font-medium">{abbreviateName(p.name)}</span>
+            <RosterStatusIndicator status={p.status} />
+          </span>
         ),
       },
       { key: "position", header: "Pos", sortable: true },

--- a/apps/web/src/components/roster/RosterStatusIndicator.tsx
+++ b/apps/web/src/components/roster/RosterStatusIndicator.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+/**
+ * Compact injury/inactive indicator for a roster row (WSM-000098).
+ *
+ * Renders NOTHING for available players, so the table stays clean. For any
+ * non-active status it shows a small icon next to the player name; tapping or
+ * clicking opens a Radix popover (dismissable via Escape / outside-click) with
+ * the status designation. The hit area expands to 44px only on coarse pointers
+ * (phones/tablets) so desktop rows stay dense — the same pointer-coarse
+ * strategy the Button primitive uses for touch targets.
+ */
+export function RosterStatusIndicator({ status }: { status: string }) {
+  // "Active" (the default) is clean — only flag genuine unavailability.
+  if (status.trim().toLowerCase() === "active") return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Status: ${status}. Show details.`}
+          className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-amber-600 transition-colors hover:text-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background pointer-coarse:h-11 pointer-coarse:w-11"
+        >
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto max-w-64">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Status
+        </p>
+        <p className="mt-0.5 text-sm font-semibold text-foreground">{status}</p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }


### PR DESCRIPTION
## Summary
Brings back the roster status signal that was removed with the wide Status column (#212 / WSM-000097), in a denser form (#213). On the team roster, non-active players get a compact icon next to their name; active players show nothing, so the table stays narrow.

### Changes
- **`RosterStatusIndicator`** (new) — renders `null` for `"Active"`; for any other status it shows an `AlertCircle` icon button that opens a Radix **popover** with the status designation. Meets the ACs:
  - *At-a-glance* — icon inline next to the name, no dedicated column.
  - *Detail on demand* — tap/click opens the popover; Escape / outside-click dismiss it.
  - *Active players clean* — nothing rendered.
  - *Accessible + touch-friendly* — `aria-label="Status: <x>. Show details."`; the hit area expands to **44px on coarse pointers** (`pointer-coarse:h-11 w-11`) while staying compact on mouse-driven desktops — the same strategy the Button primitive uses.
- **`ui/popover.tsx`** (new) — shadcn-style wrapper over the unified `radix-ui` Popover, mirroring the existing `tooltip.tsx` convention (Radix was already a dependency).
- **`team-management.tsx`** — render the indicator inline in the Player column.
- **`team-detail.spec.ts`** — assert the injured seed player (Parsons) shows the indicator + popover and the active player (Prescott) does not.

### Verification
- `pnpm lint` 0/0 · `pnpm type-check` clean · `pnpm test:unit` 445 passed · `pnpm build` compiles (`ƒ /dashboard/teams/[id]`)

### FYI (out of scope)
While here I noticed `team-detail.spec.ts` has **pre-existing stale assertions** from #212 — it still expects a "Status" column header and old header names ("Name"/"Jersey #") that the current roster table doesn't render. The e2e suite isn't in CI so these went uncaught. Not fixed here to keep this PR scoped; happy to file a cleanup follow-up if you'd like.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)