### PR TITLE
fix(web): scope dashboard stat strip to the selected league (WSM-000136)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -63,13 +63,6 @@ export default async function DashboardPage() {
     getSeasons(ids),
     getDivisions(ids),
   ]);
-  const counts: Record<string, number> = {
-    leagues: leagues.length,
-    teams: teams.length,
-    players: players.length,
-    seasons: seasons.length,
-    divisions: divisions.length,
-  };
 
   const { activeLeagueId } = await resolveActiveLeague(userId);
   const activeLeague =
@@ -103,6 +96,22 @@ export default async function DashboardPage() {
     : [];
   const activeSeason =
     leagueSeasons.find((s) => s.status === "active") ?? leagueSeasons[0] ?? null;
+
+  const leagueDivisions = activeLeague
+    ? divisions.filter((d) => d.leagueId === activeLeague.id)
+    : [];
+
+  // The quick-nav stat strip is scoped to the SELECTED league, matching the rest
+  // of the bento (which is already league-scoped). "Leagues" stays a portfolio-
+  // wide total — it's the one count where "all" is meaningful (scoping it would
+  // always be 1). Teams/Players/Seasons/Divisions reflect the active league only.
+  const counts: Record<string, number> = {
+    leagues: leagues.length,
+    teams: leagueTeams.length,
+    players: leaguePlayers.length,
+    seasons: leagueSeasons.length,
+    divisions: leagueDivisions.length,
+  };
 
   // Active-season schedule, results and standings (existing wrappers only).
   let fixturesTotal = 0;


### PR DESCRIPTION
## Problem

On the dashboard, the top quick-nav stat strip (Teams / Players / Seasons / Divisions) counted across **all visible leagues**, while the rest of the bento (hero, standings, map, season-health gauges) was already scoped to the **active/selected league**. For anyone managing more than one league, the top numbers disagreed with everything below them.

## Fix

Repoint the strip counts to the active league's slices (`leagueTeams` / `leaguePlayers` / `leagueSeasons` + a new `leagueDivisions`). **"Leagues" stays a portfolio-wide total** — it's the one count where "all" is the meaningful number (scoping it would always be 1). No new queries; reuses slices the page already computes.

## Test plan

- ✅ type-check + lint clean.

Refs WSM-000136

🤖 Generated with [Claude Code](https://claude.com/claude-code)