### PR TITLE
fix(web): mobile responsiveness — members list + dialog overflow trap

### DIFF
--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -101,6 +101,8 @@ export default function TeamEditForm({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* DialogContent caps height + scrolls (base); the footer below is pinned
+          (sticky) so Save is always reachable on a short mobile viewport. */}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit Team</DialogTitle>
@@ -248,7 +250,7 @@ export default function TeamEditForm({
             </p>
           </div>
 
-          <div className="flex justify-end gap-3 pt-2">
+          <div className="sticky bottom-0 -mx-6 -mb-6 flex justify-end gap-3 border-t border-border bg-background px-6 py-4">
             <Button
               type="button"
               variant="outline"

--- a/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/members/member-list.tsx
@@ -108,27 +108,34 @@ export default function MemberList({ orgId }: { orgId: string }) {
         return (
           <div
             key={member.userId}
-            className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
+            className="flex flex-col gap-3 rounded-lg border border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
           >
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 items-center gap-3">
               {member.imageUrl && (
                 // Clerk-hosted avatar URL; next/image would need a host allowlist.
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={member.imageUrl}
                   alt=""
-                  className="h-8 w-8 rounded-full"
+                  className="h-8 w-8 shrink-0 rounded-full"
                 />
               )}
-              <div>
-                <p className="text-sm font-medium text-foreground">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
                   {displayName}
                 </p>
-                <p className="text-xs text-muted-foreground">{member.email}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {member.email}
+                </p>
               </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Badge variant={member.role === "admin" ? "default" : "secondary"}>
+            <div className="flex items-center gap-2 sm:shrink-0">
+              {/* Role is already shown by the Select; the badge is redundant on
+                  narrow screens, so reserve it for sm+ to save width. */}
+              <Badge
+                variant={member.role === "admin" ? "default" : "secondary"}
+                className="hidden shrink-0 sm:inline-flex"
+              >
                 {roleLabel(member.role)}
               </Badge>
               <Select
@@ -138,7 +145,10 @@ export default function MemberList({ orgId }: { orgId: string }) {
                 }
                 disabled={isLoading}
               >
-                <SelectTrigger className="w-[120px]" aria-label="Member role">
+                <SelectTrigger
+                  className="min-w-0 flex-1 sm:w-[150px] sm:flex-none"
+                  aria-label="Member role"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -154,7 +164,7 @@ export default function MemberList({ orgId }: { orgId: string }) {
                 variant="outline"
                 disabled={isLoading}
                 onClick={() => handleRemove(member.userId)}
-                className="text-destructive hover:text-destructive"
+                className="shrink-0 text-destructive hover:text-destructive"
               >
                 Remove
               </Button>

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -61,7 +61,10 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          // max-h + overflow safety net: a dialog taller than the viewport
+          // (long forms on mobile) scrolls instead of pushing its footer
+          // off-screen and trapping the user. No effect on shorter dialogs.
+          "fixed top-[50%] left-[50%] z-50 grid max-h-[90dvh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Problems (both mobile, reported with screenshots)

1. **Members list** — the row was a single rigid `justify-between` flex row, so on a phone the email collided with the role badge and the role select + Remove button clipped off the right of the card.
2. **Editing a team** — the **Save button was unreachable**. `DialogContent` had no max-height/scroll, so a form taller than the viewport pushed the footer off-screen with no way to scroll → user stuck.

## Fixes

1. **Members row** stacks on mobile (`flex-col` → `sm:flex-row`), name/email truncate (`min-w-0` + `truncate`), the control group is full-width on mobile with the select growing to fit, and the redundant role **Badge is hidden `< sm`** (the select already shows the role).
2. **Team-edit footer** is now pinned (`sticky bottom-0`, full-bleed) so Cancel/Save are always visible.
3. **Base safety net** — `DialogContent` now caps at `max-h-[90dvh]` + `overflow-y-auto`, so **no** dialog (player form, fixture/result entry, go-live, etc.) can trap the user behind an off-screen footer again. No effect on dialogs shorter than the viewport.

## Test plan

- ✅ type-check + lint clean.
- ✅ Full vitest **467 passing**.
- Manual: members row stacks cleanly on a narrow viewport; team-edit dialog scrolls with Save pinned and reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)