### PR TITLE
feat(web): per-team MaxPreps Supplier ID for stat export (WSM-000112)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -78,6 +78,10 @@ export default defineSchema({
     // or undefined, duplicates are allowed (the historical default) — the UI
     // still surfaces an inline duplicate alert.
     allowDuplicateJerseys: v.optional(v.boolean()),
+    // MaxPreps export (WSM-000112): the team's own 32-char Stat Supplier ID,
+    // entered by the coach (account-bound to their MaxPreps account). Used as
+    // line 1 of the export file; absent = fall back to env / placeholder.
+    maxprepsSupplierId: v.optional(v.union(v.string(), v.null())),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_divisionId", ["divisionId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -84,6 +84,7 @@ function toTeamDto(doc: {
   primaryColor?: string | null;
   secondaryColor?: string | null;
   allowDuplicateJerseys?: boolean;
+  maxprepsSupplierId?: string | null;
 }) {
   return {
     id: doc._id,
@@ -101,6 +102,7 @@ function toTeamDto(doc: {
     secondaryColor: doc.secondaryColor ?? null,
     // Default true preserves the historical allow-by-default behavior.
     allowDuplicateJerseys: doc.allowDuplicateJerseys ?? true,
+    maxprepsSupplierId: doc.maxprepsSupplierId ?? null,
   };
 }
 
@@ -521,6 +523,7 @@ export const listTeams = queryGeneric({
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
       allowDuplicateJerseys: v.boolean(),
+      maxprepsSupplierId: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -554,6 +557,7 @@ export const listTeamsByLeague = queryGeneric({
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
       allowDuplicateJerseys: v.boolean(),
+      maxprepsSupplierId: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
   ),
@@ -583,6 +587,7 @@ export const getTeam = queryGeneric({
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
       allowDuplicateJerseys: v.boolean(),
+      maxprepsSupplierId: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1137,6 +1142,7 @@ export const upsertTeam = internalMutationGeneric({
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
       allowDuplicateJerseys: v.boolean(),
+      maxprepsSupplierId: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     created: v.boolean(),
@@ -1199,6 +1205,7 @@ export const upsertTeam = internalMutationGeneric({
         primaryColor: null,
         secondaryColor: null,
         allowDuplicateJerseys: true,
+        maxprepsSupplierId: null,
       },
       created: true,
     };
@@ -1309,6 +1316,7 @@ export const createTeam = internalMutationGeneric({
     primaryColor: v.union(v.string(), v.null()),
     secondaryColor: v.union(v.string(), v.null()),
     allowDuplicateJerseys: v.boolean(),
+    maxprepsSupplierId: v.union(v.string(), v.null()),
     rosterLimit: v.union(v.number(), v.null()),
   }),
   handler: async (ctx, args) => {
@@ -1338,6 +1346,7 @@ export const createTeam = internalMutationGeneric({
       primaryColor: null,
       secondaryColor: null,
       allowDuplicateJerseys: true,
+      maxprepsSupplierId: null,
     };
   },
 });
@@ -1356,6 +1365,7 @@ export const updateTeam = internalMutationGeneric({
     primaryColor: v.optional(v.union(v.string(), v.null())),
     secondaryColor: v.optional(v.union(v.string(), v.null())),
     allowDuplicateJerseys: v.optional(v.boolean()),
+    maxprepsSupplierId: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.union(
     v.object({
@@ -1372,6 +1382,7 @@ export const updateTeam = internalMutationGeneric({
       primaryColor: v.union(v.string(), v.null()),
       secondaryColor: v.union(v.string(), v.null()),
       allowDuplicateJerseys: v.boolean(),
+      maxprepsSupplierId: v.union(v.string(), v.null()),
       rosterLimit: v.union(v.number(), v.null()),
     }),
     v.null(),
@@ -1397,6 +1408,9 @@ export const updateTeam = internalMutationGeneric({
         : {}),
       ...(args.allowDuplicateJerseys !== undefined
         ? { allowDuplicateJerseys: args.allowDuplicateJerseys }
+        : {}),
+      ...(args.maxprepsSupplierId !== undefined
+        ? { maxprepsSupplierId: args.maxprepsSupplierId }
         : {}),
     };
     await ctx.db.patch(args.teamId, patch);

--- a/apps/web/src/app/api/teams/[teamId]/games/[gameId]/maxpreps-export/route.ts
+++ b/apps/web/src/app/api/teams/[teamId]/games/[gameId]/maxpreps-export/route.ts
@@ -67,7 +67,12 @@ export async function GET(
       stats: statsByPlayer.get(p.id)!,
     }));
 
-  const supplierId = process.env.MAXPREPS_SUPPLIER_ID || SUPPLIER_ID_PLACEHOLDER;
+  // Prefer the team's own (coach-entered) Supplier ID; fall back to a global
+  // env value, then a clearly-marked placeholder the coach edits before upload.
+  const supplierId =
+    team.maxprepsSupplierId?.trim() ||
+    process.env.MAXPREPS_SUPPLIER_ID ||
+    SUPPLIER_ID_PLACEHOLDER;
   const { text } = generateMaxPrepsTxt(supplierId, rows);
 
   // MaxPreps filename must not contain quotes or parentheses.

--- a/apps/web/src/app/dashboard/_components/team-edit-form.tsx
+++ b/apps/web/src/app/dashboard/_components/team-edit-form.tsx
@@ -57,6 +57,9 @@ export default function TeamEditForm({
     team.foundedYear?.toString() ?? "",
   );
   const [logoUrl, setLogoUrl] = useState(team.logoUrl ?? "");
+  const [maxprepsSupplierId, setMaxprepsSupplierId] = useState(
+    team.maxprepsSupplierId ?? "",
+  );
   const [useColors, setUseColors] = useState(
     team.primaryColor != null || team.secondaryColor != null,
   );
@@ -126,6 +129,7 @@ export default function TeamEditForm({
         primaryColor: useColors ? primaryColor : null,
         secondaryColor: useColors ? secondaryColor : null,
         allowDuplicateJerseys,
+        maxprepsSupplierId: maxprepsSupplierId.trim() || null,
       };
 
       const parsed = UpdateTeamInputSchema.safeParse(data);
@@ -286,6 +290,21 @@ export default function TeamEditForm({
               placeholder="https://… (optional)"
               onChange={(e) => setLogoUrl(e.target.value)}
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="team-maxpreps">MaxPreps Supplier ID</Label>
+            <Input
+              id="team-maxpreps"
+              type="text"
+              value={maxprepsSupplierId}
+              placeholder="e.g. 12345678-1234-1234-123456789012 (optional)"
+              onChange={(e) => setMaxprepsSupplierId(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              From your MaxPreps account (register as a Stat Supplier). Used as
+              line 1 of the stat export so it&apos;s ready to upload.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -127,6 +127,7 @@ export class LocalWorkspaceProvider implements WorkspaceDataProvider {
       primaryColor: null,
       secondaryColor: null,
       allowDuplicateJerseys: true,
+      maxprepsSupplierId: null,
     };
     await this.db.teams.add(team);
     return team;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -53,6 +53,7 @@ export const TeamDtoSchema = z.object({
   primaryColor: z.string().nullable(),
   secondaryColor: z.string().nullable(),
   allowDuplicateJerseys: z.boolean(),
+  maxprepsSupplierId: z.string().nullable(),
 }) satisfies z.ZodType<TeamDto>;
 
 export const PlayerDtoSchema = z.object({
@@ -162,6 +163,12 @@ export const UpdateTeamInputSchema = z.object({
   primaryColor: hexColor.nullable().optional(),
   secondaryColor: hexColor.nullable().optional(),
   allowDuplicateJerseys: z.boolean().optional(),
+  maxprepsSupplierId: z
+    .string()
+    .trim()
+    .max(64, "Supplier ID looks too long")
+    .nullable()
+    .optional(),
 }) satisfies z.ZodType<UpdateTeamInput>;
 
 // --- Stat-keeping keystone (WSM-000112) — box-score stat line ---

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -47,6 +47,8 @@ export interface TeamDto {
    * only surfaced as an inline alert.
    */
   allowDuplicateJerseys: boolean;
+  /** The team's MaxPreps Stat Supplier ID (coach-entered) for stat export. */
+  maxprepsSupplierId: string | null;
 }
 
 export interface PlayerDto {
@@ -161,6 +163,7 @@ export interface UpdateTeamInput {
   primaryColor?: string | null;
   secondaryColor?: string | null;
   allowDuplicateJerseys?: boolean;
+  maxprepsSupplierId?: string | null;
 }
 
 // --- Import types ---


### PR DESCRIPTION
## Why

The MaxPreps Stat Supplier ID is **account-bound to an individual coach's MaxPreps account** — so a single global `MAXPREPS_SUPPLIER_ID` env var was the wrong model (the platform operator can't obtain one, and shouldn't need to). Each coach who uses the app has their own. This makes it a **per-team setting** the coach enters once.

## What

- **`teams.maxprepsSupplierId`** (optional) → `TeamDto` / `UpdateTeamInput` (+ Zod schemas) → `updateTeam` mutation (arg + patch) + `toTeamDto` projection; `createTeam`/`upsertTeam` default it `null`.
- **Team edit form**: optional "MaxPreps Supplier ID" field with a hint on where to get it.
- **Export route** prefers `team.maxprepsSupplierId` → `env MAXPREPS_SUPPLIER_ID` → placeholder, so a coach's own ID lands on line 1 with no file editing.

## Test plan

- ✅ type-check + lint clean; packages build; full vitest **499**; production build compiles.
- Schema field is **additive** (no migration).

## Note

Resolves the "I can't get a Supplier ID" blocker: the platform doesn't need one — coaches bring their own per team. The export already worked with a hand-edited placeholder; this removes that friction.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)