### PR TITLE
docs(research): add coach outreach contact tracker (#309)

### DIFF
--- a/docs/research/coach-interview-guide.md
+++ b/docs/research/coach-interview-guide.md
@@ -24,6 +24,10 @@ stat-keeper is gold — they live the pain. Start from the 16 Cobb County school
 
 ## Outreach templates (recruiting the interview)
 
+_Track who's been contacted and their status in
+[coach-outreach-contacts.md](./coach-outreach-contacts.md) (status only — no personal PII in
+this public repo)._
+
 **Principles:** keep it short; **don't pitch** (the email earns the call — it doesn't describe
 a product, or the call's data is contaminated); lead with *specific, verified* homework about
 their program (specificity is the open rate — a coach smells a mail-merge); make "yes" cheap

--- a/docs/research/coach-outreach-contacts.md
+++ b/docs/research/coach-outreach-contacts.md
@@ -1,0 +1,78 @@
+# Coach Outreach — Contact Tracker (#309)
+
+_Outreach/status tracker for the coach-interview round (field-research tracker #309).
+Pairs with the outreach templates + interview script in
+[coach-interview-guide.md](./coach-interview-guide.md) and the
+[flag-football research](./flag-football-cobb-research.md)._
+
+> ⚠️ **This repo is PUBLIC. Do NOT put personal contact details here.** No personal
+> emails, cell numbers, or home info. Names + public coaching roles are public record
+> (news/school directories); that's fine. Keep actual email/phone in a **private** store
+> (your own CRM / spreadsheet / contacts app) and track only **status** here. For "how to
+> reach them," link the **public** source (school athletics staff page or MaxPreps team
+> page) rather than pasting an address.
+
+## Status legend
+
+⬜ Not contacted · 📤 Contacted · 📅 Call scheduled · ✅ Interviewed · ❌ Declined / no
+response · 🔁 Referral pending (waiting on a coach to point us to their stat-keeper)
+
+## How to use
+
+1. Start with **Tier 1** (verified, decorated, highest-yield). Use template A (head coach)
+   from the guide; personalize the first line with a *verified* accomplishment.
+2. Log the date + status in the table. No reply in ~5 days → one-line nudge (not a resend).
+3. **On every coach call, ask "who actually keeps your stats?"** → add that person as a
+   stat-keeper row (role only until you have consent) and use template B (referral-warm).
+4. The stat-keeper is the gold source — prioritize converting referrals into calls.
+5. Target **8–10 completed interviews** total across the three lanes (keystone / streaming /
+   flag). Stop adding when the verdicts in #309 are clearly supported.
+
+---
+
+## Tier 1 — flag, start here (verified)
+
+| Coach | School | Role | Find via (public) | Status | Last action | Notes |
+|---|---|---|---|---|---|---|
+| **Kevin Fraser** | Pope HS | Head coach, girls flag | Pope HS athletics staff dir. / MaxPreps Pope flag | ⬜ | — | 3× state champ (’23–’25); ’23-24 National Flag COY; ’25 Cobb COY. Highest-credibility intro. |
+| **Jake Burgdorf** | McEachern HS | Head coach, girls flag | McEachern athletics staff dir. / MaxPreps McEachern flag | ⬜ | — | ’24 state champ (unbeaten), ’24 Cobb COY, ’25 runner-up. |
+
+## Tier 2 — flag coaches (Cobb), name verified
+
+| Coach | School | Find via (public) | Status | Notes |
+|---|---|---|---|---|
+| Jordan Davis | Allatoona HS | school athletics / MaxPreps | ⬜ | 2023 state-finals run |
+| Griffin Wattley | Harrison HS | school athletics / MaxPreps | ⬜ | new 2025; 9-win ’24 program record |
+| Campbell Price | Lassiter HS | school athletics / MaxPreps | ⬜ | 1st year 2025 |
+| Jaaran Nesbitt | Campbell HS | school athletics / MaxPreps | ⬜ | 2025 inaugural season |
+| Rico Reese | Osborne HS | school athletics / MaxPreps | ⬜ | rebuilding (1-14 ’24) — pain-rich perspective |
+| Asim Narcisse-Williams | Pebblebrook HS | school athletics / MaxPreps | ⬜ | narrowly missed ’24 playoffs |
+
+## Tier 3 — flag coaches (Cobb), name UNVERIFIED (confirm before contacting)
+
+Schools confirmed to field girls flag teams; **head-coach name not yet verified** — confirm via
+the school athletics page or MaxPreps before any outreach (do not guess a name in an email):
+
+Hillgrove · Kell · North Cobb · Walton · Kennesaw Mountain · Sprayberry · Wheeler · South Cobb ·
+North Cobb Christian (private) · Mount Paran Christian (private) · **Marietta** (MaxPreps shows
+"N. Torres" — unverified; Marietta City Schools, competes outside the Cobb D5 alignment).
+
+## Stat-keepers — the gold source (populate via referral)
+
+The person who actually enters the box score (coordinator, GA, team mom, AD). Usually reached
+**after** a coach refers them — track role only until you have their OK to be listed.
+
+| Referred by | School | Role (as described) | Status | Notes |
+|---|---|---|---|---|
+| _(e.g. Fraser)_ | _(Pope)_ | _(coordinator / team mom / AD)_ | 🔁 | _add when a coach names them_ |
+
+## Other lanes (same #309 round)
+
+The interview round also validates the **keystone** (tackle-football stat pain) and **streaming**
+gates — those interviewees are HS **tackle** head coaches / coordinators / stat-keepers from the
+16 seeded Cobb schools. Add rows here as you line them up; many flag coaches above also coach or
+sit near the tackle program, so a single call can cover multiple lanes.
+
+| Name | School | Role | Lane(s) | Find via (public) | Status | Notes |
+|---|---|---|---|---|---|---|
+| _(to fill)_ | | | keystone / streaming | | ⬜ | |


### PR DESCRIPTION
New `docs/research/coach-outreach-contacts.md` — a status tracker for the coach-interview round (#309), paired with the outreach templates already in the interview guide.

## Public-repo safe by design
This repo is **public**, so the tracker holds **status + public-directory pointers only** and carries an explicit **no-PII banner**: no personal emails/cell numbers — keep those in a private store, track only status here. Coach names tied to public coaching roles are already public record (news/school directories).

## Contents
- **Tier 1 (start here, verified):** Kevin Fraser (Pope), Jake Burgdorf (McEachern).
- **Tier 2 (name-verified Cobb flag coaches):** Davis (Allatoona), Wattley (Harrison), Price (Lassiter), Nesbitt (Campbell), Reese (Osborne), Narcisse-Williams (Pebblebrook).
- **Tier 3 (UNVERIFIED coach name):** schools with a flag team but no confirmed coach — flagged "confirm before contacting" so nobody emails a guessed name.
- **Stat-keepers** (gold source) — populated via coach referral, role-only until consent.
- **Other #309 lanes** — a slot for the tackle-football keystone/streaming interviewees from the 16 seeded Cobb schools.
- Status legend + a "how to use" workflow (start Tier 1 → log status → ask "who keeps your stats?" → convert referrals).

Linked from the interview guide's outreach section. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)