### PR TITLE
feat(web): live-score overlay on the game stream (WSM-000145, #302)

### DIFF
--- a/apps/web/src/app/api/teams/[id]/games/[gameId]/maxpreps-export/route.ts
+++ b/apps/web/src/app/api/teams/[id]/games/[gameId]/maxpreps-export/route.ts
@@ -26,7 +26,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(
   _request: NextRequest,
-  { params }: { params: Promise<{ teamId: string; gameId: string }> },
+  { params }: { params: Promise<{ id: string; gameId: string }> },
 ) {
   if (!(await statKeepingV1())) {
     return NextResponse.json({ error: "flag_disabled" }, { status: 403 });
@@ -36,7 +36,7 @@ export async function GET(
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  const { teamId, gameId } = await params;
+  const { id: teamId, gameId } = await params;
   if (!(await canManageTeam(teamId, userId))) {
     return NextResponse.json({ error: "not_authorized" }, { status: 403 });
   }

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import GameStreamPlayer from "@/components/games/GameStreamPlayer";
 import PublicLiveScore from "@/components/games/PublicLiveScore";
+import LiveScoreOverlay from "@/components/games/LiveScoreOverlay";
 
 /*
  * Public game viewer route (WSM-000143, child of the streaming epic #225).
@@ -152,7 +153,10 @@ export default async function PublicGamePage({
         </h1>
       </header>
 
-      {liveEnabled && fixture.status !== "final" ? (
+      {/* Standalone scoreboard card — only when there's NO active stream. With a
+          stream, LiveScoreOverlay carries the score on the video instead (#302),
+          so we don't show it twice. */}
+      {liveEnabled && fixture.status !== "final" && !liveActive ? (
         <PublicLiveScore
           leagueId={leagueId}
           gameId={gameId}
@@ -177,11 +181,25 @@ export default async function PublicGamePage({
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <GameStreamPlayer
-              playbackId={stream!.muxPlaybackId}
-              live={liveActive}
-              title={`${fixture.homeTeamName} vs ${fixture.awayTeamName}`}
-            />
+            <div className="relative">
+              <GameStreamPlayer
+                playbackId={stream!.muxPlaybackId}
+                live={liveActive}
+                title={`${fixture.homeTeamName} vs ${fixture.awayTeamName}`}
+              />
+              {/* Live-score overlay (#302) — only over a live stream, and only
+                  when live scoring is on. Self-degrades to nothing if the fixture
+                  has no live game-state. */}
+              {liveActive && liveEnabled ? (
+                <LiveScoreOverlay
+                  leagueId={leagueId}
+                  gameId={gameId}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                  initial={liveState}
+                />
+              ) : null}
+            </div>
           </CardContent>
         </Card>
       ) : streamEndedNoReplay ? (

--- a/apps/web/src/components/games/LiveScoreOverlay.tsx
+++ b/apps/web/src/components/games/LiveScoreOverlay.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useLiveScore, type LiveScorePublic } from "@/lib/use-live-score";
+import {
+  isLiveVisible,
+  overlayPeriodLabel,
+  abbreviateTeam,
+} from "@/lib/live-score-view";
+
+interface LiveScoreOverlayProps {
+  leagueId: string;
+  gameId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  initial: LiveScorePublic | null;
+}
+
+/*
+ * Live-score overlay on the game stream (WSM-000145, child of streaming epic
+ * #225) — the "video + score in one screen" GameChanger hook. A DOM overlay
+ * layered over the Mux player (cheaper than server-side burn-in), fed the public
+ * live game-state via useLiveScore (polls the public route, pauses on hidden
+ * tabs). It is purely presentational:
+ *   - `pointer-events-none` so it never traps focus or covers the player controls
+ *   - `aria-live="polite"` so screen readers hear score/period changes
+ *   - renders NOTHING when there's no live state (degrade-cleanly AC) or final
+ *
+ * Mount it inside a `relative` wrapper around <GameStreamPlayer>, only while the
+ * stream is active. Short team abbreviations keep the chip unobtrusive.
+ */
+export default function LiveScoreOverlay({
+  leagueId,
+  gameId,
+  homeTeamName,
+  awayTeamName,
+  initial,
+}: LiveScoreOverlayProps) {
+  const live = useLiveScore(leagueId, gameId, initial);
+
+  // Degrade cleanly: no live state (or final) → no overlay, just video.
+  if (!isLiveVisible(live) || !live) return null;
+
+  const periodLabel = overlayPeriodLabel(live);
+
+  return (
+    <div
+      className="pointer-events-none absolute left-3 top-3 z-10"
+      aria-live="polite"
+      aria-label={`Live score: ${homeTeamName} ${live.homeScore}, ${awayTeamName} ${live.awayScore}, ${periodLabel}`}
+    >
+      <div className="flex items-stretch overflow-hidden rounded-md bg-black/75 text-xs font-medium text-white shadow-lg backdrop-blur-sm">
+        <div className="flex items-center gap-1.5 px-2.5 py-1.5">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-red-500" />
+          <span className="tabular-nums">
+            <span className="text-white/70">{abbreviateTeam(homeTeamName)}</span>{" "}
+            <span className="font-bold">{live.homeScore}</span>
+          </span>
+          <span className="text-white/40">·</span>
+          <span className="tabular-nums">
+            <span className="text-white/70">{abbreviateTeam(awayTeamName)}</span>{" "}
+            <span className="font-bold">{live.awayScore}</span>
+          </span>
+        </div>
+        <div className="flex items-center bg-white/10 px-2.5 py-1.5 font-mono uppercase tracking-wide tabular-nums">
+          {periodLabel}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/games/PublicLiveScore.tsx
+++ b/apps/web/src/components/games/PublicLiveScore.tsx
@@ -1,34 +1,23 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-
-interface LivePublic {
-  homeScore: number;
-  awayScore: number;
-  period: number;
-  clock: string | null;
-  status: string;
-}
+import { useLiveScore, type LiveScorePublic } from "@/lib/use-live-score";
+import { isLiveVisible, cardStatusLabel } from "@/lib/live-score-view";
 
 interface PublicLiveScoreProps {
   leagueId: string;
   gameId: string;
   homeTeamName: string;
   awayTeamName: string;
-  initial: LivePublic | null;
+  initial: LiveScorePublic | null;
 }
 
-const POLL_MS = 5000;
-
 /*
- * Public live scoreboard (WSM-000152). Polls the sibling `live-score` route
- * while the game is live and renders a running score. SSR seeds `initial` so
- * the first paint has the score with no flash; polling keeps it fresh. When the
- * operator ends the game the status flips to "final" — we stop polling and
- * refresh the server component so the page's canonical Final card takes over.
+ * Public live scoreboard CARD (WSM-000152) — shown on the public game page for a
+ * live game that has NO video stream. When a stream is active the on-video
+ * overlay (LiveScoreOverlay, WSM-000145) carries the score instead and the page
+ * suppresses this card. Polling/visibility/final-handoff live in useLiveScore.
  */
 export default function PublicLiveScore({
   leagueId,
@@ -37,46 +26,10 @@ export default function PublicLiveScore({
   awayTeamName,
   initial,
 }: PublicLiveScoreProps) {
-  const router = useRouter();
-  const [live, setLive] = useState<LivePublic | null>(initial);
-  const refreshedOnFinal = useRef(false);
-
-  const isFinal = live?.status === "final";
-
-  useEffect(() => {
-    if (isFinal) {
-      // Let the server page's Final card (from gameResults) take over once.
-      if (!refreshedOnFinal.current) {
-        refreshedOnFinal.current = true;
-        router.refresh();
-      }
-      return;
-    }
-
-    let cancelled = false;
-    async function poll() {
-      try {
-        const res = await fetch(
-          `/leagues/${leagueId}/games/${gameId}/live-score`,
-          { cache: "no-store" },
-        );
-        if (!res.ok || cancelled) return;
-        const data = (await res.json()) as { live: LivePublic | null };
-        if (!cancelled) setLive(data.live);
-      } catch {
-        // Transient network error — keep the last known score, try again next tick.
-      }
-    }
-
-    const interval = setInterval(poll, POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [isFinal, leagueId, gameId, router]);
+  const live = useLiveScore(leagueId, gameId, initial);
 
   // Nothing live yet, or already final (handed back to the server Final card).
-  if (!live || isFinal) return null;
+  if (!isLiveVisible(live) || !live) return null;
 
   return (
     <Card className="mb-6">
@@ -98,7 +51,7 @@ export default function PublicLiveScore({
           </div>
           <div className="text-xs uppercase tracking-wider text-muted-foreground">
             <div className="font-semibold text-foreground">
-              {live.status === "halftime" ? "Halftime" : "Live"}
+              {cardStatusLabel(live)}
             </div>
             <div className="mt-1">Period {live.period}</div>
             {live.clock ? (

--- a/apps/web/src/lib/__tests__/live-score-view.test.ts
+++ b/apps/web/src/lib/__tests__/live-score-view.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLiveVisible,
+  overlayPeriodLabel,
+  cardStatusLabel,
+  abbreviateTeam,
+} from "../live-score-view";
+import type { LiveScorePublic } from "../use-live-score";
+
+const base: LiveScorePublic = {
+  homeScore: 14,
+  awayScore: 7,
+  period: 2,
+  clock: "03:21",
+  status: "in_progress",
+};
+
+describe("isLiveVisible", () => {
+  it("shows for live/halftime, hides for null and final", () => {
+    expect(isLiveVisible(base)).toBe(true);
+    expect(isLiveVisible({ ...base, status: "halftime" })).toBe(true);
+    expect(isLiveVisible(null)).toBe(false);
+    expect(isLiveVisible({ ...base, status: "final" })).toBe(false);
+  });
+});
+
+describe("overlayPeriodLabel", () => {
+  it("renders quarter + clock when running", () => {
+    expect(overlayPeriodLabel(base)).toBe("Q2 03:21");
+  });
+
+  it("drops the clock when there isn't one", () => {
+    expect(overlayPeriodLabel({ ...base, clock: null })).toBe("Q2");
+  });
+
+  it("shows Half at halftime regardless of clock", () => {
+    expect(overlayPeriodLabel({ ...base, status: "halftime" })).toBe("Half");
+  });
+});
+
+describe("cardStatusLabel", () => {
+  it("maps halftime, else Live", () => {
+    expect(cardStatusLabel(base)).toBe("Live");
+    expect(cardStatusLabel({ ...base, status: "halftime" })).toBe("Halftime");
+  });
+});
+
+describe("abbreviateTeam", () => {
+  it("takes the first three letters, upper-cased, trimmed", () => {
+    expect(abbreviateTeam("Cobb County Hawks")).toBe("COB");
+    expect(abbreviateTeam("  raiders")).toBe("RAI");
+    expect(abbreviateTeam("KC")).toBe("KC");
+  });
+});

--- a/apps/web/src/lib/live-score-view.ts
+++ b/apps/web/src/lib/live-score-view.ts
@@ -1,0 +1,33 @@
+/*
+ * Pure presentational helpers for the public live score (WSM-000152 / overlay
+ * WSM-000145). Kept out of the client components so the branchy display logic is
+ * unit-testable in the repo's node test env (no DOM), like lib/liveScore and
+ * lib/standings. The components stay thin: poll via useLiveScore, then render.
+ */
+
+import type { LiveScorePublic } from "./use-live-score";
+
+/**
+ * Should the live UI (card or overlay) show anything? No state yet, or the game
+ * is final (handed back to the page's canonical Final card) → render nothing.
+ */
+export function isLiveVisible(live: LiveScorePublic | null): boolean {
+  return live !== null && live.status !== "final";
+}
+
+/** Compact period/clock tag for the on-video overlay: "Q2 03:21", "Q3", "Half". */
+export function overlayPeriodLabel(live: LiveScorePublic): string {
+  if (live.status === "halftime") return "Half";
+  if (live.clock) return `Q${live.period} ${live.clock}`;
+  return `Q${live.period}`;
+}
+
+/** Status word for the standalone scoreboard card. */
+export function cardStatusLabel(live: LiveScorePublic): string {
+  return live.status === "halftime" ? "Halftime" : "Live";
+}
+
+/** First 3 letters, upper-cased — a compact, recognizable team tag for the chip. */
+export function abbreviateTeam(name: string): string {
+  return name.trim().slice(0, 3).toUpperCase();
+}

--- a/apps/web/src/lib/use-live-score.ts
+++ b/apps/web/src/lib/use-live-score.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+/*
+ * Client polling for public live game-state (WSM-000152 / overlay WSM-000145).
+ *
+ * There is no browser Convex client in this app (Convex is admin-keyed,
+ * server-side only), so live state can't use a reactive useQuery — it polls the
+ * public route `/leagues/[id]/games/[gameId]/live-score` instead. Shared by the
+ * standalone scoreboard card and the on-video overlay so the fetch/visibility/
+ * final-handoff logic lives in one place.
+ *
+ * Guardrails: polls only while the tab is VISIBLE (pauses on a hidden tab to
+ * bound request volume), and stops once the game is "final" — handing off to the
+ * server page's canonical Final card via a one-time router.refresh().
+ */
+
+export interface LiveScorePublic {
+  homeScore: number;
+  awayScore: number;
+  period: number;
+  clock: string | null;
+  status: string;
+}
+
+export function useLiveScore(
+  leagueId: string,
+  gameId: string,
+  initial: LiveScorePublic | null,
+  intervalMs = 5000,
+): LiveScorePublic | null {
+  const router = useRouter();
+  const [live, setLive] = useState<LiveScorePublic | null>(initial);
+  const refreshedOnFinal = useRef(false);
+
+  const isFinal = live?.status === "final";
+
+  useEffect(() => {
+    if (isFinal) {
+      // Let the server page's Final card (from gameResults) take over once.
+      if (!refreshedOnFinal.current) {
+        refreshedOnFinal.current = true;
+        router.refresh();
+      }
+      return;
+    }
+
+    let cancelled = false;
+    async function poll() {
+      // Pause while the tab is hidden — no point fetching a score nobody sees.
+      if (document.visibilityState !== "visible") return;
+      try {
+        const res = await fetch(
+          `/leagues/${leagueId}/games/${gameId}/live-score`,
+          { cache: "no-store" },
+        );
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { live: LiveScorePublic | null };
+        if (!cancelled) setLive(data.live);
+      } catch {
+        // Transient network error — keep the last known score, retry next tick.
+      }
+    }
+
+    const interval = setInterval(poll, intervalMs);
+    // Refresh immediately when the fan returns to the tab (don't wait a full tick).
+    function onVisibility() {
+      if (document.visibilityState === "visible") void poll();
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [isFinal, leagueId, gameId, intervalMs, router]);
+
+  return live;
+}


### PR DESCRIPTION
## Live-score overlay on the game stream (WSM-000145) — Closes #302

The "video + score in one screen" GameChanger hook, and the last piece of the streaming epic's Phase 2. With keystone v3 (#340) shipping the running game-state and its public route, this lays the score over the video.

### What's here
- **`LiveScoreOverlay`** (`src/components/games/`) — a compact LIVE chip (team abbrev + score + `Q2 03:21` / `Half`) absolutely positioned over the Mux player. `pointer-events-none` so it never traps focus or covers the player controls; `aria-live="polite"` with a full-sentence `aria-label` so screen readers hear score/period changes. Renders **nothing** when there's no live state or the game is final — the degrade-cleanly AC.
- **`useLiveScore`** hook — shared, **visibility-aware** polling of the existing public route `GET /leagues/[id]/games/[gameId]/live-score`. Polls every 5s only while the tab is visible (pauses on a hidden tab to bound request volume; re-polls immediately on return), and stops once `status` flips to `final`, handing off to the page's canonical Final card via a one-time `router.refresh()`. The PR3 standalone `PublicLiveScore` card now uses this hook too (gains visibility-pause, removes duplication).
- **`live-score-view`** — pure display helpers (`isLiveVisible`, `overlayPeriodLabel`, `cardStatusLabel`, `abbreviateTeam`), unit-tested in node (the repo has no DOM test env, so the branchy display logic is extracted and tested directly — same approach as `lib/liveScore`/`lib/standings`).
- **Page wiring** — wrap `GameStreamPlayer` in a `relative` container and mount the overlay only while the stream is **active** AND live scoring is on. Suppress the standalone scoreboard card when a stream is active so the score isn't shown twice (overlay carries it on the video).

### Decisions (from the issue's open questions)
- **Polling, not SSE** — there's no browser Convex client (admin-keyed, server-side only), so no reactive `useQuery`. Polling the public route is the established client-data pattern; revisit SSE only if 5s feels coarse.
- **Reused the existing route** — #302 tentatively proposed `GET /api/games/[fixtureId]/live-score`; PR3 already shipped `GET /leagues/[id]/games/[gameId]/live-score`, which inherits the public-league middleware whitelist + cross-league leak guard. No second route.
- **No new flag** — the overlay rides `live_streaming_v1` (dark) + `live_scoring_v1` and self-degrades. It only appears when streaming is enabled, a stream is live, and the fixture has live state.

### Cost/perf guardrails (per issue §F)
Polls only while active + tab visible; the route has a short `s-maxage` so concurrent fans collapse onto one upstream read; zero Mux cost impact (pure app state over the existing HLS player).

### Verification
- `tsc --noEmit` clean
- `eslint` clean
- `vitest run` — **532 passed** (+6 view-helper tests). The route's guard/projection path is covered by PR3's 6 tests.
- `next build` compiles the public game route.
- **e2e deferred** (Playwright gated on #305) — needs a Mux test stream + live state, per the issue's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
