### PR TITLE
feat(web): public game viewer route /leagues/[id]/games/[gameId] (WSM-000143) (#300)

### DIFF
--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -145,6 +145,22 @@ test.describe.serial(
       await expect(
         page.getByRole("link", { name: /Standings/ }),
       ).toBeVisible();
+
+      // Schedule section (WSM-000143) lists the game and links to its public
+      // viewer; the viewer shows the final score for the matchup.
+      const gameLink = page.getByRole("link", {
+        name: /E2E Home Hawks vs E2E Away Owls/,
+      });
+      await expect(gameLink).toBeVisible();
+      await gameLink.click();
+
+      await expect(page).toHaveURL(/\/leagues\/[^/]+\/games\/[^/]+$/);
+      await expect(
+        page.getByRole("heading", {
+          name: /E2E Home Hawks vs E2E Away Owls/,
+        }),
+      ).toBeVisible();
+      await expect(page.getByText("Final")).toBeVisible();
     });
   },
 );

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { cache } from "react";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import {
+  getFixture,
+  getPublicLeagues,
+  getPublicSeason,
+  getResultByFixture,
+} from "@/lib/data-api";
+import { publicLeagueGuard } from "@/lib/public-league-guard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/*
+ * Public game viewer route (WSM-000143, child of the streaming epic #225).
+ *
+ * NO Clerk session required — middleware whitelists `/leagues/(.*)`. Defense in
+ * depth, in order:
+ *   1. `schedulesStandingsV1` flag off → 404 (games are part of the same
+ *      feature as the schedule/standings viewers it links from).
+ *   2. `publicLeagueGuard` → 404 if the league isn't opt-in public.
+ *   3. Cross-league guard: `getFixture` returns ANY fixture by id with no
+ *      league check, so we resolve its season and 404 unless the season's
+ *      leagueId matches the league in the URL. Without this, a fixture id from
+ *      a PRIVATE league could be viewed by pairing it with a public league's
+ *      path. All three reads are ungated and safe post-guard.
+ *
+ * `FixtureStatus` is only "scheduled" | "final" | "cancelled" — there is no
+ * live/in-progress state yet (live scoring is deferred to the stat-keeping
+ * keystone v3, per docs/design/live-streaming-rfc.md), so we render those three.
+ */
+
+const kickoffFormat = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+function formatKickoff(iso: string | null): string {
+  if (!iso) return "Date TBD";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "Date TBD" : kickoffFormat.format(date);
+}
+
+// Deduped across generateMetadata + the page render within one request.
+const getPublicLeagueName = cache(async (leagueId: string) => {
+  const leagues = await getPublicLeagues();
+  return leagues.find((league) => league.id === leagueId)?.name ?? null;
+});
+
+const getGameView = cache(async (leagueId: string, gameId: string) => {
+  const fixture = await getFixture(gameId);
+  if (!fixture) return null;
+
+  // Cross-league leak guard — the fixture must live in THIS public league.
+  const season = await getPublicSeason(fixture.seasonId);
+  if (!season || season.leagueId !== leagueId) return null;
+
+  const result =
+    fixture.status === "final" ? await getResultByFixture(gameId) : null;
+
+  return { fixture, result, seasonName: season.name };
+});
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string; gameId: string }>;
+}): Promise<Metadata> {
+  const { id, gameId } = await params;
+  const [view, leagueName] = await Promise.all([
+    getGameView(id, gameId),
+    getPublicLeagueName(id),
+  ]);
+  if (!view) return { title: "Game" };
+
+  const matchup = `${view.fixture.homeTeamName} vs ${view.fixture.awayTeamName}`;
+  const title = leagueName ? `${matchup} — ${leagueName}` : matchup;
+  const description =
+    view.result
+      ? `Final: ${view.fixture.homeTeamName} ${view.result.homeScore} – ${view.result.awayScore} ${view.fixture.awayTeamName}.`
+      : `${matchup} — ${formatKickoff(view.fixture.scheduledAt)}.`;
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary", title, description },
+  };
+}
+
+export default async function PublicGamePage({
+  params,
+}: {
+  params: Promise<{ id: string; gameId: string }>;
+}) {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) notFound();
+
+  const { id: leagueId, gameId } = await params;
+  await publicLeagueGuard(leagueId);
+
+  const view = await getGameView(leagueId, gameId);
+  if (!view) notFound();
+
+  const { fixture, result, seasonName } = view;
+  const isFinal = fixture.status === "final" && result !== null;
+  const isCancelled = fixture.status === "cancelled";
+  const homeWon = result !== null && result.homeScore > result.awayScore;
+  const awayWon = result !== null && result.awayScore > result.homeScore;
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Link
+        href={`/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6">
+        <p className="text-sm font-medium text-muted-foreground">
+          {seasonName}
+          {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
+        </p>
+        <h1 className="text-2xl font-bold text-foreground">
+          {fixture.homeTeamName} vs {fixture.awayTeamName}
+        </h1>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {isFinal ? "Final" : isCancelled ? "Cancelled" : "Scheduled"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isFinal ? (
+            <div className="flex items-center justify-center gap-6 text-center">
+              <div className="flex-1">
+                <p
+                  className={`text-sm ${homeWon ? "font-semibold text-foreground" : "text-muted-foreground"}`}
+                >
+                  {fixture.homeTeamName}
+                </p>
+                <p
+                  className={`text-4xl font-bold tabular-nums ${homeWon ? "text-foreground" : "text-muted-foreground"}`}
+                >
+                  {result.homeScore}
+                </p>
+              </div>
+              <span className="text-2xl text-muted-foreground">–</span>
+              <div className="flex-1">
+                <p
+                  className={`text-sm ${awayWon ? "font-semibold text-foreground" : "text-muted-foreground"}`}
+                >
+                  {fixture.awayTeamName}
+                </p>
+                <p
+                  className={`text-4xl font-bold tabular-nums ${awayWon ? "text-foreground" : "text-muted-foreground"}`}
+                >
+                  {result.awayScore}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">
+              {isCancelled
+                ? "This game was cancelled."
+                : "This game hasn’t been played yet."}
+            </p>
+          )}
+
+          <dl className="divide-y divide-border border-t border-border text-sm">
+            <div className="flex justify-between py-2">
+              <dt className="text-muted-foreground">Kickoff</dt>
+              <dd className="text-foreground">
+                {formatKickoff(fixture.scheduledAt)}
+              </dd>
+            </div>
+            <div className="flex justify-between py-2">
+              <dt className="text-muted-foreground">Venue</dt>
+              <dd className="text-foreground">{fixture.venue ?? "TBD"}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/leagues/[id]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/page.tsx
@@ -8,6 +8,8 @@ import {
   getPlayers,
   getPublicLeagueImportTree,
   getPublicLeagues,
+  getPublicLeagueSchedule,
+  type PublicScheduleRow,
 } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import {
@@ -71,6 +73,24 @@ export default async function PublicLeagueLandingPage({
     playerAttributesV1(),
   ]);
 
+  // Schedule shares the schedules_standings_v1 flag with standings. Surfacing
+  // it here is what makes the per-game viewer (WSM-000143) discoverable.
+  let schedule: { seasonName: string; rows: PublicScheduleRow[] } | null = null;
+  if (standingsOn) {
+    schedule = await getPublicLeagueSchedule(leagueId);
+  }
+  const scheduleRows = (schedule?.rows ?? [])
+    .slice()
+    .sort((a, b) => {
+      const wa = a.fixture.week ?? Number.POSITIVE_INFINITY;
+      const wb = b.fixture.week ?? Number.POSITIVE_INFINITY;
+      if (wa !== wb) return wa - wb;
+      return (a.fixture.scheduledAt ?? "").localeCompare(
+        b.fixture.scheduledAt ?? "",
+      );
+    });
+  const hasSchedule = scheduleRows.length > 0;
+
   // Player development directory — only when the viewer's flag is on. Teams
   // come from the public import tree (no org-access gate), players from the
   // ungated league query; both are safe post-guard since the league is public.
@@ -123,6 +143,19 @@ export default async function PublicLeagueLandingPage({
           </Link>
         ) : null}
 
+        {hasSchedule ? (
+          <a href="#schedule" className="group">
+            <Card className="h-full transition-colors group-hover:border-primary">
+              <CardHeader>
+                <CardTitle>Schedule</CardTitle>
+                <CardDescription>
+                  Fixtures and final scores for {schedule?.seasonName}.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </a>
+        ) : null}
+
         {hasDevelopment ? (
           <a href="#player-development" className="group">
             <Card className="h-full transition-colors group-hover:border-primary">
@@ -136,6 +169,40 @@ export default async function PublicLeagueLandingPage({
           </a>
         ) : null}
       </div>
+
+      {hasSchedule ? (
+        <section id="schedule" className="mt-10">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            Schedule
+          </h2>
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {scheduleRows.map(({ fixture, result }) => (
+              <li key={fixture.id}>
+                <Link
+                  href={`/leagues/${leagueId}/games/${fixture.id}`}
+                  className="flex items-center justify-between gap-4 px-4 py-3 transition-colors hover:bg-muted/50"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-medium text-foreground">
+                      {fixture.homeTeamName} vs {fixture.awayTeamName}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {fixture.week !== null ? `Week ${fixture.week}` : "TBD"}
+                    </span>
+                  </span>
+                  <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+                    {fixture.status === "final" && result !== null
+                      ? `${result.homeScore} – ${result.awayScore}`
+                      : fixture.status === "cancelled"
+                        ? "Cancelled"
+                        : "Scheduled"}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
 
       {hasDevelopment ? (
         <section id="player-development" className="mt-10">
@@ -171,7 +238,7 @@ export default async function PublicLeagueLandingPage({
         </section>
       ) : null}
 
-      {!standingsOn && !hasDevelopment ? (
+      {!standingsOn && !hasSchedule && !hasDevelopment ? (
         <p className="text-sm text-muted-foreground">
           Public viewers for this league aren&rsquo;t available yet.
         </p>

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -1496,3 +1496,59 @@ export async function computeStandingsPublic(
 ): Promise<{ seasonName: string; rows: Standing[] } | null> {
   return queryConvex(refs.computeStandingsPublic, { leagueId });
 }
+
+// --- Public game viewer (WSM-000143) — ungated reads for /leagues/[id]/games ---
+
+/**
+ * Ungated season lookup for public viewer routes. Unlike `getSeason`, this does
+ * NOT enforce `requireLeagueAccessLocal`, so it's callable without an org
+ * session. Used by the public game page to verify a fixture's season actually
+ * belongs to the public league in the URL (a cross-league leak guard — a
+ * fixture id from a PRIVATE league must not render under a public league's
+ * path). Always pair the returned `leagueId` with `publicLeagueGuard`.
+ */
+export async function getPublicSeason(
+  seasonId: string,
+): Promise<SeasonDto | null> {
+  return queryConvex(refs.getSeason, { seasonId });
+}
+
+export interface PublicScheduleRow {
+  fixture: FixtureDto;
+  result: GameResultDto | null;
+}
+
+/**
+ * The active season's fixtures for a public league, enriched with final scores.
+ *
+ * Mirrors `computeStandingsPublic`'s season selection (status "active", else the
+ * first season) so the public Schedule and Standings always agree on which
+ * season they're showing. Composed entirely from ungated reads; call only after
+ * `publicLeagueGuard` has confirmed the league is public. Returns null when the
+ * league has no seasons.
+ */
+export async function getPublicLeagueSchedule(leagueId: string): Promise<{
+  seasonName: string;
+  rows: PublicScheduleRow[];
+} | null> {
+  const seasons = await queryConvex(refs.listSeasons, {
+    leagueIds: [leagueId],
+  });
+  if (seasons.length === 0) return null;
+
+  const season = seasons.find((s) => s.status === "active") ?? seasons[0];
+  const fixtures = await listFixturesBySeason(season.id);
+
+  // Pull final scores only for completed games (others have no result row).
+  const rows = await Promise.all(
+    fixtures.map(async (fixture) => ({
+      fixture,
+      result:
+        fixture.status === "final"
+          ? await getResultByFixture(fixture.id)
+          : null,
+    })),
+  );
+
+  return { seasonName: season.name, rows };
+}


### PR DESCRIPTION
Closes #300 (WSM-000143). First child of the live-streaming epic (#225) — the public per-game page the streaming MVP will host the player on, independently useful today.

## What
- **New SSR route** `/leagues/[id]/games/[gameId]` under the public viewer tree.
- **Renders** home/away teams, kickoff, venue, and the **final score** from `gameResults` when `status === "final"`; otherwise **Scheduled / Cancelled**. `FixtureStatus` has no live/in-progress state yet (live scoring is deferred to keystone v3 per the streaming RFC), so only those three render.
- **`generateMetadata`** (title + OpenGraph/Twitter), consistent with the #182 landing page; reads deduped via `cache()`.
- **Landing page** gains a flag-gated **Schedule** section + card listing the active season's fixtures, each linking to its game viewer — satisfies the "linked from where games are listed" AC.
- **data-api:** ungated `getPublicSeason` + `getPublicLeagueSchedule` helpers, composed from existing public reads.

## Security (defense in depth, in order)
1. `schedules_standings_v1` flag off → 404 (games are part of the same feature as the schedule/standings viewers).
2. `publicLeagueGuard` → 404 if the league isn't opt-in public.
3. **Cross-league guard:** `getFixture` returns *any* fixture by id with no league scope, so the page resolves the fixture's season and 404s unless `season.leagueId` matches the URL. Without this, a fixture from a **private** league could be viewed by pairing its id with a public league's path.

No new Convex function — helpers reuse existing public reads, so the write-mutation `internalMutation` backstop is untouched. Schedule selection mirrors `computeStandingsPublic` (active season, else first) so the public Schedule and Standings always agree on the season.

## Acceptance criteria
- [x] New SSR route `/leagues/[id]/games/[gameId]` under the public viewer tree.
- [x] `publicLeagueGuard` 404s private/missing leagues (matches standings/development).
- [x] Renders home/away teams, scheduled date/venue, and final score from `gameResults` when present (else scheduled/cancelled per `fixtures.status`).
- [x] `generateMetadata` (title + OpenGraph), consistent with the landing page (#182).
- [x] Linked from the league landing where games are listed (new Schedule section).

## Verification
- `pnpm lint` ✅ · `pnpm type-check` ✅ · `pnpm build` ✅ (route registered as dynamic `ƒ /leagues/[id]/games/[gameId]`).
- e2e: extended the `schedules-standings` public-toggle smoke to click the new Schedule link and assert the game viewer renders the final. (Playwright suite is gated on CI secrets — #297/#305 — so not run here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)