### PR TITLE
fix(web): fail-loud admin client + admin-auth health probe (WSM-000151)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4339,3 +4339,17 @@ export const computeSeasonSprt = query({
     return out;
   },
 });
+
+/*
+ * Admin-auth probe (WSM-000151). A no-op internalQuery — callable only by an
+ * admin-keyed client. /api/health calls it through getConvexClient to verify
+ * CONVEX_ADMIN_KEY actually authenticates as admin, so a misconfigured key
+ * fails the health check loudly instead of silently breaking writes while
+ * public reads keep working (the WSM-000150 failure mode). internalQuery → not
+ * on the public api, so no #210 allow-list change.
+ */
+export const adminPing = internalQueryGeneric({
+  args: {},
+  returns: v.boolean(),
+  handler: async () => true,
+});

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getPublicLeagues } from "@/lib/data-api";
+import { getPublicLeagues, adminPing } from "@/lib/data-api";
 
 export async function GET() {
   const checks: Record<string, unknown> = {};
@@ -16,6 +16,18 @@ export async function GET() {
     checks.convex = `ok (public leagues: ${leagues.length})`;
   } catch (err) {
     checks.convex = `FAILED: ${err instanceof Error ? err.message : String(err)}`;
+    return NextResponse.json(checks, { status: 503 });
+  }
+
+  // Admin-auth probe (WSM-000151): the public read above can't detect a bad
+  // CONVEX_ADMIN_KEY — calling an internalQuery does. If this fails, every write
+  // is broken even though reads work (the WSM-000150 silent outage), so it must
+  // turn the health check red.
+  try {
+    await adminPing();
+    checks.convexAdmin = "ok";
+  } catch (err) {
+    checks.convexAdmin = `FAILED: ${err instanceof Error ? err.message : String(err)}`;
     return NextResponse.json(checks, { status: 503 });
   }
 

--- a/apps/web/src/lib/__tests__/convex-client.test.ts
+++ b/apps/web/src/lib/__tests__/convex-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Controllable mock of ConvexHttpClient: `h.has` toggles whether the client
+// exposes setAdminAuth; `h.setAdminAuth` captures the call.
+const h = vi.hoisted(() => ({ has: true, setAdminAuth: vi.fn() }));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    url: string;
+    setAdminAuth?: (key: string) => void;
+    constructor(url: string) {
+      this.url = url;
+      if (h.has) this.setAdminAuth = h.setAdminAuth;
+    }
+  },
+}));
+
+import { getConvexClient } from "../convex-client";
+
+const ORIG_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+const ORIG_KEY = process.env.CONVEX_ADMIN_KEY;
+
+beforeEach(() => {
+  h.has = true;
+  h.setAdminAuth.mockClear();
+});
+afterEach(() => {
+  if (ORIG_URL === undefined) delete process.env.NEXT_PUBLIC_CONVEX_URL;
+  else process.env.NEXT_PUBLIC_CONVEX_URL = ORIG_URL;
+  if (ORIG_KEY === undefined) delete process.env.CONVEX_ADMIN_KEY;
+  else process.env.CONVEX_ADMIN_KEY = ORIG_KEY;
+});
+
+describe("getConvexClient", () => {
+  it("applies admin auth when the key is set and setAdminAuth exists", () => {
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://prod.convex.cloud";
+    process.env.CONVEX_ADMIN_KEY = "prod:x|abc";
+    getConvexClient();
+    expect(h.setAdminAuth).toHaveBeenCalledWith("prod:x|abc");
+  });
+
+  it("throws (no silent non-admin client) when key is set but setAdminAuth is missing", () => {
+    h.has = false;
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://prod.convex.cloud";
+    process.env.CONVEX_ADMIN_KEY = "prod:x|abc";
+    expect(() => getConvexClient()).toThrow(/setAdminAuth/);
+  });
+
+  it("throws when no admin key on a non-local deployment", () => {
+    delete process.env.CONVEX_ADMIN_KEY;
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://prod.convex.cloud";
+    expect(() => getConvexClient()).toThrow(/Missing Convex admin key/);
+  });
+
+  it("allows a local deployment with no admin key", () => {
+    delete process.env.CONVEX_ADMIN_KEY;
+    process.env.NEXT_PUBLIC_CONVEX_URL = "http://127.0.0.1:3210";
+    expect(() => getConvexClient()).not.toThrow();
+  });
+
+  it("throws when the Convex URL is missing", () => {
+    delete process.env.NEXT_PUBLIC_CONVEX_URL;
+    process.env.CONVEX_ADMIN_KEY = "prod:x|abc";
+    expect(() => getConvexClient()).toThrow(/Convex deployment URL/);
+  });
+});

--- a/apps/web/src/lib/convex-client.ts
+++ b/apps/web/src/lib/convex-client.ts
@@ -19,9 +19,21 @@ export function getConvexClient(): ConvexHttpClient {
 
   const client = new ConvexHttpClient(url);
   if (adminKey) {
-    (client as ConvexHttpClient & {
+    const withAdmin = client as ConvexHttpClient & {
       setAdminAuth?: (key: string) => void;
-    }).setAdminAuth?.(adminKey);
+    };
+    // Fail loud rather than silently returning a non-admin client (WSM-000151):
+    // a missing setAdminAuth (e.g. a future Convex rename) would otherwise leave
+    // every internalMutation write broken while public reads still work — the
+    // exact silent failure mode behind WSM-000150. (An *invalid* key value can't
+    // be caught here — Convex validates it server-side; /api/health's adminPing
+    // probe covers that case.)
+    if (typeof withAdmin.setAdminAuth !== "function") {
+      throw new Error(
+        "Convex client is missing setAdminAuth — cannot authenticate admin writes.",
+      );
+    }
+    withAdmin.setAdminAuth(adminKey);
   }
   return client;
 }

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -187,6 +187,7 @@ const refs = {
       seasons: number;
     }
   >("sports:healthSummary"),
+  adminPing: queryRef<Record<string, never>, boolean>("sports:adminPing"),
   upsertLeague: mutationRef<
     { name: string; orgId: string | null },
     { dto: LeagueDto; created: boolean }
@@ -1120,6 +1121,12 @@ export async function getHealthSummary(): Promise<{
   seasons: number;
 }> {
   return queryConvex(refs.healthSummary, {});
+}
+
+/** Admin-auth probe (WSM-000151): resolves true only if the admin-keyed client
+ *  authenticates as admin; throws otherwise. Used by /api/health. */
+export async function adminPing(): Promise<boolean> {
+  return queryConvex(refs.adminPing, {});
 }
 
 export async function bulkImportLeague(


### PR DESCRIPTION
## Summary

Hardens the admin-keyed Convex path so a bad `CONVEX_ADMIN_KEY` surfaces **loudly** instead of silently breaking every write while public reads keep working — the WSM-000150 (#337) failure mode that hid in prod for ~5 days.

## Changes
- **`getConvexClient()`** (`convex-client.ts`): throws if an admin key is set but the client lacks `setAdminAuth`, instead of the silent `?.` no-op that would degrade to a non-admin client (e.g. a future Convex method rename).
- **`adminPing` internalQuery** (`convex/sports.ts`): a no-op returning `true`, callable only by an admin-keyed client. Not on the public `api`, so **no #210 allow-list change**.
- **`/api/health`**: adds an admin-auth probe via `adminPing`. The existing public read (`getPublicLeagues`) can't detect a bad admin key — this turns the health check **red (503)** when writes are broken. `data-api adminPing()` wrapper added.

## Test plan
- ✅ type-check + lint clean.
- ✅ Full vitest **504** (incl. 5 new `getConvexClient` guard tests: applies auth, throws on missing `setAdminAuth`, throws on missing key (non-local), allows local-no-key, throws on missing URL).
- ✅ Production build compiles. `adminPing` is additive (needs a Convex prod deploy on merge).

## Why
The public-read health check stayed green for 5 days while all writes were denied. An admin-scoped probe is the check that would have caught it on day one.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)