### PR TITLE
fix(web): make league schedule page responsive on mobile (WSM-000154)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -118,14 +118,14 @@ export default async function LeagueSchedulePage({
         &larr; Back to League
       </Link>
 
-      <header className="mb-6 flex items-start justify-between gap-4">
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-2xl font-bold text-foreground">{league.name}</h2>
           <p className="text-sm text-muted-foreground">
             Schedule {activeSeason ? `· ${activeSeason.name}` : ""}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href={`/dashboard/leagues/${leagueId}/standings`}
             className="text-sm text-primary hover:underline"
@@ -180,7 +180,8 @@ export default async function LeagueSchedulePage({
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-0">
-                  <table className="w-full text-sm">
+                  <div className="overflow-x-auto">
+                  <table className="w-full min-w-[640px] text-sm">
                     <thead>
                       <tr className="border-b-2 border-border bg-muted text-left text-foreground">
                         <th className="px-4 py-2 font-mono text-xs uppercase">
@@ -297,6 +298,7 @@ export default async function LeagueSchedulePage({
                       ))}
                     </tbody>
                   </table>
+                  </div>
                 </CardContent>
               </Card>
             );


### PR DESCRIPTION
Fixes #350

## Root cause
The dashboard league Schedule page (`apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx`) overflowed horizontally on phone viewports for two reasons:

1. **Header (line 121)** — `<header className="mb-6 flex items-start justify-between gap-4">` with a non-wrapping child button group (`<div className="flex gap-2">` at line 128) holding the Standings link, the "Regenerate schedule" button, and the "New fixture" dialog. The row never wrapped, forcing the page wider than the viewport.
2. **Fixtures table (lines 182-183)** — `<CardContent className="p-0">` → `<table className="w-full text-sm">` with 6 columns and no horizontal-scroll wrapper. Its min-content width overflowed the card and the page.

## What changed (Tailwind only — Option A, smallest correct change)
- Header now stacks on mobile and lays out as a row from `sm:` up: `mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between`.
- Button group now wraps: `flex flex-wrap items-center gap-2`.
- Each per-week fixtures table is wrapped in `<div className="overflow-x-auto">` so it scrolls **within its card** instead of breaking the page, and the table gets a sensible min width: `w-full min-w-[640px] text-sm`. The wrapper is inside the per-week `.map()`, so every week's table gets it.
- No desktop / `sm:+` behavior change; nothing else touched. Single file changed.

```diff
-      <header className="mb-6 flex items-start justify-between gap-4">
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
...
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center gap-2">
...
                 <CardContent className="p-0">
-                  <table className="w-full text-sm">
+                  <div className="overflow-x-auto">
+                  <table className="w-full min-w-[640px] text-sm">
...
                   </table>
+                  </div>
                 </CardContent>
```

## Verification (all from `apps/web`)
- `tsc --noEmit` — clean (exit 0). (Note: workspace dep `@sports-management/api-contracts` must be built first via `pnpm --filter ... run build` / turbo `^build`; after that, zero type errors.)
- `eslint` on the file — clean (exit 0).
- `vitest run` — **567 passed (81 files)**, suite stays green.
- `pnpm run build` — `✓ Compiled successfully`; route `ƒ /dashboard/leagues/[id]/schedule` builds.

## Regression-test note (honest)
This is a **CSS-only** change to an async server component. This repo's vitest environment is `node` with **no jsdom/testing-library** (confirmed: `environment: "node"` in `apps/web/vitest.config.ts`), so a DOM render / visual unit test is not feasible without adding a new test stack — out of scope for a bug fix. I deliberately did **not** add a hacky source-text-grep "test". The fix is therefore verified by build + lint + type-check + the established Tailwind responsive pattern (`flex-col … sm:flex-row` stacking and `overflow-x-auto` scroll containment). 

**Recommended follow-up:** add a component/visual testing setup (e.g. Playwright viewport snapshots or jsdom + Testing Library) so responsive regressions like this can be caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)