### PR TITLE
feat(seed): enrich all GHSA team cities (no more TBD)

### DIFF
--- a/apps/web/public/seed/ghsa-2024-26.json
+++ b/apps/web/public/seed/ghsa-2024-26.json
@@ -8,13 +8,13 @@
       "teams": [
         {
           "name": "Lowndes",
-          "city": "TBD",
+          "city": "Valdosta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Colquitt County",
-          "city": "TBD",
+          "city": "Norman Park",
           "stadium": "TBD",
           "players": []
         },
@@ -26,19 +26,19 @@
         },
         {
           "name": "Camden County",
-          "city": "TBD",
+          "city": "Kingsland",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Richmond Hill",
-          "city": "TBD",
+          "city": "Richmond Hill",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Tift County",
-          "city": "TBD",
+          "city": "Tifton",
           "stadium": "TBD",
           "players": []
         }
@@ -55,25 +55,25 @@
         },
         {
           "name": "Douglas County",
-          "city": "TBD",
+          "city": "Douglasville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Westlake",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "East Coweta",
-          "city": "TBD",
+          "city": "Sharpsburg",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Chapel Hill",
-          "city": "TBD",
+          "city": "Douglasville",
           "stadium": "TBD",
           "players": []
         }
@@ -84,49 +84,49 @@
       "teams": [
         {
           "name": "Harrison",
-          "city": "TBD",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hillgrove",
-          "city": "TBD",
+          "city": "Powder Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "McEachern",
-          "city": "TBD",
+          "city": "Powder Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pebblebrook",
-          "city": "TBD",
+          "city": "Mableton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Campbell",
-          "city": "TBD",
+          "city": "Smyrna",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Paulding County",
-          "city": "TBD",
+          "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Osborne",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "South Cobb",
-          "city": "TBD",
+          "city": "Austell",
           "stadium": "TBD",
           "players": []
         }
@@ -137,43 +137,43 @@
       "teams": [
         {
           "name": "Grayson",
-          "city": "TBD",
+          "city": "Grayson",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Newton",
-          "city": "TBD",
+          "city": "Covington",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "South Gwinnett",
-          "city": "TBD",
+          "city": "Snellville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Archer",
-          "city": "TBD",
+          "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Rockdale County",
-          "city": "TBD",
+          "city": "Conyers",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Grovetown",
-          "city": "TBD",
+          "city": "Grovetown",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Heritage-Conyers",
-          "city": "TBD",
+          "city": "Conyers",
           "stadium": "TBD",
           "players": []
         }
@@ -184,25 +184,25 @@
       "teams": [
         {
           "name": "North Cobb",
-          "city": "TBD",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Walton",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "North Paulding",
-          "city": "TBD",
+          "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cherokee",
-          "city": "TBD",
+          "city": "Canton",
           "stadium": "TBD",
           "players": []
         },
@@ -214,13 +214,13 @@
         },
         {
           "name": "Wheeler",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Etowah",
-          "city": "TBD",
+          "city": "Woodstock",
           "stadium": "TBD",
           "players": []
         }
@@ -231,37 +231,37 @@
       "teams": [
         {
           "name": "North Atlanta",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lambert",
-          "city": "TBD",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "West Forsyth",
-          "city": "TBD",
+          "city": "Cumming",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Denmark",
-          "city": "TBD",
+          "city": "Alpharetta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "North Forsyth",
-          "city": "TBD",
+          "city": "Cumming",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Forsyth Central",
-          "city": "TBD",
+          "city": "Cumming",
           "stadium": "TBD",
           "players": []
         },
@@ -273,7 +273,7 @@
         },
         {
           "name": "South Forsyth",
-          "city": "TBD",
+          "city": "Cumming",
           "stadium": "TBD",
           "players": []
         }
@@ -284,13 +284,13 @@
       "teams": [
         {
           "name": "North Gwinnett",
-          "city": "TBD",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Brookwood",
-          "city": "TBD",
+          "city": "Snellville",
           "stadium": "TBD",
           "players": []
         },
@@ -302,13 +302,13 @@
         },
         {
           "name": "Peachtree Ridge",
-          "city": "TBD",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Parkview",
-          "city": "TBD",
+          "city": "Lilburn",
           "stadium": "TBD",
           "players": []
         },
@@ -320,13 +320,13 @@
         },
         {
           "name": "Berkmar",
-          "city": "TBD",
+          "city": "Lilburn",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Meadowcreek",
-          "city": "TBD",
+          "city": "Norcross",
           "stadium": "TBD",
           "players": []
         }
@@ -343,13 +343,13 @@
         },
         {
           "name": "Collins Hill",
-          "city": "TBD",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mill Creek",
-          "city": "TBD",
+          "city": "Hoschton",
           "stadium": "TBD",
           "players": []
         },
@@ -361,19 +361,19 @@
         },
         {
           "name": "Mountain View",
-          "city": "TBD",
+          "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Central Gwinnett",
-          "city": "TBD",
+          "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Discovery",
-          "city": "TBD",
+          "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         }
@@ -390,31 +390,31 @@
         },
         {
           "name": "Lakeside-Evans",
-          "city": "TBD",
+          "city": "Evans",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Effingham County",
-          "city": "TBD",
+          "city": "Springfield",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Glynn Academy",
-          "city": "TBD",
+          "city": "Brunswick",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Evans",
-          "city": "TBD",
+          "city": "Evans",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Greenbrier",
-          "city": "TBD",
+          "city": "Evans",
           "stadium": "TBD",
           "players": []
         },
@@ -426,13 +426,13 @@
         },
         {
           "name": "Bradwell Institute",
-          "city": "TBD",
+          "city": "Hinesville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "South Effingham",
-          "city": "TBD",
+          "city": "Guyton",
           "stadium": "TBD",
           "players": []
         }
@@ -443,37 +443,37 @@
       "teams": [
         {
           "name": "Lee County",
-          "city": "TBD",
+          "city": "Leesburg",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Thomas County Central",
-          "city": "TBD",
+          "city": "Thomasville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Coffee",
-          "city": "TBD",
+          "city": "Douglas",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Houston County",
-          "city": "TBD",
+          "city": "Warner Robins",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Veterans",
-          "city": "TBD",
+          "city": "Kathleen",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Northside-Warner Robins",
-          "city": "TBD",
+          "city": "Warner Robins",
           "stadium": "TBD",
           "players": []
         }
@@ -484,7 +484,7 @@
       "teams": [
         {
           "name": "Hughes",
-          "city": "TBD",
+          "city": "Fairburn",
           "stadium": "TBD",
           "players": []
         },
@@ -496,19 +496,19 @@
         },
         {
           "name": "Dutchtown",
-          "city": "TBD",
+          "city": "Hampton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lovejoy",
-          "city": "TBD",
+          "city": "Hampton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "McIntosh",
-          "city": "TBD",
+          "city": "Peachtree City",
           "stadium": "TBD",
           "players": []
         },
@@ -520,13 +520,13 @@
         },
         {
           "name": "Northgate",
-          "city": "TBD",
+          "city": "Newnan",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Banneker",
-          "city": "TBD",
+          "city": "College Park",
           "stadium": "TBD",
           "players": []
         }
@@ -537,7 +537,7 @@
       "teams": [
         {
           "name": "Woodward Academy",
-          "city": "TBD",
+          "city": "College Park",
           "stadium": "TBD",
           "players": []
         },
@@ -549,7 +549,7 @@
         },
         {
           "name": "Tri-Cities",
-          "city": "TBD",
+          "city": "East Point",
           "stadium": "TBD",
           "players": []
         },
@@ -561,13 +561,13 @@
         },
         {
           "name": "Lakeside-DeKalb",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Shiloh",
-          "city": "TBD",
+          "city": "Snellville",
           "stadium": "TBD",
           "players": []
         },
@@ -579,7 +579,7 @@
         },
         {
           "name": "Arabia Mountain",
-          "city": "TBD",
+          "city": "Lithonia",
           "stadium": "TBD",
           "players": []
         }
@@ -596,13 +596,13 @@
         },
         {
           "name": "East Paulding",
-          "city": "TBD",
+          "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "New Manchester",
-          "city": "TBD",
+          "city": "Douglasville",
           "stadium": "TBD",
           "players": []
         },
@@ -614,25 +614,25 @@
         },
         {
           "name": "South Paulding",
-          "city": "TBD",
+          "city": "Douglasville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Alexander",
-          "city": "TBD",
+          "city": "Douglasville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Kennesaw Mountain",
-          "city": "TBD",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lithia Springs",
-          "city": "TBD",
+          "city": "Lithia Springs",
           "stadium": "TBD",
           "players": []
         }
@@ -643,19 +643,19 @@
       "teams": [
         {
           "name": "Sequoyah",
-          "city": "TBD",
+          "city": "Canton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Sprayberry",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "River Ridge",
-          "city": "TBD",
+          "city": "Woodstock",
           "stadium": "TBD",
           "players": []
         },
@@ -667,25 +667,25 @@
         },
         {
           "name": "Creekview",
-          "city": "TBD",
+          "city": "Canton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pope",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Riverwood",
-          "city": "TBD",
+          "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lassiter",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         }
@@ -714,19 +714,19 @@
         },
         {
           "name": "Lanier",
-          "city": "TBD",
+          "city": "Sugar Hill",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Seckinger",
-          "city": "TBD",
+          "city": "Buford",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Chattahoochee",
-          "city": "TBD",
+          "city": "Johns Creek",
           "stadium": "TBD",
           "players": []
         },
@@ -743,25 +743,25 @@
       "teams": [
         {
           "name": "Clarke Central",
-          "city": "TBD",
+          "city": "Athens",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jackson County",
-          "city": "TBD",
+          "city": "Hoschton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Winder-Barrow",
-          "city": "TBD",
+          "city": "Winder",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Habersham Central",
-          "city": "TBD",
+          "city": "Mt. Airy",
           "stadium": "TBD",
           "players": []
         },
@@ -773,13 +773,13 @@
         },
         {
           "name": "Alcovy",
-          "city": "TBD",
+          "city": "Covington",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Apalachee",
-          "city": "TBD",
+          "city": "Winder",
           "stadium": "TBD",
           "players": []
         }
@@ -802,25 +802,25 @@
         },
         {
           "name": "Benedictine",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Ware County",
-          "city": "TBD",
+          "city": "Waycross",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "New Hampstead",
-          "city": "TBD",
+          "city": "Bloomingdale",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Wayne County",
-          "city": "TBD",
+          "city": "Jesup",
           "stadium": "TBD",
           "players": []
         }
@@ -831,13 +831,13 @@
       "teams": [
         {
           "name": "Ola",
-          "city": "TBD",
+          "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jones County",
-          "city": "TBD",
+          "city": "Gray",
           "stadium": "TBD",
           "players": []
         },
@@ -849,7 +849,7 @@
         },
         {
           "name": "Eagle's Landing",
-          "city": "TBD",
+          "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
@@ -861,19 +861,19 @@
         },
         {
           "name": "Union Grove",
-          "city": "TBD",
+          "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Eagle's Landing Christian",
-          "city": "TBD",
+          "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Woodland-Stockbridge",
-          "city": "TBD",
+          "city": "Stockbridge",
           "stadium": "TBD",
           "players": []
         },
@@ -896,13 +896,13 @@
       "teams": [
         {
           "name": "Starr's Mill",
-          "city": "TBD",
+          "city": "Fayetteville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Central-Carroll",
-          "city": "TBD",
+          "city": "Carrollton",
           "stadium": "TBD",
           "players": []
         },
@@ -914,13 +914,13 @@
         },
         {
           "name": "Harris County",
-          "city": "TBD",
+          "city": "Hamilton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Northside-Columbus",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
@@ -932,7 +932,7 @@
         },
         {
           "name": "Mundy's Mill",
-          "city": "TBD",
+          "city": "Jonesboro",
           "stadium": "TBD",
           "players": []
         }
@@ -943,43 +943,43 @@
       "teams": [
         {
           "name": "Creekside",
-          "city": "TBD",
+          "city": "Fairburn",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mays",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jackson-Atlanta",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Drew",
-          "city": "TBD",
+          "city": "Riverdale",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "M.L. King",
-          "city": "TBD",
+          "city": "Lithonia",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pace Academy",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Midtown",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -996,19 +996,19 @@
       "teams": [
         {
           "name": "Marist",
-          "city": "TBD",
+          "city": "Brookhaven",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Southwest DeKalb",
-          "city": "TBD",
+          "city": "Decatur",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "St. Pius X",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -1026,19 +1026,19 @@
         },
         {
           "name": "Druid Hills",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "North Springs",
-          "city": "TBD",
+          "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Northview",
-          "city": "TBD",
+          "city": "Johns Creek",
           "stadium": "TBD",
           "players": []
         },
@@ -1050,7 +1050,7 @@
         },
         {
           "name": "Cross Keys",
-          "city": "TBD",
+          "city": "Brookhaven",
           "stadium": "TBD",
           "players": []
         }
@@ -1061,31 +1061,31 @@
       "teams": [
         {
           "name": "Blessed Trinity",
-          "city": "TBD",
+          "city": "Roswell",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cambridge",
-          "city": "TBD",
+          "city": "Milton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Kell",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Westminster",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Centennial",
-          "city": "TBD",
+          "city": "Roswell",
           "stadium": "TBD",
           "players": []
         }
@@ -1114,25 +1114,25 @@
         },
         {
           "name": "Cass",
-          "city": "TBD",
+          "city": "White",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Allatoona",
-          "city": "TBD",
+          "city": "Acworth",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Woodland-Cartersville",
-          "city": "TBD",
+          "city": "Cartersville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Southeast Whitfield",
-          "city": "TBD",
+          "city": "Dalton",
           "stadium": "TBD",
           "players": []
         },
@@ -1149,19 +1149,19 @@
       "teams": [
         {
           "name": "North Oconee",
-          "city": "TBD",
+          "city": "Bogart",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Eastside",
-          "city": "TBD",
+          "city": "Covington",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "East Forsyth",
-          "city": "TBD",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         },
@@ -1173,19 +1173,19 @@
         },
         {
           "name": "Madison County",
-          "city": "TBD",
+          "city": "Danielsville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Walnut Grove",
-          "city": "TBD",
+          "city": "Loganville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cedar Shoals",
-          "city": "TBD",
+          "city": "Athens",
           "stadium": "TBD",
           "players": []
         }
@@ -1196,13 +1196,13 @@
       "teams": [
         {
           "name": "Peach County",
-          "city": "TBD",
+          "city": "Fort Valley",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Westover",
-          "city": "TBD",
+          "city": "Albany",
           "stadium": "TBD",
           "players": []
         },
@@ -1214,7 +1214,7 @@
         },
         {
           "name": "Monroe",
-          "city": "TBD",
+          "city": "Albany",
           "stadium": "TBD",
           "players": []
         },
@@ -1226,7 +1226,7 @@
         },
         {
           "name": "Dougherty",
-          "city": "TBD",
+          "city": "Albany",
           "stadium": "TBD",
           "players": []
         }
@@ -1237,7 +1237,7 @@
       "teams": [
         {
           "name": "Sandy Creek",
-          "city": "TBD",
+          "city": "Tyrone",
           "stadium": "TBD",
           "players": []
         },
@@ -1249,43 +1249,43 @@
         },
         {
           "name": "Upson-Lee",
-          "city": "TBD",
+          "city": "Thomaston",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Whitewater",
-          "city": "TBD",
+          "city": "Fayetteville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Spalding",
-          "city": "TBD",
+          "city": "Griffin",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Troup County",
-          "city": "TBD",
+          "city": "LaGrange",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mary Persons",
-          "city": "TBD",
+          "city": "Forsyth",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Trinity Christian",
-          "city": "TBD",
+          "city": "Sharpsburg",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Fayette County",
-          "city": "TBD",
+          "city": "Fayetteville",
           "stadium": "TBD",
           "players": []
         }
@@ -1296,61 +1296,61 @@
       "teams": [
         {
           "name": "Calvary Day School",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jenkins",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Southeast Bulloch",
-          "city": "TBD",
+          "city": "Brooklet",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Long County",
-          "city": "TBD",
+          "city": "Ludowici",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Liberty County",
-          "city": "TBD",
+          "city": "Hinesville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Beach",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Johnson-Savannah",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Windsor Forest",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Groves",
-          "city": "TBD",
+          "city": "Garden City",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Islands",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         }
@@ -1367,37 +1367,37 @@
         },
         {
           "name": "West Laurens",
-          "city": "TBD",
+          "city": "Dexter",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Westside-Augusta",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Baldwin",
-          "city": "TBD",
+          "city": "Milledgeville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Aquinas",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Howard",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Richmond Academy",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
@@ -1409,7 +1409,7 @@
         },
         {
           "name": "Cross Creek",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         }
@@ -1420,37 +1420,37 @@
       "teams": [
         {
           "name": "Douglass-Atlanta",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Stephenson",
-          "city": "TBD",
+          "city": "Stone Mountain",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Luella",
-          "city": "TBD",
+          "city": "Locust Grove",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cedar Grove",
-          "city": "TBD",
+          "city": "Ellenwood",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mt. Zion-Jonesboro",
-          "city": "TBD",
+          "city": "Jonesboro",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "North Clayton",
-          "city": "TBD",
+          "city": "College Park",
           "stadium": "TBD",
           "players": []
         },
@@ -1473,49 +1473,49 @@
       "teams": [
         {
           "name": "North Hall",
-          "city": "TBD",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lumpkin County",
-          "city": "TBD",
+          "city": "Dahlonega",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Chestatee",
-          "city": "TBD",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Greater Atlanta Christian",
-          "city": "TBD",
+          "city": "Norcross",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pickens",
-          "city": "TBD",
+          "city": "Jasper",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Dawson County",
-          "city": "TBD",
+          "city": "Dawsonville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "White County",
-          "city": "TBD",
+          "city": "Cleveland",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Johnson-Gainesville",
-          "city": "TBD",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         }
@@ -1532,13 +1532,13 @@
         },
         {
           "name": "Northwest Whitfield",
-          "city": "TBD",
+          "city": "Tunnel Hill",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Heritage-Catoosa",
-          "city": "TBD",
+          "city": "Ringgold",
           "stadium": "TBD",
           "players": []
         },
@@ -1550,13 +1550,13 @@
         },
         {
           "name": "Gilmer",
-          "city": "TBD",
+          "city": "Ellijay",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Ridgeland",
-          "city": "TBD",
+          "city": "Rossville",
           "stadium": "TBD",
           "players": []
         },
@@ -1573,7 +1573,7 @@
       "teams": [
         {
           "name": "Cherokee Bluff",
-          "city": "TBD",
+          "city": "Flowery Branch",
           "stadium": "TBD",
           "players": []
         },
@@ -1585,25 +1585,25 @@
         },
         {
           "name": "Oconee County",
-          "city": "TBD",
+          "city": "Watkinsville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Monroe Area",
-          "city": "TBD",
+          "city": "Monroe",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "East Hall",
-          "city": "TBD",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "West Hall",
-          "city": "TBD",
+          "city": "Oakwood",
           "stadium": "TBD",
           "players": []
         }
@@ -1614,31 +1614,31 @@
       "teams": [
         {
           "name": "Carver-Columbus",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Sumter County",
-          "city": "TBD",
+          "city": "Americus",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Spencer",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Shaw",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hardaway",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
@@ -1650,13 +1650,13 @@
         },
         {
           "name": "Kendrick",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jordan",
-          "city": "TBD",
+          "city": "Columbus",
           "stadium": "TBD",
           "players": []
         }
@@ -1667,19 +1667,19 @@
       "teams": [
         {
           "name": "Callaway",
-          "city": "TBD",
+          "city": "Hogansville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Morgan County",
-          "city": "TBD",
+          "city": "Madison",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Westside-Macon",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
@@ -1691,13 +1691,13 @@
         },
         {
           "name": "Pike County",
-          "city": "TBD",
+          "city": "Zebulon",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Rutland",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         }
@@ -1708,31 +1708,31 @@
       "teams": [
         {
           "name": "Appling County",
-          "city": "TBD",
+          "city": "Baxley",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pierce County",
-          "city": "TBD",
+          "city": "Blackshear",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Crisp County",
-          "city": "TBD",
+          "city": "Cordele",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cook",
-          "city": "TBD",
+          "city": "Adel",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Tattnall County",
-          "city": "TBD",
+          "city": "Reidsville",
           "stadium": "TBD",
           "players": []
         }
@@ -1743,7 +1743,7 @@
       "teams": [
         {
           "name": "Burke County",
-          "city": "TBD",
+          "city": "Waynesboro",
           "stadium": "TBD",
           "players": []
         },
@@ -1755,25 +1755,25 @@
         },
         {
           "name": "Laney",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Butler",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Glenn Hills",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Josey",
-          "city": "TBD",
+          "city": "Augusta",
           "stadium": "TBD",
           "players": []
         }
@@ -1784,43 +1784,43 @@
       "teams": [
         {
           "name": "Hapeville",
-          "city": "TBD",
+          "city": "Hapeville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Carver-Atlanta",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lovett",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Holy Innocents'",
-          "city": "TBD",
+          "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Therrell",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "KIPP Atlanta Collegiate",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Washington",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         }
@@ -1831,31 +1831,31 @@
       "teams": [
         {
           "name": "Columbia",
-          "city": "TBD",
+          "city": "Decatur",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "South Atlanta",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Miller Grove",
-          "city": "TBD",
+          "city": "Lithonia",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Redan",
-          "city": "TBD",
+          "city": "Stone Mountain",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Salem",
-          "city": "TBD",
+          "city": "Conyers",
           "stadium": "TBD",
           "players": []
         }
@@ -1872,7 +1872,7 @@
         },
         {
           "name": "North Cobb Christian",
-          "city": "TBD",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
@@ -1884,37 +1884,37 @@
         },
         {
           "name": "North Murray",
-          "city": "TBD",
+          "city": "Chatsworth",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Union County",
-          "city": "TBD",
+          "city": "Blairsville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lakeview-Ft. Oglethorpe",
-          "city": "TBD",
+          "city": "Fort Oglethorpe",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Sonoraville",
-          "city": "TBD",
+          "city": "Calhoun",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Coahulla Creek",
-          "city": "TBD",
+          "city": "Dalton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Murray County",
-          "city": "TBD",
+          "city": "Chatsworth",
           "stadium": "TBD",
           "players": []
         }
@@ -1925,37 +1925,37 @@
       "teams": [
         {
           "name": "Prince Avenue Christian",
-          "city": "TBD",
+          "city": "Bogart",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hebron Christian Academy",
-          "city": "TBD",
+          "city": "Dacula",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Stephens County",
-          "city": "TBD",
+          "city": "Toccoa",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hart County",
-          "city": "TBD",
+          "city": "Hartwell",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "East Jackson",
-          "city": "TBD",
+          "city": "Commerce",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Franklin County",
-          "city": "TBD",
+          "city": "Carnesville",
           "stadium": "TBD",
           "players": []
         }
@@ -1972,7 +1972,7 @@
         },
         {
           "name": "Worth County",
-          "city": "TBD",
+          "city": "Sylvester",
           "stadium": "TBD",
           "players": []
         },
@@ -1984,25 +1984,25 @@
         },
         {
           "name": "Jeff Davis",
-          "city": "TBD",
+          "city": "Hazlehurst",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Brantley County",
-          "city": "TBD",
+          "city": "Nahunta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Bacon County",
-          "city": "TBD",
+          "city": "Alma",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Berrien",
-          "city": "TBD",
+          "city": "Nashville",
           "stadium": "TBD",
           "players": []
         }
@@ -2019,55 +2019,55 @@
         },
         {
           "name": "Northeast",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Dodge County",
-          "city": "TBD",
+          "city": "Eastman",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Washington County",
-          "city": "TBD",
+          "city": "Sandersville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "ACE Charter",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Southwest",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Bleckley County",
-          "city": "TBD",
+          "city": "Cochran",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "East Laurens",
-          "city": "TBD",
+          "city": "East Dublin",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jefferson County",
-          "city": "TBD",
+          "city": "Louisville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Central-Macon",
-          "city": "TBD",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         }
@@ -2078,13 +2078,13 @@
       "teams": [
         {
           "name": "Savannah Christian",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Toombs County",
-          "city": "TBD",
+          "city": "Lyons",
           "stadium": "TBD",
           "players": []
         },
@@ -2096,7 +2096,7 @@
         },
         {
           "name": "Savannah Country Day",
-          "city": "TBD",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
@@ -2113,7 +2113,7 @@
       "teams": [
         {
           "name": "Lamar County",
-          "city": "TBD",
+          "city": "Barnesville",
           "stadium": "TBD",
           "players": []
         },
@@ -2125,31 +2125,31 @@
         },
         {
           "name": "Jasper County",
-          "city": "TBD",
+          "city": "Monticello",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Putnam County",
-          "city": "TBD",
+          "city": "Eatonton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "McNair",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Towers",
-          "city": "TBD",
+          "city": "Decatur",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Utopian Academy",
-          "city": "TBD",
+          "city": "Ellenwood",
           "stadium": "TBD",
           "players": []
         }
@@ -2160,73 +2160,73 @@
       "teams": [
         {
           "name": "Fellowship Christian",
-          "city": "TBD",
+          "city": "Roswell",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Wesleyan",
-          "city": "TBD",
+          "city": "Peachtree Corners",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Whitefield Academy",
-          "city": "TBD",
+          "city": "Mableton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mt. Paran Christian",
-          "city": "TBD",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Landmark Christian",
-          "city": "TBD",
+          "city": "Fairburn",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "King's Ridge",
-          "city": "TBD",
+          "city": "Alpharetta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mount Vernon",
-          "city": "TBD",
+          "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "B.E.S.T Academy",
-          "city": "TBD",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mt. Pisgah Christian",
-          "city": "TBD",
+          "city": "Johns Creek",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mt. Bethel Christian",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Walker",
-          "city": "TBD",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "St. Francis",
-          "city": "TBD",
+          "city": "Alpharetta",
           "stadium": "TBD",
           "players": []
         }
@@ -2237,7 +2237,7 @@
       "teams": [
         {
           "name": "Heard County",
-          "city": "TBD",
+          "city": "Franklin",
           "stadium": "TBD",
           "players": []
         },
@@ -2255,25 +2255,25 @@
         },
         {
           "name": "Darlington",
-          "city": "TBD",
+          "city": "Rome",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pepperell",
-          "city": "TBD",
+          "city": "Lindale",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Model",
-          "city": "TBD",
+          "city": "Rome",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Haralson County",
-          "city": "TBD",
+          "city": "Tallapoosa",
           "stadium": "TBD",
           "players": []
         }
@@ -2284,49 +2284,49 @@
       "teams": [
         {
           "name": "Fannin County",
-          "city": "TBD",
+          "city": "Blue Ridge",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Christian Heritage",
-          "city": "TBD",
+          "city": "Dalton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Gordon Lee",
-          "city": "TBD",
+          "city": "Chickamauga",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Chattooga",
-          "city": "TBD",
+          "city": "Summerville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Dade County",
-          "city": "TBD",
+          "city": "Trenton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Coosa",
-          "city": "TBD",
+          "city": "Rome",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Gordon Central",
-          "city": "TBD",
+          "city": "Calhoun",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Armuchee",
-          "city": "TBD",
+          "city": "Rome",
           "stadium": "TBD",
           "players": []
         }
@@ -2337,7 +2337,7 @@
       "teams": [
         {
           "name": "Athens Academy",
-          "city": "TBD",
+          "city": "Athens",
           "stadium": "TBD",
           "players": []
         },
@@ -2349,31 +2349,31 @@
         },
         {
           "name": "Elbert County",
-          "city": "TBD",
+          "city": "Elberton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Rabun County",
-          "city": "TBD",
+          "city": "Tiger",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Banks County",
-          "city": "TBD",
+          "city": "Homer",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Providence Christian",
-          "city": "TBD",
+          "city": "Lilburn",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Oglethorpe County",
-          "city": "TBD",
+          "city": "Lexington",
           "stadium": "TBD",
           "players": []
         }
@@ -2384,37 +2384,37 @@
       "teams": [
         {
           "name": "Mitchell County",
-          "city": "TBD",
+          "city": "Camilla",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Early County",
-          "city": "TBD",
+          "city": "Blakely",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Calhoun County",
-          "city": "TBD",
+          "city": "Edison",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Miller County",
-          "city": "TBD",
+          "city": "Colquitt",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Pataula Charter",
-          "city": "TBD",
+          "city": "Edison",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Seminole County",
-          "city": "TBD",
+          "city": "Donalsonville",
           "stadium": "TBD",
           "players": []
         },
@@ -2426,37 +2426,37 @@
         },
         {
           "name": "Randolph-Clay",
-          "city": "TBD",
+          "city": "Cuthbert",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Baconton",
-          "city": "TBD",
+          "city": "Baconton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Southwest Georgia STEM",
-          "city": "TBD",
+          "city": "Shellman",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Terrell County",
-          "city": "TBD",
+          "city": "Dawson",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Baker County",
-          "city": "TBD",
+          "city": "Newton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Spring Creek",
-          "city": "TBD",
+          "city": "Bainbridge",
           "stadium": "TBD",
           "players": []
         }
@@ -2467,43 +2467,43 @@
       "teams": [
         {
           "name": "Clinch County",
-          "city": "TBD",
+          "city": "Homerville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Irwin County",
-          "city": "TBD",
+          "city": "Ocilla",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Brooks County",
-          "city": "TBD",
+          "city": "Quitman",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Charlton County",
-          "city": "TBD",
+          "city": "Folkston",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Turner County",
-          "city": "TBD",
+          "city": "Ashburn",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Atkinson County",
-          "city": "TBD",
+          "city": "Pearson",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lanier County",
-          "city": "TBD",
+          "city": "Lakeland",
           "stadium": "TBD",
           "players": []
         }
@@ -2520,37 +2520,37 @@
         },
         {
           "name": "Jenkins County",
-          "city": "TBD",
+          "city": "Millen",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "McIntosh County Academy",
-          "city": "TBD",
+          "city": "Darien",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Emanuel County Institute",
-          "city": "TBD",
+          "city": "Twin City",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Bryan County",
-          "city": "TBD",
+          "city": "Pembroke",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Portal",
-          "city": "TBD",
+          "city": "Portal",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Screven County",
-          "city": "TBD",
+          "city": "Sylvania",
           "stadium": "TBD",
           "players": []
         },
@@ -2573,7 +2573,7 @@
       "teams": [
         {
           "name": "Telfair County",
-          "city": "TBD",
+          "city": "McRae",
           "stadium": "TBD",
           "players": []
         },
@@ -2585,31 +2585,31 @@
         },
         {
           "name": "Wheeler County",
-          "city": "TBD",
+          "city": "Alamo",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Wilcox County",
-          "city": "TBD",
+          "city": "Rochelle",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Treutlen",
-          "city": "TBD",
+          "city": "Soperton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Dooly County",
-          "city": "TBD",
+          "city": "Vienna",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Montgomery County",
-          "city": "TBD",
+          "city": "Mount Vernon",
           "stadium": "TBD",
           "players": []
         }
@@ -2620,37 +2620,37 @@
       "teams": [
         {
           "name": "Johnson County",
-          "city": "TBD",
+          "city": "Wrightsville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Wilkinson County",
-          "city": "TBD",
+          "city": "Irwinton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hancock Central",
-          "city": "TBD",
+          "city": "Sparta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Glascock County",
-          "city": "TBD",
+          "city": "Gibson",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Twiggs County",
-          "city": "TBD",
+          "city": "Jeffersonville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Georgia Military College",
-          "city": "TBD",
+          "city": "Milledgeville",
           "stadium": "TBD",
           "players": []
         }
@@ -2661,43 +2661,43 @@
       "teams": [
         {
           "name": "Macon County",
-          "city": "TBD",
+          "city": "Montezuma",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Schley County",
-          "city": "TBD",
+          "city": "Ellaville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Taylor County",
-          "city": "TBD",
+          "city": "Butler",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Marion County",
-          "city": "TBD",
+          "city": "Buena Vista",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Crawford County",
-          "city": "TBD",
+          "city": "Roberta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Chattahoochee County",
-          "city": "TBD",
+          "city": "Cusseta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Central-Talbotton",
-          "city": "TBD",
+          "city": "Talbotton",
           "stadium": "TBD",
           "players": []
         }
@@ -2732,7 +2732,7 @@
         },
         {
           "name": "Mt. Zion-Carroll",
-          "city": "TBD",
+          "city": "Carrollton",
           "stadium": "TBD",
           "players": []
         }
@@ -2743,37 +2743,37 @@
       "teams": [
         {
           "name": "Lincoln County",
-          "city": "TBD",
+          "city": "Lincolnton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Greene County",
-          "city": "TBD",
+          "city": "Greensboro",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Warren County",
-          "city": "TBD",
+          "city": "Warrenton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Washington-Wilkes",
-          "city": "TBD",
+          "city": "Washington",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Towns County",
-          "city": "TBD",
+          "city": "Hiawassee",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Lake Oconee Academy",
-          "city": "TBD",
+          "city": "Greensboro",
           "stadium": "TBD",
           "players": []
         }

--- a/scripts/ghsa-seed/README.md
+++ b/scripts/ghsa-seed/README.md
@@ -19,9 +19,10 @@ name:
 | School            | `team.name` (+ city)  | `Valdosta` / `Valdosta`         |
 | —                 | `players: []`         | (empty — seeded later)          |
 
-`city` and `stadium` are required by the schema. Schools without a known city
-get a `TBD` placeholder the coach corrects when they **claim** the team
-(claim support already exists: `claimable` / `ownerOrgId`, WSM-000109).
+`city` and `stadium` are required by the schema. All 416 schools now carry a
+real `city` (see "Cities" below); `stadium` is still seeded as a `TBD`
+placeholder the coach corrects when they **claim** the team (claim support
+already exists: `claimable` / `ownerOrgId`, WSM-000109).
 
 ## Run
 
@@ -94,8 +95,9 @@ earlier — is **confirmed** in the official football alignment.
 
 1. **2025-season refresh** — regenerate from the 2025 football standings when
    seeding for the 2025 season (same shape, a few schools move).
-2. **Cities** — add `"city"` to a school entry to override the `TBD` placeholder.
-   74 are filled in; the rest are a separate enrichment pass.
+2. **Cities** — all 416 schools have a `city`, enriched from public sources
+   (Wikipedia / MaxPreps / school sites), resolved to the municipality (not the
+   county). Edit a school's `"city"` to correct any.
 3. **Other states** — the alignment JSON is association-agnostic; point `--in`
    at e.g. a CIF/FHSAA file with the same shape to seed another state.
 

--- a/scripts/ghsa-seed/data/ghsa-2024-26.json
+++ b/scripts/ghsa-seed/data/ghsa-2024-26.json
@@ -10,23 +10,28 @@
           "region": 1,
           "schools": [
             {
-              "name": "Lowndes"
+              "name": "Lowndes",
+              "city": "Valdosta"
             },
             {
-              "name": "Colquitt County"
+              "name": "Colquitt County",
+              "city": "Norman Park"
             },
             {
               "name": "Valdosta",
               "city": "Valdosta"
             },
             {
-              "name": "Camden County"
+              "name": "Camden County",
+              "city": "Kingsland"
             },
             {
-              "name": "Richmond Hill"
+              "name": "Richmond Hill",
+              "city": "Richmond Hill"
             },
             {
-              "name": "Tift County"
+              "name": "Tift County",
+              "city": "Tifton"
             }
           ]
         },
@@ -38,16 +43,20 @@
               "city": "Carrollton"
             },
             {
-              "name": "Douglas County"
+              "name": "Douglas County",
+              "city": "Douglasville"
             },
             {
-              "name": "Westlake"
+              "name": "Westlake",
+              "city": "Atlanta"
             },
             {
-              "name": "East Coweta"
+              "name": "East Coweta",
+              "city": "Sharpsburg"
             },
             {
-              "name": "Chapel Hill"
+              "name": "Chapel Hill",
+              "city": "Douglasville"
             }
           ]
         },
@@ -55,28 +64,36 @@
           "region": 3,
           "schools": [
             {
-              "name": "Harrison"
+              "name": "Harrison",
+              "city": "Kennesaw"
             },
             {
-              "name": "Hillgrove"
+              "name": "Hillgrove",
+              "city": "Powder Springs"
             },
             {
-              "name": "McEachern"
+              "name": "McEachern",
+              "city": "Powder Springs"
             },
             {
-              "name": "Pebblebrook"
+              "name": "Pebblebrook",
+              "city": "Mableton"
             },
             {
-              "name": "Campbell"
+              "name": "Campbell",
+              "city": "Smyrna"
             },
             {
-              "name": "Paulding County"
+              "name": "Paulding County",
+              "city": "Dallas"
             },
             {
-              "name": "Osborne"
+              "name": "Osborne",
+              "city": "Marietta"
             },
             {
-              "name": "South Cobb"
+              "name": "South Cobb",
+              "city": "Austell"
             }
           ]
         },
@@ -84,25 +101,32 @@
           "region": 4,
           "schools": [
             {
-              "name": "Grayson"
+              "name": "Grayson",
+              "city": "Grayson"
             },
             {
-              "name": "Newton"
+              "name": "Newton",
+              "city": "Covington"
             },
             {
-              "name": "South Gwinnett"
+              "name": "South Gwinnett",
+              "city": "Snellville"
             },
             {
-              "name": "Archer"
+              "name": "Archer",
+              "city": "Lawrenceville"
             },
             {
-              "name": "Rockdale County"
+              "name": "Rockdale County",
+              "city": "Conyers"
             },
             {
-              "name": "Grovetown"
+              "name": "Grovetown",
+              "city": "Grovetown"
             },
             {
-              "name": "Heritage-Conyers"
+              "name": "Heritage-Conyers",
+              "city": "Conyers"
             }
           ]
         },
@@ -110,26 +134,32 @@
           "region": 5,
           "schools": [
             {
-              "name": "North Cobb"
+              "name": "North Cobb",
+              "city": "Kennesaw"
             },
             {
-              "name": "Walton"
+              "name": "Walton",
+              "city": "Marietta"
             },
             {
-              "name": "North Paulding"
+              "name": "North Paulding",
+              "city": "Dallas"
             },
             {
-              "name": "Cherokee"
+              "name": "Cherokee",
+              "city": "Canton"
             },
             {
               "name": "Marietta",
               "city": "Marietta"
             },
             {
-              "name": "Wheeler"
+              "name": "Wheeler",
+              "city": "Marietta"
             },
             {
-              "name": "Etowah"
+              "name": "Etowah",
+              "city": "Woodstock"
             }
           ]
         },
@@ -137,29 +167,36 @@
           "region": 6,
           "schools": [
             {
-              "name": "North Atlanta"
+              "name": "North Atlanta",
+              "city": "Atlanta"
             },
             {
-              "name": "Lambert"
+              "name": "Lambert",
+              "city": "Suwanee"
             },
             {
-              "name": "West Forsyth"
+              "name": "West Forsyth",
+              "city": "Cumming"
             },
             {
-              "name": "Denmark"
+              "name": "Denmark",
+              "city": "Alpharetta"
             },
             {
-              "name": "North Forsyth"
+              "name": "North Forsyth",
+              "city": "Cumming"
             },
             {
-              "name": "Forsyth Central"
+              "name": "Forsyth Central",
+              "city": "Cumming"
             },
             {
               "name": "Alpharetta",
               "city": "Alpharetta"
             },
             {
-              "name": "South Forsyth"
+              "name": "South Forsyth",
+              "city": "Cumming"
             }
           ]
         },
@@ -167,30 +204,36 @@
           "region": 7,
           "schools": [
             {
-              "name": "North Gwinnett"
+              "name": "North Gwinnett",
+              "city": "Suwanee"
             },
             {
-              "name": "Brookwood"
+              "name": "Brookwood",
+              "city": "Snellville"
             },
             {
               "name": "Norcross",
               "city": "Norcross"
             },
             {
-              "name": "Peachtree Ridge"
+              "name": "Peachtree Ridge",
+              "city": "Suwanee"
             },
             {
-              "name": "Parkview"
+              "name": "Parkview",
+              "city": "Lilburn"
             },
             {
               "name": "Duluth",
               "city": "Duluth"
             },
             {
-              "name": "Berkmar"
+              "name": "Berkmar",
+              "city": "Lilburn"
             },
             {
-              "name": "Meadowcreek"
+              "name": "Meadowcreek",
+              "city": "Norcross"
             }
           ]
         },
@@ -202,23 +245,28 @@
               "city": "Buford"
             },
             {
-              "name": "Collins Hill"
+              "name": "Collins Hill",
+              "city": "Suwanee"
             },
             {
-              "name": "Mill Creek"
+              "name": "Mill Creek",
+              "city": "Hoschton"
             },
             {
               "name": "Dacula",
               "city": "Dacula"
             },
             {
-              "name": "Mountain View"
+              "name": "Mountain View",
+              "city": "Lawrenceville"
             },
             {
-              "name": "Central Gwinnett"
+              "name": "Central Gwinnett",
+              "city": "Lawrenceville"
             },
             {
-              "name": "Discovery"
+              "name": "Discovery",
+              "city": "Lawrenceville"
             }
           ]
         }
@@ -235,29 +283,36 @@
               "city": "Brunswick"
             },
             {
-              "name": "Lakeside-Evans"
+              "name": "Lakeside-Evans",
+              "city": "Evans"
             },
             {
-              "name": "Effingham County"
+              "name": "Effingham County",
+              "city": "Springfield"
             },
             {
-              "name": "Glynn Academy"
+              "name": "Glynn Academy",
+              "city": "Brunswick"
             },
             {
-              "name": "Evans"
+              "name": "Evans",
+              "city": "Evans"
             },
             {
-              "name": "Greenbrier"
+              "name": "Greenbrier",
+              "city": "Evans"
             },
             {
               "name": "Statesboro",
               "city": "Statesboro"
             },
             {
-              "name": "Bradwell Institute"
+              "name": "Bradwell Institute",
+              "city": "Hinesville"
             },
             {
-              "name": "South Effingham"
+              "name": "South Effingham",
+              "city": "Guyton"
             }
           ]
         },
@@ -265,22 +320,28 @@
           "region": 2,
           "schools": [
             {
-              "name": "Lee County"
+              "name": "Lee County",
+              "city": "Leesburg"
             },
             {
-              "name": "Thomas County Central"
+              "name": "Thomas County Central",
+              "city": "Thomasville"
             },
             {
-              "name": "Coffee"
+              "name": "Coffee",
+              "city": "Douglas"
             },
             {
-              "name": "Houston County"
+              "name": "Houston County",
+              "city": "Warner Robins"
             },
             {
-              "name": "Veterans"
+              "name": "Veterans",
+              "city": "Kathleen"
             },
             {
-              "name": "Northside-Warner Robins"
+              "name": "Northside-Warner Robins",
+              "city": "Warner Robins"
             }
           ]
         },
@@ -288,30 +349,36 @@
           "region": 3,
           "schools": [
             {
-              "name": "Hughes"
+              "name": "Hughes",
+              "city": "Fairburn"
             },
             {
               "name": "Newnan",
               "city": "Newnan"
             },
             {
-              "name": "Dutchtown"
+              "name": "Dutchtown",
+              "city": "Hampton"
             },
             {
-              "name": "Lovejoy"
+              "name": "Lovejoy",
+              "city": "Hampton"
             },
             {
-              "name": "McIntosh"
+              "name": "McIntosh",
+              "city": "Peachtree City"
             },
             {
               "name": "Morrow",
               "city": "Morrow"
             },
             {
-              "name": "Northgate"
+              "name": "Northgate",
+              "city": "Newnan"
             },
             {
-              "name": "Banneker"
+              "name": "Banneker",
+              "city": "College Park"
             }
           ]
         },
@@ -319,31 +386,36 @@
           "region": 4,
           "schools": [
             {
-              "name": "Woodward Academy"
+              "name": "Woodward Academy",
+              "city": "College Park"
             },
             {
               "name": "Decatur",
               "city": "Decatur"
             },
             {
-              "name": "Tri-Cities"
+              "name": "Tri-Cities",
+              "city": "East Point"
             },
             {
               "name": "Dunwoody",
               "city": "Dunwoody"
             },
             {
-              "name": "Lakeside-DeKalb"
+              "name": "Lakeside-DeKalb",
+              "city": "Atlanta"
             },
             {
-              "name": "Shiloh"
+              "name": "Shiloh",
+              "city": "Snellville"
             },
             {
               "name": "Chamblee",
               "city": "Chamblee"
             },
             {
-              "name": "Arabia Mountain"
+              "name": "Arabia Mountain",
+              "city": "Lithonia"
             }
           ]
         },
@@ -355,26 +427,32 @@
               "city": "Rome"
             },
             {
-              "name": "East Paulding"
+              "name": "East Paulding",
+              "city": "Dallas"
             },
             {
-              "name": "New Manchester"
+              "name": "New Manchester",
+              "city": "Douglasville"
             },
             {
               "name": "Villa Rica",
               "city": "Villa Rica"
             },
             {
-              "name": "South Paulding"
+              "name": "South Paulding",
+              "city": "Douglasville"
             },
             {
-              "name": "Alexander"
+              "name": "Alexander",
+              "city": "Douglasville"
             },
             {
-              "name": "Kennesaw Mountain"
+              "name": "Kennesaw Mountain",
+              "city": "Kennesaw"
             },
             {
-              "name": "Lithia Springs"
+              "name": "Lithia Springs",
+              "city": "Lithia Springs"
             }
           ]
         },
@@ -382,29 +460,36 @@
           "region": 6,
           "schools": [
             {
-              "name": "Sequoyah"
+              "name": "Sequoyah",
+              "city": "Canton"
             },
             {
-              "name": "Sprayberry"
+              "name": "Sprayberry",
+              "city": "Marietta"
             },
             {
-              "name": "River Ridge"
+              "name": "River Ridge",
+              "city": "Woodstock"
             },
             {
               "name": "Woodstock",
               "city": "Woodstock"
             },
             {
-              "name": "Creekview"
+              "name": "Creekview",
+              "city": "Canton"
             },
             {
-              "name": "Pope"
+              "name": "Pope",
+              "city": "Marietta"
             },
             {
-              "name": "Riverwood"
+              "name": "Riverwood",
+              "city": "Sandy Springs"
             },
             {
-              "name": "Lassiter"
+              "name": "Lassiter",
+              "city": "Marietta"
             }
           ]
         },
@@ -424,13 +509,16 @@
               "city": "Gainesville"
             },
             {
-              "name": "Lanier"
+              "name": "Lanier",
+              "city": "Sugar Hill"
             },
             {
-              "name": "Seckinger"
+              "name": "Seckinger",
+              "city": "Buford"
             },
             {
-              "name": "Chattahoochee"
+              "name": "Chattahoochee",
+              "city": "Johns Creek"
             },
             {
               "name": "Johns Creek",
@@ -442,26 +530,32 @@
           "region": 8,
           "schools": [
             {
-              "name": "Clarke Central"
+              "name": "Clarke Central",
+              "city": "Athens"
             },
             {
-              "name": "Jackson County"
+              "name": "Jackson County",
+              "city": "Hoschton"
             },
             {
-              "name": "Winder-Barrow"
+              "name": "Winder-Barrow",
+              "city": "Winder"
             },
             {
-              "name": "Habersham Central"
+              "name": "Habersham Central",
+              "city": "Mt. Airy"
             },
             {
               "name": "Loganville",
               "city": "Loganville"
             },
             {
-              "name": "Alcovy"
+              "name": "Alcovy",
+              "city": "Covington"
             },
             {
-              "name": "Apalachee"
+              "name": "Apalachee",
+              "city": "Winder"
             }
           ]
         }
@@ -482,16 +576,20 @@
               "city": "Warner Robins"
             },
             {
-              "name": "Benedictine"
+              "name": "Benedictine",
+              "city": "Savannah"
             },
             {
-              "name": "Ware County"
+              "name": "Ware County",
+              "city": "Waycross"
             },
             {
-              "name": "New Hampstead"
+              "name": "New Hampstead",
+              "city": "Bloomingdale"
             },
             {
-              "name": "Wayne County"
+              "name": "Wayne County",
+              "city": "Jesup"
             }
           ]
         },
@@ -499,30 +597,36 @@
           "region": 2,
           "schools": [
             {
-              "name": "Ola"
+              "name": "Ola",
+              "city": "McDonough"
             },
             {
-              "name": "Jones County"
+              "name": "Jones County",
+              "city": "Gray"
             },
             {
               "name": "Hampton",
               "city": "Hampton"
             },
             {
-              "name": "Eagle's Landing"
+              "name": "Eagle's Landing",
+              "city": "McDonough"
             },
             {
               "name": "Locust Grove",
               "city": "Locust Grove"
             },
             {
-              "name": "Union Grove"
+              "name": "Union Grove",
+              "city": "McDonough"
             },
             {
-              "name": "Eagle's Landing Christian"
+              "name": "Eagle's Landing Christian",
+              "city": "McDonough"
             },
             {
-              "name": "Woodland-Stockbridge"
+              "name": "Woodland-Stockbridge",
+              "city": "Stockbridge"
             },
             {
               "name": "McDonough",
@@ -538,27 +642,32 @@
           "region": 3,
           "schools": [
             {
-              "name": "Starr's Mill"
+              "name": "Starr's Mill",
+              "city": "Fayetteville"
             },
             {
-              "name": "Central-Carroll"
+              "name": "Central-Carroll",
+              "city": "Carrollton"
             },
             {
               "name": "Jonesboro",
               "city": "Jonesboro"
             },
             {
-              "name": "Harris County"
+              "name": "Harris County",
+              "city": "Hamilton"
             },
             {
-              "name": "Northside-Columbus"
+              "name": "Northside-Columbus",
+              "city": "Columbus"
             },
             {
               "name": "Griffin",
               "city": "Griffin"
             },
             {
-              "name": "Mundy's Mill"
+              "name": "Mundy's Mill",
+              "city": "Jonesboro"
             }
           ]
         },
@@ -566,25 +675,32 @@
           "region": 4,
           "schools": [
             {
-              "name": "Creekside"
+              "name": "Creekside",
+              "city": "Fairburn"
             },
             {
-              "name": "Mays"
+              "name": "Mays",
+              "city": "Atlanta"
             },
             {
-              "name": "Jackson-Atlanta"
+              "name": "Jackson-Atlanta",
+              "city": "Atlanta"
             },
             {
-              "name": "Drew"
+              "name": "Drew",
+              "city": "Riverdale"
             },
             {
-              "name": "M.L. King"
+              "name": "M.L. King",
+              "city": "Lithonia"
             },
             {
-              "name": "Pace Academy"
+              "name": "Pace Academy",
+              "city": "Atlanta"
             },
             {
-              "name": "Midtown"
+              "name": "Midtown",
+              "city": "Atlanta"
             },
             {
               "name": "Forest Park",
@@ -596,13 +712,16 @@
           "region": 5,
           "schools": [
             {
-              "name": "Marist"
+              "name": "Marist",
+              "city": "Brookhaven"
             },
             {
-              "name": "Southwest DeKalb"
+              "name": "Southwest DeKalb",
+              "city": "Decatur"
             },
             {
-              "name": "St. Pius X"
+              "name": "St. Pius X",
+              "city": "Atlanta"
             },
             {
               "name": "Tucker",
@@ -613,20 +732,24 @@
               "city": "Lithonia"
             },
             {
-              "name": "Druid Hills"
+              "name": "Druid Hills",
+              "city": "Atlanta"
             },
             {
-              "name": "North Springs"
+              "name": "North Springs",
+              "city": "Sandy Springs"
             },
             {
-              "name": "Northview"
+              "name": "Northview",
+              "city": "Johns Creek"
             },
             {
               "name": "Clarkston",
               "city": "Clarkston"
             },
             {
-              "name": "Cross Keys"
+              "name": "Cross Keys",
+              "city": "Brookhaven"
             }
           ]
         },
@@ -634,19 +757,24 @@
           "region": 6,
           "schools": [
             {
-              "name": "Blessed Trinity"
+              "name": "Blessed Trinity",
+              "city": "Roswell"
             },
             {
-              "name": "Cambridge"
+              "name": "Cambridge",
+              "city": "Milton"
             },
             {
-              "name": "Kell"
+              "name": "Kell",
+              "city": "Marietta"
             },
             {
-              "name": "Westminster"
+              "name": "Westminster",
+              "city": "Atlanta"
             },
             {
-              "name": "Centennial"
+              "name": "Centennial",
+              "city": "Roswell"
             }
           ]
         },
@@ -666,16 +794,20 @@
               "city": "Hiram"
             },
             {
-              "name": "Cass"
+              "name": "Cass",
+              "city": "White"
             },
             {
-              "name": "Allatoona"
+              "name": "Allatoona",
+              "city": "Acworth"
             },
             {
-              "name": "Woodland-Cartersville"
+              "name": "Woodland-Cartersville",
+              "city": "Cartersville"
             },
             {
-              "name": "Southeast Whitfield"
+              "name": "Southeast Whitfield",
+              "city": "Dalton"
             },
             {
               "name": "Dalton",
@@ -687,26 +819,32 @@
           "region": 8,
           "schools": [
             {
-              "name": "North Oconee"
+              "name": "North Oconee",
+              "city": "Bogart"
             },
             {
-              "name": "Eastside"
+              "name": "Eastside",
+              "city": "Covington"
             },
             {
-              "name": "East Forsyth"
+              "name": "East Forsyth",
+              "city": "Gainesville"
             },
             {
               "name": "Flowery Branch",
               "city": "Flowery Branch"
             },
             {
-              "name": "Madison County"
+              "name": "Madison County",
+              "city": "Danielsville"
             },
             {
-              "name": "Walnut Grove"
+              "name": "Walnut Grove",
+              "city": "Loganville"
             },
             {
-              "name": "Cedar Shoals"
+              "name": "Cedar Shoals",
+              "city": "Athens"
             }
           ]
         }
@@ -719,24 +857,28 @@
           "region": 1,
           "schools": [
             {
-              "name": "Peach County"
+              "name": "Peach County",
+              "city": "Fort Valley"
             },
             {
-              "name": "Westover"
+              "name": "Westover",
+              "city": "Albany"
             },
             {
               "name": "Cairo",
               "city": "Cairo"
             },
             {
-              "name": "Monroe"
+              "name": "Monroe",
+              "city": "Albany"
             },
             {
               "name": "Bainbridge",
               "city": "Bainbridge"
             },
             {
-              "name": "Dougherty"
+              "name": "Dougherty",
+              "city": "Albany"
             }
           ]
         },
@@ -744,32 +886,40 @@
           "region": 2,
           "schools": [
             {
-              "name": "Sandy Creek"
+              "name": "Sandy Creek",
+              "city": "Tyrone"
             },
             {
               "name": "LaGrange",
               "city": "LaGrange"
             },
             {
-              "name": "Upson-Lee"
+              "name": "Upson-Lee",
+              "city": "Thomaston"
             },
             {
-              "name": "Whitewater"
+              "name": "Whitewater",
+              "city": "Fayetteville"
             },
             {
-              "name": "Spalding"
+              "name": "Spalding",
+              "city": "Griffin"
             },
             {
-              "name": "Troup County"
+              "name": "Troup County",
+              "city": "LaGrange"
             },
             {
-              "name": "Mary Persons"
+              "name": "Mary Persons",
+              "city": "Forsyth"
             },
             {
-              "name": "Trinity Christian"
+              "name": "Trinity Christian",
+              "city": "Sharpsburg"
             },
             {
-              "name": "Fayette County"
+              "name": "Fayette County",
+              "city": "Fayetteville"
             }
           ]
         },
@@ -777,34 +927,44 @@
           "region": 3,
           "schools": [
             {
-              "name": "Calvary Day School"
+              "name": "Calvary Day School",
+              "city": "Savannah"
             },
             {
-              "name": "Jenkins"
+              "name": "Jenkins",
+              "city": "Savannah"
             },
             {
-              "name": "Southeast Bulloch"
+              "name": "Southeast Bulloch",
+              "city": "Brooklet"
             },
             {
-              "name": "Long County"
+              "name": "Long County",
+              "city": "Ludowici"
             },
             {
-              "name": "Liberty County"
+              "name": "Liberty County",
+              "city": "Hinesville"
             },
             {
-              "name": "Beach"
+              "name": "Beach",
+              "city": "Savannah"
             },
             {
-              "name": "Johnson-Savannah"
+              "name": "Johnson-Savannah",
+              "city": "Savannah"
             },
             {
-              "name": "Windsor Forest"
+              "name": "Windsor Forest",
+              "city": "Savannah"
             },
             {
-              "name": "Groves"
+              "name": "Groves",
+              "city": "Garden City"
             },
             {
-              "name": "Islands"
+              "name": "Islands",
+              "city": "Savannah"
             }
           ]
         },
@@ -816,29 +976,36 @@
               "city": "Harlem"
             },
             {
-              "name": "West Laurens"
+              "name": "West Laurens",
+              "city": "Dexter"
             },
             {
-              "name": "Westside-Augusta"
+              "name": "Westside-Augusta",
+              "city": "Augusta"
             },
             {
-              "name": "Baldwin"
+              "name": "Baldwin",
+              "city": "Milledgeville"
             },
             {
-              "name": "Aquinas"
+              "name": "Aquinas",
+              "city": "Augusta"
             },
             {
-              "name": "Howard"
+              "name": "Howard",
+              "city": "Macon"
             },
             {
-              "name": "Richmond Academy"
+              "name": "Richmond Academy",
+              "city": "Augusta"
             },
             {
               "name": "Hephzibah",
               "city": "Hephzibah"
             },
             {
-              "name": "Cross Creek"
+              "name": "Cross Creek",
+              "city": "Augusta"
             }
           ]
         },
@@ -846,22 +1013,28 @@
           "region": 5,
           "schools": [
             {
-              "name": "Douglass-Atlanta"
+              "name": "Douglass-Atlanta",
+              "city": "Atlanta"
             },
             {
-              "name": "Stephenson"
+              "name": "Stephenson",
+              "city": "Stone Mountain"
             },
             {
-              "name": "Luella"
+              "name": "Luella",
+              "city": "Locust Grove"
             },
             {
-              "name": "Cedar Grove"
+              "name": "Cedar Grove",
+              "city": "Ellenwood"
             },
             {
-              "name": "Mt. Zion-Jonesboro"
+              "name": "Mt. Zion-Jonesboro",
+              "city": "Jonesboro"
             },
             {
-              "name": "North Clayton"
+              "name": "North Clayton",
+              "city": "College Park"
             },
             {
               "name": "Riverdale",
@@ -877,28 +1050,36 @@
           "region": 6,
           "schools": [
             {
-              "name": "North Hall"
+              "name": "North Hall",
+              "city": "Gainesville"
             },
             {
-              "name": "Lumpkin County"
+              "name": "Lumpkin County",
+              "city": "Dahlonega"
             },
             {
-              "name": "Chestatee"
+              "name": "Chestatee",
+              "city": "Gainesville"
             },
             {
-              "name": "Greater Atlanta Christian"
+              "name": "Greater Atlanta Christian",
+              "city": "Norcross"
             },
             {
-              "name": "Pickens"
+              "name": "Pickens",
+              "city": "Jasper"
             },
             {
-              "name": "Dawson County"
+              "name": "Dawson County",
+              "city": "Dawsonville"
             },
             {
-              "name": "White County"
+              "name": "White County",
+              "city": "Cleveland"
             },
             {
-              "name": "Johnson-Gainesville"
+              "name": "Johnson-Gainesville",
+              "city": "Gainesville"
             }
           ]
         },
@@ -910,20 +1091,24 @@
               "city": "Calhoun"
             },
             {
-              "name": "Northwest Whitfield"
+              "name": "Northwest Whitfield",
+              "city": "Tunnel Hill"
             },
             {
-              "name": "Heritage-Catoosa"
+              "name": "Heritage-Catoosa",
+              "city": "Ringgold"
             },
             {
               "name": "Adairsville",
               "city": "Adairsville"
             },
             {
-              "name": "Gilmer"
+              "name": "Gilmer",
+              "city": "Ellijay"
             },
             {
-              "name": "Ridgeland"
+              "name": "Ridgeland",
+              "city": "Rossville"
             },
             {
               "name": "LaFayette",
@@ -935,23 +1120,28 @@
           "region": 8,
           "schools": [
             {
-              "name": "Cherokee Bluff"
+              "name": "Cherokee Bluff",
+              "city": "Flowery Branch"
             },
             {
               "name": "Jefferson",
               "city": "Jefferson"
             },
             {
-              "name": "Oconee County"
+              "name": "Oconee County",
+              "city": "Watkinsville"
             },
             {
-              "name": "Monroe Area"
+              "name": "Monroe Area",
+              "city": "Monroe"
             },
             {
-              "name": "East Hall"
+              "name": "East Hall",
+              "city": "Gainesville"
             },
             {
-              "name": "West Hall"
+              "name": "West Hall",
+              "city": "Oakwood"
             }
           ]
         }
@@ -964,29 +1154,36 @@
           "region": 1,
           "schools": [
             {
-              "name": "Carver-Columbus"
+              "name": "Carver-Columbus",
+              "city": "Columbus"
             },
             {
-              "name": "Sumter County"
+              "name": "Sumter County",
+              "city": "Americus"
             },
             {
-              "name": "Spencer"
+              "name": "Spencer",
+              "city": "Columbus"
             },
             {
-              "name": "Shaw"
+              "name": "Shaw",
+              "city": "Columbus"
             },
             {
-              "name": "Hardaway"
+              "name": "Hardaway",
+              "city": "Columbus"
             },
             {
               "name": "Columbus",
               "city": "Columbus"
             },
             {
-              "name": "Kendrick"
+              "name": "Kendrick",
+              "city": "Columbus"
             },
             {
-              "name": "Jordan"
+              "name": "Jordan",
+              "city": "Columbus"
             }
           ]
         },
@@ -994,23 +1191,28 @@
           "region": 2,
           "schools": [
             {
-              "name": "Callaway"
+              "name": "Callaway",
+              "city": "Hogansville"
             },
             {
-              "name": "Morgan County"
+              "name": "Morgan County",
+              "city": "Madison"
             },
             {
-              "name": "Westside-Macon"
+              "name": "Westside-Macon",
+              "city": "Macon"
             },
             {
               "name": "Jackson",
               "city": "Jackson"
             },
             {
-              "name": "Pike County"
+              "name": "Pike County",
+              "city": "Zebulon"
             },
             {
-              "name": "Rutland"
+              "name": "Rutland",
+              "city": "Macon"
             }
           ]
         },
@@ -1018,19 +1220,24 @@
           "region": 3,
           "schools": [
             {
-              "name": "Appling County"
+              "name": "Appling County",
+              "city": "Baxley"
             },
             {
-              "name": "Pierce County"
+              "name": "Pierce County",
+              "city": "Blackshear"
             },
             {
-              "name": "Crisp County"
+              "name": "Crisp County",
+              "city": "Cordele"
             },
             {
-              "name": "Cook"
+              "name": "Cook",
+              "city": "Adel"
             },
             {
-              "name": "Tattnall County"
+              "name": "Tattnall County",
+              "city": "Reidsville"
             }
           ]
         },
@@ -1038,23 +1245,28 @@
           "region": 4,
           "schools": [
             {
-              "name": "Burke County"
+              "name": "Burke County",
+              "city": "Waynesboro"
             },
             {
               "name": "Thomson",
               "city": "Thomson"
             },
             {
-              "name": "Laney"
+              "name": "Laney",
+              "city": "Augusta"
             },
             {
-              "name": "Butler"
+              "name": "Butler",
+              "city": "Augusta"
             },
             {
-              "name": "Glenn Hills"
+              "name": "Glenn Hills",
+              "city": "Augusta"
             },
             {
-              "name": "Josey"
+              "name": "Josey",
+              "city": "Augusta"
             }
           ]
         },
@@ -1062,25 +1274,32 @@
           "region": 5,
           "schools": [
             {
-              "name": "Hapeville"
+              "name": "Hapeville",
+              "city": "Hapeville"
             },
             {
-              "name": "Carver-Atlanta"
+              "name": "Carver-Atlanta",
+              "city": "Atlanta"
             },
             {
-              "name": "Lovett"
+              "name": "Lovett",
+              "city": "Atlanta"
             },
             {
-              "name": "Holy Innocents'"
+              "name": "Holy Innocents'",
+              "city": "Sandy Springs"
             },
             {
-              "name": "Therrell"
+              "name": "Therrell",
+              "city": "Atlanta"
             },
             {
-              "name": "KIPP Atlanta Collegiate"
+              "name": "KIPP Atlanta Collegiate",
+              "city": "Atlanta"
             },
             {
-              "name": "Washington"
+              "name": "Washington",
+              "city": "Atlanta"
             }
           ]
         },
@@ -1088,19 +1307,24 @@
           "region": 6,
           "schools": [
             {
-              "name": "Columbia"
+              "name": "Columbia",
+              "city": "Decatur"
             },
             {
-              "name": "South Atlanta"
+              "name": "South Atlanta",
+              "city": "Atlanta"
             },
             {
-              "name": "Miller Grove"
+              "name": "Miller Grove",
+              "city": "Lithonia"
             },
             {
-              "name": "Redan"
+              "name": "Redan",
+              "city": "Stone Mountain"
             },
             {
-              "name": "Salem"
+              "name": "Salem",
+              "city": "Conyers"
             }
           ]
         },
@@ -1112,29 +1336,36 @@
               "city": "Rockmart"
             },
             {
-              "name": "North Cobb Christian"
+              "name": "North Cobb Christian",
+              "city": "Kennesaw"
             },
             {
               "name": "Ringgold",
               "city": "Ringgold"
             },
             {
-              "name": "North Murray"
+              "name": "North Murray",
+              "city": "Chatsworth"
             },
             {
-              "name": "Union County"
+              "name": "Union County",
+              "city": "Blairsville"
             },
             {
-              "name": "Lakeview-Ft. Oglethorpe"
+              "name": "Lakeview-Ft. Oglethorpe",
+              "city": "Fort Oglethorpe"
             },
             {
-              "name": "Sonoraville"
+              "name": "Sonoraville",
+              "city": "Calhoun"
             },
             {
-              "name": "Coahulla Creek"
+              "name": "Coahulla Creek",
+              "city": "Dalton"
             },
             {
-              "name": "Murray County"
+              "name": "Murray County",
+              "city": "Chatsworth"
             }
           ]
         },
@@ -1142,22 +1373,28 @@
           "region": 8,
           "schools": [
             {
-              "name": "Prince Avenue Christian"
+              "name": "Prince Avenue Christian",
+              "city": "Bogart"
             },
             {
-              "name": "Hebron Christian Academy"
+              "name": "Hebron Christian Academy",
+              "city": "Dacula"
             },
             {
-              "name": "Stephens County"
+              "name": "Stephens County",
+              "city": "Toccoa"
             },
             {
-              "name": "Hart County"
+              "name": "Hart County",
+              "city": "Hartwell"
             },
             {
-              "name": "East Jackson"
+              "name": "East Jackson",
+              "city": "Commerce"
             },
             {
-              "name": "Franklin County"
+              "name": "Franklin County",
+              "city": "Carnesville"
             }
           ]
         }
@@ -1174,23 +1411,28 @@
               "city": "Thomasville"
             },
             {
-              "name": "Worth County"
+              "name": "Worth County",
+              "city": "Sylvester"
             },
             {
               "name": "Fitzgerald",
               "city": "Fitzgerald"
             },
             {
-              "name": "Jeff Davis"
+              "name": "Jeff Davis",
+              "city": "Hazlehurst"
             },
             {
-              "name": "Brantley County"
+              "name": "Brantley County",
+              "city": "Nahunta"
             },
             {
-              "name": "Bacon County"
+              "name": "Bacon County",
+              "city": "Alma"
             },
             {
-              "name": "Berrien"
+              "name": "Berrien",
+              "city": "Nashville"
             }
           ]
         },
@@ -1202,31 +1444,40 @@
               "city": "Dublin"
             },
             {
-              "name": "Northeast"
+              "name": "Northeast",
+              "city": "Macon"
             },
             {
-              "name": "Dodge County"
+              "name": "Dodge County",
+              "city": "Eastman"
             },
             {
-              "name": "Washington County"
+              "name": "Washington County",
+              "city": "Sandersville"
             },
             {
-              "name": "ACE Charter"
+              "name": "ACE Charter",
+              "city": "Macon"
             },
             {
-              "name": "Southwest"
+              "name": "Southwest",
+              "city": "Macon"
             },
             {
-              "name": "Bleckley County"
+              "name": "Bleckley County",
+              "city": "Cochran"
             },
             {
-              "name": "East Laurens"
+              "name": "East Laurens",
+              "city": "East Dublin"
             },
             {
-              "name": "Jefferson County"
+              "name": "Jefferson County",
+              "city": "Louisville"
             },
             {
-              "name": "Central-Macon"
+              "name": "Central-Macon",
+              "city": "Macon"
             }
           ]
         },
@@ -1234,17 +1485,20 @@
           "region": 3,
           "schools": [
             {
-              "name": "Savannah Christian"
+              "name": "Savannah Christian",
+              "city": "Savannah"
             },
             {
-              "name": "Toombs County"
+              "name": "Toombs County",
+              "city": "Lyons"
             },
             {
               "name": "Swainsboro",
               "city": "Swainsboro"
             },
             {
-              "name": "Savannah Country Day"
+              "name": "Savannah Country Day",
+              "city": "Savannah"
             },
             {
               "name": "Vidalia",
@@ -1256,26 +1510,32 @@
           "region": 4,
           "schools": [
             {
-              "name": "Lamar County"
+              "name": "Lamar County",
+              "city": "Barnesville"
             },
             {
               "name": "Social Circle",
               "city": "Social Circle"
             },
             {
-              "name": "Jasper County"
+              "name": "Jasper County",
+              "city": "Monticello"
             },
             {
-              "name": "Putnam County"
+              "name": "Putnam County",
+              "city": "Eatonton"
             },
             {
-              "name": "McNair"
+              "name": "McNair",
+              "city": "Atlanta"
             },
             {
-              "name": "Towers"
+              "name": "Towers",
+              "city": "Decatur"
             },
             {
-              "name": "Utopian Academy"
+              "name": "Utopian Academy",
+              "city": "Ellenwood"
             }
           ]
         },
@@ -1283,40 +1543,52 @@
           "region": 5,
           "schools": [
             {
-              "name": "Fellowship Christian"
+              "name": "Fellowship Christian",
+              "city": "Roswell"
             },
             {
-              "name": "Wesleyan"
+              "name": "Wesleyan",
+              "city": "Peachtree Corners"
             },
             {
-              "name": "Whitefield Academy"
+              "name": "Whitefield Academy",
+              "city": "Mableton"
             },
             {
-              "name": "Mt. Paran Christian"
+              "name": "Mt. Paran Christian",
+              "city": "Kennesaw"
             },
             {
-              "name": "Landmark Christian"
+              "name": "Landmark Christian",
+              "city": "Fairburn"
             },
             {
-              "name": "King's Ridge"
+              "name": "King's Ridge",
+              "city": "Alpharetta"
             },
             {
-              "name": "Mount Vernon"
+              "name": "Mount Vernon",
+              "city": "Sandy Springs"
             },
             {
-              "name": "B.E.S.T Academy"
+              "name": "B.E.S.T Academy",
+              "city": "Atlanta"
             },
             {
-              "name": "Mt. Pisgah Christian"
+              "name": "Mt. Pisgah Christian",
+              "city": "Johns Creek"
             },
             {
-              "name": "Mt. Bethel Christian"
+              "name": "Mt. Bethel Christian",
+              "city": "Marietta"
             },
             {
-              "name": "Walker"
+              "name": "Walker",
+              "city": "Marietta"
             },
             {
-              "name": "St. Francis"
+              "name": "St. Francis",
+              "city": "Alpharetta"
             }
           ]
         },
@@ -1324,7 +1596,8 @@
           "region": 6,
           "schools": [
             {
-              "name": "Heard County"
+              "name": "Heard County",
+              "city": "Franklin"
             },
             {
               "name": "Temple",
@@ -1335,16 +1608,20 @@
               "city": "Bremen"
             },
             {
-              "name": "Darlington"
+              "name": "Darlington",
+              "city": "Rome"
             },
             {
-              "name": "Pepperell"
+              "name": "Pepperell",
+              "city": "Lindale"
             },
             {
-              "name": "Model"
+              "name": "Model",
+              "city": "Rome"
             },
             {
-              "name": "Haralson County"
+              "name": "Haralson County",
+              "city": "Tallapoosa"
             }
           ]
         },
@@ -1352,28 +1629,36 @@
           "region": 7,
           "schools": [
             {
-              "name": "Fannin County"
+              "name": "Fannin County",
+              "city": "Blue Ridge"
             },
             {
-              "name": "Christian Heritage"
+              "name": "Christian Heritage",
+              "city": "Dalton"
             },
             {
-              "name": "Gordon Lee"
+              "name": "Gordon Lee",
+              "city": "Chickamauga"
             },
             {
-              "name": "Chattooga"
+              "name": "Chattooga",
+              "city": "Summerville"
             },
             {
-              "name": "Dade County"
+              "name": "Dade County",
+              "city": "Trenton"
             },
             {
-              "name": "Coosa"
+              "name": "Coosa",
+              "city": "Rome"
             },
             {
-              "name": "Gordon Central"
+              "name": "Gordon Central",
+              "city": "Calhoun"
             },
             {
-              "name": "Armuchee"
+              "name": "Armuchee",
+              "city": "Rome"
             }
           ]
         },
@@ -1381,26 +1666,32 @@
           "region": 8,
           "schools": [
             {
-              "name": "Athens Academy"
+              "name": "Athens Academy",
+              "city": "Athens"
             },
             {
               "name": "Commerce",
               "city": "Commerce"
             },
             {
-              "name": "Elbert County"
+              "name": "Elbert County",
+              "city": "Elberton"
             },
             {
-              "name": "Rabun County"
+              "name": "Rabun County",
+              "city": "Tiger"
             },
             {
-              "name": "Banks County"
+              "name": "Banks County",
+              "city": "Homer"
             },
             {
-              "name": "Providence Christian"
+              "name": "Providence Christian",
+              "city": "Lilburn"
             },
             {
-              "name": "Oglethorpe County"
+              "name": "Oglethorpe County",
+              "city": "Lexington"
             }
           ]
         }
@@ -1413,44 +1704,56 @@
           "region": 1,
           "schools": [
             {
-              "name": "Mitchell County"
+              "name": "Mitchell County",
+              "city": "Camilla"
             },
             {
-              "name": "Early County"
+              "name": "Early County",
+              "city": "Blakely"
             },
             {
-              "name": "Calhoun County"
+              "name": "Calhoun County",
+              "city": "Edison"
             },
             {
-              "name": "Miller County"
+              "name": "Miller County",
+              "city": "Colquitt"
             },
             {
-              "name": "Pataula Charter"
+              "name": "Pataula Charter",
+              "city": "Edison"
             },
             {
-              "name": "Seminole County"
+              "name": "Seminole County",
+              "city": "Donalsonville"
             },
             {
               "name": "Pelham",
               "city": "Pelham"
             },
             {
-              "name": "Randolph-Clay"
+              "name": "Randolph-Clay",
+              "city": "Cuthbert"
             },
             {
-              "name": "Baconton"
+              "name": "Baconton",
+              "city": "Baconton"
             },
             {
-              "name": "Southwest Georgia STEM"
+              "name": "Southwest Georgia STEM",
+              "city": "Shellman"
             },
             {
-              "name": "Terrell County"
+              "name": "Terrell County",
+              "city": "Dawson"
             },
             {
-              "name": "Baker County"
+              "name": "Baker County",
+              "city": "Newton"
             },
             {
-              "name": "Spring Creek"
+              "name": "Spring Creek",
+              "city": "Bainbridge"
             }
           ]
         },
@@ -1458,25 +1761,32 @@
           "region": 2,
           "schools": [
             {
-              "name": "Clinch County"
+              "name": "Clinch County",
+              "city": "Homerville"
             },
             {
-              "name": "Irwin County"
+              "name": "Irwin County",
+              "city": "Ocilla"
             },
             {
-              "name": "Brooks County"
+              "name": "Brooks County",
+              "city": "Quitman"
             },
             {
-              "name": "Charlton County"
+              "name": "Charlton County",
+              "city": "Folkston"
             },
             {
-              "name": "Turner County"
+              "name": "Turner County",
+              "city": "Ashburn"
             },
             {
-              "name": "Atkinson County"
+              "name": "Atkinson County",
+              "city": "Pearson"
             },
             {
-              "name": "Lanier County"
+              "name": "Lanier County",
+              "city": "Lakeland"
             }
           ]
         },
@@ -1488,22 +1798,28 @@
               "city": "Metter"
             },
             {
-              "name": "Jenkins County"
+              "name": "Jenkins County",
+              "city": "Millen"
             },
             {
-              "name": "McIntosh County Academy"
+              "name": "McIntosh County Academy",
+              "city": "Darien"
             },
             {
-              "name": "Emanuel County Institute"
+              "name": "Emanuel County Institute",
+              "city": "Twin City"
             },
             {
-              "name": "Bryan County"
+              "name": "Bryan County",
+              "city": "Pembroke"
             },
             {
-              "name": "Portal"
+              "name": "Portal",
+              "city": "Portal"
             },
             {
-              "name": "Screven County"
+              "name": "Screven County",
+              "city": "Sylvania"
             },
             {
               "name": "Claxton",
@@ -1519,26 +1835,32 @@
           "region": 4,
           "schools": [
             {
-              "name": "Telfair County"
+              "name": "Telfair County",
+              "city": "McRae"
             },
             {
               "name": "Hawkinsville",
               "city": "Hawkinsville"
             },
             {
-              "name": "Wheeler County"
+              "name": "Wheeler County",
+              "city": "Alamo"
             },
             {
-              "name": "Wilcox County"
+              "name": "Wilcox County",
+              "city": "Rochelle"
             },
             {
-              "name": "Treutlen"
+              "name": "Treutlen",
+              "city": "Soperton"
             },
             {
-              "name": "Dooly County"
+              "name": "Dooly County",
+              "city": "Vienna"
             },
             {
-              "name": "Montgomery County"
+              "name": "Montgomery County",
+              "city": "Mount Vernon"
             }
           ]
         },
@@ -1546,22 +1868,28 @@
           "region": 5,
           "schools": [
             {
-              "name": "Johnson County"
+              "name": "Johnson County",
+              "city": "Wrightsville"
             },
             {
-              "name": "Wilkinson County"
+              "name": "Wilkinson County",
+              "city": "Irwinton"
             },
             {
-              "name": "Hancock Central"
+              "name": "Hancock Central",
+              "city": "Sparta"
             },
             {
-              "name": "Glascock County"
+              "name": "Glascock County",
+              "city": "Gibson"
             },
             {
-              "name": "Twiggs County"
+              "name": "Twiggs County",
+              "city": "Jeffersonville"
             },
             {
-              "name": "Georgia Military College"
+              "name": "Georgia Military College",
+              "city": "Milledgeville"
             }
           ]
         },
@@ -1569,25 +1897,32 @@
           "region": 6,
           "schools": [
             {
-              "name": "Macon County"
+              "name": "Macon County",
+              "city": "Montezuma"
             },
             {
-              "name": "Schley County"
+              "name": "Schley County",
+              "city": "Ellaville"
             },
             {
-              "name": "Taylor County"
+              "name": "Taylor County",
+              "city": "Butler"
             },
             {
-              "name": "Marion County"
+              "name": "Marion County",
+              "city": "Buena Vista"
             },
             {
-              "name": "Crawford County"
+              "name": "Crawford County",
+              "city": "Roberta"
             },
             {
-              "name": "Chattahoochee County"
+              "name": "Chattahoochee County",
+              "city": "Cusseta"
             },
             {
-              "name": "Central-Talbotton"
+              "name": "Central-Talbotton",
+              "city": "Talbotton"
             }
           ]
         },
@@ -1611,7 +1946,8 @@
               "city": "Greenville"
             },
             {
-              "name": "Mt. Zion-Carroll"
+              "name": "Mt. Zion-Carroll",
+              "city": "Carrollton"
             }
           ]
         },
@@ -1619,22 +1955,28 @@
           "region": 8,
           "schools": [
             {
-              "name": "Lincoln County"
+              "name": "Lincoln County",
+              "city": "Lincolnton"
             },
             {
-              "name": "Greene County"
+              "name": "Greene County",
+              "city": "Greensboro"
             },
             {
-              "name": "Warren County"
+              "name": "Warren County",
+              "city": "Warrenton"
             },
             {
-              "name": "Washington-Wilkes"
+              "name": "Washington-Wilkes",
+              "city": "Washington"
             },
             {
-              "name": "Towns County"
+              "name": "Towns County",
+              "city": "Hiawassee"
             },
             {
-              "name": "Lake Oconee Academy"
+              "name": "Lake Oconee Academy",
+              "city": "Greensboro"
             }
           ]
         }


### PR DESCRIPTION
## What

Fills the `city` for the **342 GHSA schools** previously seeded as `TBD`, so **all 416** football teams now carry their real municipality. Builds on the merged seed importer (#341).

- `data/ghsa-2024-26.json`: **416/416** schools have a city (was 74/416).
- `apps/web/public/seed/ghsa-2024-26.json` regenerated — builder reports **0 `TBD`**.
- `stadium` is intentionally still a `TBD` placeholder a coach fills on claim.

## Source & method (the "second source")

Cities were resolved by parallel web research across **Wikipedia, MaxPreps, and school sites**, mapped to the **municipality, not the county**, and verified against school identity — including the disambiguated names:

| School | City |
|---|---|
| Heritage-Conyers | Conyers |
| Central-Carroll | Carrollton |
| Veterans | Kathleen |
| Cass | White |
| Salem | Conyers |
| Rabun County | Tiger |
| Mt. Zion-Carroll | Carrollton |

Every school resolved with confidence (no nulls). Any individual city is a one-line edit to `"city"` if a correction is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)