### PR TITLE
feat(web): keystone v3 live scoring — operator scoreboard UI (WSM-000152, PR2)

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as e2eSeed from "../e2eSeed.js";
 import type * as lib_auditLog from "../lib/auditLog.js";
 import type * as lib_hsSprt from "../lib/hsSprt.js";
+import type * as lib_liveScore from "../lib/liveScore.js";
 import type * as lib_playerStats from "../lib/playerStats.js";
 import type * as lib_standings from "../lib/standings.js";
 import type * as migrations_20260422_seasonsRosterLocked from "../migrations/20260422_seasonsRosterLocked.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   e2eSeed: typeof e2eSeed;
   "lib/auditLog": typeof lib_auditLog;
   "lib/hsSprt": typeof lib_hsSprt;
+  "lib/liveScore": typeof lib_liveScore;
   "lib/playerStats": typeof lib_playerStats;
   "lib/standings": typeof lib_standings;
   "migrations/20260422_seasonsRosterLocked": typeof migrations_20260422_seasonsRosterLocked;

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,8 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { ClipboardList } from "lucide-react";
-import { schedulesStandingsV1, liveStreamingV1, statKeepingV1 } from "@/lib/flags";
+import { ClipboardList, Radio } from "lucide-react";
+import {
+  schedulesStandingsV1,
+  liveStreamingV1,
+  statKeepingV1,
+  liveScoringV1,
+} from "@/lib/flags";
 import {
   getLeague,
   getLeagueOrgId,
@@ -53,6 +58,9 @@ export default async function LeagueSchedulePage({
   // Box-score entry (WSM-000112): a league admin/coach can enter either team's
   // stats; the entry page re-checks canManageTeam for the specific team.
   const statsEnabled = await statKeepingV1();
+  // Live scoring (WSM-000152): operator-driven running scoreboard. Same
+  // admin/coach surface as stats; the live page re-checks canManageTeam.
+  const liveEnabled = await liveScoringV1();
 
   // Pick the active season — fall back to whichever exists if none flagged active.
   const allSeasons = await getSeasons([leagueId]);
@@ -249,6 +257,24 @@ export default async function LeagueSchedulePage({
                                     <span className="text-muted-foreground">/</span>
                                     <Link
                                       href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
+                                      className="text-primary hover:underline"
+                                    >
+                                      {fixture.awayTeamName}
+                                    </Link>
+                                  </span>
+                                ) : null}
+                                {liveEnabled ? (
+                                  <span className="flex items-center gap-1 text-xs">
+                                    <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+                                    <Link
+                                      href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
+                                      className="text-primary hover:underline"
+                                    >
+                                      {fixture.homeTeamName}
+                                    </Link>
+                                    <span className="text-muted-foreground">/</span>
+                                    <Link
+                                      href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
                                       className="text-primary hover:underline"
                                     >
                                       {fixture.awayTeamName}

--- a/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/__tests__/actions.test.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/__tests__/actions.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockLiveScoringV1,
+  mockAuth,
+  mockGetFixture,
+  mockStartLiveGame,
+  mockAddLiveScore,
+  mockUpdateLiveState,
+  mockEndLiveGame,
+  mockCanManageTeam,
+} = vi.hoisted(() => ({
+  mockLiveScoringV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetFixture: vi.fn(),
+  mockStartLiveGame: vi.fn(),
+  mockAddLiveScore: vi.fn(),
+  mockUpdateLiveState: vi.fn(),
+  mockEndLiveGame: vi.fn(),
+  mockCanManageTeam: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ liveScoringV1: mockLiveScoringV1 }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  getFixture: mockGetFixture,
+  startLiveGame: mockStartLiveGame,
+  addLiveScore: mockAddLiveScore,
+  updateLiveState: mockUpdateLiveState,
+  endLiveGame: mockEndLiveGame,
+}));
+vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  startLiveGameAction,
+  addLiveScoreAction,
+  updateLiveStateAction,
+  endLiveGameAction,
+} from "../actions";
+
+const TEAM = "team_home";
+const FIX = "fixture_1";
+
+const STATE = {
+  id: "lgs_1",
+  fixtureId: FIX,
+  homeScore: 6,
+  awayScore: 0,
+  period: 1,
+  clock: null,
+  status: "in_progress",
+  startedBy: "user_1",
+  startedAt: "2026-06-18T00:00:00.000Z",
+  updatedAt: "2026-06-18T00:00:00.000Z",
+};
+
+function happy() {
+  mockLiveScoringV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockGetFixture.mockResolvedValue({
+    id: FIX,
+    seasonId: "season_1",
+    homeTeamId: TEAM,
+    awayTeamId: "team_away",
+  });
+  mockCanManageTeam.mockResolvedValue(true);
+  mockStartLiveGame.mockResolvedValue(STATE);
+  mockAddLiveScore.mockResolvedValue(STATE);
+  mockUpdateLiveState.mockResolvedValue(STATE);
+  mockEndLiveGame.mockResolvedValue({ ...STATE, status: "final" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  happy();
+});
+
+// All four actions share the same authorize() guard — exercise it once per
+// branch through startLiveGameAction, then spot-check each action's forward.
+describe("authorize (via startLiveGameAction)", () => {
+  const call = () => startLiveGameAction({ teamId: TEAM, fixtureId: FIX });
+
+  it("blocks when the flag is off", async () => {
+    mockLiveScoringV1.mockResolvedValue(false);
+    expect(await call()).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockStartLiveGame).not.toHaveBeenCalled();
+  });
+
+  it("blocks an unauthenticated caller", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    expect(await call()).toEqual({ ok: false, error: "unauthorized" });
+  });
+
+  it("404s a fixture that doesn't exist", async () => {
+    mockGetFixture.mockResolvedValue(null);
+    expect(await call()).toEqual({ ok: false, error: "fixture_not_found" });
+  });
+
+  it("rejects a team not in the fixture (cross-fixture guard)", async () => {
+    mockGetFixture.mockResolvedValue({
+      id: FIX,
+      seasonId: "season_1",
+      homeTeamId: "other_a",
+      awayTeamId: "other_b",
+    });
+    expect(await call()).toEqual({ ok: false, error: "team_not_in_fixture" });
+    expect(mockStartLiveGame).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller who can't manage the team", async () => {
+    mockCanManageTeam.mockResolvedValue(false);
+    expect(await call()).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockStartLiveGame).not.toHaveBeenCalled();
+  });
+});
+
+describe("startLiveGameAction", () => {
+  it("starts the game with the actor and returns state", async () => {
+    const res = await startLiveGameAction({ teamId: TEAM, fixtureId: FIX });
+    expect(res).toEqual({ ok: true, state: STATE });
+    expect(mockStartLiveGame).toHaveBeenCalledWith(FIX, "user_1");
+  });
+});
+
+describe("addLiveScoreAction", () => {
+  it("forwards the scoring event", async () => {
+    const res = await addLiveScoreAction({
+      teamId: TEAM,
+      fixtureId: FIX,
+      team: "home",
+      points: 6,
+    });
+    expect(res).toEqual({ ok: true, state: STATE });
+    expect(mockAddLiveScore).toHaveBeenCalledWith(FIX, "home", 6);
+  });
+
+  it("returns the error when Convex rejects the points", async () => {
+    mockAddLiveScore.mockRejectedValue(new Error("invalid_points"));
+    const res = await addLiveScoreAction({
+      teamId: TEAM,
+      fixtureId: FIX,
+      team: "away",
+      points: 4,
+    });
+    expect(res).toEqual({ ok: false, error: "invalid_points" });
+  });
+});
+
+describe("updateLiveStateAction", () => {
+  it("forwards the patch", async () => {
+    const res = await updateLiveStateAction({
+      teamId: TEAM,
+      fixtureId: FIX,
+      patch: { status: "halftime", period: 2 },
+    });
+    expect(res).toEqual({ ok: true, state: STATE });
+    expect(mockUpdateLiveState).toHaveBeenCalledWith(FIX, {
+      status: "halftime",
+      period: 2,
+    });
+  });
+});
+
+describe("endLiveGameAction", () => {
+  it("ends the game and returns the final state", async () => {
+    const res = await endLiveGameAction({ teamId: TEAM, fixtureId: FIX });
+    expect(res).toEqual({ ok: true, state: { ...STATE, status: "final" } });
+    expect(mockEndLiveGame).toHaveBeenCalledWith(FIX, "user_1");
+  });
+});

--- a/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/actions.ts
+++ b/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/actions.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { liveScoringV1 } from "@/lib/flags";
+import {
+  getFixture,
+  startLiveGame,
+  addLiveScore,
+  updateLiveState,
+  endLiveGame,
+  type LiveGameStateDto,
+} from "@/lib/data-api";
+import { canManageTeam } from "@/lib/authorization";
+
+/*
+ * Live-scoreboard operator actions (WSM-000152, keystone v3). Same authz stance
+ * as box-score entry (stats/actions.ts): a coach/admin of the team
+ * (canManageTeam — league OR owner org) drives the running scoreboard. The team
+ * must actually be in the fixture (cross-fixture guard), gated behind
+ * liveScoringV1. The Convex layer (PR1) validates point values + state
+ * transitions; these actions just authorize and forward.
+ */
+
+type Result =
+  | { ok: true; state: LiveGameStateDto }
+  | { ok: false; error: string };
+
+async function authorize(
+  teamId: string,
+  fixtureId: string,
+): Promise<{ ok: true; userId: string } | { ok: false; error: string }> {
+  const enabled = await liveScoringV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const fixture = await getFixture(fixtureId);
+  if (!fixture) return { ok: false, error: "fixture_not_found" };
+  if (fixture.homeTeamId !== teamId && fixture.awayTeamId !== teamId) {
+    return { ok: false, error: "team_not_in_fixture" };
+  }
+
+  if (!(await canManageTeam(teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+  return { ok: true, userId };
+}
+
+function revalidate(teamId: string, fixtureId: string): void {
+  revalidatePath(`/dashboard/teams/${teamId}/games/${fixtureId}/live`);
+}
+
+export async function startLiveGameAction(input: {
+  teamId: string;
+  fixtureId: string;
+}): Promise<Result> {
+  const guard = await authorize(input.teamId, input.fixtureId);
+  if (!guard.ok) return guard;
+  try {
+    const state = await startLiveGame(input.fixtureId, guard.userId);
+    revalidate(input.teamId, input.fixtureId);
+    return { ok: true, state };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function addLiveScoreAction(input: {
+  teamId: string;
+  fixtureId: string;
+  team: "home" | "away";
+  points: number;
+}): Promise<Result> {
+  const guard = await authorize(input.teamId, input.fixtureId);
+  if (!guard.ok) return guard;
+  try {
+    const state = await addLiveScore(input.fixtureId, input.team, input.points);
+    revalidate(input.teamId, input.fixtureId);
+    return { ok: true, state };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function updateLiveStateAction(input: {
+  teamId: string;
+  fixtureId: string;
+  patch: { period?: number; clock?: string | null; status?: string };
+}): Promise<Result> {
+  const guard = await authorize(input.teamId, input.fixtureId);
+  if (!guard.ok) return guard;
+  try {
+    const state = await updateLiveState(input.fixtureId, input.patch);
+    revalidate(input.teamId, input.fixtureId);
+    return { ok: true, state };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function endLiveGameAction(input: {
+  teamId: string;
+  fixtureId: string;
+}): Promise<Result> {
+  const guard = await authorize(input.teamId, input.fixtureId);
+  if (!guard.ok) return guard;
+  try {
+    const state = await endLiveGame(input.fixtureId, guard.userId);
+    revalidate(input.teamId, input.fixtureId);
+    return { ok: true, state };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/games/[gameId]/live/page.tsx
@@ -1,0 +1,63 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { liveScoringV1 } from "@/lib/flags";
+import { getTeam, getFixture, getLiveGameState } from "@/lib/data-api";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgContext } from "@/lib/org-context";
+import LiveScoreboard from "@/components/live/LiveScoreboard";
+
+export default async function LiveScoreboardPage({
+  params,
+}: {
+  params: Promise<{ id: string; gameId: string }>;
+}) {
+  const enabled = await liveScoringV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: teamId, gameId } = await params;
+
+  // Owner-edits-only: must manage this team (coach/admin of its league/owner org).
+  if (!(await canManageTeam(teamId, userId))) notFound();
+
+  const orgContext = await resolveOrgContext(userId);
+  const [team, fixture] = await Promise.all([
+    getTeam(teamId, orgContext).catch(() => null),
+    getFixture(gameId),
+  ]);
+  if (!team || !fixture) notFound();
+  // The team must actually be in this game.
+  if (fixture.homeTeamId !== teamId && fixture.awayTeamId !== teamId) notFound();
+
+  const initial = await getLiveGameState(gameId);
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <Link
+        href={`/dashboard/leagues/${team.leagueId}/schedule`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Schedule
+      </Link>
+
+      <header className="mb-6">
+        <h2 className="text-2xl font-bold text-foreground">Live scoreboard</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {fixture.homeTeamName} vs {fixture.awayTeamName}
+          {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
+        </p>
+      </header>
+
+      <LiveScoreboard
+        teamId={teamId}
+        fixtureId={gameId}
+        homeTeamName={fixture.homeTeamName}
+        awayTeamName={fixture.awayTeamName}
+        initial={initial}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/live/LiveScoreboard.tsx
+++ b/apps/web/src/components/live/LiveScoreboard.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Flag, Play, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  startLiveGameAction,
+  addLiveScoreAction,
+  updateLiveStateAction,
+  endLiveGameAction,
+} from "@/app/dashboard/teams/[id]/games/[gameId]/live/actions";
+
+interface LiveState {
+  homeScore: number;
+  awayScore: number;
+  period: number;
+  clock: string | null;
+  status: string;
+}
+
+interface LiveScoreboardProps {
+  teamId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  initial: LiveState | null;
+}
+
+// Football scoring events the operator taps. Mirrors the points Convex accepts
+// (lib/liveScore: 1,2,3,6,7,8) — common values surfaced as buttons.
+const SCORE_BUTTONS: { label: string; points: number }[] = [
+  { label: "TD +6", points: 6 },
+  { label: "FG +3", points: 3 },
+  { label: "Safety +2", points: 2 },
+  { label: "XP +1", points: 1 },
+  { label: "2-pt +2", points: 2 },
+];
+
+export default function LiveScoreboard({
+  teamId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+  initial,
+}: LiveScoreboardProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [state, setState] = useState<LiveState | null>(initial);
+  const [clockDraft, setClockDraft] = useState(initial?.clock ?? "");
+
+  const isFinal = state?.status === "final";
+  const isHalftime = state?.status === "halftime";
+
+  function run(fn: () => Promise<{ ok: true; state: LiveState } | { ok: false; error: string }>, success?: string) {
+    startTransition(async () => {
+      const res = await fn();
+      if (res.ok) {
+        setState(res.state);
+        setClockDraft(res.state.clock ?? "");
+        if (success) toast.success(success);
+        router.refresh();
+      } else {
+        toast.error(errorLabel(res.error));
+      }
+    });
+  }
+
+  function start() {
+    run(() => startLiveGameAction({ teamId, fixtureId }), "Game started");
+  }
+
+  function score(team: "home" | "away", points: number) {
+    run(() => addLiveScoreAction({ teamId, fixtureId, team, points }));
+  }
+
+  function patch(p: { period?: number; clock?: string | null; status?: string }) {
+    run(() => updateLiveStateAction({ teamId, fixtureId, patch: p }));
+  }
+
+  function end() {
+    if (!window.confirm("End the game? This records the final score and can't be undone here."))
+      return;
+    run(() => endLiveGameAction({ teamId, fixtureId }), "Game ended — final recorded");
+  }
+
+  // Pre-kickoff: nothing live yet.
+  if (!state) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-4 py-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            No live game yet. Start it when the game kicks off — fans will see the
+            score update live.
+          </p>
+          <Button type="button" disabled={pending} onClick={start}>
+            <Play className="mr-1.5 h-4 w-4" />
+            {pending ? "Starting…" : "Start live game"}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Scoreboard */}
+      <Card>
+        <CardContent className="py-6">
+          <div className="flex items-center justify-around gap-4 text-center">
+            <ScoreCol name={homeTeamName} score={state.homeScore} />
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">
+              <div className="font-semibold text-foreground">
+                {statusLabel(state.status)}
+              </div>
+              <div className="mt-1">Period {state.period}</div>
+              {state.clock ? (
+                <div className="mt-1 font-mono tabular-nums">{state.clock}</div>
+              ) : null}
+            </div>
+            <ScoreCol name={awayTeamName} score={state.awayScore} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {!isFinal && (
+        <>
+          {/* Per-team scoring */}
+          <div className="grid grid-cols-2 gap-3">
+            <TeamScorePad
+              name={homeTeamName}
+              disabled={pending}
+              onScore={(pts) => score("home", pts)}
+            />
+            <TeamScorePad
+              name={awayTeamName}
+              disabled={pending}
+              onScore={(pts) => score("away", pts)}
+            />
+          </div>
+
+          {/* Game controls */}
+          <Card>
+            <CardContent className="flex flex-wrap items-center gap-2 py-4">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                onClick={() => patch({ period: state.period + 1 })}
+              >
+                Next period
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                onClick={() =>
+                  patch({ status: isHalftime ? "in_progress" : "halftime" })
+                }
+              >
+                <Flag className="mr-1 h-4 w-4" />
+                {isHalftime ? "Resume" : "Halftime"}
+              </Button>
+
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="12:00"
+                  value={clockDraft}
+                  onChange={(e) => setClockDraft(e.target.value)}
+                  className="h-9 w-20 rounded-md border border-input bg-background px-2 text-center text-sm tabular-nums outline-none focus:border-primary"
+                  aria-label="Game clock"
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={pending}
+                  onClick={() => patch({ clock: clockDraft.trim() || null })}
+                >
+                  Set clock
+                </Button>
+              </div>
+
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                disabled={pending}
+                onClick={end}
+                className="ml-auto text-destructive hover:text-destructive"
+              >
+                <Square className="mr-1 h-4 w-4" /> End game
+              </Button>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {isFinal && (
+        <p className="text-center text-sm text-muted-foreground">
+          Final score recorded. This game is closed.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ScoreCol({ name, score }: { name: string; score: number }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-sm font-medium text-muted-foreground">
+        {name}
+      </div>
+      <div className="text-5xl font-bold tabular-nums text-foreground">
+        {score}
+      </div>
+    </div>
+  );
+}
+
+function TeamScorePad({
+  name,
+  disabled,
+  onScore,
+}: {
+  name: string;
+  disabled: boolean;
+  onScore: (points: number) => void;
+}) {
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <p className="mb-2 truncate text-center text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {name}
+        </p>
+        <div className="flex flex-wrap justify-center gap-2">
+          {SCORE_BUTTONS.map((b) => (
+            <Button
+              key={b.label}
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={disabled}
+              onClick={() => onScore(b.points)}
+            >
+              {b.label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "in_progress":
+      return "Live";
+    case "halftime":
+      return "Halftime";
+    case "final":
+      return "Final";
+    default:
+      return status;
+  }
+}
+
+function errorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Live scoring isn't enabled yet.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "Only a coach or admin of this team can run the scoreboard.";
+    case "team_not_in_fixture":
+    case "fixture_not_found":
+      return "Game not found.";
+    case "invalid_points":
+      return "That isn't a valid score value.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -121,6 +121,22 @@ export const statKeepingV1 = flag<boolean>({
   },
 });
 
+export const liveScoringV1 = flag<boolean>({
+  key: "live_scoring_v1",
+  description:
+    "Keystone v3 live scoring: operator-driven running scoreboard + public live game-state (WSM-000152)",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_LIVE_SCORING_V1");
+    void trackFlagExposure("live_scoring_v1", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
## Keystone v3 live scoring — PR2: operator scoreboard UI (WSM-000152)

The dashboard screen a single operator drives during a game. PR1 (#342) shipped the data layer + `getLiveGameState`; this is the UI that calls it.

### What's here
- **`/dashboard/teams/[id]/games/[gameId]/live`** — server page: flag → auth → `canManageTeam` → team-in-fixture guard, loads `getLiveGameState`, renders the scoreboard.
- **`LiveScoreboard`** client component — Start live game; per-team score buttons (TD +6, FG +3, Safety +2, XP +1, 2-pt); Next period; Halftime/Resume toggle; optional game clock; End game (records the final via PR1's `endLiveGame`). Live score display with status/period/clock.
- **`live/actions.ts`** — `startLiveGameAction` / `addLiveScoreAction` / `updateLiveStateAction` / `endLiveGameAction`, all behind a shared `authorize()` (flag `liveScoringV1` → `auth()` → `getFixture` → cross-fixture guard → `canManageTeam`), forwarding to the PR1 data-api wrappers.
- **`live_scoring_v1`** flag (defaults ON outside production; `FLAG_LIVE_SCORING_V1` override in prod).
- **Schedule entry point** — a "Live" link per team in the league schedule row, parallel to the existing "Stats" links (admin/coach only).

### Authz
Same stance as box-score entry (WSM-000121): a coach/admin of the team drives the running scoreboard. The Convex layer validates point values and is the security boundary (all writes `internalMutation`, admin-keyed); these actions authorize and forward.

### No Convex change
The data layer (`startLiveGame`/`addLiveScore`/`updateLiveState`/`endLiveGame` + public `getLiveGameState`) shipped and deployed in PR1.

### Verification
- `tsc --noEmit` clean
- `eslint` clean
- `vitest run` — **520 passed** (+10 new live authz tests in `live/__tests__/actions.test.ts`)
- `next build` compiles the `/dashboard/teams/[id]/games/[gameId]/live` route

### Next
PR3 — public `/api/games/[fixtureId]/live-score` route + public game-page scoreboard, which unblocks #302 (live-score overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
