### PR TITLE
feat(web): stat-keeping keystone — season totals on player profile (WSM-000112, PR3)

### DIFF
--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -7,12 +7,15 @@ import {
   getTeam,
   getPlayerSeasonAttributes,
   getPlayerMaddenRating,
+  getSeasons,
+  getPlayerSeasonTotals,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { derivePositionGroup } from "@/lib/position-group";
 import { orderedComponents } from "@/lib/ratings/component-labels";
 import { orderedMaddenAttributes } from "@/lib/madden/attributes";
-import { playerAttributesV1 } from "@/lib/flags";
+import { playerAttributesV1, statKeepingV1 } from "@/lib/flags";
+import { SeasonStatsCard } from "@/components/stats/SeasonStatsCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
@@ -80,6 +83,27 @@ export default async function PlayerProfilePage({
   const maddenAttributes = madden
     ? orderedMaddenAttributes(madden.attributes)
     : [];
+
+  // Season box-score totals (WSM-000112) — aggregated from entered game stats
+  // for the team's active season. Flag-gated; never blocks the page.
+  let seasonStats: {
+    stats: Awaited<ReturnType<typeof getPlayerSeasonTotals>>["stats"];
+    gameCount: number;
+    seasonName: string;
+  } | null = null;
+  if ((await statKeepingV1()) && team) {
+    const seasons = await getSeasons([team.leagueId]).catch(() => []);
+    const activeSeason =
+      seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+    if (activeSeason) {
+      const totals = await getPlayerSeasonTotals(playerId, activeSeason.id).catch(
+        () => null,
+      );
+      if (totals && totals.gameCount > 0) {
+        seasonStats = { ...totals, seasonName: activeSeason.name };
+      }
+    }
+  }
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -168,6 +192,14 @@ export default async function PlayerProfilePage({
           )}
         </CardContent>
       </Card>
+
+      {seasonStats && (
+        <SeasonStatsCard
+          stats={seasonStats.stats}
+          gameCount={seasonStats.gameCount}
+          seasonName={seasonStats.seasonName}
+        />
+      )}
 
       {rating && (
         <Card className="mt-6">

--- a/apps/web/src/components/stats/SeasonStatsCard.tsx
+++ b/apps/web/src/components/stats/SeasonStatsCard.tsx
@@ -1,0 +1,65 @@
+import type { PlayerGameStatLine } from "@sports-management/shared-types";
+import { Card, CardContent } from "@/components/ui/card";
+import { STAT_GROUPS } from "@/lib/stat-groups";
+
+/*
+ * Read-only season stat line (WSM-000112, PR3) — the aggregated box-score
+ * totals from getPlayerSeasonTotals, rendered group by group. Only groups/fields
+ * the player actually accumulated are shown. Presentational; safe to server-render.
+ */
+export function SeasonStatsCard({
+  stats,
+  gameCount,
+  seasonName,
+}: {
+  stats: PlayerGameStatLine;
+  gameCount: number;
+  seasonName: string;
+}) {
+  const groups = STAT_GROUPS.map((g) => {
+    const groupStats = stats[g.key] as Record<string, number> | undefined;
+    const fields = g.fields.filter(
+      (f) => typeof groupStats?.[f.key] === "number",
+    );
+    return { def: g, groupStats, fields };
+  }).filter((g) => g.fields.length > 0);
+
+  return (
+    <Card className="mt-6">
+      <CardContent className="pt-6">
+        <div className="flex items-baseline justify-between">
+          <h3 className="text-lg font-semibold text-foreground">Season stats</h3>
+          <span className="text-sm text-muted-foreground">
+            {seasonName} · {gameCount} game{gameCount === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {groups.length === 0 ? (
+          <p className="mt-4 text-sm text-muted-foreground">
+            No stats recorded yet this season.
+          </p>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {groups.map(({ def, groupStats, fields }) => (
+              <div key={def.key}>
+                <p className="mb-1.5 text-xs font-semibold text-foreground">
+                  {def.label}
+                </p>
+                <dl className="flex flex-wrap gap-x-5 gap-y-1.5">
+                  {fields.map((f) => (
+                    <div key={f.key} className="flex items-baseline gap-1.5">
+                      <dt className="text-xs text-muted-foreground">{f.label}</dt>
+                      <dd className="font-mono text-sm font-medium tabular-nums text-foreground">
+                        {groupStats?.[f.key]}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

PR3 of the keystone — makes the entered box-score data **visible** as a player's season stat line. Reads the PR1 computed-on-read aggregation (`getPlayerSeasonTotals`) for the team's active season and renders it on the dashboard player profile.

## What's in this PR

- **`SeasonStatsCard`** (presentational) — renders the aggregated totals group-by-group, showing only the groups/fields the player actually accumulated (a QB sees a Passing + Rushing line; a DB sees Defense), with the season name + game count.
- **Player profile page** resolves the team's active season and fetches totals behind `statKeepingV1`; the card appears only when ≥1 game has stats. Best-effort — never blocks the page (same pattern as the SPRT/Madden sections).

## Test plan

- ✅ type-check + lint clean.
- ✅ Full vitest **489** (the aggregation itself is already unit-tested from PR1; this PR is display-only).
- ✅ Production build compiles.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)