### PR TITLE
feat(web): Phase 1 live game streaming MVP behind dark flag (WSM-000144)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -31,6 +31,16 @@ NEXT_PUBLIC_APP_URL=https://sprtsmng.andrewsolomon.dev
 # FLAG_ROSTER_SNAPSHOTS_V1=on
 # FLAG_PLAYER_ATTRIBUTES_V1=on
 # FLAG_SCHEDULES_STANDINGS_V1=on
+# live_streaming_v1 is a TRUE DARK FLAG: OFF in every env (incl. preview/dev)
+# unless explicitly set to "on". Flipping it on provisions real, billable Mux
+# live streams — only enable per pilot after demand validation (#225).
+# FLAG_LIVE_STREAMING_V1=on
+
+# Mux Video (live streaming — WSM-000144). Server-side only; none are
+# NEXT_PUBLIC. The public HLS playback id is stored in the DB, not here.
+# MUX_TOKEN_ID=...
+# MUX_TOKEN_SECRET=...
+# MUX_WEBHOOK_SECRET=...           # signing secret from the Mux dashboard webhook
 
 # E2E Test Harness (Playwright + Convex)
 # Required only when running e2e specs that use apps/web/e2e/helpers/seed-roster.ts.

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -44,6 +44,8 @@ void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;
 void internal.sports.forkConferenceToWorkspace;
 void internal.sports.unforkTeamFromWorkspace;
+void internal.sports.createGameStream;
+void internal.sports.updateGameStreamStatus;
 
 // --- Writes MUST NOT be on the public API (each access must be a type error) ---
 // @ts-expect-error createTeam is internal, not public
@@ -66,6 +68,10 @@ void api.sports.forkDivisionToWorkspace;
 void api.sports.forkConferenceToWorkspace;
 // @ts-expect-error unforkTeamFromWorkspace is internal, not public
 void api.sports.unforkTeamFromWorkspace;
+// @ts-expect-error createGameStream is internal, not public
+void api.sports.createGameStream;
+// @ts-expect-error updateGameStreamStatus is internal, not public
+void api.sports.updateGameStreamStatus;
 
 // --- Public READ queries must remain public (these must exist on api) ---
 void api.sports.listTeams;
@@ -113,11 +119,13 @@ type AllowedPublicSportsReads =
   | "getPlayerDevelopmentPublic"
   | "getPlayerMaddenRating"
   | "getPlayerSeasonAttributes"
+  | "getActiveStreamCountForLeague"
   | "getResultByFixture"
   | "getRosterAssignmentHistory"
   | "getRosterBySeasonTeam"
   | "getSeason"
   | "getSeasonAttributesByPosition"
+  | "getStreamByFixture"
   | "getSyncConfig"
   | "getTeam"
   | "getTeamAttributeSnapshots"

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -274,4 +274,27 @@ export default defineSchema({
     recordedAt: v.string(),
     recordedBy: v.string(),
   }).index("by_fixtureId", ["fixtureId"]),
+
+  /*
+   * One live stream per fixture (WSM-000144, streaming epic #225). The Mux
+   * stream KEY is never stored — Mux holds it; we keep only the live-stream id
+   * (server-side) and the public HLS playback id. Public reads project to
+   * status/playbackId/vodAssetId only; the key + live-stream id never transit a
+   * public query (see getStreamByFixture).
+   */
+  gameStreams: defineTable({
+    fixtureId: v.id("fixtures"),
+    muxLiveStreamId: v.string(), // server-side; never returned by a public read
+    muxPlaybackId: v.string(), // public HLS id
+    status: v.string(), // "idle" | "active" | "ended"
+    vodAssetId: v.union(v.string(), v.null()),
+    startedBy: v.string(),
+    startedAt: v.string(),
+    endedAt: v.union(v.string(), v.null()),
+    maxDurationMinutes: v.number(),
+  })
+    .index("by_fixtureId", ["fixtureId"])
+    .index("by_status", ["status"])
+    // Mux webhooks identify the stream by its Mux live-stream id, not fixtureId.
+    .index("by_muxLiveStreamId", ["muxLiveStreamId"]),
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1,4 +1,8 @@
-import { internalMutationGeneric, queryGeneric } from "convex/server";
+import {
+  internalMutationGeneric,
+  internalQueryGeneric,
+  queryGeneric,
+} from "convex/server";
 import { v } from "convex/values";
 import { internalMutation, query } from "./_generated/server";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
@@ -3965,5 +3969,175 @@ export const computeStandingsPublic = query({
     });
 
     return { seasonName: activeSeason.name, rows };
+  },
+});
+
+/*
+ * Phase 1 live game streaming (WSM-000144, streaming epic #225).
+ *
+ * One Mux live stream per fixture. The stream KEY is never persisted (Mux holds
+ * it; the server action returns it in-memory to the starting admin only). Writes
+ * are internalMutation — only trusted server code (data-api.ts holding the admin
+ * key) can call them. The public read projects to public fields ONLY, so the Mux
+ * live-stream id (server-side) and key never transit a public query.
+ */
+
+// Public projection — what an unauthenticated viewer is allowed to see.
+const publicStreamDtoValidator = v.union(
+  v.object({
+    status: v.string(),
+    muxPlaybackId: v.string(),
+    vodAssetId: v.union(v.string(), v.null()),
+  }),
+  v.null(),
+);
+
+export const createGameStream = internalMutationGeneric({
+  args: {
+    fixtureId: v.id("fixtures"),
+    muxLiveStreamId: v.string(),
+    muxPlaybackId: v.string(),
+    startedBy: v.string(),
+    maxDurationMinutes: v.number(),
+  },
+  returns: v.object({
+    id: v.string(),
+    fixtureId: v.string(),
+    status: v.string(),
+    muxPlaybackId: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+
+    const payload = {
+      fixtureId: args.fixtureId,
+      muxLiveStreamId: args.muxLiveStreamId,
+      muxPlaybackId: args.muxPlaybackId,
+      status: "idle",
+      vodAssetId: null,
+      startedBy: args.startedBy,
+      startedAt: new Date().toISOString(),
+      endedAt: null,
+      maxDurationMinutes: args.maxDurationMinutes,
+    };
+
+    // One stream per fixture: replace any prior (e.g. ended) stream in place so
+    // a coach can re-go-live on the same game.
+    const existing = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+
+    let id: string;
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+      id = existing._id;
+    } else {
+      id = await ctx.db.insert("gameStreams", payload);
+    }
+
+    return {
+      id,
+      fixtureId: args.fixtureId,
+      status: payload.status,
+      muxPlaybackId: args.muxPlaybackId,
+    };
+  },
+});
+
+export const updateGameStreamStatus = internalMutationGeneric({
+  args: {
+    muxLiveStreamId: v.string(),
+    // Optional so a `video.asset.ready` webhook can attach the VOD id without
+    // changing status (the stream has already ended by then).
+    status: v.optional(v.string()),
+    vodAssetId: v.optional(v.union(v.string(), v.null())),
+    endedAt: v.optional(v.union(v.string(), v.null())),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_muxLiveStreamId", (q) =>
+        q.eq("muxLiveStreamId", args.muxLiveStreamId),
+      )
+      .first();
+    // Idempotent: an unknown stream id (or a duplicate webhook delivery) is a
+    // no-op, not an error — Mux retries on non-2xx and may deliver out of order.
+    if (!row) return false;
+
+    const patch: {
+      status?: string;
+      vodAssetId?: string | null;
+      endedAt?: string | null;
+    } = {};
+    if (args.status !== undefined) patch.status = args.status;
+    if (args.vodAssetId !== undefined) patch.vodAssetId = args.vodAssetId;
+    if (args.endedAt !== undefined) patch.endedAt = args.endedAt;
+
+    await ctx.db.patch(row._id, patch);
+    return true;
+  },
+});
+
+export const getStreamByFixture = queryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: publicStreamDtoValidator,
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    if (!row) return null;
+    // PUBLIC PROJECTION ONLY — never return muxLiveStreamId (server-side) here.
+    return {
+      status: row.status,
+      muxPlaybackId: row.muxPlaybackId,
+      vodAssetId: row.vodAssetId,
+    };
+  },
+});
+
+/*
+ * INTERNAL read — returns the server-side Mux live-stream id for a fixture so a
+ * trusted server action (holding the admin key) can disable/transition it. This
+ * is internalQueryGeneric, so it is NOT on the public `api` object and can never
+ * be called by an anonymous client — that's why it's allowed to expose the
+ * live-stream id (which getStreamByFixture intentionally hides from the public).
+ */
+export const getStreamAdminByFixture = internalQueryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.union(
+    v.object({ muxLiveStreamId: v.string(), status: v.string() }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    if (!row) return null;
+    return { muxLiveStreamId: row.muxLiveStreamId, status: row.status };
+  },
+});
+
+export const getActiveStreamCountForLeague = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    const active = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .collect();
+
+    let count = 0;
+    for (const stream of active) {
+      const fixture = await ctx.db.get(stream.fixtureId);
+      if (!fixture) continue;
+      const season = await ctx.db.get(fixture.seasonId);
+      if (season && season.leagueId === args.leagueId) count += 1;
+    }
+    return count;
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@mux/mux-node": "14.1.1",
+    "@mux/mux-player-react": "3.13.0",
     "@radix-ui/react-accordion": "^1.2.13",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/src/app/api/streams/mux/webhook/route.ts
+++ b/apps/web/src/app/api/streams/mux/webhook/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMux } from "@/lib/mux";
+import {
+  handleMuxEvent,
+  type MuxWebhookEvent,
+} from "@/lib/mux-webhook-handlers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/*
+ * Mux live-stream webhook (WSM-000144). Mirrors the Stripe webhook route:
+ * read the RAW body, verify the signature with MUX_WEBHOOK_SECRET (via the SDK's
+ * webhooks.unwrap, which uses the secret configured on the client), structured
+ * JSON logging, 400 on bad signature, 500 (so Mux retries) on handler failure.
+ */
+export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.MUX_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        message: "MUX_WEBHOOK_SECRET not configured",
+        route: "/api/streams/mux/webhook",
+      }),
+    );
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+
+  const body = await request.text();
+
+  let event: MuxWebhookEvent;
+  try {
+    const mux = getMux();
+    // Verifies the Mux-Signature header against the raw body using the
+    // configured webhookSecret; throws if the signature is invalid.
+    event = mux.webhooks.unwrap(
+      body,
+      request.headers,
+    ) as unknown as MuxWebhookEvent;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        message: `Mux webhook signature verification failed: ${message}`,
+        route: "/api/streams/mux/webhook",
+      }),
+    );
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  try {
+    await handleMuxEvent(event);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        message: `Mux webhook handler failed: ${message}`,
+        eventType: event.type,
+        route: "/api/streams/mux/webhook",
+      }),
+    );
+    // 500 → Mux retries the delivery.
+    return NextResponse.json({ error: "Handler failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockLiveStreamingV1,
+  mockAuth,
+  mockGetFixture,
+  mockGetPublicSeason,
+  mockCreateGameStream,
+  mockUpdateGameStreamStatus,
+  mockGetActiveStreamCountForLeague,
+  mockGetStreamAdminByFixture,
+  mockCanAdministerTeam,
+  mockCreateMuxLiveStream,
+  mockDisableMuxLiveStream,
+} = vi.hoisted(() => ({
+  mockLiveStreamingV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetFixture: vi.fn(),
+  mockGetPublicSeason: vi.fn(),
+  mockCreateGameStream: vi.fn(),
+  mockUpdateGameStreamStatus: vi.fn(),
+  mockGetActiveStreamCountForLeague: vi.fn(),
+  mockGetStreamAdminByFixture: vi.fn(),
+  mockCanAdministerTeam: vi.fn(),
+  mockCreateMuxLiveStream: vi.fn(),
+  mockDisableMuxLiveStream: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ liveStreamingV1: mockLiveStreamingV1 }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  getFixture: mockGetFixture,
+  getPublicSeason: mockGetPublicSeason,
+  createGameStream: mockCreateGameStream,
+  updateGameStreamStatus: mockUpdateGameStreamStatus,
+  getActiveStreamCountForLeague: mockGetActiveStreamCountForLeague,
+  getStreamAdminByFixture: mockGetStreamAdminByFixture,
+}));
+vi.mock("@/lib/authorization", () => ({
+  canAdministerTeam: mockCanAdministerTeam,
+}));
+vi.mock("@/lib/mux", () => ({
+  createMuxLiveStream: mockCreateMuxLiveStream,
+  disableMuxLiveStream: mockDisableMuxLiveStream,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { startGameStream, stopGameStream } from "../stream-actions";
+
+const LEAGUE = "league_1";
+const FIXTURE = "fixture_1";
+
+function happyFixture() {
+  mockLiveStreamingV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockGetFixture.mockResolvedValue({
+    id: FIXTURE,
+    seasonId: "season_1",
+    homeTeamId: "team_home",
+    awayTeamId: "team_away",
+    homeTeamName: "Home",
+    awayTeamName: "Away",
+  });
+  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
+}
+
+describe("startGameStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+    mockCanAdministerTeam.mockResolvedValue(true);
+    mockGetActiveStreamCountForLeague.mockResolvedValue(0);
+    mockCreateMuxLiveStream.mockResolvedValue({
+      liveStreamId: "ls_1",
+      streamKey: "sk_secret",
+      playbackId: "pb_1",
+      rtmpUrl: "rtmps://global-live.mux.com:443/app",
+    });
+    mockCreateGameStream.mockResolvedValue({
+      id: "gs_1",
+      fixtureId: FIXTURE,
+      status: "idle",
+      muxPlaybackId: "pb_1",
+    });
+  });
+
+  it("blocks when the dark flag is off", async () => {
+    mockLiveStreamingV1.mockResolvedValue(false);
+    const res = await startGameStream(LEAGUE, FIXTURE);
+    expect(res).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
+  });
+
+  it("blocks an unauthenticated caller", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "unauthorized",
+    });
+  });
+
+  it("404s a fixture from another league (cross-league guard)", async () => {
+    mockGetPublicSeason.mockResolvedValue({
+      id: "season_1",
+      leagueId: "other_league",
+    });
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "fixture_not_in_league",
+    });
+    expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller who administers neither team", async () => {
+    mockCanAdministerTeam.mockResolvedValue(false);
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "not_authorized",
+    });
+  });
+
+  it("enforces the per-league concurrent cap", async () => {
+    mockGetActiveStreamCountForLeague.mockResolvedValue(3);
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "stream_cap_reached",
+    });
+    expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
+  });
+
+  it("returns the rtmp url + key to the starter and persists the stream", async () => {
+    const res = await startGameStream(LEAGUE, FIXTURE);
+    expect(res).toEqual({
+      ok: true,
+      rtmpUrl: "rtmps://global-live.mux.com:443/app",
+      streamKey: "sk_secret",
+      playbackId: "pb_1",
+    });
+    expect(mockCreateGameStream).toHaveBeenCalledWith({
+      fixtureId: FIXTURE,
+      muxLiveStreamId: "ls_1",
+      muxPlaybackId: "pb_1",
+      startedBy: "user_1",
+      maxDurationMinutes: 180,
+    });
+  });
+});
+
+describe("stopGameStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+    mockCanAdministerTeam.mockResolvedValue(true);
+  });
+
+  it("disables the Mux stream and marks it ended", async () => {
+    mockGetStreamAdminByFixture.mockResolvedValue({
+      muxLiveStreamId: "ls_1",
+      status: "active",
+    });
+    const res = await stopGameStream(LEAGUE, FIXTURE);
+    expect(res).toEqual({ ok: true });
+    expect(mockDisableMuxLiveStream).toHaveBeenCalledWith("ls_1");
+    expect(mockUpdateGameStreamStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ muxLiveStreamId: "ls_1", status: "ended" }),
+    );
+  });
+
+  it("returns stream_not_found when there is no stream", async () => {
+    mockGetStreamAdminByFixture.mockResolvedValue(null);
+    expect(await stopGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "stream_not_found",
+    });
+    expect(mockDisableMuxLiveStream).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,22 +1,26 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { schedulesStandingsV1 } from "@/lib/flags";
+import { schedulesStandingsV1, liveStreamingV1 } from "@/lib/flags";
 import {
   getLeague,
   getLeagueOrgId,
   getSeasons,
   getResultByFixture,
+  getStreamByFixture,
   getTeamsByLeague,
   listFixturesBySeason,
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
-import { canManageRoster } from "@/lib/permissions";
+import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
+import GoLiveControl from "@/components/schedule/GoLiveControl";
 import { Button } from "@/components/ui/button";
+
+type StreamStatus = "idle" | "active" | "ended";
 
 export default async function LeagueSchedulePage({
   params,
@@ -39,6 +43,12 @@ export default async function LeagueSchedulePage({
   const orgId = await getLeagueOrgId(leagueId);
   const role = orgId ? await resolveOrgRole(orgId, userId) : null;
   const isAdmin = canManageRoster(role);
+  // Live streaming is a dark flag (default OFF everywhere). The "Go live"
+  // control is admin-only — it maps to the action's `canAdministerTeam` gate, so
+  // coaches (who can manage rosters but not administer) never see a button that
+  // would just 403.
+  const streamingEnabled = await liveStreamingV1();
+  const canStream = streamingEnabled && canManageOrgSettings(role);
 
   // Pick the active season — fall back to whichever exists if none flagged active.
   const allSeasons = await getSeasons([leagueId]);
@@ -59,6 +69,18 @@ export default async function LeagueSchedulePage({
       return { fixture: f, result };
     }),
   );
+
+  // Per-fixture live-stream status — only fetched when the dark flag is on for
+  // an admin, so the default (flag off) path adds zero reads.
+  const streamStatuses = new Map<string, StreamStatus | null>();
+  if (canStream) {
+    await Promise.all(
+      fixtures.map(async (f) => {
+        const stream = await getStreamByFixture(f.id);
+        streamStatuses.set(f.id, (stream?.status as StreamStatus) ?? null);
+      }),
+    );
+  }
 
   // Group by week (null week → "Unscheduled" bucket at the end).
   const buckets = new Map<number | null, typeof fixturesWithResults>();
@@ -202,6 +224,15 @@ export default async function LeagueSchedulePage({
                                   homeTeamName={fixture.homeTeamName}
                                   awayTeamName={fixture.awayTeamName}
                                 />
+                                {canStream ? (
+                                  <GoLiveControl
+                                    leagueId={leagueId}
+                                    fixtureId={fixture.id}
+                                    homeTeamName={fixture.homeTeamName}
+                                    awayTeamName={fixture.awayTeamName}
+                                    status={streamStatuses.get(fixture.id) ?? null}
+                                  />
+                                ) : null}
                               </div>
                             </td>
                           ) : null}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -1,0 +1,141 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { liveStreamingV1 } from "@/lib/flags";
+import {
+  getFixture,
+  getPublicSeason,
+  createGameStream,
+  updateGameStreamStatus,
+  getActiveStreamCountForLeague,
+  getStreamAdminByFixture,
+} from "@/lib/data-api";
+import { canAdministerTeam } from "@/lib/authorization";
+import { createMuxLiveStream, disableMuxLiveStream } from "@/lib/mux";
+
+/*
+ * Live-stream start/stop server actions (WSM-000144, dark behind
+ * `live_streaming_v1`). Watch is public (the #300 game page); START/MANAGE is
+ * authenticated and lives here in the dashboard, because the RTMP key must never
+ * touch a public surface. The Mux stream key is returned in-memory to the
+ * starting admin only — it is never persisted and never read back.
+ *
+ * Cost posture (decided 2026-06-16): absorbed + capped. No billing/entitlement
+ * gate; guardrails bound the spend — a Mux max-duration auto-stop (set at
+ * stream-create) plus the per-league concurrent cap below. The TODO marks the
+ * clean seam where an entitlement check drops in for a later paid tier.
+ */
+
+const MAX_STREAM_DURATION_MINUTES = 180; // 3h hard cap → Mux max_continuous_duration
+const PER_LEAGUE_CONCURRENT_CAP = 3; // bound blast radius for a pilot
+
+type StartResult =
+  | { ok: true; rtmpUrl: string; streamKey: string; playbackId: string }
+  | { ok: false; error: string };
+
+type StopResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Shared auth chain: dark flag on → Clerk session → caller administers EITHER
+ * the home or away team (WSM-000121 team ownership) → fixture's season actually
+ * belongs to the league in the URL (cross-league guard, mirrors the public page).
+ * Returns the resolved leagueId for cap-checking + revalidation.
+ */
+async function authorizeStreamAction(
+  leagueId: string,
+  fixtureId: string,
+): Promise<
+  { ok: true; userId: string } | { ok: false; error: string }
+> {
+  const enabled = await liveStreamingV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const fixture = await getFixture(fixtureId);
+  if (!fixture) return { ok: false, error: "fixture_not_found" };
+
+  // Cross-league guard: the fixture's season must live in THIS league.
+  const season = await getPublicSeason(fixture.seasonId);
+  if (!season || season.leagueId !== leagueId) {
+    return { ok: false, error: "fixture_not_in_league" };
+  }
+
+  const [canHome, canAway] = await Promise.all([
+    canAdministerTeam(fixture.homeTeamId, userId),
+    canAdministerTeam(fixture.awayTeamId, userId),
+  ]);
+  if (!canHome && !canAway) return { ok: false, error: "not_authorized" };
+
+  return { ok: true, userId };
+}
+
+export async function startGameStream(
+  leagueId: string,
+  fixtureId: string,
+): Promise<StartResult> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  // Concurrent-stream cap — bounds the absorbed cost for a pilot league.
+  // TODO(streaming paid tier): replace/augment with an entitlement check here.
+  const activeCount = await getActiveStreamCountForLeague(leagueId);
+  if (activeCount >= PER_LEAGUE_CONCURRENT_CAP) {
+    return { ok: false, error: "stream_cap_reached" };
+  }
+
+  try {
+    const mux = await createMuxLiveStream(MAX_STREAM_DURATION_MINUTES);
+    await createGameStream({
+      fixtureId,
+      muxLiveStreamId: mux.liveStreamId,
+      muxPlaybackId: mux.playbackId,
+      startedBy: guard.userId,
+      maxDurationMinutes: MAX_STREAM_DURATION_MINUTES,
+    });
+
+    revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+    revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);
+
+    // Key returned to the starting admin ONLY — never persisted, never re-read.
+    return {
+      ok: true,
+      rtmpUrl: mux.rtmpUrl,
+      streamKey: mux.streamKey,
+      playbackId: mux.playbackId,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export async function stopGameStream(
+  leagueId: string,
+  fixtureId: string,
+): Promise<StopResult> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  try {
+    const stream = await getStreamAdminByFixture(fixtureId);
+    if (!stream) return { ok: false, error: "stream_not_found" };
+
+    await disableMuxLiveStream(stream.muxLiveStreamId);
+    // Reflect the stop immediately; the webhook also flips this idempotently.
+    await updateGameStreamStatus({
+      muxLiveStreamId: stream.muxLiveStreamId,
+      status: "ended",
+      endedAt: new Date().toISOString(),
+    });
+
+    revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+    revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -2,15 +2,18 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { cache } from "react";
-import { schedulesStandingsV1 } from "@/lib/flags";
+import { schedulesStandingsV1, liveStreamingV1 } from "@/lib/flags";
 import {
   getFixture,
   getPublicLeagues,
   getPublicSeason,
   getResultByFixture,
+  getStreamByFixture,
 } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import GameStreamPlayer from "@/components/games/GameStreamPlayer";
 
 /*
  * Public game viewer route (WSM-000143, child of the streaming epic #225).
@@ -102,6 +105,15 @@ export default async function PublicGamePage({
   const view = await getGameView(leagueId, gameId);
   if (!view) notFound();
 
+  // Live streaming is a TRUE dark flag — OFF in every env unless opted in. When
+  // off, the stream read is skipped and the page renders exactly as before.
+  const streamingEnabled = await liveStreamingV1();
+  const stream = streamingEnabled ? await getStreamByFixture(gameId) : null;
+  const liveActive = stream?.status === "active";
+  const hasReplay = stream?.status === "ended" && stream.vodAssetId !== null;
+  const streamEndedNoReplay =
+    stream?.status === "ended" && stream.vodAssetId === null;
+
   const { fixture, result, seasonName } = view;
   const isFinal = fixture.status === "final" && result !== null;
   const isCancelled = fixture.status === "cancelled";
@@ -126,6 +138,36 @@ export default async function PublicGamePage({
           {fixture.homeTeamName} vs {fixture.awayTeamName}
         </h1>
       </header>
+
+      {liveActive || hasReplay ? (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              {liveActive ? (
+                <>
+                  <Badge variant="destructive">LIVE</Badge>
+                  <span>Watch live</span>
+                </>
+              ) : (
+                <span>Replay</span>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <GameStreamPlayer
+              playbackId={stream!.muxPlaybackId}
+              live={liveActive}
+              title={`${fixture.homeTeamName} vs ${fixture.awayTeamName}`}
+            />
+          </CardContent>
+        </Card>
+      ) : streamEndedNoReplay ? (
+        <Card className="mb-6">
+          <CardContent className="p-6 text-center text-sm text-muted-foreground">
+            The live stream has ended.
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card>
         <CardHeader>

--- a/apps/web/src/components/games/GameStreamPlayer.tsx
+++ b/apps/web/src/components/games/GameStreamPlayer.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import MuxPlayer from "@mux/mux-player-react";
+
+/*
+ * Public HLS player for a game's live stream / replay (WSM-000144). Takes only
+ * the public Mux playback id — no key, no live-stream id ever reaches here.
+ * While live, the live-stream playback id streams the live edge; once ended it
+ * serves the recorded replay (streamType "on-demand").
+ */
+export interface GameStreamPlayerProps {
+  playbackId: string;
+  live: boolean;
+  title: string;
+}
+
+export default function GameStreamPlayer({
+  playbackId,
+  live,
+  title,
+}: GameStreamPlayerProps) {
+  return (
+    <MuxPlayer
+      streamType={live ? "live" : "on-demand"}
+      playbackId={playbackId}
+      metadata={{ video_title: title }}
+      accentColor="#dc2626"
+      className="aspect-video w-full overflow-hidden rounded-md"
+    />
+  );
+}

--- a/apps/web/src/components/schedule/GoLiveControl.tsx
+++ b/apps/web/src/components/schedule/GoLiveControl.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Radio, Square, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  startGameStream,
+  stopGameStream,
+} from "@/app/dashboard/leagues/[id]/schedule/stream-actions";
+
+export interface GoLiveControlProps {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  /** Current stream status from getStreamByFixture, or null if none exists. */
+  status: "idle" | "active" | "ended" | null;
+}
+
+interface Credentials {
+  rtmpUrl: string;
+  streamKey: string;
+}
+
+export default function GoLiveControl({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+  status,
+}: GoLiveControlProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  // The stream key is returned ONCE by startGameStream and never re-readable —
+  // hold it in local state to show the coach; it's gone on refresh.
+  const [creds, setCreds] = useState<Credentials | null>(null);
+
+  const isLive = status === "active";
+
+  function goLive() {
+    startTransition(async () => {
+      const res = await startGameStream(leagueId, fixtureId);
+      if (res.ok) {
+        setCreds({ rtmpUrl: res.rtmpUrl, streamKey: res.streamKey });
+        toast.success("Live stream ready — paste the camera settings below.");
+        router.refresh();
+      } else {
+        toast.error(errorLabel(res.error));
+      }
+    });
+  }
+
+  function stop() {
+    if (!window.confirm(`Stop the live stream for ${homeTeamName} vs ${awayTeamName}?`)) {
+      return;
+    }
+    startTransition(async () => {
+      const res = await stopGameStream(leagueId, fixtureId);
+      if (res.ok) {
+        toast.success("Live stream stopped.");
+        router.refresh();
+      } else {
+        toast.error(errorLabel(res.error));
+      }
+    });
+  }
+
+  async function copy(value: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} copied.`);
+    } catch {
+      toast.error("Copy failed — select and copy manually.");
+    }
+  }
+
+  return (
+    <>
+      {isLive ? (
+        <div className="flex items-center gap-2">
+          <Badge variant="destructive" className="gap-1">
+            <Radio className="h-3 w-3" /> LIVE
+          </Badge>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={stop}
+            aria-label={`Stop live stream for ${homeTeamName} vs ${awayTeamName}`}
+          >
+            <Square className="h-4 w-4 text-destructive" />
+          </Button>
+        </div>
+      ) : (
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={pending}
+          onClick={goLive}
+          aria-label={`Go live for ${homeTeamName} vs ${awayTeamName}`}
+        >
+          <Radio className="mr-1 h-4 w-4" /> Go live
+        </Button>
+      )}
+
+      <Dialog open={creds !== null} onOpenChange={(open) => !open && setCreds(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Camera settings</DialogTitle>
+            <DialogDescription>
+              Paste these into your camera or encoder&apos;s &ldquo;Custom
+              RTMP&rdquo; settings (Mevo, OBS, etc.). The stream key is shown
+              once — copy it now.
+            </DialogDescription>
+          </DialogHeader>
+          {creds ? (
+            <div className="space-y-3">
+              <CredentialRow
+                label="RTMP URL"
+                value={creds.rtmpUrl}
+                onCopy={() => copy(creds.rtmpUrl, "RTMP URL")}
+              />
+              <CredentialRow
+                label="Stream key"
+                value={creds.streamKey}
+                secret
+                onCopy={() => copy(creds.streamKey, "Stream key")}
+              />
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function CredentialRow({
+  label,
+  value,
+  secret,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  secret?: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-xs font-medium text-muted-foreground">{label}</p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 overflow-x-auto rounded border border-border bg-muted px-2 py-1 font-mono text-xs">
+          {secret ? "•".repeat(Math.min(value.length, 32)) : value}
+        </code>
+        <Button size="sm" variant="outline" onClick={onCopy} aria-label={`Copy ${label}`}>
+          <Copy className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function errorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Live streaming isn't enabled for this environment.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "Only an admin of one of the two teams can start a stream.";
+    case "stream_cap_reached":
+      return "This league already has the maximum number of live streams running.";
+    case "fixture_not_found":
+    case "fixture_not_in_league":
+      return "Game not found.";
+    case "stream_not_found":
+      return "No live stream to stop.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
+++ b/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockUpdateGameStreamStatus } = vi.hoisted(() => ({
+  mockUpdateGameStreamStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/data-api", () => ({
+  updateGameStreamStatus: mockUpdateGameStreamStatus,
+}));
+
+import {
+  mapMuxEventToUpdate,
+  handleMuxEvent,
+} from "../mux-webhook-handlers";
+
+const NOW = "2026-06-16T12:00:00.000Z";
+
+describe("mapMuxEventToUpdate (pure)", () => {
+  it("maps live_stream.active → status active", () => {
+    expect(
+      mapMuxEventToUpdate(
+        { type: "video.live_stream.active", data: { id: "ls_1" } },
+        NOW,
+      ),
+    ).toEqual({ muxLiveStreamId: "ls_1", status: "active" });
+  });
+
+  it("maps live_stream.idle → status ended with endedAt (authoritative end)", () => {
+    expect(
+      mapMuxEventToUpdate(
+        { type: "video.live_stream.idle", data: { id: "ls_1" } },
+        NOW,
+      ),
+    ).toEqual({ muxLiveStreamId: "ls_1", status: "ended", endedAt: NOW });
+  });
+
+  it("does NOT end on disconnected (transient — reconnect window)", () => {
+    expect(
+      mapMuxEventToUpdate(
+        { type: "video.live_stream.disconnected", data: { id: "ls_1" } },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it("maps asset.ready (with live_stream_id) → attach vodAssetId only", () => {
+    expect(
+      mapMuxEventToUpdate(
+        {
+          type: "video.asset.ready",
+          data: { id: "asset_9", live_stream_id: "ls_1" },
+        },
+        NOW,
+      ),
+    ).toEqual({ muxLiveStreamId: "ls_1", vodAssetId: "asset_9" });
+  });
+
+  it("ignores asset.ready for uploads (no live_stream_id)", () => {
+    expect(
+      mapMuxEventToUpdate(
+        { type: "video.asset.ready", data: { id: "asset_9" } },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores unknown event types", () => {
+    expect(
+      mapMuxEventToUpdate(
+        { type: "video.live_stream.connected", data: { id: "ls_1" } },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores events missing the live-stream id", () => {
+    expect(
+      mapMuxEventToUpdate({ type: "video.live_stream.active", data: {} }, NOW),
+    ).toBeNull();
+  });
+});
+
+describe("handleMuxEvent (side effect)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("applies a mapped update via updateGameStreamStatus", async () => {
+    await handleMuxEvent({
+      type: "video.live_stream.active",
+      data: { id: "ls_1" },
+    });
+    expect(mockUpdateGameStreamStatus).toHaveBeenCalledWith({
+      muxLiveStreamId: "ls_1",
+      status: "active",
+    });
+  });
+
+  it("is a no-op for ignored events (no write)", async () => {
+    await handleMuxEvent({
+      type: "video.live_stream.disconnected",
+      data: { id: "ls_1" },
+    });
+    expect(mockUpdateGameStreamStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -501,6 +501,37 @@ const refs = {
     { leagueId: string },
     { seasonName: string; rows: Standing[] } | null
   >("sports:computeStandingsPublic"),
+  createGameStream: mutationRef<
+    {
+      fixtureId: string;
+      muxLiveStreamId: string;
+      muxPlaybackId: string;
+      startedBy: string;
+      maxDurationMinutes: number;
+    },
+    { id: string; fixtureId: string; status: string; muxPlaybackId: string }
+  >("sports:createGameStream"),
+  updateGameStreamStatus: mutationRef<
+    {
+      muxLiveStreamId: string;
+      status?: string;
+      vodAssetId?: string | null;
+      endedAt?: string | null;
+    },
+    boolean
+  >("sports:updateGameStreamStatus"),
+  getStreamByFixture: queryRef<
+    { fixtureId: string },
+    PublicGameStream | null
+  >("sports:getStreamByFixture"),
+  getActiveStreamCountForLeague: queryRef<{ leagueId: string }, number>(
+    "sports:getActiveStreamCountForLeague",
+  ),
+  // Internal query (not on public api) — admin-keyed server code only.
+  getStreamAdminByFixture: queryRef<
+    { fixtureId: string },
+    { muxLiveStreamId: string; status: string } | null
+  >("sports:getStreamAdminByFixture"),
 };
 
 function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
@@ -1476,6 +1507,65 @@ export async function getResultByFixture(
   fixtureId: string,
 ): Promise<GameResultDto | null> {
   return queryConvex(refs.getResultByFixture, { fixtureId });
+}
+
+// --- Phase 1 live streaming wrappers (WSM-000144) ---
+
+/** Public projection of a game stream — what an unauthenticated viewer sees.
+ *  Never carries the Mux live-stream id or stream key. */
+export interface PublicGameStream {
+  status: string; // "idle" | "active" | "ended"
+  muxPlaybackId: string;
+  vodAssetId: string | null;
+}
+
+export interface CreateGameStreamInput {
+  fixtureId: string;
+  muxLiveStreamId: string;
+  muxPlaybackId: string;
+  startedBy: string;
+  maxDurationMinutes: number;
+}
+
+export async function createGameStream(
+  input: CreateGameStreamInput,
+): Promise<{
+  id: string;
+  fixtureId: string;
+  status: string;
+  muxPlaybackId: string;
+}> {
+  return mutateConvex(refs.createGameStream, input);
+}
+
+export async function updateGameStreamStatus(input: {
+  muxLiveStreamId: string;
+  status?: string;
+  vodAssetId?: string | null;
+  endedAt?: string | null;
+}): Promise<boolean> {
+  return mutateConvex(refs.updateGameStreamStatus, input);
+}
+
+/** Public read — projects to public fields only (status/playbackId/vodAssetId). */
+export async function getStreamByFixture(
+  fixtureId: string,
+): Promise<PublicGameStream | null> {
+  return queryConvex(refs.getStreamByFixture, { fixtureId });
+}
+
+export async function getActiveStreamCountForLeague(
+  leagueId: string,
+): Promise<number> {
+  return queryConvex(refs.getActiveStreamCountForLeague, { leagueId });
+}
+
+/** Internal admin read — returns the server-side Mux live-stream id so a server
+ *  action can disable/transition it. Admin-keyed; not a public projection. */
+export async function getStreamAdminByFixture(
+  fixtureId: string,
+): Promise<{ muxLiveStreamId: string; status: string } | null> {
+  return queryConvex(refs.getStreamAdminByFixture, { fixtureId });
 }
 
 // --- Phase 3 — standings wrappers ---

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -79,6 +79,32 @@ export const schedulesStandingsV1 = flag<boolean>({
   },
 });
 
+/*
+ * `live_streaming_v1` is a TRUE DARK FLAG (WSM-000144 / streaming epic #225).
+ *
+ * Unlike the flags above, it must default OFF in EVERY environment — including
+ * preview/dev — because flipping it on provisions real Mux live streams that
+ * cost money. It therefore does NOT use `resolveFlag` (which defaults ON when
+ * `VERCEL_ENV !== "production"`). The only way it turns on is an explicit
+ * `FLAG_LIVE_STREAMING_V1=on` per pilot env. Demand validation gates enabling
+ * it; the code can ship dark with zero exposure and zero cost until then.
+ */
+export const liveStreamingV1 = flag<boolean>({
+  key: "live_streaming_v1",
+  description:
+    "DARK — Phase 1 video-only live game streaming (Mux). OFF in every env unless FLAG_LIVE_STREAMING_V1=on.",
+  defaultValue: false,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = process.env.FLAG_LIVE_STREAMING_V1 === "on";
+    void trackFlagExposure("live_streaming_v1", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {

--- a/apps/web/src/lib/mux-webhook-handlers.ts
+++ b/apps/web/src/lib/mux-webhook-handlers.ts
@@ -1,0 +1,74 @@
+import { updateGameStreamStatus } from "@/lib/data-api";
+
+/*
+ * Mux webhook event handling (WSM-000144). The event→action mapping is a PURE
+ * function (mapMuxEventToUpdate) so it can be unit-tested without Mux or Convex;
+ * handleMuxEvent applies the side effect via the admin-keyed data-api.
+ *
+ * Event semantics (Mux live streams):
+ *   video.live_stream.active        → playable; status "active"
+ *   video.live_stream.idle          → returned to idle AFTER the reconnect
+ *                                      window; this is the authoritative END.
+ *   video.live_stream.disconnected  → RTMP dropped, but Mux may still reconnect
+ *                                      within the window — TRANSIENT, so we do
+ *                                      NOT end on it (idle is authoritative).
+ *                                      Ending here would kill a stream on a
+ *                                      brief network blip.
+ *   video.asset.ready               → the recording's VOD asset is ready; attach
+ *                                      vodAssetId (keyed by live_stream_id).
+ * Everything else is a no-op.
+ */
+
+// Minimal shape we depend on — avoids coupling tests to the full Mux SDK type.
+export interface MuxWebhookEvent {
+  type: string;
+  data: {
+    id?: string;
+    live_stream_id?: string | null;
+  };
+}
+
+export interface StreamStatusUpdate {
+  muxLiveStreamId: string;
+  status?: "active" | "ended";
+  vodAssetId?: string;
+  endedAt?: string;
+}
+
+/**
+ * Pure mapping from a Mux event to a stream-status update, or null for events
+ * we ignore. `nowIso` is injected (not read from the clock) to keep this pure
+ * and deterministically testable.
+ */
+export function mapMuxEventToUpdate(
+  event: MuxWebhookEvent,
+  nowIso: string,
+): StreamStatusUpdate | null {
+  switch (event.type) {
+    case "video.live_stream.active": {
+      const id = event.data.id;
+      return id ? { muxLiveStreamId: id, status: "active" } : null;
+    }
+    case "video.live_stream.idle": {
+      const id = event.data.id;
+      return id ? { muxLiveStreamId: id, status: "ended", endedAt: nowIso } : null;
+    }
+    case "video.asset.ready": {
+      // Only assets created FROM a live stream carry live_stream_id; uploads
+      // (no live_stream_id) aren't ours — ignore them.
+      const liveStreamId = event.data.live_stream_id;
+      const assetId = event.data.id;
+      if (!liveStreamId || !assetId) return null;
+      return { muxLiveStreamId: liveStreamId, vodAssetId: assetId };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Apply a verified Mux event. No-op for ignored events and unknown streams. */
+export async function handleMuxEvent(event: MuxWebhookEvent): Promise<void> {
+  const update = mapMuxEventToUpdate(event, new Date().toISOString());
+  if (!update) return;
+  await updateGameStreamStatus(update);
+}

--- a/apps/web/src/lib/mux.ts
+++ b/apps/web/src/lib/mux.ts
@@ -1,0 +1,86 @@
+import "server-only";
+import Mux from "@mux/mux-node";
+
+/*
+ * Mux Video integration for Phase 1 live streaming (WSM-000144, epic #225).
+ *
+ * Server-only: the token id/secret and webhook secret are never exposed to the
+ * client (none are NEXT_PUBLIC_*). The public HLS playback id is the only Mux
+ * identifier that ever reaches a browser, and it comes from the DB, not here.
+ *
+ * Mux ingest is a single global RTMP endpoint; only the per-stream key is
+ * secret. We return the key in-memory to the starting admin and never persist
+ * it (Mux holds it).
+ */
+
+// Mux's global RTMP(S) ingest endpoint — same for every live stream; the
+// per-stream key (not this URL) is the secret part.
+export const MUX_RTMP_INGEST_URL = "rtmps://global-live.mux.com:443/app";
+
+let client: Mux | null = null;
+
+export function getMux(): Mux {
+  if (client) return client;
+  const tokenId = process.env.MUX_TOKEN_ID;
+  const tokenSecret = process.env.MUX_TOKEN_SECRET;
+  if (!tokenId || !tokenSecret) {
+    throw new Error(
+      "Missing Mux credentials. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET.",
+    );
+  }
+  client = new Mux({
+    tokenId,
+    tokenSecret,
+    // Used by webhooks.unwrap() to verify inbound webhook signatures.
+    webhookSecret: process.env.MUX_WEBHOOK_SECRET,
+  });
+  return client;
+}
+
+export interface CreatedMuxLiveStream {
+  liveStreamId: string;
+  streamKey: string;
+  playbackId: string;
+  rtmpUrl: string;
+}
+
+/**
+ * Create a public live stream with a hard max-duration cap so a forgotten
+ * stream can never bill indefinitely. Recordings become public VOD assets.
+ */
+export async function createMuxLiveStream(
+  maxDurationMinutes: number,
+): Promise<CreatedMuxLiveStream> {
+  const mux = getMux();
+  const liveStream = await mux.video.liveStreams.create({
+    playback_policy: ["public"],
+    new_asset_settings: { playback_policy: ["public"] },
+    // Mux expects seconds; this is the guardrail auto-stop.
+    max_continuous_duration: maxDurationMinutes * 60,
+  });
+
+  const playbackId = liveStream.playback_ids?.[0]?.id;
+  if (!liveStream.id || !liveStream.stream_key || !playbackId) {
+    throw new Error("mux_live_stream_incomplete");
+  }
+
+  return {
+    liveStreamId: liveStream.id,
+    streamKey: liveStream.stream_key,
+    playbackId,
+    rtmpUrl: MUX_RTMP_INGEST_URL,
+  };
+}
+
+/** Disable a live stream (admin manual stop). Idempotent-ish: Mux 404s are
+ *  swallowed so a double-stop doesn't surface an error to the coach. */
+export async function disableMuxLiveStream(liveStreamId: string): Promise<void> {
+  const mux = getMux();
+  try {
+    await mux.video.liveStreams.disable(liveStreamId);
+  } catch (err) {
+    const status = (err as { status?: number } | null)?.status;
+    if (status === 404) return;
+    throw err;
+  }
+}

--- a/docs/design/live-streaming-rfc.md
+++ b/docs/design/live-streaming-rfc.md
@@ -1,8 +1,12 @@
 # RFC — Live Game Streaming + Live-Score Overlay (WSM-000108 / #225)
 
-**Status:** Scope / design only — **do NOT build yet.** Gated on coach-interview
-validation ([../research/coach-interview-guide.md](../research/coach-interview-guide.md)),
-the same gate as the stat-keeping keystone.
+**Status:** **Phase 1 (WSM-000144) BUILT behind the `live_streaming_v1` dark flag
+(2026-06-16)** — OFF in every environment, so it exposes nothing and costs nothing
+until explicitly enabled. **Enabling the flag remains gated on coach-interview
+validation** ([../research/coach-interview-guide.md](../research/coach-interview-guide.md)),
+the same gate as the stat-keeping keystone — building danced ahead of that gate by
+explicit owner decision; the demand question still governs ramp/enable, not the code.
+Phase 2 (overlay) additionally needs keystone v3.
 **Target provider:** **Mux Video** (decision recorded 2026-06-15).
 **Pairs with:** [../research/coach-platform-competitive-teardown.md](../research/coach-platform-competitive-teardown.md),
 [../research/stat-keeping-keystone-prd.md](../research/stat-keeping-keystone-prd.md) (WSM-000112).
@@ -84,10 +88,28 @@ actions use the admin-keyed `getConvexClient()`. Stream key handling: server-sid
 
 ## 5. Cost & guardrails (metered — the main risk)
 
-Live transcode + delivery is **metered per-minute ingest + per-GB delivery**. Ballpark Mux
-(≈ Jan 2026 — **verify current pricing before build**): live encoding ~\$0.04/min, delivery
-~\$0.001/min·viewer. A 2.5 h game ≈ 150 min → ~\$6 encode + delivery × viewers. A league of
-many concurrent games could run real money.
+Live transcode + delivery is **metered per-minute ingest + per-minute delivery**.
+
+**Verified Mux pricing (official docs, June 2026 — gate item cleared):**
+
+| Item | Plus 1080p | Premium 1080p |
+|---|---|---|
+| Live **encoding** (ingest) | \$0.03125/min | \$0.046875/min |
+| **Delivery** (after 100k free min/mo) | \$0.001/viewer-min | \$0.0015/viewer-min |
+| **Storage** (VOD retained) | \$0.003/min/mo | \$0.0045/min/mo |
+
+**Modeled per HS game (~3 h = 180 min), Plus 1080p** (our default — Premium and
+low-latency aren't worth it for "follow along"):
+- Encoding **~\$5.63/game** (fixed; viewer-independent — the dominant cost).
+- Delivery **~\$0** at pilot scale (50 viewers × 180 min = 9k viewer-min, well under
+  the 100k/mo free tier); ~\$9/game only past the free tier.
+- VOD storage **~\$0.54/game/month** if the replay is kept.
+- **Per active league:** ~16 games/mo → **~\$90/month**, encoding-dominated.
+
+The **3-hour max-duration auto-stop caps a forgotten stream at ~\$5.63** — blast radius
+is small and bounded by design. **Cost posture (decided 2026-06-16): absorbed + capped**
+for the pilot — no billing/entitlement gate; guardrails (auto-stop + per-league concurrent
+cap) bound the spend, with a clean seam in `startGameStream` to add entitlement later.
 
 Guardrails (all ACs):
 - **Auth to start** — team admins only.
@@ -110,8 +132,9 @@ Guardrails (all ACs):
 1. **Validation** — do coaches/parents actually want *in-app* streaming, or is the school's
    existing stream (Hudl/NFHS/YouTube) good enough? (Coach-interview gate.) If "good enough,"
    #225 may not be worth the spend at all.
-2. **Pricing reality** — confirm current Mux live + delivery rates and model a per-league
-   monthly ceiling; decide if cost is passed through (paid tier) or capped.
+2. ~~**Pricing reality**~~ **RESOLVED 2026-06-16** — current Mux rates verified and modeled
+   in §5 (~\$5.63/game encode, ~\$90/league/month at Plus 1080p; auto-stop caps a runaway
+   at one game's encode). Cost posture: **absorbed + capped** for the pilot (no paid gate).
 3. **Latency target** — standard HLS (~10–30 s) vs Mux low-latency (~5 s). Standard is fine
    for "follow along"; revisit only if validation shows otherwise.
 4. **Auth on playback** — public (anyone with the league) vs signed playback URLs for

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
+      '@mux/mux-node':
+        specifier: 14.1.1
+        version: 14.1.1
+      '@mux/mux-player-react':
+        specifier: 3.13.0
+        version: 3.13.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-accordion':
         specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1859,6 +1865,35 @@ packages:
 
   '@mdn/browser-compat-data@5.7.6':
     resolution: {integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==}
+
+  '@mux/mux-data-google-ima@0.3.17':
+    resolution: {integrity: sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==}
+
+  '@mux/mux-node@14.1.1':
+    resolution: {integrity: sha512-Am79fhXU6A15zef1y+2UKfbIQ/UMGiVOjKKV3fOAqR8IS0A4HbL6WLDs0rNlMRHrefvASAftM2NWwLLBU3Peaw==}
+    hasBin: true
+
+  '@mux/mux-player-react@3.13.0':
+    resolution: {integrity: sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==}
+    peerDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': '*'
+      react: ^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+      react-dom: ^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@mux/mux-player@3.13.0':
+    resolution: {integrity: sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==}
+
+  '@mux/mux-video@0.31.0':
+    resolution: {integrity: sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==}
+
+  '@mux/playback-core@0.35.0':
+    resolution: {integrity: sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3968,6 +4003,14 @@ packages:
   caniuse-lite@1.0.30001779:
     resolution: {integrity: sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==}
 
+  castable-video@1.1.16:
+    resolution: {integrity: sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==}
+
+  ce-la-react@0.3.2:
+    resolution: {integrity: sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==}
+    peerDependencies:
+      react: '>=17.0.0'
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4257,6 +4300,9 @@ packages:
 
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
+
+  custom-media-element@1.4.6:
+    resolution: {integrity: sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -5064,6 +5110,9 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
@@ -5969,6 +6018,12 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-chrome@4.19.2:
+    resolution: {integrity: sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA==}
+
+  media-tracks@0.3.5:
+    resolution: {integrity: sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -6025,6 +6080,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mux-embed@5.18.1:
+    resolution: {integrity: sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -6433,6 +6491,9 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  player.style@0.3.4:
+    resolution: {integrity: sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -9584,6 +9645,45 @@ snapshots:
 
   '@mdn/browser-compat-data@5.7.6': {}
 
+  '@mux/mux-data-google-ima@0.3.17':
+    dependencies:
+      mux-embed: 5.18.1
+
+  '@mux/mux-node@14.1.1': {}
+
+  '@mux/mux-player-react@3.13.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@mux/mux-player': 3.13.0(react@19.2.7)
+      '@mux/playback-core': 0.35.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@mux/mux-player@3.13.0(react@19.2.7)':
+    dependencies:
+      '@mux/mux-video': 0.31.0
+      '@mux/playback-core': 0.35.0
+      media-chrome: 4.19.2(react@19.2.7)
+      player.style: 0.3.4(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  '@mux/mux-video@0.31.0':
+    dependencies:
+      '@mux/mux-data-google-ima': 0.3.17
+      '@mux/playback-core': 0.35.0
+      castable-video: 1.1.16
+      custom-media-element: 1.4.6
+      media-tracks: 0.3.5
+
+  '@mux/playback-core@0.35.0':
+    dependencies:
+      hls.js: 1.6.16
+      mux-embed: 5.18.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.0
@@ -11792,6 +11892,14 @@ snapshots:
 
   caniuse-lite@1.0.30001779: {}
 
+  castable-video@1.1.16:
+    dependencies:
+      custom-media-element: 1.4.6
+
+  ce-la-react@0.3.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -12066,6 +12174,8 @@ snapshots:
   csstype@3.2.3: {}
 
   csv-parse@5.6.0: {}
+
+  custom-media-element@1.4.6: {}
 
   d3-array@3.2.4:
     dependencies:
@@ -12404,7 +12514,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -12427,7 +12537,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@9.4.0)
@@ -12442,14 +12552,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12484,7 +12594,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13120,6 +13230,8 @@ snapshots:
   hex-rgb@4.3.0: {}
 
   highlight.js@10.7.3: {}
+
+  hls.js@1.6.16: {}
 
   hook-std@4.0.0: {}
 
@@ -14245,6 +14357,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-chrome@4.19.2(react@19.2.7):
+    dependencies:
+      ce-la-react: 0.3.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  media-tracks@0.3.5: {}
+
   meow@12.1.1: {}
 
   meow@13.2.0: {}
@@ -14285,6 +14405,8 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
+
+  mux-embed@5.18.1: {}
 
   mz@2.7.0:
     dependencies:
@@ -14597,6 +14719,12 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  player.style@0.3.4(react@19.2.7):
+    dependencies:
+      media-chrome: 4.19.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
 
   playwright-core@1.58.2: {}
 


### PR DESCRIPTION
## Summary

Phase 1 of the live-streaming epic (#225) — **video-only live game streaming via Mux**, shipped **DARK**. Resolves the build scope of #301.

The `live_streaming_v1` flag defaults **OFF in every environment** (it deliberately does *not* use `resolveFlag`, which defaults ON in non-prod). So this PR exposes nothing to users and incurs **$0 Mux cost** until someone sets `FLAG_LIVE_STREAMING_V1=on` and starts a real stream. **Enabling the flag remains gated on coach-interview demand validation** — building ahead of that gate was an explicit owner decision, and the dark flag is exactly what makes that safe. Cost posture: **absorbed + capped** (no billing gate; guardrails bound the spend).

## What landed

- **Dark flag** `liveStreamingV1` + Mux env docs in `.env.local.example`.
- **`gameStreams` Convex table** (one stream per fixture). The Mux **stream key is never persisted** — Mux holds it; `startGameStream` returns it in-memory to the starting admin only. The public read projects to `status`/`muxPlaybackId`/`vodAssetId` **only**; the Mux live-stream id never transits a public query.
- **Convex fns**: `createGameStream` + `updateGameStreamStatus` (`internalMutation`, idempotent), `getStreamByFixture` (public, projected), `getActiveStreamCountForLeague`, and `getStreamAdminByFixture` (`internalQuery` — off the public `api`, so it may expose the live-stream id for the stop path). WSM-000096 backstop allow-list + internal-write assertions updated.
- **Server actions** `startGameStream`/`stopGameStream`: dark-flag gate → Clerk auth → `canAdministerTeam` (either team) → cross-league guard → per-league concurrent cap (3) → Mux create with a **3h max-duration auto-stop**. Clean `TODO` seam for a later paid-tier entitlement check.
- **Mux webhook** `POST /api/streams/mux/webhook` mirroring the Stripe route (nodejs, raw body, signature verify, structured logging, 500→retry). Pure event→update mapping: `active`→active, `idle`→ended (authoritative), `asset.ready`→attach VOD; **`disconnected` is transient and intentionally NOT ended**.
- **Dashboard "Go live" control** (admin-only; surfaces the RTMP URL + key once) and the **public game-page player** (`@mux/mux-player-react`): LIVE badge / replay / stream-ended states.

## Verified Mux pricing (gate item cleared, recorded in the RFC)

~**$5.63/game** encode (Plus 1080p, viewer-independent), delivery ~$0 at pilot scale (100k free min/mo), **~$90/league/month**. The 3h auto-stop caps a forgotten stream at one game's encode.

## Test plan

- ✅ `type-check` clean, `lint` clean.
- ✅ Full vitest suite **462 passing**, incl. **20 new**: pure webhook event-mapping + `startGameStream`/`stopGameStream` authz paths (flag-off, unauth, cross-league, not-authorized, cap, happy path, stop).
- ⏸️ e2e deferred — needs a Mux test mode/mock + the #305/#297 CI secrets.

Refs #301 #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)