### PR TITLE
fix(web): resolve api/teams dynamic-slug route conflict

### DIFF
--- a/apps/web/src/app/api/teams/[id]/games/[gameId]/maxpreps-export/route.ts
+++ b/apps/web/src/app/api/teams/[id]/games/[gameId]/maxpreps-export/route.ts
@@ -26,7 +26,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(
   _request: NextRequest,
-  { params }: { params: Promise<{ teamId: string; gameId: string }> },
+  { params }: { params: Promise<{ id: string; gameId: string }> },
 ) {
   if (!(await statKeepingV1())) {
     return NextResponse.json({ error: "flag_disabled" }, { status: 403 });
@@ -36,7 +36,7 @@ export async function GET(
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  const { teamId, gameId } = await params;
+  const { id: teamId, gameId } = await params;
   if (!(await canManageTeam(teamId, userId))) {
     return NextResponse.json({ error: "not_authorized" }, { status: 403 });
   }


### PR DESCRIPTION
## Problem

`next dev` / `next build` failed to boot:

```
Error: You cannot use different slug names for the same dynamic path ('id' !== 'teamId').
```

`api/teams/` mixed two dynamic-segment names: the established team resource uses **`[id]`** (`route.ts`, `claim/`, `unclaim/`), but the MaxPreps export route (WSM-000112) introduced a sibling **`[teamId]`**, which Next.js disallows.

## Fix

Move the offending route and align the param name:

```
api/teams/[teamId]/games/[gameId]/maxpreps-export/route.ts
→ api/teams/[id]/games/[gameId]/maxpreps-export/route.ts
```

Read it as `{ id: teamId }` — matching the existing `[id]/claim/route.ts` convention. Handler body is otherwise byte-identical.

**No caller changes:** the folder slug name doesn't change the URL (`/api/teams/:id/games/:gameId/maxpreps-export`); the only caller (`stats/page.tsx`) already builds that path.

## Verification

- ✅ `next dev` boots clean (no slug error)
- ✅ route registered at the new path (500 from the auth/flag layer in a bare local env, not 404)
- ✅ `type-check` + `lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)