### PR TITLE
ci: gated Playwright e2e workflow + fix stale roster specs (WSM-000141)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,94 @@
+name: E2E
+
+# Playwright end-to-end suite for apps/web (WSM-000141).
+#
+# Safe-by-default: the suite needs a seedable Convex dev deployment + a Clerk
+# test instance, so this job is GATED on repo secrets. When they're absent the
+# "Check e2e secrets" step skips the rest and the job still succeeds — it can
+# never falsely block a PR. Add the secrets/variables below (Settings →
+# Secrets and variables → Actions) to turn the suite on.
+#
+# Required repo SECRETS:
+#   CLERK_SECRET_KEY, NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+#   CONVEX_ADMIN_KEY (the DEV deployment's admin/deploy key — used to seed),
+#   E2E_CLERK_USER_ID, E2E_CLERK_USER_ID_B, E2E_CLERK_ORG_ID, E2E_CLERK_ORG_ID_B
+# Required repo VARIABLES (non-secret):
+#   NEXT_PUBLIC_CONVEX_URL, NEXT_PUBLIC_CONVEX_SITE_URL, CONVEX_DEPLOYMENT
+# Also: set CONVEX_ENABLE_E2E_SEED=1 on the target Convex DEV deployment so the
+# internal e2eSeed mutations accept fixture calls.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: Playwright (apps/web)
+    runs-on: ubuntu-latest
+    env:
+      # Dev server + specs read these from the process env (see e2e helpers).
+      NEXT_PUBLIC_CONVEX_URL: ${{ vars.NEXT_PUBLIC_CONVEX_URL }}
+      NEXT_PUBLIC_CONVEX_SITE_URL: ${{ vars.NEXT_PUBLIC_CONVEX_SITE_URL }}
+      CONVEX_DEPLOYMENT: ${{ vars.CONVEX_DEPLOYMENT }}
+      CONVEX_ADMIN_KEY: ${{ secrets.CONVEX_ADMIN_KEY }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
+      NEXT_PUBLIC_CLERK_SIGN_UP_URL: /sign-up
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      E2E_CLERK_USER_ID: ${{ secrets.E2E_CLERK_USER_ID }}
+      E2E_CLERK_USER_ID_B: ${{ secrets.E2E_CLERK_USER_ID_B }}
+      E2E_CLERK_ORG_ID: ${{ secrets.E2E_CLERK_ORG_ID }}
+      E2E_CLERK_ORG_ID_B: ${{ secrets.E2E_CLERK_ORG_ID_B }}
+
+    steps:
+      - name: Check e2e secrets
+        id: secrets
+        run: |
+          if [ -z "${CLERK_SECRET_KEY}" ] || [ -z "${NEXT_PUBLIC_CONVEX_URL}" ]; then
+            echo "::notice::e2e secrets not configured (CLERK_SECRET_KEY / NEXT_PUBLIC_CONVEX_URL). Skipping the Playwright suite — see WSM-000141 for the required repo secrets and variables."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.secrets.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        if: steps.secrets.outputs.run == 'true'
+        run: corepack enable
+
+      - name: Setup Node.js
+        if: steps.secrets.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm --filter @sports-management/web exec playwright install --with-deps chromium
+
+      - name: Run e2e (apps/web)
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm --filter @sports-management/web test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ always() && steps.secrets.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore

--- a/apps/web/e2e/tests/team-detail.spec.ts
+++ b/apps/web/e2e/tests/team-detail.spec.ts
@@ -28,35 +28,38 @@ test.describe("Team Detail Page", () => {
     await expect(rosterHeading).toBeVisible();
   });
 
-  test("roster table has correct columns", async ({ page }) => {
-    const headers = page.locator("thead th");
-    await expect(headers.nth(0)).toHaveText("Name");
-    await expect(headers.nth(1)).toHaveText("Position");
-    await expect(headers.nth(2)).toHaveText("Jersey #");
-    await expect(headers.nth(3)).toHaveText("Status");
+  test("roster table shows the compact columns (no wide Status column)", async ({
+    page,
+  }) => {
+    // The roster table uses compact headers (Player / Pos / #) plus optional
+    // ratings columns. WSM-000097 removed the dedicated wide Status column;
+    // status is now a per-row indicator (WSM-000098), so it must NOT be a header.
+    const headerText = await page.locator("thead th").allInnerTexts();
+    expect(headerText).toEqual(expect.arrayContaining(["Player", "Pos", "#"]));
+    expect(headerText).not.toContain("Status");
   });
 
   test("known Cowboys players are present with correct data", async ({ page }) => {
     const tbody = page.locator("tbody");
 
-    // Dak Prescott
-    const prescottRow = tbody.locator("tr", { hasText: PLAYERS.PRESCOTT.name });
+    // The Player column renders abbreviated names (e.g. "D. Prescott" via
+    // abbreviateName), so match rows on the surname, which is preserved.
+    const prescottRow = tbody.locator("tr", { hasText: "Prescott" });
     await expect(prescottRow).toBeVisible();
     await expect(prescottRow).toContainText(PLAYERS.PRESCOTT.position);
     await expect(prescottRow).toContainText(String(PLAYERS.PRESCOTT.jersey));
 
-    // CeeDee Lamb
-    const lambRow = tbody.locator("tr", { hasText: PLAYERS.LAMB.name });
+    const lambRow = tbody.locator("tr", { hasText: "Lamb" });
     await expect(lambRow).toBeVisible();
     await expect(lambRow).toContainText(PLAYERS.LAMB.position);
     await expect(lambRow).toContainText(String(PLAYERS.LAMB.jersey));
 
-    // Micah Parsons
-    const parsonsRow = tbody.locator("tr", { hasText: PLAYERS.PARSONS.name });
+    const parsonsRow = tbody.locator("tr", { hasText: "Parsons" });
     await expect(parsonsRow).toBeVisible();
     await expect(parsonsRow).toContainText(PLAYERS.PARSONS.position);
     await expect(parsonsRow).toContainText(String(PLAYERS.PARSONS.jersey));
-    await expect(parsonsRow).toContainText(PLAYERS.PARSONS.status);
+    // Status is no longer a column — it's the WSM-000098 indicator, asserted
+    // in its own test below.
   });
 
   test("Back to Teams link navigates back", async ({ page }) => {
@@ -72,8 +75,9 @@ test.describe("Team Detail Page", () => {
   }) => {
     const tbody = page.locator("tbody");
 
+    // Names render abbreviated (e.g. "M. Parsons"), so match rows on the surname.
     // Micah Parsons is seeded as "Injured" → indicator with an accessible label.
-    const parsonsRow = tbody.locator("tr", { hasText: PLAYERS.PARSONS.name });
+    const parsonsRow = tbody.locator("tr", { hasText: "Parsons" });
     const indicator = parsonsRow.getByRole("button", {
       name: /Status: Injured/i,
     });
@@ -85,7 +89,7 @@ test.describe("Team Detail Page", () => {
     await page.keyboard.press("Escape");
 
     // Dak Prescott is "Active" → no indicator in his row.
-    const prescottRow = tbody.locator("tr", { hasText: PLAYERS.PRESCOTT.name });
+    const prescottRow = tbody.locator("tr", { hasText: "Prescott" });
     await expect(
       prescottRow.getByRole("button", { name: /Status:/i }),
     ).toHaveCount(0);


### PR DESCRIPTION
## Summary
Part of #297 — wire the Playwright e2e suite into CI and fix the roster specs that had silently rotted (because e2e wasn't running anywhere).

### 1. Gated e2e workflow (`.github/workflows/e2e.yml`)
Runs the `apps/web` Playwright suite on PRs, **safe-by-default**: a "Check e2e secrets" gate skips the suite (job still succeeds + logs a `::notice::`) when the required secrets aren't configured, so it **can't falsely block a PR**. Once the maintainer adds the secrets, the suite runs for real on every PR and drift gets caught.

### 2. Fix stale `team-detail.spec.ts` (drift from #212/#213)
Uncaught precisely because e2e wasn't in CI:
- **Columns test** asserted a removed `"Status"` column and old header labels (`"Name"`, `"Jersey #"`). Now asserts the real compact headers (`Player`/`Pos`/`#`) and that **no** Status column exists.
- **Row lookups used full names**, but the Player column abbreviates (`"Micah Parsons"` → `"M. Parsons"`), so they never matched. Now match on **surname** — this also fixes the WSM-000098 indicator test I added in #296 (it had the same latent bug).
- Dropped the obsolete status-column-text assertion (status is now the per-row indicator, covered by its own test).

## Verification
- `pnpm lint` 0/0 · `pnpm type-check` clean
- `playwright test --list` discovers all **115** specs incl. the 3 updated `team-detail` tests
- Workflow YAML validated (1 job, 8 steps)

## ⚠️ Maintainer step to fully enable (why this is `Refs`, not `Closes`)
Until these are added, the workflow **skips** (green no-op) and drift still isn't caught. Add under **Settings → Secrets and variables → Actions**:
- **Secrets:** `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CONVEX_ADMIN_KEY` (DEV deployment key), `E2E_CLERK_USER_ID`, `E2E_CLERK_USER_ID_B`, `E2E_CLERK_ORG_ID`, `E2E_CLERK_ORG_ID_B`
- **Variables:** `NEXT_PUBLIC_CONVEX_URL`, `NEXT_PUBLIC_CONVEX_SITE_URL`, `CONVEX_DEPLOYMENT`
- **On the Convex DEV deployment:** `CONVEX_ENABLE_E2E_SEED=1`

I could not verify a green *seeded* run from here, so please confirm the first real run passes before closing #297.

Refs #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)