### PR TITLE
feat(web): stat-keeping keystone — SPRT ratings from game stats (WSM-000112, PR5)

### DIFF
--- a/apps/web/convex/__tests__/hsSprt.test.ts
+++ b/apps/web/convex/__tests__/hsSprt.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeHsSprtRatings,
+  positionToRatingGroup,
+  type HsRatingInput,
+} from "../lib/hsSprt";
+
+describe("positionToRatingGroup", () => {
+  it("maps roster positions to rating groups", () => {
+    expect(positionToRatingGroup("QB")).toBe("QB");
+    expect(positionToRatingGroup("hb")).toBe("RB");
+    expect(positionToRatingGroup("CB")).toBe("DB");
+    expect(positionToRatingGroup("MLB")).toBe("LB");
+  });
+  it("returns null for unrated positions (OL/K/unknown)", () => {
+    expect(positionToRatingGroup("OL")).toBeNull();
+    expect(positionToRatingGroup("K")).toBeNull();
+    expect(positionToRatingGroup("XYZ")).toBeNull();
+  });
+});
+
+describe("computeHsSprtRatings", () => {
+  it("ranks the more productive player higher, both in 40–99", () => {
+    const inputs: HsRatingInput[] = [
+      { id: "a", group: "QB", games: 2, totals: { passing: { comp: 20, att: 30, yards: 600, td: 6, int: 1 } } },
+      { id: "b", group: "QB", games: 2, totals: { passing: { comp: 10, att: 30, yards: 200, td: 1, int: 4 } } },
+    ];
+    const r = computeHsSprtRatings(inputs);
+    expect(r.size).toBe(2);
+    const a = r.get("a")!;
+    const b = r.get("b")!;
+    expect(a.overall).toBeGreaterThan(b.overall);
+    expect(a.positionGroup).toBe("QB");
+    expect(Object.keys(a.attributes)).toEqual(
+      expect.arrayContaining(["efficiency", "production", "scoring"]),
+    );
+    for (const v of [a.overall, b.overall]) {
+      expect(v).toBeGreaterThanOrEqual(40);
+      expect(v).toBeLessThanOrEqual(99);
+    }
+  });
+
+  it("skips a group with fewer than two qualified players", () => {
+    const r = computeHsSprtRatings([
+      { id: "solo", group: "RB", games: 3, totals: { rushing: { carries: 30, yards: 200, td: 3 } } },
+    ]);
+    expect(r.has("solo")).toBe(false);
+  });
+
+  it("rates each group independently", () => {
+    const r = computeHsSprtRatings([
+      { id: "qb1", group: "QB", games: 1, totals: { passing: { yards: 300, td: 3 } } },
+      { id: "qb2", group: "QB", games: 1, totals: { passing: { yards: 100, td: 0 } } },
+      { id: "db1", group: "DB", games: 1, totals: { defense: { passDef: 4, int: 2 } } },
+      { id: "db2", group: "DB", games: 1, totals: { defense: { passDef: 1, int: 0 } } },
+    ]);
+    expect(r.get("qb1")!.positionGroup).toBe("QB");
+    expect(r.get("db1")!.positionGroup).toBe("DB");
+    expect(r.get("qb1")!.overall).toBeGreaterThan(r.get("qb2")!.overall);
+    expect(r.get("db1")!.overall).toBeGreaterThan(r.get("db2")!.overall);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -106,6 +106,7 @@ void api.sports.getPlayerDevelopmentPublic;
  */
 type AllowedPublicSportsReads =
   | "computeDivisionStandings"
+  | "computeSeasonSprt"
   | "computeStandings"
   | "computeStandingsPublic"
   | "getDepthChartByTeamSeason"

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as e2eSeed from "../e2eSeed.js";
 import type * as lib_auditLog from "../lib/auditLog.js";
+import type * as lib_hsSprt from "../lib/hsSprt.js";
 import type * as lib_playerStats from "../lib/playerStats.js";
 import type * as lib_standings from "../lib/standings.js";
 import type * as migrations_20260422_seasonsRosterLocked from "../migrations/20260422_seasonsRosterLocked.js";
@@ -26,6 +27,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   e2eSeed: typeof e2eSeed;
   "lib/auditLog": typeof lib_auditLog;
+  "lib/hsSprt": typeof lib_hsSprt;
   "lib/playerStats": typeof lib_playerStats;
   "lib/standings": typeof lib_standings;
   "migrations/20260422_seasonsRosterLocked": typeof migrations_20260422_seasonsRosterLocked;

--- a/apps/web/convex/lib/hsSprt.ts
+++ b/apps/web/convex/lib/hsSprt.ts
@@ -1,0 +1,171 @@
+/*
+ * HS SPRT rating from real game stats (WSM-000112, PR5). Same idea as the
+ * nflverse SPRT model (z-score per position group → 0–99, centered 70), but the
+ * components use ONLY box-score stats a stat-keeper actually enters — HS games
+ * have no EPA. Pure + unit-tested; consumed by the computeSeasonSprt query,
+ * which feeds it season aggregates from playerGameStats.
+ *
+ * Ratings are RELATIVE within a season's cohort: each component is z-scored
+ * across qualified players at the same group, so it needs ≥2 of them; groups
+ * with fewer are skipped (caller shows no rating).
+ */
+
+export type RatingGroup = "QB" | "RB" | "WR" | "TE" | "DL" | "LB" | "DB";
+
+type StatLine = Record<string, Record<string, number>>;
+
+const g = (line: StatLine, group: string, field: string): number =>
+  line[group]?.[field] ?? 0;
+const perGame = (total: number, games: number) => (games > 0 ? total / games : 0);
+const rate = (num: number, den: number) => (den > 0 ? num / den : 0);
+
+interface Component {
+  key: string;
+  value: number;
+  weight: number;
+}
+
+const MODELS: Record<
+  RatingGroup,
+  { minGames: number; components: (l: StatLine, games: number) => Component[] }
+> = {
+  QB: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "efficiency", value: rate(g(l, "passing", "comp"), g(l, "passing", "att")), weight: 0.3 },
+      { key: "production", value: perGame(g(l, "passing", "yards"), games), weight: 0.35 },
+      { key: "scoring", value: perGame(g(l, "passing", "td") - 1.5 * g(l, "passing", "int"), games), weight: 0.25 },
+      { key: "mobility", value: perGame(g(l, "rushing", "yards"), games), weight: 0.1 },
+    ],
+  },
+  RB: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "efficiency", value: rate(g(l, "rushing", "yards"), g(l, "rushing", "carries")), weight: 0.35 },
+      { key: "volume", value: perGame(g(l, "rushing", "yards"), games), weight: 0.35 },
+      { key: "scoring", value: perGame(g(l, "rushing", "td") + g(l, "receiving", "td"), games), weight: 0.2 },
+      { key: "receiving", value: perGame(g(l, "receiving", "yards"), games), weight: 0.1 },
+    ],
+  },
+  WR: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "volume", value: perGame(g(l, "receiving", "yards"), games), weight: 0.45 },
+      { key: "catches", value: perGame(g(l, "receiving", "rec"), games), weight: 0.3 },
+      { key: "scoring", value: perGame(g(l, "receiving", "td"), games), weight: 0.25 },
+    ],
+  },
+  TE: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "volume", value: perGame(g(l, "receiving", "yards"), games), weight: 0.5 },
+      { key: "catches", value: perGame(g(l, "receiving", "rec"), games), weight: 0.3 },
+      { key: "scoring", value: perGame(g(l, "receiving", "td"), games), weight: 0.2 },
+    ],
+  },
+  DL: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "passRush", value: perGame(g(l, "defense", "sacks"), games), weight: 0.4 },
+      { key: "runStop", value: perGame(g(l, "defense", "tfl"), games), weight: 0.3 },
+      { key: "tackling", value: perGame(g(l, "defense", "tacklesSolo") + g(l, "defense", "tacklesAst"), games), weight: 0.3 },
+    ],
+  },
+  LB: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "tackling", value: perGame(g(l, "defense", "tacklesSolo") + g(l, "defense", "tacklesAst"), games), weight: 0.35 },
+      { key: "passRush", value: perGame(g(l, "defense", "sacks"), games), weight: 0.25 },
+      { key: "runStop", value: perGame(g(l, "defense", "tfl"), games), weight: 0.2 },
+      { key: "coverage", value: perGame(g(l, "defense", "passDef") + g(l, "defense", "int"), games), weight: 0.2 },
+    ],
+  },
+  DB: {
+    minGames: 1,
+    components: (l, games) => [
+      { key: "coverage", value: perGame(g(l, "defense", "passDef"), games), weight: 0.4 },
+      { key: "ballHawk", value: perGame(g(l, "defense", "int"), games), weight: 0.35 },
+      { key: "tackling", value: perGame(g(l, "defense", "tacklesSolo") + g(l, "defense", "tacklesAst"), games), weight: 0.25 },
+    ],
+  },
+};
+
+const POSITION_TO_GROUP: Record<string, RatingGroup> = {
+  QB: "QB",
+  HB: "RB", RB: "RB", FB: "RB",
+  WR: "WR",
+  TE: "TE",
+  DE: "DL", DT: "DL", NT: "DL", EDGE: "DL", DL: "DL",
+  OLB: "LB", MLB: "LB", ILB: "LB", LB: "LB",
+  CB: "DB", S: "DB", FS: "DB", SS: "DB", NB: "DB", DB: "DB",
+};
+
+/** Map a roster position to a rating group, or null (OL/K/unmapped — unrated). */
+export function positionToRatingGroup(position: string): RatingGroup | null {
+  return POSITION_TO_GROUP[position.trim().toUpperCase()] ?? null;
+}
+
+function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+}
+function stdev(xs: number[], m: number): number {
+  if (xs.length < 2) return 0;
+  return Math.sqrt(xs.reduce((a, b) => a + (b - m) ** 2, 0) / (xs.length - 1));
+}
+/** z-score → 0–99, centered 70, ~12 pts per σ (matches the NFL SPRT scale). */
+function zToRating(z: number): number {
+  return Math.max(40, Math.min(99, Math.round(70 + 12 * z)));
+}
+
+export interface HsRatingInput {
+  id: string;
+  group: RatingGroup;
+  totals: StatLine;
+  games: number;
+}
+
+export interface HsRating {
+  positionGroup: RatingGroup;
+  overall: number;
+  attributes: Record<string, number>;
+}
+
+export function computeHsSprtRatings(
+  players: readonly HsRatingInput[],
+): Map<string, HsRating> {
+  const result = new Map<string, HsRating>();
+
+  for (const group of Object.keys(MODELS) as RatingGroup[]) {
+    const model = MODELS[group];
+    const qualified = players.filter(
+      (p) => p.group === group && p.games >= model.minGames,
+    );
+    if (qualified.length < 2) continue;
+
+    const rows = qualified.map((p) => ({
+      id: p.id,
+      components: model.components(p.totals, p.games),
+    }));
+    const keys = rows[0].components.map((c) => c.key);
+    const stats: Record<string, { m: number; sd: number; w: number }> = {};
+    for (let i = 0; i < keys.length; i++) {
+      const vals = rows.map((r) => r.components[i].value);
+      const m = mean(vals);
+      stats[keys[i]] = { m, sd: stdev(vals, m), w: rows[0].components[i].weight };
+    }
+
+    for (const row of rows) {
+      const attributes: Record<string, number> = {};
+      let overallZ = 0;
+      for (const c of row.components) {
+        const { m, sd, w } = stats[c.key];
+        const z = sd > 0 ? (c.value - m) / sd : 0;
+        attributes[c.key] = zToRating(z);
+        overallZ += w * z;
+      }
+      result.set(row.id, { positionGroup: group, overall: zToRating(overallZ), attributes });
+    }
+  }
+
+  return result;
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -317,5 +317,6 @@ export default defineSchema({
     .index("by_fixtureId", ["fixtureId"]) // a game's entered lines (entry/review)
     .index("by_fixtureId_playerId", ["fixtureId", "playerId"]) // upsert key
     .index("by_playerId_seasonId", ["playerId", "seasonId"]) // season totals
-    .index("by_teamId_seasonId", ["teamId", "seasonId"]), // team season view
+    .index("by_teamId_seasonId", ["teamId", "seasonId"]) // team season view
+    .index("by_seasonId", ["seasonId"]), // whole-season cohort (SPRT ratings)
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -10,6 +10,11 @@ import type { Id } from "./_generated/dataModel";
 import { writeAuditLog } from "./lib/auditLog";
 import { computeStandingsPure } from "./lib/standings";
 import { aggregateStatLines, parseStatLine } from "./lib/playerStats";
+import {
+  computeHsSprtRatings,
+  positionToRatingGroup,
+  type HsRatingInput,
+} from "./lib/hsSprt";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -4255,5 +4260,68 @@ export const getPlayerSeasonTotals = query({
       .collect();
     const totals = aggregateStatLines(rows.map((r) => parseStatLine(r.statsJson)));
     return { statsJson: JSON.stringify(totals), gameCount: rows.length };
+  },
+});
+
+/*
+ * HS SPRT ratings for a season, computed on-read from entered game stats
+ * (WSM-000112, PR5). Aggregates each player's playerGameStats rows, maps their
+ * roster position to a rating group, and z-scores within the season cohort (see
+ * lib/hsSprt.ts). Returns only qualified, rated players — a player profile picks
+ * its own id out of the list. Public read (allow-listed in the #210 backstop).
+ */
+export const computeSeasonSprt = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(
+    v.object({
+      playerId: v.string(),
+      positionGroup: v.string(),
+      overall: v.number(),
+      attributesJson: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    const byPlayer = new Map<string, string[]>();
+    for (const r of rows) {
+      const arr = byPlayer.get(r.playerId) ?? [];
+      arr.push(r.statsJson);
+      byPlayer.set(r.playerId, arr);
+    }
+
+    const inputs: HsRatingInput[] = [];
+    for (const [playerId, jsons] of byPlayer) {
+      const player = await ctx.db.get(playerId as Id<"players">);
+      if (!player) continue;
+      const group = positionToRatingGroup(player.position);
+      if (!group) continue;
+      inputs.push({
+        id: playerId,
+        group,
+        totals: aggregateStatLines(jsons.map(parseStatLine)),
+        games: jsons.length,
+      });
+    }
+
+    const ratings = computeHsSprtRatings(inputs);
+    const out: Array<{
+      playerId: string;
+      positionGroup: string;
+      overall: number;
+      attributesJson: string;
+    }> = [];
+    for (const [playerId, r] of ratings) {
+      out.push({
+        playerId,
+        positionGroup: r.positionGroup,
+        overall: r.overall,
+        attributesJson: JSON.stringify(r.attributes),
+      });
+    }
+    return out;
   },
 });

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   getPlayerMaddenRating,
   getSeasons,
   getPlayerSeasonTotals,
+  computeSeasonSprt,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { derivePositionGroup } from "@/lib/position-group";
@@ -16,6 +17,7 @@ import { orderedComponents } from "@/lib/ratings/component-labels";
 import { orderedMaddenAttributes } from "@/lib/madden/attributes";
 import { playerAttributesV1, statKeepingV1 } from "@/lib/flags";
 import { SeasonStatsCard } from "@/components/stats/SeasonStatsCard";
+import { HsRatingCard } from "@/components/stats/HsRatingCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
@@ -91,16 +93,25 @@ export default async function PlayerProfilePage({
     gameCount: number;
     seasonName: string;
   } | null = null;
+  let gameRating: {
+    overall: number;
+    attributes: Record<string, number>;
+  } | null = null;
   if ((await statKeepingV1()) && team) {
     const seasons = await getSeasons([team.leagueId]).catch(() => []);
     const activeSeason =
       seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
     if (activeSeason) {
-      const totals = await getPlayerSeasonTotals(playerId, activeSeason.id).catch(
-        () => null,
-      );
+      const [totals, sprt] = await Promise.all([
+        getPlayerSeasonTotals(playerId, activeSeason.id).catch(() => null),
+        computeSeasonSprt(activeSeason.id).catch(() => []),
+      ]);
       if (totals && totals.gameCount > 0) {
         seasonStats = { ...totals, seasonName: activeSeason.name };
+      }
+      const mine = sprt.find((r) => r.playerId === playerId);
+      if (mine) {
+        gameRating = { overall: mine.overall, attributes: mine.attributes };
       }
     }
   }
@@ -198,6 +209,13 @@ export default async function PlayerProfilePage({
           stats={seasonStats.stats}
           gameCount={seasonStats.gameCount}
           seasonName={seasonStats.seasonName}
+        />
+      )}
+
+      {gameRating && (
+        <HsRatingCard
+          overall={gameRating.overall}
+          attributes={gameRating.attributes}
         />
       )}
 

--- a/apps/web/src/components/stats/HsRatingCard.tsx
+++ b/apps/web/src/components/stats/HsRatingCard.tsx
@@ -1,0 +1,89 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+/*
+ * HS SPRT rating from real game stats (WSM-000112, PR5). Same look as the
+ * nflverse SPRT card, but the number is earned from the player's own entered
+ * box scores (z-scored within the season cohort). Presentational.
+ */
+
+const LABELS: Record<string, string> = {
+  efficiency: "Efficiency",
+  production: "Production",
+  scoring: "Scoring",
+  mobility: "Mobility",
+  volume: "Volume",
+  catches: "Catches",
+  receiving: "Receiving",
+  passRush: "Pass rush",
+  runStop: "Run stop",
+  tackling: "Tackling",
+  coverage: "Coverage",
+  ballHawk: "Ball hawk",
+};
+
+const label = (key: string) =>
+  LABELS[key] ?? key.charAt(0).toUpperCase() + key.slice(1);
+
+export function HsRatingCard({
+  overall,
+  attributes,
+}: {
+  overall: number;
+  attributes: Record<string, number>;
+}) {
+  const components = Object.entries(attributes);
+
+  return (
+    <Card className="mt-6">
+      <CardContent className="pt-6">
+        <div className="flex items-baseline justify-between">
+          <h3 className="text-lg font-semibold text-foreground">
+            SPRT Rating
+            <span className="ml-2 text-xs font-normal text-muted-foreground">
+              from game stats
+            </span>
+          </h3>
+          <span className="font-mono text-2xl font-bold text-green-500">
+            {overall}
+            <span className="ml-1 text-xs font-normal text-muted-foreground">
+              OVR
+            </span>
+          </span>
+        </div>
+
+        {components.length > 0 && (
+          <dl className="mt-4 space-y-2">
+            {components.map(([key, value]) => (
+              <div key={key} className="flex items-center gap-3">
+                <dt className="w-32 shrink-0 text-sm text-muted-foreground">
+                  {label(key)}
+                </dt>
+                <div
+                  className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+                  role="meter"
+                  aria-valuenow={value}
+                  aria-valuemin={0}
+                  aria-valuemax={99}
+                  aria-label={label(key)}
+                >
+                  <div
+                    className="h-full rounded-full bg-foreground"
+                    style={{ width: `${Math.min(100, (value / 99) * 100)}%` }}
+                  />
+                </div>
+                <dd className="w-8 shrink-0 text-right font-mono text-sm text-foreground">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        <p className="mt-4 text-xs text-muted-foreground">
+          Derived from this player&apos;s entered game stats, ranked against
+          others at their position this season.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -558,6 +558,15 @@ const refs = {
     { playerId: string; seasonId: string },
     { statsJson: string; gameCount: number }
   >("sports:getPlayerSeasonTotals"),
+  computeSeasonSprt: queryRef<
+    { seasonId: string },
+    Array<{
+      playerId: string;
+      positionGroup: string;
+      overall: number;
+      attributesJson: string;
+    }>
+  >("sports:computeSeasonSprt"),
 };
 
 /** Raw playerGameStats row as returned by Convex (statsJson unparsed). */
@@ -1668,6 +1677,35 @@ export async function getPlayerSeasonTotals(
 ): Promise<{ stats: PlayerGameStatLine; gameCount: number }> {
   const res = await queryConvex(refs.getPlayerSeasonTotals, { playerId, seasonId });
   return { stats: parseStatLine(res.statsJson), gameCount: res.gameCount };
+}
+
+export interface HsSprtRating {
+  playerId: string;
+  positionGroup: string;
+  overall: number;
+  attributes: Record<string, number>;
+}
+
+/** Season-wide HS SPRT ratings from entered game stats (rated players only). */
+export async function computeSeasonSprt(
+  seasonId: string,
+): Promise<HsSprtRating[]> {
+  const rows = await queryConvex(refs.computeSeasonSprt, { seasonId });
+  return rows.map((r) => {
+    let attributes: Record<string, number> = {};
+    try {
+      const parsed = JSON.parse(r.attributesJson);
+      if (parsed && typeof parsed === "object") attributes = parsed;
+    } catch {
+      // leave empty
+    }
+    return {
+      playerId: r.playerId,
+      positionGroup: r.positionGroup,
+      overall: r.overall,
+      attributes,
+    };
+  });
 }
 
 // --- Phase 3 — standings wrappers ---


### PR DESCRIPTION
## Summary

PR5 — closes the keystone loop. A player's **entered box scores now earn an SPRT rating** ("ratings from your own games"), the HS-level differentiator no competitor has.

## What's in this PR

- **`convex/lib/hsSprt.ts`** — pure HS rating model. Same z-score-per-position-group → 0–99 machinery as the nflverse SPRT, but components use **only box-score stats** (HS games have no EPA): QB efficiency/production/scoring/mobility, RB eff/volume/scoring/receiving, WR·TE volume/catches/scoring, DL·LB·DB pass-rush/run-stop/tackling/coverage/ball-hawk. **Relative within the season cohort** (needs ≥2 players at a group). `positionToRatingGroup` maps roster positions (OL/K/unmapped → unrated).
- **`computeSeasonSprt(seasonId)`** query — aggregates each player's `playerGameStats` (via a new `by_seasonId` index), maps position → group, z-scores the cohort, returns rated players. Public read; allow-listed in the #210 backstop. data-api wrapper parses attributes.
- **Player profile** shows an **"SPRT Rating — from game stats"** card (`HsRatingCard`) with overall + component bars, behind `statKeepingV1`. Distinct from the nflverse SPRT card — in practice they never both show (HS players have no nflverse data and vice-versa).

## Test plan

- ✅ type-check + lint clean.
- ✅ Full vitest **499** (incl. 5 new — HS model ranking, the ≥2-qualified rule, independent per-group rating, and position→group mapping).
- ✅ Production build compiles. Schema index is additive.

## Design note

HS box scores have no EPA, so reusing the NFL model verbatim would flatten its EPA-weighted components. I wrote box-score-only components instead — honest to the available data. Ratings are intentionally **relative within a season** (z-scored), so they're meaningful once a couple of players at a position have games entered.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)