### PR TITLE
docs(gtm): add live-streaming epic status to the product roadmap (#225)

### DIFF
--- a/docs/market-insights/business-plan.md
+++ b/docs/market-insights/business-plan.md
@@ -282,12 +282,14 @@ Three sprints completed across 17 user stories and 24 merged PRs:
 - Notification system (email/push for game reminders, roster changes)
 - Mobile-responsive optimization pass
 - AppExchange security review submission
+- **Live game streaming — video MVP** (BYO-RTMP → Mux, in-app HLS viewer + LIVE badge; epic #225, fully scoped). _Validation-gated:_ build only after coach-interview validation confirms demand + the metered-cost model. The public game-viewer prerequisite (#300) has already shipped.
 
 ### Long-Term (Q4 2026 - Q1 2027) — Scale
 
 - Additional sport modules (basketball, baseball, soccer)
 - Payment collection for registration fees and dues (Stripe Connect)
 - Statistics tracking and analytics dashboards
+- **Live-score overlay + streaming polish** (the GameChanger "video + live score in one screen" hook — #302/#303). Depends on the live-scorekeeping keystone (provides realtime game-state) on top of the Q3 video MVP; polish covers VOD replay, clips, and low-latency.
 - AppExchange listing goes live
 - Public API for third-party integrations
 - Venue management and facility scheduling


### PR DESCRIPTION
Updates the canonical GTM artifact (`docs/market-insights/business-plan.md` §9 Product Roadmap) to reflect the now-complete scoping of the live-streaming epic (#225).

## Changes (docs-only)
- **Growth (Q3 2026):** adds **live game streaming — video MVP** (BYO-RTMP → Mux, in-app HLS + LIVE badge), explicitly **validation-gated**, and notes the public game-viewer prerequisite (#300) has already shipped.
- **Scale (Q4 2026–Q1 2027):** adds **live-score overlay + streaming polish** (#302/#303) — the GameChanger "video + live score" hook — noting its dependency on the live-scorekeeping keystone for realtime game-state.

No code or behavior change. Issue bodies for #225/#301/#302/#303 already carry the detailed build-ready scopes; this records the roadmap-level status where the GTM plan lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)