### PR TITLE
docs(research): resolve MaxPreps import format (keystone open question)

### DIFF
--- a/docs/research/coach-interview-guide.md
+++ b/docs/research/coach-interview-guide.md
@@ -145,11 +145,13 @@ line and open with "I'm researching how flag programs keep their stats…"._
 ## Block D — Export format (technical, ask the stat-keeper or AD)
 
 - When you (or a partner tool) get stats **into** MaxPreps, what's the exact path — typing it
-  in, or uploading a file? If a file: **what format/columns**, and can you send me a sample?
+  in, or uploading a file? **If a file, can you send me a sample `.txt`?**
 - Does your state/GHSA require a specific stat submission, and by when after each game?
 
-_(This nails the "exact MaxPreps import-file format" open question without scraping — coaches
-have the real upload screens and sample files.)_
+_(Mostly answered by desk research — see [maxpreps-import-format.md](./maxpreps-import-format.md):
+the import is a public pipe-delimited `.txt` spec. The **only** thing still worth getting from a
+coach is a **real football export sample**, which would reveal the exact field-name strings — or
+just register as a MaxPreps Stat Supplier to read them directly. Lower priority now.)_
 
 ## Block E — Game video & streaming (validation gate for #225)
 

--- a/docs/research/maxpreps-import-format.md
+++ b/docs/research/maxpreps-import-format.md
@@ -1,0 +1,121 @@
+# MaxPreps Stat Import Format — Research
+
+_Research date: 2026-06-16. Resolves the keystone's top open question — "the exact MaxPreps
+import-file format" ([coach-interview-guide.md](./coach-interview-guide.md) Block D;
+[stat-keeping-keystone-prd.md](./stat-keeping-keystone-prd.md)). Sourced web research into the
+**documented** format — **not** scraping MaxPreps data (per the project's standing no-scrape
+stance). Login-gated areas were not accessed._
+
+## TL;DR — the export is documented and buildable
+
+MaxPreps stat ingest is **not an API** — it's a public, documented **pipe-delimited `.txt`
+file spec**. A coach uploads the file via **Save & Import Stats** on their MaxPreps Coach Admin,
+or an approved partner pushes it automatically. **So the keystone's "MaxPreps export" is a
+concrete, buildable `.txt` generator, not a reverse-engineering project.** The single remaining
+unknown is the *exact football field-name strings* (gated behind a JS dropdown / supplier
+registration) — narrow enough to close by registering as a Stat Supplier or reading one real
+export. Spec: https://www.maxpreps.com/utility/stat_import/field_specs.aspx
+
+## 1. How stats get into MaxPreps (football)
+
+Three documented paths ([MaxPreps Stat Management](https://support.maxpreps.com/hc/en-us/articles/202103644-Stat-Management), [GHSA: Enter Scores & Stats](https://www.ghsa.net/how-enter-scores-stats-maxprepscom)):
+
+1. **Manual web-form entry (default).** Coach Admin → Scores/Stats → edit a game → enter box
+   score → "Save & Enter Stats" → type each player stat category into web forms. Publishes in
+   ~15–30 min. This is what most coaches actually do — the friction the keystone targets.
+2. **"Teams by MaxPreps" mobile app** — game-by-game scores/results (full stat entry is the website).
+3. **Import from a stat partner** — "Save & **Import** Stats" consumes a partner-generated
+   `.txt` file. MaxPreps imports from "**80+ stat partners**," nearly all via the *same* file
+   spec (not bespoke APIs). [[Stat Import Partners]](https://support.maxpreps.com/hc/en-us/articles/202266384-Stat-Import-Partners)
+
+There is also a printable paper stat sheet (source-of-truth during the game, hand-keyed after) —
+the official football one documents the field set (see §3). [[MaxPreps Stat Sheets]](https://support.maxpreps.com/hc/en-us/articles/4405313793563-MaxPreps-Stat-Sheets)
+
+## 2. The import file spec (the prize)
+
+From the public **Export Field Specifications** (https://www.maxpreps.com/utility/stat_import/field_specs.aspx):
+
+- **Format:** plain text, **pipe (`|`) delimited**, `.txt` extension. Filename cannot contain
+  quotes or parentheses (rename to e.g. `import.txt` if needed).
+- **Line 1:** the **32-character Stat Supplier ID** (e.g. `12345678-1234-1234-123456789012`).
+- **Line 2:** header row of **exact MaxPreps field names**. **First field must be `Jersey`**;
+  all others optional, any order.
+- **Lines 3+:** one row per player, values in the same column order as line 2.
+- **Rules:** omit zeros *unless* the stat is genuinely zero (e.g. INTs/turnovers); imports do
+  **not** overwrite undeclared fields → multiple imports per game are allowed (e.g. a separate
+  offense file and defense file). The published example is baseball:
+  ```
+  12345678-1234-1234-123456789012
+  Jersey|AtBats|BaseOnBalls|Doubles|HitByPitch|Hits
+  12|3|2|1|0|2
+  ```
+- **Getting a Supplier ID:** register as a "Stat Supplier" from a MaxPreps account → fill
+  general info → issued the 32-char ID. Self-serve. [[Stat Import Partners]](https://support.maxpreps.com/hc/en-us/articles/202266384-Stat-Import-Partners)
+- **`UNVERIFIED` (the one gap):** the **exact football field-name strings** (the real MaxPreps
+  names for rushing yards, passing TDs, tackles, sacks, etc.). The spec page exposes them only
+  through a JavaScript "available fields for [sport]" dropdown that static fetches can't render.
+  Closeable by registering as a supplier or inspecting one real football export.
+
+## 3. The football stat field set (categories)
+
+Verified from the official MaxPreps football stat-sheet PDF
+([boys_football_stats.pdf](https://www.maxpreps.com/documents/stats/boys_football_stats.pdf)) —
+this is the *schema* our capture model must produce (field-name strings TBD per §2):
+
+- **Rushing:** rushes, yards, longest, TD, conversions, fumbles
+- **Passing:** completions, attempts, interceptions, yards, TD, longest, fumbles
+- **Receiving:** catches, yards, longest, TD, conversions, fumbles
+- **Defense (per jersey #):** assisted/unassisted tackles, TFL, sacks (+yds), INT (+ret yds),
+  fumble recovery (+yds), fumbles caused, pass defended, QB hurries, blocked kick/punt, safety
+- **Special teams:** punt/kick returns, punts, kickoffs (att/yds/longest/TD, inside-20, TB, FC)
+- **Scoring:** TDs (run/rec/misc), PAT, conversions, field goals (made/att/longest), safety
+- **Team:** first downs, penalty yards
+
+_(Flag football's set is the §3 offense plus **flag pulls**-centric defense — see
+[flag-football-cobb-research.md](./flag-football-cobb-research.md) §3. Whether MaxPreps exposes
+flag-specific import fields is unconfirmed.)_
+
+## 4. How rival tools push to MaxPreps (validates the path)
+
+| Tool | Football mechanism | Source |
+|---|---|---|
+| **Hudl** | Was direct auto-sync; **sync discontinued ~Jan 1, 2025** → now **manual `.txt` export + upload**. | [[MaxPreps/Hudl sync]](https://support.maxpreps.com/hc/en-us/articles/5493128608283-MaxPreps-HUDL-Data-Sync) |
+| **GameChanger** | Manual "MaxPreps TXT Export"; **football not on its documented sport list** (baseball/softball/etc.). | [[GC manual upload]](https://help.gc.com/hc/en-us/articles/11298180524685-MaxPreps-Manual-Stat-Upload) |
+| **Modern Football Technology** | **Automated** football stat push — MaxPreps "Xport Enabled Stat Partner" (Aug 2025). **First football-specific automated partner — a direct competitor in our lane.** | [[PRNewswire 2025-08-14]](https://www.prnewswire.com/news-releases/maxpreps-and-modern-football-technology-announce-partnership-to-automate-stat-reporting-for-high-school-football-teams-302529598.html) |
+| QwikCut / TurboStats / PrestoStats | Market a MaxPreps export; mechanism/format not publicly documented. | `UNVERIFIED` |
+
+**No vendor-neutral / NFHS box-score interchange standard exists** — MaxPreps' pipe-delimited
+TXT is the de facto standard purely via market dominance.
+
+## 5. GHSA submission context (football)
+
+GHSA requires coaches to submit box scores to MaxPreps (powers media + region standings).
+Football carries a **dual obligation**: MaxPreps (stats) **and** the separate **GHSA MIS** site
+for results feeding the **Post-Season Ranking Formula** seeding. [[GHSA–MaxPreps]](https://www.ghsa.net/ghsa-and-maxpreps-sign-multi-year-agreement) [[PSR formula]](https://www.ghsa.net/constitution-section-2025-2026-appendix-psr-post-season-ranking-formula)
+_(Recall: this mandate covers **tackle football**, not flag — see flag research §4.)_
+
+## 6. What this means for the keystone
+
+- **Build a "MaxPreps TXT Export" generator first** — pipe-delimited `.txt`, Line 1 = our
+  Supplier ID, Line 2 = `Jersey|<football fields>`, one row per player. This is the universal,
+  documented, coach-uploadable path and mirrors exactly what Hudl/GameChanger do.
+- **Two-file trick:** since imports don't overwrite undeclared fields, we can emit separate
+  offense and defense files — convenient for incremental/box-score-section workflows.
+- **Automated "Xport Enabled" sync is a BD conversation with MaxPreps**, not a public API
+  integration (the Modern Football model). Treat as a later, partnership-gated phase.
+- **Competitive note:** Modern Football Technology already automates football stat push (Aug
+  2025). Our differentiation stays the *capture* experience + the **flag** angle (where the
+  tooling gap is wider), not "we can export to MaxPreps" alone.
+
+## 7. Residual open questions (much narrower now)
+
+1. **Exact football field-name strings** for the `.txt` header (§2) — get by registering as a
+   Stat Supplier (self-serve) or reading one real export. **This is the precise, bounded task
+   that remains** — far narrower than the original "what's the format?"
+2. Whether MaxPreps exposes **flag-football-specific** import fields (flag pulls etc.).
+3. Whether the "Save & Import Stats" screen strictly validates the partner format (likely yes).
+4. Exact GHSA per-game submission deadline/penalty wording (2025 Football Coaches Manual didn't load).
+
+**Note on sourcing:** `support.maxpreps.com` and `help.gc.com` article bodies returned HTTP 403
+to direct fetch; findings there are reconstructed from search snippets + state-association
+mirrors (GHSA/NCHSAA/UHSAA) and the directly-read official stat-sheet PDF + field-spec page.

--- a/docs/research/stat-keeping-keystone-prd.md
+++ b/docs/research/stat-keeping-keystone-prd.md
@@ -100,7 +100,8 @@ Team-level: score by quarter, total; (W/L derives from the existing standings la
 ## 9. MaxPreps export
 
 - From a completed game (or a season) → **"Export for MaxPreps"** → download a file in
-  MaxPreps' accepted **manual stat-upload** format (CSV/columns TBD from research).
+  MaxPreps' accepted **manual stat-upload** format: a **pipe-delimited `.txt`** (Supplier ID +
+  `Jersey|<fields>` header + one row per player — see [maxpreps-import-format.md](./maxpreps-import-format.md)).
 - Carries **our roster identities + stats together**, so there's no "did you also add them on
   MaxPreps?" mismatch (the GameChanger failure mode).
 - v1 = manual download + upload by the coach (same path Hudl uses). A contracted MaxPreps
@@ -144,7 +145,10 @@ at HS. Reuses the rating pipeline; swaps nflverse inputs for `playerGameStats` a
 
 ## 13. Risks & open questions
 
-- **Exact MaxPreps import format** — _blocker for the export; resolve via interviews (Block D)._
+- **MaxPreps import format** — ~~blocker~~ **largely resolved** ([maxpreps-import-format.md](./maxpreps-import-format.md)):
+  it's a public pipe-delimited `.txt` spec (Line 1 = 32-char Supplier ID, Line 2 = `Jersey|<fields>`,
+  one row per player), coach-uploadable via "Save & Import Stats." Build a TXT-export generator.
+  _Residual:_ exact football field-name strings (register as a Stat Supplier or read one real export).
 - **Will coaches enter stats here vs. their existing flow?** — the core demand question the
   interviews must answer; if "no," this whole keystone is wrong.
 - **Entry speed** — if it's slower than typing into MaxPreps, it fails. Usability-test the


### PR DESCRIPTION
Desk research (no scraping — public docs/specs only) **resolves the keystone's top open question**: the exact MaxPreps stat import format.

## The finding
MaxPreps stat ingest is **not an API** — it's a public, documented **pipe-delimited `.txt` spec** ([field_specs.aspx](https://www.maxpreps.com/utility/stat_import/field_specs.aspx)):
- **Line 1:** 32-char Stat Supplier ID · **Line 2:** `Jersey|<exact field names>` (first field must be `Jersey`) · **Lines 3+:** one row per player.
- Coach uploads via **Save & Import Stats**; or an approved partner pushes it automatically ("Xport Enabled").
- The football **stat field set** is captured from MaxPreps' official stat-sheet PDF.

So the keystone's "MaxPreps export" is a **concrete, buildable `.txt` generator**, not a reverse-engineering project.

## Residual (narrowed)
Only the **exact football field-name strings** remain unknown (behind a JS dropdown) — closeable by registering as a Stat Supplier (self-serve) or reading one real export. Far narrower than the original "what's the format?"

## Competitive note
**Modern Football Technology** became MaxPreps' first *automated* football stat partner (Aug 2025) — a direct competitor in our lane. Our differentiation stays the *capture* experience + the **flag** angle, not "we can export to MaxPreps" alone.

## Doc updates
- New `maxpreps-import-format.md` (full spec, field set, rival mechanisms, GHSA context, build implications).
- `stat-keeping-keystone-prd.md`: format no longer a blocker; corrected "CSV" → pipe-delimited TXT.
- `coach-interview-guide.md` Block D: format mostly answered; only a real export sample still useful (now lower priority).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)