### PR TITLE
feat(web): keystone v3 live scoring — public live-score route + scoreboard (WSM-000152, PR3)

### DIFF
--- a/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/__tests__/route.test.ts
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockLiveScoringV1,
+  mockGetFixture,
+  mockGetLeagueVisibility,
+  mockGetPublicSeason,
+  mockGetLiveGameState,
+} = vi.hoisted(() => ({
+  mockLiveScoringV1: vi.fn(),
+  mockGetFixture: vi.fn(),
+  mockGetLeagueVisibility: vi.fn(),
+  mockGetPublicSeason: vi.fn(),
+  mockGetLiveGameState: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ liveScoringV1: mockLiveScoringV1 }));
+vi.mock("@/lib/data-api", () => ({
+  getFixture: mockGetFixture,
+  getLeagueVisibility: mockGetLeagueVisibility,
+  getPublicSeason: mockGetPublicSeason,
+  getLiveGameState: mockGetLiveGameState,
+}));
+
+import { GET } from "../route";
+
+const LEAGUE = "lg_1";
+const GAME = "fixture_1";
+
+const params = Promise.resolve({ id: LEAGUE, gameId: GAME });
+const req = new Request("https://x/leagues/lg_1/games/fixture_1/live-score");
+const call = () => GET(req, { params });
+
+const LIVE = {
+  homeScore: 14,
+  awayScore: 7,
+  period: 2,
+  clock: "03:21",
+  status: "in_progress",
+};
+
+function happy() {
+  mockLiveScoringV1.mockResolvedValue(true);
+  mockGetLeagueVisibility.mockResolvedValue({ isPublic: true });
+  mockGetFixture.mockResolvedValue({ id: GAME, seasonId: "season_1" });
+  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
+  mockGetLiveGameState.mockResolvedValue(LIVE);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  happy();
+});
+
+describe("GET /leagues/[id]/games/[gameId]/live-score", () => {
+  it("404s when the flag is off", async () => {
+    mockLiveScoringV1.mockResolvedValue(false);
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(mockGetLiveGameState).not.toHaveBeenCalled();
+  });
+
+  it("404s when the league isn't public", async () => {
+    mockGetLeagueVisibility.mockResolvedValue({ isPublic: false });
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(mockGetLiveGameState).not.toHaveBeenCalled();
+  });
+
+  it("404s when the fixture doesn't exist", async () => {
+    mockGetFixture.mockResolvedValue(null);
+    expect((await call()).status).toBe(404);
+  });
+
+  it("404s on a cross-league fixture (leak guard)", async () => {
+    mockGetPublicSeason.mockResolvedValue({
+      id: "season_1",
+      leagueId: "other_league",
+    });
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect(mockGetLiveGameState).not.toHaveBeenCalled();
+  });
+
+  it("returns the live projection for a public, in-league fixture", async () => {
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ live: LIVE });
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage=3");
+  });
+
+  it("returns { live: null } before kickoff", async () => {
+    mockGetLiveGameState.mockResolvedValue(null);
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ live: null });
+  });
+});

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/route.ts
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { liveScoringV1 } from "@/lib/flags";
+import {
+  getFixture,
+  getLeagueVisibility,
+  getPublicSeason,
+  getLiveGameState,
+} from "@/lib/data-api";
+
+/*
+ * Public live game-state poll (WSM-000152, keystone v3). The seam #302's
+ * live-score overlay consumes, and the public game page's scoreboard refreshes
+ * against.
+ *
+ * NO Clerk session — it lives under `/leagues/(.*)`, which middleware (proxy.ts)
+ * whitelists. Same defense-in-depth as the public game PAGE it sits beside:
+ *   1. `live_scoring_v1` off → 404 (the feature doesn't exist in this env).
+ *   2. league not opted-in public → 404.
+ *   3. cross-league leak guard — `getFixture` resolves ANY fixture by id with
+ *      no league check, so we 404 unless the fixture's season belongs to THIS
+ *      public league. Prevents pairing a private fixture id with a public path.
+ * Only after all three do we return the (non-sensitive) score projection.
+ *
+ * Response: `{ live: { homeScore, awayScore, period, clock, status } | null }`.
+ * `live` is null before kickoff / when no live state exists yet — the overlay
+ * polls and simply shows nothing until it appears.
+ */
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; gameId: string }> },
+) {
+  const enabled = await liveScoringV1();
+  if (!enabled) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const { id: leagueId, gameId } = await params;
+
+  const visibility = await getLeagueVisibility(leagueId);
+  if (!visibility || !visibility.isPublic) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const fixture = await getFixture(gameId);
+  if (!fixture) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  // Cross-league leak guard — the fixture must live in THIS public league.
+  const season = await getPublicSeason(fixture.seasonId);
+  if (!season || season.leagueId !== leagueId) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const live = await getLiveGameState(gameId);
+
+  // Short-lived edge cache so a crowd refreshing doesn't hammer Convex, while
+  // the score still feels live (≤5s stale). The overlay polls on its own cadence.
+  return NextResponse.json(
+    { live },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=0, s-maxage=3, stale-while-revalidate=5",
+      },
+    },
+  );
+}

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -2,18 +2,20 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { cache } from "react";
-import { schedulesStandingsV1, liveStreamingV1 } from "@/lib/flags";
+import { schedulesStandingsV1, liveStreamingV1, liveScoringV1 } from "@/lib/flags";
 import {
   getFixture,
   getPublicLeagues,
   getPublicSeason,
   getResultByFixture,
   getStreamByFixture,
+  getLiveGameState,
 } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import GameStreamPlayer from "@/components/games/GameStreamPlayer";
+import PublicLiveScore from "@/components/games/PublicLiveScore";
 
 /*
  * Public game viewer route (WSM-000143, child of the streaming epic #225).
@@ -29,9 +31,11 @@ import GameStreamPlayer from "@/components/games/GameStreamPlayer";
  *      a PRIVATE league could be viewed by pairing it with a public league's
  *      path. All three reads are ungated and safe post-guard.
  *
- * `FixtureStatus` is only "scheduled" | "final" | "cancelled" — there is no
- * live/in-progress state yet (live scoring is deferred to the stat-keeping
- * keystone v3, per docs/design/live-streaming-rfc.md), so we render those three.
+ * `FixtureStatus` is "scheduled" | "final" | "cancelled". The in-progress state
+ * lives separately in `liveGameState` (keystone v3, WSM-000152): while a game is
+ * live the `PublicLiveScore` client component polls and shows a running score
+ * above these three; on "End game" the operator writes the final to gameResults
+ * and flips the fixture to "final", so the Final card below takes over.
  */
 
 const kickoffFormat = new Intl.DateTimeFormat("en-US", {
@@ -109,6 +113,15 @@ export default async function PublicGamePage({
   // off, the stream read is skipped and the page renders exactly as before.
   const streamingEnabled = await liveStreamingV1();
   const stream = streamingEnabled ? await getStreamByFixture(gameId) : null;
+
+  // Live scoring (WSM-000152): when on, seed the running scoreboard from the
+  // server so first paint has the score; the client component then polls. Skip
+  // entirely for already-final games — the Final card below is canonical.
+  const liveEnabled = await liveScoringV1();
+  const liveState =
+    liveEnabled && view.fixture.status !== "final"
+      ? await getLiveGameState(gameId)
+      : null;
   const liveActive = stream?.status === "active";
   const hasReplay = stream?.status === "ended" && stream.vodAssetId !== null;
   const streamEndedNoReplay =
@@ -138,6 +151,16 @@ export default async function PublicGamePage({
           {fixture.homeTeamName} vs {fixture.awayTeamName}
         </h1>
       </header>
+
+      {liveEnabled && fixture.status !== "final" ? (
+        <PublicLiveScore
+          leagueId={leagueId}
+          gameId={gameId}
+          homeTeamName={fixture.homeTeamName}
+          awayTeamName={fixture.awayTeamName}
+          initial={liveState}
+        />
+      ) : null}
 
       {liveActive || hasReplay ? (
         <Card className="mb-6">

--- a/apps/web/src/components/games/PublicLiveScore.tsx
+++ b/apps/web/src/components/games/PublicLiveScore.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface LivePublic {
+  homeScore: number;
+  awayScore: number;
+  period: number;
+  clock: string | null;
+  status: string;
+}
+
+interface PublicLiveScoreProps {
+  leagueId: string;
+  gameId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  initial: LivePublic | null;
+}
+
+const POLL_MS = 5000;
+
+/*
+ * Public live scoreboard (WSM-000152). Polls the sibling `live-score` route
+ * while the game is live and renders a running score. SSR seeds `initial` so
+ * the first paint has the score with no flash; polling keeps it fresh. When the
+ * operator ends the game the status flips to "final" — we stop polling and
+ * refresh the server component so the page's canonical Final card takes over.
+ */
+export default function PublicLiveScore({
+  leagueId,
+  gameId,
+  homeTeamName,
+  awayTeamName,
+  initial,
+}: PublicLiveScoreProps) {
+  const router = useRouter();
+  const [live, setLive] = useState<LivePublic | null>(initial);
+  const refreshedOnFinal = useRef(false);
+
+  const isFinal = live?.status === "final";
+
+  useEffect(() => {
+    if (isFinal) {
+      // Let the server page's Final card (from gameResults) take over once.
+      if (!refreshedOnFinal.current) {
+        refreshedOnFinal.current = true;
+        router.refresh();
+      }
+      return;
+    }
+
+    let cancelled = false;
+    async function poll() {
+      try {
+        const res = await fetch(
+          `/leagues/${leagueId}/games/${gameId}/live-score`,
+          { cache: "no-store" },
+        );
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { live: LivePublic | null };
+        if (!cancelled) setLive(data.live);
+      } catch {
+        // Transient network error — keep the last known score, try again next tick.
+      }
+    }
+
+    const interval = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isFinal, leagueId, gameId, router]);
+
+  // Nothing live yet, or already final (handed back to the server Final card).
+  if (!live || isFinal) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="py-6">
+        <div className="mb-3 flex justify-center">
+          <Badge variant="destructive" className="gap-1.5">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-current" />
+            LIVE
+          </Badge>
+        </div>
+        <div className="flex items-center justify-around gap-4 text-center">
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm text-muted-foreground">
+              {homeTeamName}
+            </p>
+            <p className="text-5xl font-bold tabular-nums text-foreground">
+              {live.homeScore}
+            </p>
+          </div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">
+            <div className="font-semibold text-foreground">
+              {live.status === "halftime" ? "Halftime" : "Live"}
+            </div>
+            <div className="mt-1">Period {live.period}</div>
+            {live.clock ? (
+              <div className="mt-1 font-mono tabular-nums">{live.clock}</div>
+            ) : null}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm text-muted-foreground">
+              {awayTeamName}
+            </p>
+            <p className="text-5xl font-bold tabular-nums text-foreground">
+              {live.awayScore}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Keystone v3 live scoring — PR3: public route + game-page scoreboard (WSM-000152)

The public face of live scoring, and the seam that **unblocks #302** (live-score overlay). PR1 (#342) shipped the data layer; PR2 (#343) the operator UI; this is what fans see.

### What's here
- **`GET /leagues/[id]/games/[gameId]/live-score`** — returns `{ live: { homeScore, awayScore, period, clock, status } | null }`. Lives under `/leagues/(.*)`, which middleware (`proxy.ts`) already whitelists, so **no auth** and no proxy change. Same defense-in-depth as the public game page:
  1. `live_scoring_v1` off → 404
  2. league not opted-in public → 404
  3. cross-league leak guard (fixture's season must belong to this public league) → 404

  `Cache-Control: s-maxage=3, stale-while-revalidate=5` so a crowd refreshing doesn't hammer Convex while the score still feels live.
- **`PublicLiveScore`** client component — SSR-seeded running scoreboard (LIVE badge, per-team score, period/clock, Halftime). Polls the route every 5s while live; on `final` it stops and `router.refresh()`es so the page's canonical **Final** card (from `gameResults`) takes over. Only mounts when the flag is on and the fixture isn't already final — never polls when the feature is dark.
- Wired into the public game page above the stream/status cards.

### Why this route shape
The overlay (#302) and the public scoreboard both already live at `/leagues/[id]/games/[gameId]`. A sibling `live-score` route inherits that path's public whitelist *and* lets it reuse the exact cross-league guard — safer and simpler than a new top-level `/api/...` path needing a `proxy.ts` edit.

### Verification
- `tsc --noEmit` clean
- `eslint` clean
- `vitest run` — **526 passed** (+6 route guard tests covering all three 404 branches + the in-league 200 + null-before-kickoff)
- `next build` compiles `/leagues/[id]/games/[gameId]/live-score`

### Flag / rollout
`live_scoring_v1` is dark in production by default (`FLAG_LIVE_SCORING_V1` unset → OFF in prod); ON elsewhere. No Convex change in this PR (data layer deployed with PR1).

### Closes the v3 arc
With PR1–PR3 merged, #340 (keystone v3 live scoring) is complete and #302's overlay has its data seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
