### PR TITLE
feat(web): stat-keeping keystone — data layer (WSM-000112, PR1)

### DIFF
--- a/apps/web/convex/__tests__/playerStats.test.ts
+++ b/apps/web/convex/__tests__/playerStats.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { aggregateStatLines, parseStatLine } from "../lib/playerStats";
+
+describe("aggregateStatLines", () => {
+  it("sums fields across games, group by group", () => {
+    const totals = aggregateStatLines([
+      { passing: { comp: 18, att: 27, yards: 243, td: 3, int: 1 } },
+      { passing: { comp: 20, att: 30, yards: 310, td: 2, int: 0 } },
+    ]);
+    expect(totals.passing).toEqual({
+      comp: 38,
+      att: 57,
+      yards: 553,
+      td: 5,
+      int: 1,
+    });
+  });
+
+  it("takes MAX for `long` fields, SUM for the rest", () => {
+    const totals = aggregateStatLines([
+      { rushing: { carries: 12, yards: 88, td: 1, long: 22 } },
+      { rushing: { carries: 9, yards: 140, td: 2, long: 61 } },
+    ]);
+    expect(totals.rushing).toEqual({ carries: 21, yards: 228, td: 3, long: 61 });
+  });
+
+  it("merges disjoint groups and ignores non-numeric values", () => {
+    const totals = aggregateStatLines([
+      { rushing: { carries: 5, yards: 30 } },
+      { receiving: { rec: 4, yards: 51 } },
+      // @ts-expect-error intentionally malformed value is ignored
+      { rushing: { carries: "x", yards: 12 } },
+    ]);
+    expect(totals.rushing).toEqual({ carries: 5, yards: 42 });
+    expect(totals.receiving).toEqual({ rec: 4, yards: 51 });
+  });
+
+  it("returns {} for no games", () => {
+    expect(aggregateStatLines([])).toEqual({});
+  });
+});
+
+describe("parseStatLine", () => {
+  it("parses valid json", () => {
+    expect(parseStatLine('{"passing":{"td":2}}')).toEqual({
+      passing: { td: 2 },
+    });
+  });
+
+  it("returns {} for bad or non-object json", () => {
+    expect(parseStatLine("not json")).toEqual({});
+    expect(parseStatLine("42")).toEqual({});
+    expect(parseStatLine("")).toEqual({});
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -46,6 +46,8 @@ void internal.sports.forkConferenceToWorkspace;
 void internal.sports.unforkTeamFromWorkspace;
 void internal.sports.createGameStream;
 void internal.sports.updateGameStreamStatus;
+void internal.sports.upsertPlayerGameStats;
+void internal.sports.deletePlayerGameStats;
 
 // --- Writes MUST NOT be on the public API (each access must be a type error) ---
 // @ts-expect-error createTeam is internal, not public
@@ -72,6 +74,10 @@ void api.sports.unforkTeamFromWorkspace;
 void api.sports.createGameStream;
 // @ts-expect-error updateGameStreamStatus is internal, not public
 void api.sports.updateGameStreamStatus;
+// @ts-expect-error upsertPlayerGameStats is internal, not public
+void api.sports.upsertPlayerGameStats;
+// @ts-expect-error deletePlayerGameStats is internal, not public
+void api.sports.deletePlayerGameStats;
 
 // --- Public READ queries must remain public (these must exist on api) ---
 void api.sports.listTeams;
@@ -117,8 +123,10 @@ type AllowedPublicSportsReads =
   | "getPlayer"
   | "getPlayerDevelopment"
   | "getPlayerDevelopmentPublic"
+  | "getPlayerGameStatsByFixture"
   | "getPlayerMaddenRating"
   | "getPlayerSeasonAttributes"
+  | "getPlayerSeasonTotals"
   | "getActiveStreamCountForLeague"
   | "getResultByFixture"
   | "getRosterAssignmentHistory"

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as e2eSeed from "../e2eSeed.js";
 import type * as lib_auditLog from "../lib/auditLog.js";
+import type * as lib_playerStats from "../lib/playerStats.js";
 import type * as lib_standings from "../lib/standings.js";
 import type * as migrations_20260422_seasonsRosterLocked from "../migrations/20260422_seasonsRosterLocked.js";
 import type * as migrations_20260428_depthChartToRoster from "../migrations/20260428_depthChartToRoster.js";
@@ -25,6 +26,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   e2eSeed: typeof e2eSeed;
   "lib/auditLog": typeof lib_auditLog;
+  "lib/playerStats": typeof lib_playerStats;
   "lib/standings": typeof lib_standings;
   "migrations/20260422_seasonsRosterLocked": typeof migrations_20260422_seasonsRosterLocked;
   "migrations/20260428_depthChartToRoster": typeof migrations_20260428_depthChartToRoster;

--- a/apps/web/convex/lib/playerStats.ts
+++ b/apps/web/convex/lib/playerStats.ts
@@ -1,0 +1,42 @@
+/*
+ * Pure aggregation for the stat-keeping keystone (WSM-000112). Sums a player's
+ * per-game box-score lines into season totals, group-by-group. Type-light by
+ * design (operates on parsed JSON) so it stays in the Convex bundle without a
+ * cross-package import and is trivially unit-testable.
+ *
+ * Most fields SUM; "long" fields (longest run/catch/punt/return) take the MAX —
+ * a season long is the single longest play, not a sum.
+ */
+
+type StatGroup = Record<string, number>;
+type StatLine = Record<string, StatGroup>;
+
+const MAX_FIELDS = new Set(["long"]);
+
+export function aggregateStatLines(lines: StatLine[]): StatLine {
+  const out: StatLine = {};
+  for (const line of lines) {
+    if (!line || typeof line !== "object") continue;
+    for (const [group, fields] of Object.entries(line)) {
+      if (!fields || typeof fields !== "object") continue;
+      const acc = (out[group] = out[group] ?? {});
+      for (const [field, value] of Object.entries(fields)) {
+        if (typeof value !== "number" || !Number.isFinite(value)) continue;
+        acc[field] = MAX_FIELDS.has(field)
+          ? Math.max(acc[field] ?? 0, value)
+          : (acc[field] ?? 0) + value;
+      }
+    }
+  }
+  return out;
+}
+
+/** Parse a statsJson string into a StatLine, tolerating bad/empty input. */
+export function parseStatLine(json: string): StatLine {
+  try {
+    const v = JSON.parse(json);
+    return v && typeof v === "object" ? (v as StatLine) : {};
+  } catch {
+    return {};
+  }
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -297,4 +297,25 @@ export default defineSchema({
     .index("by_status", ["status"])
     // Mux webhooks identify the stream by its Mux live-stream id, not fixtureId.
     .index("by_muxLiveStreamId", ["muxLiveStreamId"]),
+
+  /*
+   * Stat-keeping keystone (WSM-000112). One row per player per game — the
+   * player's box-score line, stored as typed JSON (`statsJson`, validated at the
+   * edge like playerAttributes). Supersedes the reserved gameResults.player-
+   * StatsJson hook for queryability. Season totals = aggregation over a player's
+   * rows; also feeds SPRT at the HS level.
+   */
+  playerGameStats: defineTable({
+    fixtureId: v.id("fixtures"),
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    statsJson: v.string(),
+    enteredBy: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_fixtureId", ["fixtureId"]) // a game's entered lines (entry/review)
+    .index("by_fixtureId_playerId", ["fixtureId", "playerId"]) // upsert key
+    .index("by_playerId_seasonId", ["playerId", "seasonId"]) // season totals
+    .index("by_teamId_seasonId", ["teamId", "seasonId"]), // team season view
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -9,6 +9,7 @@ import type { MutationCtx, QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { writeAuditLog } from "./lib/auditLog";
 import { computeStandingsPure } from "./lib/standings";
+import { aggregateStatLines, parseStatLine } from "./lib/playerStats";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -4139,5 +4140,120 @@ export const getActiveStreamCountForLeague = queryGeneric({
       if (season && season.leagueId === args.leagueId) count += 1;
     }
     return count;
+  },
+});
+
+/*
+ * Stat-keeping keystone (WSM-000112) — per-player box-score lines.
+ *
+ * Writes are internalMutation (only the admin-keyed server reaches them). One
+ * row per (fixture, player); `statsJson` is the typed box-score line validated
+ * at the edge before it gets here. Season totals are computed-on-read by
+ * aggregating a player's rows (pure helper in lib/playerStats.ts).
+ */
+
+const playerGameStatsRowValidator = v.object({
+  id: v.string(),
+  fixtureId: v.string(),
+  playerId: v.string(),
+  teamId: v.string(),
+  seasonId: v.string(),
+  statsJson: v.string(),
+  enteredBy: v.string(),
+  updatedAt: v.string(),
+});
+
+export const upsertPlayerGameStats = internalMutation({
+  args: {
+    fixtureId: v.id("fixtures"),
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    statsJson: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({ id: v.string() }),
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+
+    const payload = {
+      fixtureId: args.fixtureId,
+      playerId: args.playerId,
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      statsJson: args.statsJson,
+      enteredBy: args.actorUserId,
+      updatedAt: new Date().toISOString(),
+    };
+
+    // One row per (fixture, player) — re-entry replaces the line in place.
+    const existing = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_fixtureId_playerId", (q) =>
+        q.eq("fixtureId", args.fixtureId).eq("playerId", args.playerId),
+      )
+      .first();
+
+    let id: string;
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+      id = existing._id;
+    } else {
+      id = await ctx.db.insert("playerGameStats", payload);
+    }
+    return { id };
+  },
+});
+
+export const deletePlayerGameStats = internalMutation({
+  args: { fixtureId: v.id("fixtures"), playerId: v.id("players") },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_fixtureId_playerId", (q) =>
+        q.eq("fixtureId", args.fixtureId).eq("playerId", args.playerId),
+      )
+      .first();
+    if (!row) return false;
+    await ctx.db.delete(row._id);
+    return true;
+  },
+});
+
+export const getPlayerGameStatsByFixture = query({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.array(playerGameStatsRowValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    return rows.map((r) => ({
+      id: r._id,
+      fixtureId: r.fixtureId,
+      playerId: r.playerId,
+      teamId: r.teamId,
+      seasonId: r.seasonId,
+      statsJson: r.statsJson,
+      enteredBy: r.enteredBy,
+      updatedAt: r.updatedAt,
+    }));
+  },
+});
+
+export const getPlayerSeasonTotals = query({
+  args: { playerId: v.id("players"), seasonId: v.id("seasons") },
+  returns: v.object({ statsJson: v.string(), gameCount: v.number() }),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", args.playerId).eq("seasonId", args.seasonId),
+      )
+      .collect();
+    const totals = aggregateStatLines(rows.map((r) => parseStatLine(r.statsJson)));
+    return { statsJson: JSON.stringify(totals), gameCount: rows.length };
   },
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -11,6 +11,8 @@ import type {
   ImportResult,
   LeagueDto,
   PlayerDto,
+  PlayerGameStatLine,
+  PlayerGameStatsDto,
   RosterAssignmentDto,
   RosterAuditLogDto,
   SeasonDto,
@@ -532,7 +534,43 @@ const refs = {
     { fixtureId: string },
     { muxLiveStreamId: string; status: string } | null
   >("sports:getStreamAdminByFixture"),
+  // Stat-keeping keystone (WSM-000112)
+  upsertPlayerGameStats: mutationRef<
+    {
+      fixtureId: string;
+      playerId: string;
+      teamId: string;
+      seasonId: string;
+      statsJson: string;
+      actorUserId: string;
+    },
+    { id: string }
+  >("sports:upsertPlayerGameStats"),
+  deletePlayerGameStats: mutationRef<
+    { fixtureId: string; playerId: string },
+    boolean
+  >("sports:deletePlayerGameStats"),
+  getPlayerGameStatsByFixture: queryRef<
+    { fixtureId: string },
+    PlayerGameStatsRow[]
+  >("sports:getPlayerGameStatsByFixture"),
+  getPlayerSeasonTotals: queryRef<
+    { playerId: string; seasonId: string },
+    { statsJson: string; gameCount: number }
+  >("sports:getPlayerSeasonTotals"),
 };
+
+/** Raw playerGameStats row as returned by Convex (statsJson unparsed). */
+interface PlayerGameStatsRow {
+  id: string;
+  fixtureId: string;
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  statsJson: string;
+  enteredBy: string;
+  updatedAt: string;
+}
 
 function requireLeagueAccessLocal(leagueId: string, orgContext: OrgContext): void {
   if (!orgContext.visibleLeagueIds.includes(leagueId)) {
@@ -1566,6 +1604,70 @@ export async function getStreamAdminByFixture(
   fixtureId: string,
 ): Promise<{ muxLiveStreamId: string; status: string } | null> {
   return queryConvex(refs.getStreamAdminByFixture, { fixtureId });
+}
+
+// --- Stat-keeping keystone wrappers (WSM-000112) ---
+
+function parseStatLine(json: string): PlayerGameStatLine {
+  try {
+    const v = JSON.parse(json);
+    return v && typeof v === "object" ? (v as PlayerGameStatLine) : {};
+  } catch {
+    return {};
+  }
+}
+
+export interface UpsertPlayerGameStatsInput {
+  fixtureId: string;
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  stats: PlayerGameStatLine;
+  actorUserId: string;
+}
+
+export async function upsertPlayerGameStats(
+  input: UpsertPlayerGameStatsInput,
+): Promise<{ id: string }> {
+  return mutateConvex(refs.upsertPlayerGameStats, {
+    fixtureId: input.fixtureId,
+    playerId: input.playerId,
+    teamId: input.teamId,
+    seasonId: input.seasonId,
+    statsJson: JSON.stringify(input.stats),
+    actorUserId: input.actorUserId,
+  });
+}
+
+export async function deletePlayerGameStats(
+  fixtureId: string,
+  playerId: string,
+): Promise<boolean> {
+  return mutateConvex(refs.deletePlayerGameStats, { fixtureId, playerId });
+}
+
+export async function getPlayerGameStatsByFixture(
+  fixtureId: string,
+): Promise<PlayerGameStatsDto[]> {
+  const rows = await queryConvex(refs.getPlayerGameStatsByFixture, { fixtureId });
+  return rows.map((r) => ({
+    id: r.id,
+    fixtureId: r.fixtureId,
+    playerId: r.playerId,
+    teamId: r.teamId,
+    seasonId: r.seasonId,
+    stats: parseStatLine(r.statsJson),
+    enteredBy: r.enteredBy,
+    updatedAt: r.updatedAt,
+  }));
+}
+
+export async function getPlayerSeasonTotals(
+  playerId: string,
+  seasonId: string,
+): Promise<{ stats: PlayerGameStatLine; gameCount: number }> {
+  const res = await queryConvex(refs.getPlayerSeasonTotals, { playerId, seasonId });
+  return { stats: parseStatLine(res.statsJson), gameCount: res.gameCount };
 }
 
 // --- Phase 3 — standings wrappers ---

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -164,6 +164,92 @@ export const UpdateTeamInputSchema = z.object({
   allowDuplicateJerseys: z.boolean().optional(),
 }) satisfies z.ZodType<UpdateTeamInput>;
 
+// --- Stat-keeping keystone (WSM-000112) — box-score stat line ---
+// Each group is optional (a player only has the groups relevant to their
+// snaps); within a group every field is an optional non-negative integer that
+// defaults to 0 when aggregated. Validated at the edge before persisting.
+
+const statCount = z.number().int().min(0);
+
+export const PlayerGameStatLineSchema = z
+  .object({
+    passing: z
+      .object({
+        comp: statCount,
+        att: statCount,
+        yards: z.number().int(),
+        td: statCount,
+        int: statCount,
+        sacked: statCount,
+      })
+      .partial()
+      .optional(),
+    rushing: z
+      .object({
+        carries: statCount,
+        yards: z.number().int(),
+        td: statCount,
+        long: z.number().int(),
+      })
+      .partial()
+      .optional(),
+    receiving: z
+      .object({
+        rec: statCount,
+        yards: z.number().int(),
+        td: statCount,
+        long: z.number().int(),
+        targets: statCount,
+      })
+      .partial()
+      .optional(),
+    defense: z
+      .object({
+        tacklesSolo: statCount,
+        tacklesAst: statCount,
+        tfl: statCount,
+        sacks: z.number().min(0),
+        int: statCount,
+        passDef: statCount,
+        ff: statCount,
+        fr: statCount,
+        defTd: statCount,
+      })
+      .partial()
+      .optional(),
+    kicking: z
+      .object({
+        fgMade: statCount,
+        fgAtt: statCount,
+        xpMade: statCount,
+        xpAtt: statCount,
+      })
+      .partial()
+      .optional(),
+    punting: z
+      .object({ punts: statCount, yards: z.number().int(), long: z.number().int() })
+      .partial()
+      .optional(),
+    returns: z
+      .object({
+        krCount: statCount,
+        krYards: z.number().int(),
+        krTd: statCount,
+        prCount: statCount,
+        prYards: z.number().int(),
+        prTd: statCount,
+      })
+      .partial()
+      .optional(),
+    ballSecurity: z
+      .object({ fumbles: statCount, fumblesLost: statCount })
+      .partial()
+      .optional(),
+  })
+  .strict();
+
+export type PlayerGameStatLineInput = z.infer<typeof PlayerGameStatLineSchema>;
+
 // --- Import schema ---
 
 export {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -248,6 +248,90 @@ export interface GameResultDto {
   recordedBy: string;
 }
 
+// --- Stat-keeping keystone (WSM-000112) — football box-score stat model (§6) ---
+// One player's game line, grouped. Only the groups relevant to a player's snaps
+// need be present; within a group, fields default to 0 when absent. This is the
+// "typed shape validated at the edge" stored as playerGameStats.statsJson.
+
+export interface StatPassing {
+  comp?: number;
+  att?: number;
+  yards?: number;
+  td?: number;
+  int?: number;
+  sacked?: number;
+}
+export interface StatRushing {
+  carries?: number;
+  yards?: number;
+  td?: number;
+  long?: number;
+}
+export interface StatReceiving {
+  rec?: number;
+  yards?: number;
+  td?: number;
+  long?: number;
+  targets?: number;
+}
+export interface StatDefense {
+  tacklesSolo?: number;
+  tacklesAst?: number;
+  tfl?: number;
+  sacks?: number;
+  int?: number;
+  passDef?: number;
+  ff?: number;
+  fr?: number;
+  defTd?: number;
+}
+export interface StatKicking {
+  fgMade?: number;
+  fgAtt?: number;
+  xpMade?: number;
+  xpAtt?: number;
+}
+export interface StatPunting {
+  punts?: number;
+  yards?: number;
+  long?: number;
+}
+export interface StatReturns {
+  krCount?: number;
+  krYards?: number;
+  krTd?: number;
+  prCount?: number;
+  prYards?: number;
+  prTd?: number;
+}
+export interface StatBallSecurity {
+  fumbles?: number;
+  fumblesLost?: number;
+}
+
+export interface PlayerGameStatLine {
+  passing?: StatPassing;
+  rushing?: StatRushing;
+  receiving?: StatReceiving;
+  defense?: StatDefense;
+  kicking?: StatKicking;
+  punting?: StatPunting;
+  returns?: StatReturns;
+  ballSecurity?: StatBallSecurity;
+}
+
+/** A player's entered stat line for one game (statsJson parsed into `stats`). */
+export interface PlayerGameStatsDto {
+  id: string;
+  fixtureId: string;
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  stats: PlayerGameStatLine;
+  enteredBy: string;
+  updatedAt: string;
+}
+
 export interface Standing {
   teamId: string;
   teamName: string;


### PR DESCRIPTION
## Summary

PR1 of the stat-keeping keystone (WSM-000112) — the **data layer**. Persists per-player box-score lines and aggregates season totals. Entry UX, MaxPreps export, and SPRT integration build on this in PRs 2–5.

(This is the first build under the lifted validation gate — see #225.)

## What's in this PR

- **Types** — the football box-score stat model (PRD §6) in `shared-types`: `PlayerGameStatLine` (passing / rushing / receiving / defense / kicking / punting / returns / ballSecurity; each group optional, fields default 0) + `PlayerGameStatsDto`. Zod `PlayerGameStatLineSchema` in `api-contracts` to validate at the edge.
- **Schema** — `playerGameStats` table (one row per fixture+player; `statsJson` typed JSON, same pattern as `playerAttributes`) with indexes `by_fixtureId`, `by_fixtureId_playerId` (upsert key), `by_playerId_seasonId`, `by_teamId_seasonId`.
- **Convex fns** — `upsertPlayerGameStats` + `deletePlayerGameStats` (**internalMutation**), `getPlayerGameStatsByFixture` + `getPlayerSeasonTotals` (public reads). Season totals are **computed-on-read** via a pure aggregator (`lib/playerStats.ts` — SUM fields, MAX for `long`). Uses the schema-typed `internalMutation`/`query` (compound-index support). WSM-000096 backstop updated (internal-write assertions + allow-listed reads).
- **data-api wrappers** parse `statsJson` ↔ typed `stats`.

## Test plan

- ✅ type-check + lint clean.
- ✅ Full vitest **478 passing** (incl. 6 new: `aggregateStatLines` SUM/MAX/merge/empty + `parseStatLine`).
- Schema change is **additive** (new table + indexes; no migration).

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)