### PR TITLE
feat(web): stat-keeping keystone — MaxPreps export (WSM-000112, PR4)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -31,6 +31,13 @@ NEXT_PUBLIC_APP_URL=https://sprtsmng.andrewsolomon.dev
 # FLAG_ROSTER_SNAPSHOTS_V1=on
 # FLAG_PLAYER_ATTRIBUTES_V1=on
 # FLAG_SCHEDULES_STANDINGS_V1=on
+# FLAG_STAT_KEEPING_V1=on   # box-score entry + season totals + MaxPreps export
+
+# MaxPreps export (WSM-000112). The 32-char Stat Supplier ID is account-bound —
+# register a MaxPreps account as a Stat Supplier to obtain it. When unset, the
+# export file uses a clearly-marked placeholder on line 1 for the coach to edit.
+# MAXPREPS_SUPPLIER_ID=12345678-1234-1234-123456789012
+
 # live_streaming_v1 is a TRUE DARK FLAG: OFF in every env (incl. preview/dev)
 # unless explicitly set to "on". Flipping it on provisions real, billable Mux
 # live streams — only enable per pilot after demand validation (#225).

--- a/apps/web/src/app/api/teams/[teamId]/games/[gameId]/maxpreps-export/route.ts
+++ b/apps/web/src/app/api/teams/[teamId]/games/[gameId]/maxpreps-export/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { statKeepingV1 } from "@/lib/flags";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgContext } from "@/lib/org-context";
+import {
+  getTeam,
+  getFixture,
+  getPlayersByTeam,
+  getPlayerGameStatsByFixture,
+} from "@/lib/data-api";
+import {
+  generateMaxPrepsTxt,
+  SUPPLIER_ID_PLACEHOLDER,
+} from "@/lib/maxpreps-export";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/*
+ * MaxPreps stat-import file download (WSM-000112, PR4). Authed GET → attachment.
+ * Builds the pipe-delimited .txt for one team's entered stats in a game. The
+ * 32-char Supplier ID is a build-time, account-bound credential (env
+ * MAXPREPS_SUPPLIER_ID); when unset, a clearly-marked placeholder goes on line 1
+ * for the coach to replace.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ teamId: string; gameId: string }> },
+) {
+  if (!(await statKeepingV1())) {
+    return NextResponse.json({ error: "flag_disabled" }, { status: 403 });
+  }
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { teamId, gameId } = await params;
+  if (!(await canManageTeam(teamId, userId))) {
+    return NextResponse.json({ error: "not_authorized" }, { status: 403 });
+  }
+
+  const orgContext = await resolveOrgContext(userId);
+  const [team, fixture] = await Promise.all([
+    getTeam(teamId, orgContext).catch(() => null),
+    getFixture(gameId),
+  ]);
+  if (!team || !fixture) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  if (fixture.homeTeamId !== teamId && fixture.awayTeamId !== teamId) {
+    return NextResponse.json({ error: "team_not_in_fixture" }, { status: 404 });
+  }
+
+  const [players, entered] = await Promise.all([
+    getPlayersByTeam(teamId, orgContext),
+    getPlayerGameStatsByFixture(gameId),
+  ]);
+  const statsByPlayer = new Map(
+    entered.filter((s) => s.teamId === teamId).map((s) => [s.playerId, s.stats]),
+  );
+  const rows = players
+    .filter((p) => p.jerseyNumber != null && statsByPlayer.has(p.id))
+    .map((p) => ({
+      jersey: p.jerseyNumber as number,
+      stats: statsByPlayer.get(p.id)!,
+    }));
+
+  const supplierId = process.env.MAXPREPS_SUPPLIER_ID || SUPPLIER_ID_PLACEHOLDER;
+  const { text } = generateMaxPrepsTxt(supplierId, rows);
+
+  // MaxPreps filename must not contain quotes or parentheses.
+  const slug = team.name.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "");
+  const wk = fixture.week != null ? `wk${fixture.week}` : "game";
+  const filename = `maxpreps-${slug}-${wk}.txt`;
+
+  return new NextResponse(text, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/stats/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/stats/page.tsx
@@ -1,7 +1,9 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
+import { Download } from "lucide-react";
 import type { PlayerGameStatLine } from "@sports-management/shared-types";
+import { Button } from "@/components/ui/button";
 import { statKeepingV1 } from "@/lib/flags";
 import {
   getTeam,
@@ -60,12 +62,21 @@ export default async function StatsEntryPage({
         &larr; Back to Schedule
       </Link>
 
-      <header className="mb-6">
-        <h2 className="text-2xl font-bold text-foreground">Enter stats</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {team.name} {homeAway} {opponent}
-          {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
-        </p>
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Enter stats</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {team.name} {homeAway} {opponent}
+            {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          {/* Plain anchor → the route returns the file as an attachment. */}
+          <a href={`/api/teams/${teamId}/games/${gameId}/maxpreps-export`}>
+            <Download className="mr-1 h-4 w-4" />
+            Export for MaxPreps
+          </a>
+        </Button>
       </header>
 
       <StatsEntry

--- a/apps/web/src/lib/__tests__/maxpreps-export.test.ts
+++ b/apps/web/src/lib/__tests__/maxpreps-export.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapStatLineToMaxPreps,
+  generateMaxPrepsTxt,
+} from "../maxpreps-export";
+
+describe("mapStatLineToMaxPreps", () => {
+  it("maps our fields to the verbatim MaxPreps names", () => {
+    const m = mapStatLineToMaxPreps({
+      passing: { comp: 18, att: 27, yards: 243, td: 3, int: 1 },
+      rushing: { carries: 5, yards: 30, long: 12, td: 1 },
+      defense: { tacklesSolo: 5, tacklesAst: 2, sacks: 1 },
+    });
+    expect(m).toMatchObject({
+      PassingComp: 18,
+      PassingAtt: 27,
+      PassingYards: 243,
+      PassingTD: 3,
+      PassingInt: 1,
+      RushingNum: 5,
+      RushingYards: 30,
+      RushingLong: 12,
+      RushingTDNum: 1,
+      Tackles: 5,
+      Assists: 2,
+      Sacks: 1,
+    });
+  });
+
+  it("omits our fields with no MaxPreps Football target", () => {
+    const m = mapStatLineToMaxPreps({
+      passing: { sacked: 3 },
+      receiving: { rec: 4, targets: 7 },
+      defense: { defTd: 1 },
+    });
+    expect(m).toEqual({ ReceivingNum: 4 }); // sacked, targets, defTd dropped
+  });
+});
+
+describe("generateMaxPrepsTxt", () => {
+  const rows = [
+    { jersey: 12, stats: { passing: { comp: 18, att: 27, yards: 243, td: 3 } } },
+    { jersey: 5, stats: { rushing: { carries: 14, yards: 92, td: 2 } } },
+  ];
+
+  it("writes supplier id, Jersey-first header, and one row per player", () => {
+    const { text, rowCount } = generateMaxPrepsTxt("SUPPLIER-123", rows);
+    const lines = text.split("\n");
+    expect(lines[0]).toBe("SUPPLIER-123");
+    expect(lines[1].startsWith("Jersey|")).toBe(true);
+    expect(rowCount).toBe(2);
+    expect(lines).toHaveLength(4); // supplier + header + 2 players
+  });
+
+  it("includes only columns some player has, with blanks for gaps", () => {
+    const { text } = generateMaxPrepsTxt("SID", rows);
+    const [, header, row12, row5] = text.split("\n");
+    const cols = header.split("|");
+    // QB-only and RB-only columns both present
+    expect(cols).toContain("PassingComp");
+    expect(cols).toContain("RushingNum");
+    // Player 12 (passing) has a blank in the RushingNum column
+    const rushIdx = cols.indexOf("RushingNum");
+    expect(row12.split("|")[rushIdx]).toBe("");
+    expect(row5.split("|")[rushIdx]).toBe("14");
+  });
+
+  it("skips players with no mappable stats", () => {
+    const { text, rowCount } = generateMaxPrepsTxt("SID", [
+      { jersey: 99, stats: {} },
+      { jersey: 7, stats: { rushing: { carries: 3 } } },
+    ]);
+    expect(rowCount).toBe(1);
+    expect(text.split("\n")).toHaveLength(3); // supplier + header + 1 player
+  });
+});

--- a/apps/web/src/lib/maxpreps-export.ts
+++ b/apps/web/src/lib/maxpreps-export.ts
@@ -1,0 +1,120 @@
+import type { PlayerGameStatLine } from "@sports-management/shared-types";
+
+/*
+ * MaxPreps stat-import file generator (WSM-000112, PR4). Produces the documented
+ * pipe-delimited `.txt`: Line 1 = 32-char Stat Supplier ID, Line 2 =
+ * `Jersey|<exact MaxPreps field names>`, Lines 3+ = one row per player.
+ * Spec + verbatim Football/Boys field names: docs/research/maxpreps-import-format.md §2a.
+ *
+ * Maps our internal PlayerGameStatLine groups → MaxPreps field names. A few of
+ * our fields have no MaxPreps Football/Boys target and are intentionally omitted:
+ *   passing.sacked, receiving.targets (no field), defense.defTd (MaxPreps splits
+ *   Int/Fumble return TDs — our model lumps them, so we don't guess).
+ * Column order follows the mapping below (a sensible offense→defense→ST→scoring).
+ */
+
+type Group = keyof PlayerGameStatLine;
+
+// [our group, our field, MaxPreps field name] — order here is the column order.
+const FIELD_MAP: ReadonlyArray<readonly [Group, string, string]> = [
+  ["passing", "comp", "PassingComp"],
+  ["passing", "att", "PassingAtt"],
+  ["passing", "int", "PassingInt"],
+  ["passing", "yards", "PassingYards"],
+  ["passing", "td", "PassingTD"],
+  ["rushing", "carries", "RushingNum"],
+  ["rushing", "yards", "RushingYards"],
+  ["rushing", "long", "RushingLong"],
+  ["rushing", "td", "RushingTDNum"],
+  ["receiving", "rec", "ReceivingNum"],
+  ["receiving", "yards", "ReceivingYards"],
+  ["receiving", "long", "ReceivingLong"],
+  ["receiving", "td", "ReceivingTDNum"],
+  ["defense", "tacklesSolo", "Tackles"],
+  ["defense", "tacklesAst", "Assists"],
+  ["defense", "tfl", "TacklesForLoss"],
+  ["defense", "sacks", "Sacks"],
+  ["defense", "int", "INTs"],
+  ["defense", "passDef", "PassesDefensed"],
+  ["defense", "ff", "CausedFumbles"],
+  ["defense", "fr", "FumbleRecoveries"],
+  ["ballSecurity", "fumbles", "OffensiveFumbles"],
+  ["ballSecurity", "fumblesLost", "OffensiveFumblesLost"],
+  ["kicking", "fgMade", "FGMade"],
+  ["kicking", "fgAtt", "FGAttempted"],
+  ["kicking", "xpMade", "PATKickingMade"],
+  ["kicking", "xpAtt", "PATKickingAtt"],
+  ["punting", "punts", "PuntNum"],
+  ["punting", "yards", "PuntYards"],
+  ["punting", "long", "PuntLong"],
+  ["returns", "krCount", "KickoffReturnNum"],
+  ["returns", "krYards", "KickoffReturnYards"],
+  ["returns", "krTd", "KickoffReturnedTDNum"],
+  ["returns", "prCount", "PuntReturnNum"],
+  ["returns", "prYards", "PuntReturnYards"],
+  ["returns", "prTd", "PuntReturnedTDNum"],
+];
+
+export const SUPPLIER_ID_PLACEHOLDER = "REPLACE_WITH_32_CHAR_SUPPLIER_ID";
+
+export interface MaxPrepsExportRow {
+  jersey: number;
+  stats: PlayerGameStatLine;
+}
+
+/** Flatten a stat line to its MaxPreps field→value pairs (present fields only). */
+export function mapStatLineToMaxPreps(
+  line: PlayerGameStatLine,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [group, field, maxField] of FIELD_MAP) {
+    const groupStats = line[group] as Record<string, number> | undefined;
+    const value = groupStats?.[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out[maxField] = value;
+    }
+  }
+  return out;
+}
+
+export interface GenerateResult {
+  /** The file contents. */
+  text: string;
+  /** Players included (had a jersey number + at least one mappable stat). */
+  rowCount: number;
+}
+
+/**
+ * Build the MaxPreps import file. Only players with a jersey number and at least
+ * one mappable stat are included (MaxPreps keys rows by Jersey). The header lists
+ * only the columns at least one player has data for; a player missing a column
+ * gets a blank cell (per spec: undeclared fields aren't overwritten).
+ */
+export function generateMaxPrepsTxt(
+  supplierId: string,
+  rows: MaxPrepsExportRow[],
+): GenerateResult {
+  const mapped = rows
+    .map((r) => ({ jersey: r.jersey, fields: mapStatLineToMaxPreps(r.stats) }))
+    .filter((r) => Object.keys(r.fields).length > 0);
+
+  // Columns = MaxPreps fields present on at least one player, in mapping order.
+  const present = new Set<string>();
+  for (const r of mapped) for (const k of Object.keys(r.fields)) present.add(k);
+  const columns = FIELD_MAP.map(([, , maxField]) => maxField).filter(
+    (f, i, arr) => arr.indexOf(f) === i && present.has(f),
+  );
+
+  const header = ["Jersey", ...columns].join("|");
+  const playerLines = mapped.map((r) =>
+    [
+      String(r.jersey),
+      ...columns.map((c) => (c in r.fields ? String(r.fields[c]) : "")),
+    ].join("|"),
+  );
+
+  return {
+    text: [supplierId, header, ...playerLines].join("\n"),
+    rowCount: mapped.length,
+  };
+}


### PR DESCRIPTION
## Summary

PR4 — **the differentiator.** Exports a game's entered box score to MaxPreps' documented import format, eliminating the double-entry coaches do today.

## What's in this PR

- **`lib/maxpreps-export.ts`** — pure generator for the pipe-delimited `.txt`: Line 1 = 32-char Supplier ID, Line 2 = `Jersey|<exact MaxPreps field names>`, one row per player. Maps our `PlayerGameStatLine` → **verbatim Football/Boys field names** (`docs/research/maxpreps-import-format.md §2a`). The header lists only columns some player has data for; gaps are blank cells (undeclared fields aren't overwritten, per spec). Players need a jersey number (MaxPreps keys rows by it). Our fields with no MaxPreps target (`passing.sacked`, `receiving.targets`, `defense.defTd`) are intentionally omitted.
- **Authed GET route** `/api/teams/[teamId]/games/[gameId]/maxpreps-export` → file attachment. `statKeepingV1` + `canManageTeam` + cross-fixture guard. Supplier ID from `MAXPREPS_SUPPLIER_ID` (build-time, account-bound credential); a clearly-marked placeholder on line 1 when unset.
- **"Export for MaxPreps"** button on the stats entry page. Env var documented.

## Test plan

- ✅ type-check + lint clean.
- ✅ Full vitest **494** (incl. 5 new — field mapping incl. omitted-field cases + file generation: supplier/header/rows, blank-for-gaps columns, skip-players-with-no-stats).
- ✅ Production build compiles the new route.

## Note

The only thing between this and a real upload is the **Supplier ID** — an account-bound credential the team registers for on MaxPreps (set `MAXPREPS_SUPPLIER_ID`). Until then the file downloads with a placeholder line 1 the coach can edit.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)