### PR TITLE
fix(web): map metro-Atlanta/Cobb cities on the league map (WSM-000136)

### DIFF
--- a/apps/web/src/lib/geo-cities.ts
+++ b/apps/web/src/lib/geo-cities.ts
@@ -74,6 +74,22 @@ export const US_CITIES: Record<string, { lat: number; lng: number }> = {
   "st. louis": { lat: 38.63, lng: -90.2 },
   "st louis": { lat: 38.63, lng: -90.2 },
   "salt lake city": { lat: 40.76, lng: -111.89 },
+  // Metro Atlanta / Cobb County (WSM-000136) — the real HS-league footprint
+  // (Marietta/Kennesaw/etc.), which the original NFL-metro list didn't cover.
+  marietta: { lat: 33.95, lng: -84.55 },
+  kennesaw: { lat: 34.02, lng: -84.62 },
+  "powder springs": { lat: 33.86, lng: -84.68 },
+  acworth: { lat: 34.07, lng: -84.68 },
+  austell: { lat: 33.81, lng: -84.63 },
+  mableton: { lat: 33.82, lng: -84.58 },
+  smyrna: { lat: 33.88, lng: -84.51 },
+  vinings: { lat: 33.86, lng: -84.47 },
+  roswell: { lat: 34.02, lng: -84.36 },
+  "sandy springs": { lat: 33.92, lng: -84.38 },
+  alpharetta: { lat: 34.07, lng: -84.29 },
+  "johns creek": { lat: 34.03, lng: -84.2 },
+  duluth: { lat: 34.0, lng: -84.14 },
+  douglasville: { lat: 33.75, lng: -84.75 },
 };
 
 /** Continental-US bounding box used by the projection (P5). */


### PR DESCRIPTION
## Problem

The dashboard "Where your teams are" map showed **"0 of 16 teams mapped · 16 without a known city"** even though the **Regions** list right below it correctly listed Marietta (7), Kennesaw (3), Powder Springs (2), Acworth, Austell, Mableton, Smyrna.

## Cause

Two different code paths consume the city:
- **Regions** group by the raw `team.city` string → always works.
- **The map** plots via `lookupCoords(city)` → `US_CITIES`, a curated **NFL-metro** coordinate table (its header says as much). It contained `atlanta` but **none of the Cobb County / metro-Atlanta cities**, so every real HS team missed the lookup and counted as "without a known city."

A coverage gap in the bundled lookup, not bad data.

## Fix

Add the Cobb County footprint (Marietta, Kennesaw, Powder Springs, Acworth, Austell, Mableton, Smyrna, Vinings) plus common neighbors (Roswell, Sandy Springs, Alpharetta, Johns Creek, Duluth, Douglasville). `atlanta` was already present; no key collisions with existing metros. Additive, one file.

## Test plan

- ✅ All 7 cities from the screenshot now resolve via `lookupCoords`.
- ✅ `geo` + `geo-basemap` suites green (11 tests); type-check clean.

Refs WSM-000136

🤖 Generated with [Claude Code](https://claude.com/claude-code)