### PR TITLE
chore(web): no-op marker to verify domain auto-assign (WSM-000149)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -42,6 +42,8 @@ NEXT_PUBLIC_APP_URL=https://sprtsmng.andrewsolomon.dev
 # MUX_TOKEN_SECRET=...
 # MUX_WEBHOOK_SECRET=...           # signing secret from the Mux dashboard webhook
 
+# (no-op marker for WSM-000149 — verifying production-domain auto-assign on merge)
+
 # E2E Test Harness (Playwright + Convex)
 # Required only when running e2e specs that use apps/web/e2e/helpers/seed-roster.ts.
 # Enable the seed mutations on the target Convex deployment via:


### PR DESCRIPTION
Verification no-op for #327 — checks whether merging to `main` auto-advances the production domain without a manual `vercel --prod`. Safe to merge; pure comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)