### PR TITLE
feat(web): season schedule generation — single round-robin (WSM-000153)

### DIFF
--- a/apps/web/convex/__tests__/roundRobin.test.ts
+++ b/apps/web/convex/__tests__/roundRobin.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  roundRobinSchedule,
+  type RoundRobinPairing,
+} from "../lib/roundRobin";
+
+/** Unordered key for a pairing so home/away swaps compare equal. */
+function matchupKey(p: RoundRobinPairing): string {
+  return [p.homeTeamId, p.awayTeamId].sort().join("|");
+}
+
+function ids(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `t${i + 1}`);
+}
+
+describe("roundRobinSchedule (WSM-000153)", () => {
+  it("rejects fewer than two teams", () => {
+    expect(() => roundRobinSchedule([])).toThrow("need_at_least_two_teams");
+    expect(() => roundRobinSchedule(["t1"])).toThrow("need_at_least_two_teams");
+  });
+
+  it("rejects duplicate team ids", () => {
+    expect(() => roundRobinSchedule(["t1", "t1"])).toThrow("duplicate_team_ids");
+  });
+
+  it("schedules two teams as a single week, one game", () => {
+    const p = roundRobinSchedule(ids(2));
+    expect(p).toHaveLength(1);
+    expect(p[0].week).toBe(1);
+    expect(matchupKey(p[0])).toBe("t1|t2");
+  });
+
+  it.each([2, 3, 4, 5, 6, 8, 10])(
+    "with %i teams: every pair meets exactly once (C(n,2) games)",
+    (n) => {
+      const pairings = roundRobinSchedule(ids(n));
+      const expectedGames = (n * (n - 1)) / 2;
+      expect(pairings).toHaveLength(expectedGames);
+
+      const keys = pairings.map(matchupKey);
+      // No duplicate matchups.
+      expect(new Set(keys).size).toBe(expectedGames);
+      // Every possible pair is present.
+      const teams = ids(n);
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          expect(keys).toContain([teams[i], teams[j]].sort().join("|"));
+        }
+      }
+    },
+  );
+
+  it.each([
+    [4, 3],
+    [6, 5],
+    [8, 7],
+  ])("even count (%i teams) spans n-1 weeks", (n, weeks) => {
+    const pairings = roundRobinSchedule(ids(n));
+    const maxWeek = Math.max(...pairings.map((p) => p.week));
+    expect(maxWeek).toBe(weeks);
+  });
+
+  it.each([
+    [3, 3],
+    [5, 5],
+    [7, 7],
+  ])("odd count (%i teams) spans n weeks with one team resting each", (n, weeks) => {
+    const pairings = roundRobinSchedule(ids(n));
+    const maxWeek = Math.max(...pairings.map((p) => p.week));
+    expect(maxWeek).toBe(weeks);
+  });
+
+  it("never schedules a team twice in the same week", () => {
+    const pairings = roundRobinSchedule(ids(6));
+    const byWeek = new Map<number, string[]>();
+    for (const p of pairings) {
+      const arr = byWeek.get(p.week) ?? [];
+      arr.push(p.homeTeamId, p.awayTeamId);
+      byWeek.set(p.week, arr);
+    }
+    for (const teams of byWeek.values()) {
+      expect(new Set(teams).size).toBe(teams.length);
+    }
+  });
+
+  it("never pairs a team against itself", () => {
+    for (const p of roundRobinSchedule(ids(7))) {
+      expect(p.homeTeamId).not.toBe(p.awayTeamId);
+    }
+  });
+
+  it.each([
+    [4, 1],
+    [6, 1],
+    [8, 1],
+    [10, 1],
+    [5, 2],
+    [7, 2],
+    [9, 2],
+  ])(
+    "balances home/away load for %i teams (max diff %i)",
+    (n, maxDiff) => {
+      const homeCount = new Map<string, number>();
+      const awayCount = new Map<string, number>();
+      for (const p of roundRobinSchedule(ids(n))) {
+        homeCount.set(p.homeTeamId, (homeCount.get(p.homeTeamId) ?? 0) + 1);
+        awayCount.set(p.awayTeamId, (awayCount.get(p.awayTeamId) ?? 0) + 1);
+      }
+      // Even counts alternate perfectly (diff <= 1); odd counts carry a bye
+      // each week that unavoidably pushes the worst team to diff <= 2.
+      for (const team of ids(n)) {
+        const home = homeCount.get(team) ?? 0;
+        const away = awayCount.get(team) ?? 0;
+        expect(Math.abs(home - away)).toBeLessThanOrEqual(maxDiff);
+      }
+    },
+  );
+});

--- a/apps/web/convex/__tests__/scheduleGeneration.test.ts
+++ b/apps/web/convex/__tests__/scheduleGeneration.test.ts
@@ -1,0 +1,196 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/** Seed a league + season with `teamCount` teams; return the ids. */
+async function seedLeague(
+  t: ReturnType<typeof convexTest>,
+  teamCount: number,
+) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Schedule League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "Div 1",
+      leagueId,
+    });
+    const teamIds: Id<"teams">[] = [];
+    for (let i = 0; i < teamCount; i++) {
+      teamIds.push(
+        await ctx.db.insert("teams", {
+          name: `Team ${i}`,
+          leagueId,
+          divisionId,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Loc",
+          logoUrl: null,
+          rosterLimit: 53,
+        }),
+      );
+    }
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    return { leagueId, seasonId, teamIds };
+  });
+}
+
+function countFixtures(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) =>
+    (await ctx.db.query("fixtures").collect()).length,
+  );
+}
+
+describe("generateSeasonSchedule (WSM-000153)", () => {
+  it("creates C(n,2) scheduled fixtures with week numbers and null dates", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 6);
+
+    const res = await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+
+    expect(res.teamCount).toBe(6);
+    expect(res.created).toBe(15); // C(6,2)
+    expect(res.weeks).toBe(5); // n-1
+
+    const fixtures = await t.run((ctx) =>
+      ctx.db.query("fixtures").collect(),
+    );
+    expect(fixtures).toHaveLength(15);
+    for (const f of fixtures) {
+      expect(f.status).toBe("scheduled");
+      expect(f.scheduledAt).toBeNull();
+      expect(f.venue).toBeNull();
+      expect(f.week).toBeGreaterThanOrEqual(1);
+      expect(f.createdBy).toBe("user_1");
+    }
+  });
+
+  it("throws when the league has fewer than two teams", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 1);
+    await expect(
+      t.mutation(internal.sports.generateSeasonSchedule, {
+        seasonId,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("need_at_least_two_teams");
+  });
+
+  it("regenerates freely while all fixtures are unplayed", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+    expect(await countFixtures(t)).toBe(6);
+
+    // Second run replaces rather than appends.
+    const res = await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+    expect(res.created).toBe(6);
+    expect(await countFixtures(t)).toBe(6);
+  });
+
+  it("blocks regeneration once a fixture has a recorded result", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+
+    // Record a result on the first fixture.
+    await t.run(async (ctx) => {
+      const first = await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .first();
+      await ctx.db.insert("gameResults", {
+        fixtureId: first!._id,
+        homeScore: 14,
+        awayScore: 7,
+        playerStatsJson: null,
+        recordedAt: "2026-01-01",
+        recordedBy: "user_1",
+      });
+    });
+
+    await expect(
+      t.mutation(internal.sports.generateSeasonSchedule, {
+        seasonId,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("schedule_has_results");
+
+    // Confirm overrides the guard and wipes the result with the old slate.
+    const res = await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+      confirm: true,
+    });
+    expect(res.created).toBe(6);
+    const results = await t.run((ctx) =>
+      ctx.db.query("gameResults").collect(),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("blocks regeneration when a fixture has live game state", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+
+    await t.run(async (ctx) => {
+      const first = await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .first();
+      await ctx.db.insert("liveGameState", {
+        fixtureId: first!._id,
+        homeScore: 0,
+        awayScore: 0,
+        period: 1,
+        clock: "12:00",
+        status: "in_progress",
+        startedBy: "user_1",
+        startedAt: "2026-01-01",
+        updatedAt: "2026-01-01",
+      });
+    });
+
+    await expect(
+      t.mutation(internal.sports.generateSeasonSchedule, {
+        seasonId,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("schedule_has_results");
+  });
+});

--- a/apps/web/convex/lib/roundRobin.ts
+++ b/apps/web/convex/lib/roundRobin.ts
@@ -1,0 +1,80 @@
+/*
+ * WSM-000153 — Single round-robin schedule generation.
+ *
+ * Pure function isolated from Convex `db` calls so it can be unit-tested
+ * directly. `generateSeasonSchedule` in `sports.ts` loads the league's teams
+ * and delegates the pairing math here, then inserts the resulting fixtures.
+ *
+ * Algorithm: the "circle" (polygon) method. Fix the first team and rotate the
+ * rest around it; each rotation is one week and yields N/2 pairings. For an
+ * odd team count we add a sentinel BYE — whichever team is paired with it
+ * simply has no fixture that week (no bye row is stored). Home/away alternates
+ * by round so the home-game load stays balanced.
+ */
+
+/** A single generated pairing. `week` is 1-based. */
+export interface RoundRobinPairing {
+  week: number;
+  homeTeamId: string;
+  awayTeamId: string;
+}
+
+const BYE = "__BYE__";
+
+/**
+ * Build a single round-robin: every team plays every other team exactly once.
+ *
+ * @param teamIds distinct team ids (order is preserved as seeded)
+ * @returns pairings across weeks 1..(N-1 for even N, N for odd N)
+ * @throws if fewer than two teams, or ids are not distinct
+ */
+export function roundRobinSchedule(teamIds: string[]): RoundRobinPairing[] {
+  if (teamIds.length < 2) {
+    throw new Error("need_at_least_two_teams");
+  }
+  if (new Set(teamIds).size !== teamIds.length) {
+    throw new Error("duplicate_team_ids");
+  }
+
+  // Pad to an even count with a single BYE sentinel for odd team counts.
+  const teams = [...teamIds];
+  if (teams.length % 2 !== 0) {
+    teams.push(BYE);
+  }
+
+  const n = teams.length;
+  const rounds = n - 1; // weeks needed
+  const half = n / 2;
+
+  // `rotating` holds every team except the fixed pivot (teams[0]).
+  const pivot = teams[0];
+  let rotating = teams.slice(1);
+
+  const pairings: RoundRobinPairing[] = [];
+
+  for (let round = 0; round < rounds; round++) {
+    const week = round + 1;
+    const column = [pivot, ...rotating];
+
+    for (let i = 0; i < half; i++) {
+      const a = column[i];
+      const b = column[n - 1 - i];
+      if (a === BYE || b === BYE) continue; // resting team — no fixture
+
+      // Balance home/away. The pivot sits in slot 0 every round, so its side
+      // must alternate by round to stay even. Every other team rotates through
+      // the remaining slots, so fixing their home side by slot-index parity
+      // spreads home games evenly: each team ends within one home game of n/2
+      // (within two for odd counts, where the bye unavoidably breaks the
+      // alternation).
+      const aIsHome = i === 0 ? round % 2 === 0 : i % 2 === 0;
+      const [homeTeamId, awayTeamId] = aIsHome ? [a, b] : [b, a];
+      pairings.push({ week, homeTeamId, awayTeamId });
+    }
+
+    // Rotate clockwise: last element moves to the front of the rotating ring.
+    rotating = [rotating[rotating.length - 1], ...rotating.slice(0, -1)];
+  }
+
+  return pairings;
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -16,6 +16,7 @@ import {
   type HsRatingInput,
 } from "./lib/hsSprt";
 import { applyScore, isLiveStatus, isNonNegInt } from "./lib/liveScore";
+import { roundRobinSchedule } from "./lib/roundRobin";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -3665,6 +3666,97 @@ export const listFixturesBySeason = queryGeneric({
         };
       }),
     );
+  },
+});
+
+/*
+ * WSM-000153 — Generate a single round-robin schedule for a season.
+ *
+ * Pulls every team in the season's league and creates one fixture per pairing
+ * (week numbers only; scheduledAt/venue left null for the admin to fill in).
+ *
+ * Regeneration guard: if fixtures already exist and any of them carry a
+ * recorded result or live game state, the mutation throws `schedule_has_results`
+ * unless the caller passes `confirm: true`. Otherwise existing fixtures are
+ * cleared (cascading gameResults + liveGameState, mirroring deleteFixture) and
+ * replaced. This keeps a re-run safe while the slate is unplayed but refuses to
+ * silently orphan recorded scores.
+ */
+export const generateSeasonSchedule = internalMutationGeneric({
+  args: {
+    seasonId: v.id("seasons"),
+    actorUserId: v.string(),
+    confirm: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    created: v.number(),
+    weeks: v.number(),
+    teamCount: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .collect();
+    if (teams.length < 2) throw new Error("need_at_least_two_teams");
+
+    const existing = await ctx.db
+      .query("fixtures")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    // Results-guard: refuse to wipe a played/in-progress slate unless confirmed.
+    if (existing.length > 0 && !args.confirm) {
+      for (const f of existing) {
+        const result = await ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+          .first();
+        if (result) throw new Error("schedule_has_results");
+        const live = await ctx.db
+          .query("liveGameState")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+          .first();
+        if (live) throw new Error("schedule_has_results");
+      }
+    }
+
+    // Clear existing fixtures, cascading their results + live state.
+    for (const f of existing) {
+      for (const gr of await ctx.db
+        .query("gameResults")
+        .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+        .collect())
+        await ctx.db.delete(gr._id);
+      for (const lg of await ctx.db
+        .query("liveGameState")
+        .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+        .collect())
+        await ctx.db.delete(lg._id);
+      await ctx.db.delete(f._id);
+    }
+
+    const pairings = roundRobinSchedule(teams.map((t) => t._id));
+    const createdAt = new Date().toISOString();
+    for (const p of pairings) {
+      await ctx.db.insert("fixtures", {
+        seasonId: args.seasonId,
+        homeTeamId: p.homeTeamId as Id<"teams">,
+        awayTeamId: p.awayTeamId as Id<"teams">,
+        scheduledAt: null,
+        week: p.week,
+        venue: null,
+        status: "scheduled",
+        createdAt,
+        createdBy: args.actorUserId,
+      });
+    }
+
+    const weeks = pairings.reduce((max, p) => Math.max(max, p.week), 0);
+    return { created: pairings.length, weeks, teamCount: teams.length };
   },
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockSchedulesStandingsV1,
+  mockAuth,
+  mockGetLeague,
+  mockGetLeagueOrgId,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockCanManageRoster,
+  mockGenerateSeasonSchedule,
+} = vi.hoisted(() => ({
+  mockSchedulesStandingsV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetLeague: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockCanManageRoster: vi.fn(),
+  mockGenerateSeasonSchedule: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({
+  schedulesStandingsV1: mockSchedulesStandingsV1,
+}));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  generateSeasonSchedule: mockGenerateSeasonSchedule,
+  getLeague: mockGetLeague,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  // Unused by this action but imported by the module under test.
+  createFixture: vi.fn(),
+  deleteFixture: vi.fn(),
+  recordGameResult: vi.fn(),
+}));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/permissions", () => ({
+  canManageRoster: mockCanManageRoster,
+}));
+vi.mock("@/lib/analytics", () => ({
+  trackFixtureCreated: vi.fn(),
+  trackResultRecorded: vi.fn(),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { generateScheduleAction } from "../actions";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+
+/** Put every gate in the "manager allowed" state. */
+function authorize() {
+  mockSchedulesStandingsV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
+  mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue("org:admin");
+  mockCanManageRoster.mockReturnValue(true);
+}
+
+describe("generateScheduleAction (WSM-000153)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("generates a schedule for an authorized manager", async () => {
+    authorize();
+    mockGenerateSeasonSchedule.mockResolvedValue({
+      created: 15,
+      weeks: 5,
+      teamCount: 6,
+    });
+
+    const res = await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: true, created: 15, weeks: 5, teamCount: 6 });
+    expect(mockGenerateSeasonSchedule).toHaveBeenCalledWith({
+      seasonId: SEASON,
+      actorUserId: "user_1",
+      confirm: undefined,
+    });
+  });
+
+  it("returns needsConfirm when the slate has recorded results", async () => {
+    authorize();
+    mockGenerateSeasonSchedule.mockRejectedValue(
+      new Error("Uncaught Error: schedule_has_results"),
+    );
+
+    const res = await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, needsConfirm: true });
+  });
+
+  it("passes confirm through to the mutation", async () => {
+    authorize();
+    mockGenerateSeasonSchedule.mockResolvedValue({
+      created: 6,
+      weeks: 3,
+      teamCount: 4,
+    });
+
+    await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      confirm: true,
+    });
+
+    expect(mockGenerateSeasonSchedule).toHaveBeenCalledWith({
+      seasonId: SEASON,
+      actorUserId: "user_1",
+      confirm: true,
+    });
+  });
+
+  it("rejects a caller who cannot manage rosters", async () => {
+    authorize();
+    mockCanManageRoster.mockReturnValue(false);
+
+    const res = await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockGenerateSeasonSchedule).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the schedules flag is off", async () => {
+    authorize();
+    mockSchedulesStandingsV1.mockResolvedValue(false);
+
+    const res = await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockGenerateSeasonSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -6,6 +6,7 @@ import { schedulesStandingsV1 } from "@/lib/flags";
 import {
   createFixture,
   deleteFixture,
+  generateSeasonSchedule,
   getLeague,
   getLeagueOrgId,
   recordGameResult,
@@ -89,6 +90,45 @@ export async function createFixtureAction(
     return { ok: true, id: fixture.id };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/*
+ * Generate a single round-robin schedule for the league's active season
+ * (WSM-000153). The mutation refuses to overwrite a slate that already has
+ * recorded results / live state; that surfaces here as `needsConfirm` so the
+ * UI can re-call with `confirm: true`.
+ */
+export async function generateScheduleAction(input: {
+  leagueId: string;
+  seasonId: string;
+  confirm?: boolean;
+}): Promise<
+  | { ok: true; created: number; weeks: number; teamCount: number }
+  | { ok: false; needsConfirm: true }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  try {
+    const res = await generateSeasonSchedule({
+      seasonId: input.seasonId,
+      actorUserId: userId,
+      confirm: input.confirm,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    return { ok: true, ...res };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("schedule_has_results")) {
+      return { ok: false, needsConfirm: true };
+    }
     return { ok: false, error: message };
   }
 }

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -21,6 +21,7 @@ import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
+import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
@@ -131,6 +132,14 @@ export default async function LeagueSchedulePage({
           >
             Standings &rarr;
           </Link>
+          {isAdmin && activeSeason && teams.length >= 2 ? (
+            <GenerateScheduleButton
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+              seasonName={activeSeason.name}
+              hasFixtures={fixtures.length > 0}
+            />
+          ) : null}
           {isAdmin && activeSeason ? (
             <FixtureFormDialog
               leagueId={leagueId}

--- a/apps/web/src/components/schedule/GenerateScheduleButton.tsx
+++ b/apps/web/src/components/schedule/GenerateScheduleButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { CalendarPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { generateScheduleAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+
+export interface GenerateScheduleButtonProps {
+  leagueId: string;
+  seasonId: string;
+  seasonName: string;
+  /** Whether the season already has fixtures (changes the button label). */
+  hasFixtures: boolean;
+}
+
+function friendlyError(code: string): string {
+  if (code.includes("need_at_least_two_teams")) {
+    return "Add at least two teams to this league before generating a schedule.";
+  }
+  if (code.includes("season_not_found")) {
+    return "This season no longer exists.";
+  }
+  return "Could not generate the schedule.";
+}
+
+export default function GenerateScheduleButton({
+  leagueId,
+  seasonId,
+  seasonName,
+  hasFixtures,
+}: GenerateScheduleButtonProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  function run(confirm: boolean) {
+    startTransition(async () => {
+      const res = await generateScheduleAction({ leagueId, seasonId, confirm });
+
+      if (res.ok) {
+        toast.success(
+          `Generated ${res.created} games across ${res.weeks} weeks for ${res.teamCount} teams.`,
+        );
+        router.refresh();
+        return;
+      }
+
+      if ("needsConfirm" in res) {
+        const proceed = window.confirm(
+          `${seasonName} already has games with recorded results or a live game. Regenerating deletes the entire schedule and those results. This can't be undone. Continue?`,
+        );
+        if (proceed) run(true);
+        return;
+      }
+
+      toast.error(friendlyError(res.error));
+    });
+  }
+
+  function onClick() {
+    // Plain re-runs (no results yet) still wipe the current slate; confirm
+    // first so a stray click can't blow away manually-entered fixtures.
+    if (
+      hasFixtures &&
+      !window.confirm(
+        `Replace the current schedule for ${seasonName} with a fresh round-robin? Existing fixtures will be removed.`,
+      )
+    ) {
+      return;
+    }
+    run(false);
+  }
+
+  return (
+    <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
+      <CalendarPlus className="mr-1.5 h-4 w-4" />
+      {pending
+        ? "Generating…"
+        : hasFixtures
+          ? "Regenerate schedule"
+          : "Generate schedule"}
+    </Button>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -475,6 +475,10 @@ const refs = {
   deleteFixture: mutationRef<{ fixtureId: string }, null>(
     "sports:deleteFixture",
   ),
+  generateSeasonSchedule: mutationRef<
+    { seasonId: string; actorUserId: string; confirm?: boolean },
+    { created: number; weeks: number; teamCount: number }
+  >("sports:generateSeasonSchedule"),
   listFixturesBySeason: queryRef<{ seasonId: string }, FixtureDto[]>(
     "sports:listFixturesBySeason",
   ),
@@ -1581,6 +1585,14 @@ export async function updateFixture(input: {
 
 export async function deleteFixture(fixtureId: string): Promise<void> {
   await mutateConvex(refs.deleteFixture, { fixtureId });
+}
+
+export async function generateSeasonSchedule(input: {
+  seasonId: string;
+  actorUserId: string;
+  confirm?: boolean;
+}): Promise<{ created: number; weeks: number; teamCount: number }> {
+  return mutateConvex(refs.generateSeasonSchedule, input);
 }
 
 export async function listFixturesBySeason(


### PR DESCRIPTION
Closes #347

## Problem
Creating a season produced an empty shell — the only way to add games was one fixture at a time on the league schedule page.

## Solution
Adds a **Generate schedule** action that creates a single round-robin slate (every team plays every other team once) for the league's active season.

### How it works
- **Algorithm** — `convex/lib/roundRobin.ts`: pure circle-method generator. Home/away balanced within 1 of n/2 for even team counts, 2 for odd counts (the weekly bye unavoidably breaks the alternation). No I/O → unit-tested directly.
- **Mutation** — `generateSeasonSchedule` (`internalMutation` in `sports.ts`): pulls all teams in the season's league, then:
  - throws `need_at_least_two_teams` if < 2 teams,
  - **results-guard**: throws `schedule_has_results` if any existing fixture has a recorded `gameResult` or live game state, unless `confirm: true`,
  - otherwise clears existing fixtures (cascading results + live state) and inserts the new slate. Fixtures get `week` numbers only; `scheduledAt`/`venue` are left null.
- **Action** — `generateScheduleAction` reuses the existing schedule manager gate (`schedulesStandingsV1` flag + `canManageRoster`, i.e. admins **and** coaches) and maps the results-guard to a `needsConfirm` response.
- **UI** — `GenerateScheduleButton` added to the existing league schedule page header. Confirms before replacing an existing slate; double-confirms (destructive) when results/live state exist.

### Decisions (from design grill)
| Area | Decision |
|---|---|
| Format | Single round-robin, circle method |
| Participants | All teams in the league |
| Trigger | Button on the existing schedule page (no new page) |
| Regenerate | Free while unplayed; blocked (explicit confirm) once results/live state exist |
| Fixture detail | Week numbers only; dates/venue null |
| Odd teams | Resting team has no fixture that week (no bye row) |

### Note for review
Lands on the existing league schedule surface rather than a new season-detail page (avoids duplication), which means it inherits the `canManageRoster` gate — **coaches can generate schedules too**, not just org admins. Flag me if it should be admin-only.

## Tests
35 new (round-robin 25, mutation 5, action 5). Full suite: **567 passing**. `tsc` + `eslint` clean.

## Out of scope
Double/division formats, date/venue assignment, manual editing (already exists), playoffs, roster carryover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)