### PR TITLE
feat(seed): refresh GHSA alignment to the 2025 football season

### DIFF
--- a/apps/web/public/seed/ghsa-2024-26.json
+++ b/apps/web/public/seed/ghsa-2024-26.json
@@ -13,26 +13,26 @@
           "players": []
         },
         {
-          "name": "Colquitt County",
-          "city": "Norman Park",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Valdosta",
           "city": "Valdosta",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Camden County",
-          "city": "Kingsland",
+          "name": "Colquitt County",
+          "city": "Norman Park",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Richmond Hill",
           "city": "Richmond Hill",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Camden County",
+          "city": "Kingsland",
           "stadium": "TBD",
           "players": []
         },
@@ -60,14 +60,14 @@
           "players": []
         },
         {
-          "name": "Westlake",
-          "city": "Atlanta",
+          "name": "East Coweta",
+          "city": "Sharpsburg",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "East Coweta",
-          "city": "Sharpsburg",
+          "name": "Westlake",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -83,6 +83,12 @@
       "name": "Region 3-6A",
       "teams": [
         {
+          "name": "McEachern",
+          "city": "Powder Springs",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Harrison",
           "city": "Kennesaw",
           "stadium": "TBD",
@@ -95,14 +101,8 @@
           "players": []
         },
         {
-          "name": "McEachern",
-          "city": "Powder Springs",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Pebblebrook",
-          "city": "Mableton",
+          "name": "Paulding County",
+          "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
@@ -113,8 +113,8 @@
           "players": []
         },
         {
-          "name": "Paulding County",
-          "city": "Dallas",
+          "name": "Pebblebrook",
+          "city": "Mableton",
           "stadium": "TBD",
           "players": []
         },
@@ -148,14 +148,14 @@
           "players": []
         },
         {
-          "name": "South Gwinnett",
-          "city": "Snellville",
+          "name": "Archer",
+          "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Archer",
-          "city": "Lawrenceville",
+          "name": "South Gwinnett",
+          "city": "Snellville",
           "stadium": "TBD",
           "players": []
         },
@@ -183,31 +183,25 @@
       "name": "Region 5-6A",
       "teams": [
         {
-          "name": "North Cobb",
-          "city": "Kennesaw",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Walton",
-          "city": "Marietta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "North Paulding",
           "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Cherokee",
-          "city": "Canton",
+          "name": "North Cobb",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Marietta",
+          "city": "Marietta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Walton",
           "city": "Marietta",
           "stadium": "TBD",
           "players": []
@@ -223,24 +217,18 @@
           "city": "Woodstock",
           "stadium": "TBD",
           "players": []
+        },
+        {
+          "name": "Cherokee",
+          "city": "Canton",
+          "stadium": "TBD",
+          "players": []
         }
       ]
     },
     {
       "name": "Region 6-6A",
       "teams": [
-        {
-          "name": "North Atlanta",
-          "city": "Atlanta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Lambert",
-          "city": "Suwanee",
-          "stadium": "TBD",
-          "players": []
-        },
         {
           "name": "West Forsyth",
           "city": "Cumming",
@@ -254,20 +242,32 @@
           "players": []
         },
         {
+          "name": "Lambert",
+          "city": "Suwanee",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "North Forsyth",
           "city": "Cumming",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Forsyth Central",
-          "city": "Cumming",
+          "name": "North Atlanta",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Alpharetta",
           "city": "Alpharetta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Forsyth Central",
+          "city": "Cumming",
           "stadium": "TBD",
           "players": []
         },
@@ -295,14 +295,14 @@
           "players": []
         },
         {
-          "name": "Norcross",
-          "city": "Norcross",
+          "name": "Peachtree Ridge",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Peachtree Ridge",
-          "city": "Suwanee",
+          "name": "Norcross",
+          "city": "Norcross",
           "stadium": "TBD",
           "players": []
         },
@@ -319,14 +319,14 @@
           "players": []
         },
         {
-          "name": "Berkmar",
-          "city": "Lilburn",
+          "name": "Meadowcreek",
+          "city": "Norcross",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Meadowcreek",
-          "city": "Norcross",
+          "name": "Berkmar",
+          "city": "Lilburn",
           "stadium": "TBD",
           "players": []
         }
@@ -342,14 +342,14 @@
           "players": []
         },
         {
-          "name": "Collins Hill",
-          "city": "Suwanee",
+          "name": "Mill Creek",
+          "city": "Hoschton",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Mill Creek",
-          "city": "Hoschton",
+          "name": "Collins Hill",
+          "city": "Suwanee",
           "stadium": "TBD",
           "players": []
         },
@@ -360,13 +360,13 @@
           "players": []
         },
         {
-          "name": "Mountain View",
+          "name": "Central Gwinnett",
           "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Central Gwinnett",
+          "name": "Mountain View",
           "city": "Lawrenceville",
           "stadium": "TBD",
           "players": []
@@ -389,32 +389,8 @@
           "players": []
         },
         {
-          "name": "Lakeside-Evans",
-          "city": "Evans",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Effingham County",
           "city": "Springfield",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Glynn Academy",
-          "city": "Brunswick",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Evans",
-          "city": "Evans",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Greenbrier",
-          "city": "Evans",
           "stadium": "TBD",
           "players": []
         },
@@ -425,14 +401,38 @@
           "players": []
         },
         {
-          "name": "Bradwell Institute",
-          "city": "Hinesville",
+          "name": "Glynn Academy",
+          "city": "Brunswick",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "South Effingham",
           "city": "Guyton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Evans",
+          "city": "Evans",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Bradwell Institute",
+          "city": "Hinesville",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Greenbrier",
+          "city": "Evans",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Lakeside-Evans",
+          "city": "Evans",
           "stadium": "TBD",
           "players": []
         }
@@ -442,20 +442,8 @@
       "name": "Region 2-5A",
       "teams": [
         {
-          "name": "Lee County",
-          "city": "Leesburg",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Thomas County Central",
           "city": "Thomasville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Coffee",
-          "city": "Douglas",
           "stadium": "TBD",
           "players": []
         },
@@ -466,14 +454,26 @@
           "players": []
         },
         {
-          "name": "Veterans",
-          "city": "Kathleen",
+          "name": "Lee County",
+          "city": "Leesburg",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Coffee",
+          "city": "Douglas",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Northside-Warner Robins",
           "city": "Warner Robins",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Veterans",
+          "city": "Kathleen",
           "stadium": "TBD",
           "players": []
         }
@@ -489,7 +489,19 @@
           "players": []
         },
         {
+          "name": "Lovejoy",
+          "city": "Hampton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Newnan",
+          "city": "Newnan",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Northgate",
           "city": "Newnan",
           "stadium": "TBD",
           "players": []
@@ -501,32 +513,20 @@
           "players": []
         },
         {
-          "name": "Lovejoy",
-          "city": "Hampton",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "McIntosh",
           "city": "Peachtree City",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Morrow",
-          "city": "Morrow",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Northgate",
-          "city": "Newnan",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Banneker",
           "city": "College Park",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Morrow",
+          "city": "Morrow",
           "stadium": "TBD",
           "players": []
         }
@@ -542,14 +542,8 @@
           "players": []
         },
         {
-          "name": "Decatur",
-          "city": "Decatur",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Tri-Cities",
-          "city": "East Point",
+          "name": "Shiloh",
+          "city": "Snellville",
           "stadium": "TBD",
           "players": []
         },
@@ -560,26 +554,32 @@
           "players": []
         },
         {
-          "name": "Lakeside-DeKalb",
-          "city": "Atlanta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Shiloh",
-          "city": "Snellville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Chamblee",
           "city": "Chamblee",
           "stadium": "TBD",
           "players": []
         },
         {
+          "name": "Decatur",
+          "city": "Decatur",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Arabia Mountain",
           "city": "Lithonia",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Lakeside-DeKalb",
+          "city": "Atlanta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Tri-Cities",
+          "city": "East Point",
           "stadium": "TBD",
           "players": []
         }
@@ -595,12 +595,6 @@
           "players": []
         },
         {
-          "name": "East Paulding",
-          "city": "Dallas",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "New Manchester",
           "city": "Douglasville",
           "stadium": "TBD",
@@ -609,6 +603,12 @@
         {
           "name": "Villa Rica",
           "city": "Villa Rica",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "East Paulding",
+          "city": "Dallas",
           "stadium": "TBD",
           "players": []
         },
@@ -654,6 +654,12 @@
           "players": []
         },
         {
+          "name": "Creekview",
+          "city": "Canton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "River Ridge",
           "city": "Woodstock",
           "stadium": "TBD",
@@ -666,8 +672,8 @@
           "players": []
         },
         {
-          "name": "Creekview",
-          "city": "Canton",
+          "name": "Lassiter",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
@@ -682,24 +688,12 @@
           "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
-        },
-        {
-          "name": "Lassiter",
-          "city": "Marietta",
-          "stadium": "TBD",
-          "players": []
         }
       ]
     },
     {
       "name": "Region 7-5A",
       "teams": [
-        {
-          "name": "Milton",
-          "city": "Milton",
-          "stadium": "TBD",
-          "players": []
-        },
         {
           "name": "Roswell",
           "city": "Roswell",
@@ -713,14 +707,20 @@
           "players": []
         },
         {
-          "name": "Lanier",
-          "city": "Sugar Hill",
+          "name": "Milton",
+          "city": "Milton",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Seckinger",
           "city": "Buford",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Lanier",
+          "city": "Sugar Hill",
           "stadium": "TBD",
           "players": []
         },
@@ -742,20 +742,8 @@
       "name": "Region 8-5A",
       "teams": [
         {
-          "name": "Clarke Central",
-          "city": "Athens",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Jackson County",
           "city": "Hoschton",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Winder-Barrow",
-          "city": "Winder",
           "stadium": "TBD",
           "players": []
         },
@@ -766,8 +754,20 @@
           "players": []
         },
         {
-          "name": "Loganville",
-          "city": "Loganville",
+          "name": "Clarke Central",
+          "city": "Athens",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Winder-Barrow",
+          "city": "Winder",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Apalachee",
+          "city": "Winder",
           "stadium": "TBD",
           "players": []
         },
@@ -778,8 +778,8 @@
           "players": []
         },
         {
-          "name": "Apalachee",
-          "city": "Winder",
+          "name": "Loganville",
+          "city": "Loganville",
           "stadium": "TBD",
           "players": []
         }
@@ -789,8 +789,14 @@
       "name": "Region 1-4A",
       "teams": [
         {
-          "name": "Perry",
-          "city": "Perry",
+          "name": "Benedictine",
+          "city": "Savannah",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Ware County",
+          "city": "Waycross",
           "stadium": "TBD",
           "players": []
         },
@@ -801,14 +807,8 @@
           "players": []
         },
         {
-          "name": "Benedictine",
-          "city": "Savannah",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Ware County",
-          "city": "Waycross",
+          "name": "Perry",
+          "city": "Perry",
           "stadium": "TBD",
           "players": []
         },
@@ -830,14 +830,20 @@
       "name": "Region 2-4A",
       "teams": [
         {
+          "name": "Locust Grove",
+          "city": "Locust Grove",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Ola",
           "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Jones County",
-          "city": "Gray",
+          "name": "Stockbridge",
+          "city": "Stockbridge",
           "stadium": "TBD",
           "players": []
         },
@@ -854,19 +860,13 @@
           "players": []
         },
         {
-          "name": "Locust Grove",
-          "city": "Locust Grove",
+          "name": "Jones County",
+          "city": "Gray",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Union Grove",
-          "city": "McDonough",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Eagle's Landing Christian",
+          "name": "McDonough",
           "city": "McDonough",
           "stadium": "TBD",
           "players": []
@@ -878,14 +878,14 @@
           "players": []
         },
         {
-          "name": "McDonough",
+          "name": "Eagle's Landing Christian",
           "city": "McDonough",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Stockbridge",
-          "city": "Stockbridge",
+          "name": "Union Grove",
+          "city": "McDonough",
           "stadium": "TBD",
           "players": []
         }
@@ -895,20 +895,26 @@
       "name": "Region 3-4A",
       "teams": [
         {
-          "name": "Starr's Mill",
-          "city": "Fayetteville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Central-Carroll",
           "city": "Carrollton",
           "stadium": "TBD",
           "players": []
         },
         {
+          "name": "Griffin",
+          "city": "Griffin",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Jonesboro",
           "city": "Jonesboro",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Starr's Mill",
+          "city": "Fayetteville",
           "stadium": "TBD",
           "players": []
         },
@@ -921,12 +927,6 @@
         {
           "name": "Northside-Columbus",
           "city": "Columbus",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Griffin",
-          "city": "Griffin",
           "stadium": "TBD",
           "players": []
         },
@@ -948,6 +948,12 @@
           "players": []
         },
         {
+          "name": "M.L. King",
+          "city": "Lithonia",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Mays",
           "city": "Atlanta",
           "stadium": "TBD",
@@ -960,14 +966,8 @@
           "players": []
         },
         {
-          "name": "Drew",
-          "city": "Riverdale",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "M.L. King",
-          "city": "Lithonia",
+          "name": "Midtown",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -978,14 +978,14 @@
           "players": []
         },
         {
-          "name": "Midtown",
-          "city": "Atlanta",
+          "name": "Forest Park",
+          "city": "Forest Park",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Forest Park",
-          "city": "Forest Park",
+          "name": "Drew",
+          "city": "Riverdale",
           "stadium": "TBD",
           "players": []
         }
@@ -1007,8 +1007,8 @@
           "players": []
         },
         {
-          "name": "St. Pius X",
-          "city": "Atlanta",
+          "name": "Lithonia",
+          "city": "Lithonia",
           "stadium": "TBD",
           "players": []
         },
@@ -1019,8 +1019,8 @@
           "players": []
         },
         {
-          "name": "Lithonia",
-          "city": "Lithonia",
+          "name": "St. Pius X",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -1031,26 +1031,26 @@
           "players": []
         },
         {
-          "name": "North Springs",
-          "city": "Sandy Springs",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Northview",
           "city": "Johns Creek",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Clarkston",
-          "city": "Clarkston",
+          "name": "North Springs",
+          "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Cross Keys",
           "city": "Brookhaven",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Clarkston",
+          "city": "Clarkston",
           "stadium": "TBD",
           "players": []
         }
@@ -1060,8 +1060,8 @@
       "name": "Region 6-4A",
       "teams": [
         {
-          "name": "Blessed Trinity",
-          "city": "Roswell",
+          "name": "Kell",
+          "city": "Marietta",
           "stadium": "TBD",
           "players": []
         },
@@ -1072,20 +1072,20 @@
           "players": []
         },
         {
-          "name": "Kell",
-          "city": "Marietta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Westminster",
-          "city": "Atlanta",
+          "name": "Blessed Trinity",
+          "city": "Roswell",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Centennial",
           "city": "Roswell",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Westminster",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         }
@@ -1101,8 +1101,8 @@
           "players": []
         },
         {
-          "name": "Cedartown",
-          "city": "Cedartown",
+          "name": "Cass",
+          "city": "White",
           "stadium": "TBD",
           "players": []
         },
@@ -1113,8 +1113,8 @@
           "players": []
         },
         {
-          "name": "Cass",
-          "city": "White",
+          "name": "Dalton",
+          "city": "Dalton",
           "stadium": "TBD",
           "players": []
         },
@@ -1131,13 +1131,13 @@
           "players": []
         },
         {
-          "name": "Southeast Whitfield",
-          "city": "Dalton",
+          "name": "Cedartown",
+          "city": "Cedartown",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Dalton",
+          "name": "Southeast Whitfield",
           "city": "Dalton",
           "stadium": "TBD",
           "players": []
@@ -1154,6 +1154,12 @@
           "players": []
         },
         {
+          "name": "Flowery Branch",
+          "city": "Flowery Branch",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Eastside",
           "city": "Covington",
           "stadium": "TBD",
@@ -1162,12 +1168,6 @@
         {
           "name": "East Forsyth",
           "city": "Gainesville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Flowery Branch",
-          "city": "Flowery Branch",
           "stadium": "TBD",
           "players": []
         },
@@ -1195,6 +1195,12 @@
       "name": "Region 1-3A",
       "teams": [
         {
+          "name": "Cairo",
+          "city": "Cairo",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Peach County",
           "city": "Fort Valley",
           "stadium": "TBD",
@@ -1207,13 +1213,13 @@
           "players": []
         },
         {
-          "name": "Cairo",
-          "city": "Cairo",
+          "name": "Monroe",
+          "city": "Albany",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Monroe",
+          "name": "Dougherty",
           "city": "Albany",
           "stadium": "TBD",
           "players": []
@@ -1221,12 +1227,6 @@
         {
           "name": "Bainbridge",
           "city": "Bainbridge",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Dougherty",
-          "city": "Albany",
           "stadium": "TBD",
           "players": []
         }
@@ -1242,14 +1242,14 @@
           "players": []
         },
         {
-          "name": "LaGrange",
+          "name": "Troup County",
           "city": "LaGrange",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Upson-Lee",
-          "city": "Thomaston",
+          "name": "LaGrange",
+          "city": "LaGrange",
           "stadium": "TBD",
           "players": []
         },
@@ -1260,26 +1260,26 @@
           "players": []
         },
         {
-          "name": "Spalding",
-          "city": "Griffin",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Troup County",
-          "city": "LaGrange",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Mary Persons",
           "city": "Forsyth",
           "stadium": "TBD",
           "players": []
         },
         {
+          "name": "Upson-Lee",
+          "city": "Thomaston",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Trinity Christian",
           "city": "Sharpsburg",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Spalding",
+          "city": "Griffin",
           "stadium": "TBD",
           "players": []
         },
@@ -1295,13 +1295,31 @@
       "name": "Region 3-3A",
       "teams": [
         {
+          "name": "Jenkins",
+          "city": "Savannah",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Calvary Day School",
           "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Jenkins",
+          "name": "Liberty County",
+          "city": "Hinesville",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Long County",
+          "city": "Ludowici",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Beach",
           "city": "Savannah",
           "stadium": "TBD",
           "players": []
@@ -1313,19 +1331,7 @@
           "players": []
         },
         {
-          "name": "Long County",
-          "city": "Ludowici",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Liberty County",
-          "city": "Hinesville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Beach",
+          "name": "Windsor Forest",
           "city": "Savannah",
           "stadium": "TBD",
           "players": []
@@ -1337,7 +1343,7 @@
           "players": []
         },
         {
-          "name": "Windsor Forest",
+          "name": "Islands",
           "city": "Savannah",
           "stadium": "TBD",
           "players": []
@@ -1347,24 +1353,12 @@
           "city": "Garden City",
           "stadium": "TBD",
           "players": []
-        },
-        {
-          "name": "Islands",
-          "city": "Savannah",
-          "stadium": "TBD",
-          "players": []
         }
       ]
     },
     {
       "name": "Region 4-3A",
       "teams": [
-        {
-          "name": "Harlem",
-          "city": "Harlem",
-          "stadium": "TBD",
-          "players": []
-        },
         {
           "name": "West Laurens",
           "city": "Dexter",
@@ -1378,20 +1372,8 @@
           "players": []
         },
         {
-          "name": "Baldwin",
-          "city": "Milledgeville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Aquinas",
-          "city": "Augusta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Howard",
-          "city": "Macon",
+          "name": "Harlem",
+          "city": "Harlem",
           "stadium": "TBD",
           "players": []
         },
@@ -1402,8 +1384,26 @@
           "players": []
         },
         {
+          "name": "Aquinas",
+          "city": "Augusta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Baldwin",
+          "city": "Milledgeville",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Hephzibah",
           "city": "Hephzibah",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Howard",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
@@ -1419,20 +1419,20 @@
       "name": "Region 5-3A",
       "teams": [
         {
-          "name": "Douglass-Atlanta",
-          "city": "Atlanta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Stephenson",
           "city": "Stone Mountain",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Luella",
-          "city": "Locust Grove",
+          "name": "North Clayton",
+          "city": "College Park",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Douglass-Atlanta",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -1443,14 +1443,14 @@
           "players": []
         },
         {
-          "name": "Mt. Zion-Jonesboro",
-          "city": "Jonesboro",
+          "name": "Luella",
+          "city": "Locust Grove",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "North Clayton",
-          "city": "College Park",
+          "name": "Mt. Zion-Jonesboro",
+          "city": "Jonesboro",
           "stadium": "TBD",
           "players": []
         },
@@ -1478,18 +1478,6 @@
           "players": []
         },
         {
-          "name": "Lumpkin County",
-          "city": "Dahlonega",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Chestatee",
-          "city": "Gainesville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Greater Atlanta Christian",
           "city": "Norcross",
           "stadium": "TBD",
@@ -1502,6 +1490,12 @@
           "players": []
         },
         {
+          "name": "Lumpkin County",
+          "city": "Dahlonega",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Dawson County",
           "city": "Dawsonville",
           "stadium": "TBD",
@@ -1510,6 +1504,12 @@
         {
           "name": "White County",
           "city": "Cleveland",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Chestatee",
+          "city": "Gainesville",
           "stadium": "TBD",
           "players": []
         },
@@ -1531,20 +1531,14 @@
           "players": []
         },
         {
-          "name": "Northwest Whitfield",
-          "city": "Tunnel Hill",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Heritage-Catoosa",
           "city": "Ringgold",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Adairsville",
-          "city": "Adairsville",
+          "name": "Northwest Whitfield",
+          "city": "Tunnel Hill",
           "stadium": "TBD",
           "players": []
         },
@@ -1555,14 +1549,20 @@
           "players": []
         },
         {
-          "name": "Ridgeland",
-          "city": "Rossville",
+          "name": "Adairsville",
+          "city": "Adairsville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "LaFayette",
           "city": "LaFayette",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Ridgeland",
+          "city": "Rossville",
           "stadium": "TBD",
           "players": []
         }
@@ -1572,14 +1572,14 @@
       "name": "Region 8-3A",
       "teams": [
         {
-          "name": "Cherokee Bluff",
-          "city": "Flowery Branch",
+          "name": "Jefferson",
+          "city": "Jefferson",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Jefferson",
-          "city": "Jefferson",
+          "name": "Monroe Area",
+          "city": "Monroe",
           "stadium": "TBD",
           "players": []
         },
@@ -1590,8 +1590,8 @@
           "players": []
         },
         {
-          "name": "Monroe Area",
-          "city": "Monroe",
+          "name": "Cherokee Bluff",
+          "city": "Flowery Branch",
           "stadium": "TBD",
           "players": []
         },
@@ -1631,25 +1631,25 @@
           "players": []
         },
         {
-          "name": "Shaw",
-          "city": "Columbus",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Hardaway",
-          "city": "Columbus",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Columbus",
           "city": "Columbus",
           "stadium": "TBD",
           "players": []
         },
         {
+          "name": "Shaw",
+          "city": "Columbus",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Kendrick",
+          "city": "Columbus",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Hardaway",
           "city": "Columbus",
           "stadium": "TBD",
           "players": []
@@ -1666,26 +1666,26 @@
       "name": "Region 2-2A",
       "teams": [
         {
-          "name": "Callaway",
-          "city": "Hogansville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Morgan County",
           "city": "Madison",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Westside-Macon",
-          "city": "Macon",
+          "name": "Callaway",
+          "city": "Hogansville",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Jackson",
           "city": "Jackson",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Westside-Macon",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
@@ -1713,14 +1713,14 @@
           "players": []
         },
         {
-          "name": "Pierce County",
-          "city": "Blackshear",
+          "name": "Crisp County",
+          "city": "Cordele",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Crisp County",
-          "city": "Cordele",
+          "name": "Pierce County",
+          "city": "Blackshear",
           "stadium": "TBD",
           "players": []
         },
@@ -1742,14 +1742,14 @@
       "name": "Region 4-2A",
       "teams": [
         {
-          "name": "Burke County",
-          "city": "Waynesboro",
+          "name": "Thomson",
+          "city": "Thomson",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Thomson",
-          "city": "Thomson",
+          "name": "Burke County",
+          "city": "Waynesboro",
           "stadium": "TBD",
           "players": []
         },
@@ -1766,13 +1766,13 @@
           "players": []
         },
         {
-          "name": "Glenn Hills",
+          "name": "Josey",
           "city": "Augusta",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Josey",
+          "name": "Glenn Hills",
           "city": "Augusta",
           "stadium": "TBD",
           "players": []
@@ -1783,20 +1783,14 @@
       "name": "Region 5-2A",
       "teams": [
         {
-          "name": "Hapeville",
-          "city": "Hapeville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Carver-Atlanta",
           "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Lovett",
-          "city": "Atlanta",
+          "name": "Hapeville",
+          "city": "Hapeville",
           "stadium": "TBD",
           "players": []
         },
@@ -1807,7 +1801,7 @@
           "players": []
         },
         {
-          "name": "Therrell",
+          "name": "Lovett",
           "city": "Atlanta",
           "stadium": "TBD",
           "players": []
@@ -1820,6 +1814,12 @@
         },
         {
           "name": "Washington",
+          "city": "Atlanta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Therrell",
           "city": "Atlanta",
           "stadium": "TBD",
           "players": []
@@ -1836,12 +1836,6 @@
           "players": []
         },
         {
-          "name": "South Atlanta",
-          "city": "Atlanta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Miller Grove",
           "city": "Lithonia",
           "stadium": "TBD",
@@ -1850,6 +1844,12 @@
         {
           "name": "Redan",
           "city": "Stone Mountain",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "South Atlanta",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -1871,26 +1871,8 @@
           "players": []
         },
         {
-          "name": "North Cobb Christian",
-          "city": "Kennesaw",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Ringgold",
-          "city": "Ringgold",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "North Murray",
           "city": "Chatsworth",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Union County",
-          "city": "Blairsville",
           "stadium": "TBD",
           "players": []
         },
@@ -1901,8 +1883,26 @@
           "players": []
         },
         {
+          "name": "Ringgold",
+          "city": "Ringgold",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Sonoraville",
           "city": "Calhoun",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Union County",
+          "city": "Blairsville",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "North Cobb Christian",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
@@ -1924,20 +1924,26 @@
       "name": "Region 8-2A",
       "teams": [
         {
+          "name": "Hebron Christian",
+          "city": "Dacula",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Prince Avenue Christian",
           "city": "Bogart",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Hebron Christian Academy",
-          "city": "Dacula",
+          "name": "Stephens County",
+          "city": "Toccoa",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Stephens County",
-          "city": "Toccoa",
+          "name": "Franklin County",
+          "city": "Carnesville",
           "stadium": "TBD",
           "players": []
         },
@@ -1952,24 +1958,12 @@
           "city": "Commerce",
           "stadium": "TBD",
           "players": []
-        },
-        {
-          "name": "Franklin County",
-          "city": "Carnesville",
-          "stadium": "TBD",
-          "players": []
         }
       ]
     },
     {
       "name": "Region 1-A Division I",
       "teams": [
-        {
-          "name": "Thomasville",
-          "city": "Thomasville",
-          "stadium": "TBD",
-          "players": []
-        },
         {
           "name": "Worth County",
           "city": "Sylvester",
@@ -1983,14 +1977,14 @@
           "players": []
         },
         {
-          "name": "Jeff Davis",
-          "city": "Hazlehurst",
+          "name": "Thomasville",
+          "city": "Thomasville",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Brantley County",
-          "city": "Nahunta",
+          "name": "Jeff Davis",
+          "city": "Hazlehurst",
           "stadium": "TBD",
           "players": []
         },
@@ -2003,6 +1997,12 @@
         {
           "name": "Berrien",
           "city": "Nashville",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Brantley County",
+          "city": "Nahunta",
           "stadium": "TBD",
           "players": []
         }
@@ -2020,6 +2020,12 @@
         {
           "name": "Northeast",
           "city": "Macon",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Bleckley County",
+          "city": "Cochran",
           "stadium": "TBD",
           "players": []
         },
@@ -2042,20 +2048,14 @@
           "players": []
         },
         {
-          "name": "Southwest",
-          "city": "Macon",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Bleckley County",
-          "city": "Cochran",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "East Laurens",
           "city": "East Dublin",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Southwest",
+          "city": "Macon",
           "stadium": "TBD",
           "players": []
         },
@@ -2077,14 +2077,14 @@
       "name": "Region 3-A Division I",
       "teams": [
         {
-          "name": "Savannah Christian",
-          "city": "Savannah",
+          "name": "Toombs County",
+          "city": "Lyons",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Toombs County",
-          "city": "Lyons",
+          "name": "Savannah Christian",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
@@ -2118,14 +2118,14 @@
           "players": []
         },
         {
-          "name": "Social Circle",
-          "city": "Social Circle",
+          "name": "Jasper County",
+          "city": "Monticello",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Jasper County",
-          "city": "Monticello",
+          "name": "Social Circle",
+          "city": "Social Circle",
           "stadium": "TBD",
           "players": []
         },
@@ -2165,20 +2165,14 @@
           "players": []
         },
         {
-          "name": "Wesleyan",
-          "city": "Peachtree Corners",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Whitefield Academy",
           "city": "Mableton",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Mt. Paran Christian",
-          "city": "Kennesaw",
+          "name": "Wesleyan",
+          "city": "Peachtree Corners",
           "stadium": "TBD",
           "players": []
         },
@@ -2189,26 +2183,32 @@
           "players": []
         },
         {
-          "name": "King's Ridge",
-          "city": "Alpharetta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Mount Vernon",
           "city": "Sandy Springs",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "B.E.S.T Academy",
-          "city": "Atlanta",
+          "name": "King's Ridge",
+          "city": "Alpharetta",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Mt. Paran Christian",
+          "city": "Kennesaw",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Mt. Pisgah Christian",
           "city": "Johns Creek",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "B.E.S.T Academy",
+          "city": "Atlanta",
           "stadium": "TBD",
           "players": []
         },
@@ -2221,12 +2221,6 @@
         {
           "name": "Walker",
           "city": "Marietta",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "St. Francis",
-          "city": "Alpharetta",
           "stadium": "TBD",
           "players": []
         }
@@ -2242,8 +2236,14 @@
           "players": []
         },
         {
-          "name": "Temple",
-          "city": "Temple",
+          "name": "Pepperell",
+          "city": "Lindale",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Haralson County",
+          "city": "Tallapoosa",
           "stadium": "TBD",
           "players": []
         },
@@ -2254,26 +2254,20 @@
           "players": []
         },
         {
+          "name": "Temple",
+          "city": "Temple",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Darlington",
           "city": "Rome",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Pepperell",
-          "city": "Lindale",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Model",
           "city": "Rome",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Haralson County",
-          "city": "Tallapoosa",
           "stadium": "TBD",
           "players": []
         }
@@ -2283,8 +2277,8 @@
       "name": "Region 7-A Division I",
       "teams": [
         {
-          "name": "Fannin County",
-          "city": "Blue Ridge",
+          "name": "Gordon Lee",
+          "city": "Chickamauga",
           "stadium": "TBD",
           "players": []
         },
@@ -2295,8 +2289,14 @@
           "players": []
         },
         {
-          "name": "Gordon Lee",
-          "city": "Chickamauga",
+          "name": "Gordon Central",
+          "city": "Calhoun",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Fannin County",
+          "city": "Blue Ridge",
           "stadium": "TBD",
           "players": []
         },
@@ -2307,20 +2307,14 @@
           "players": []
         },
         {
-          "name": "Dade County",
-          "city": "Trenton",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Coosa",
           "city": "Rome",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Gordon Central",
-          "city": "Calhoun",
+          "name": "Dade County",
+          "city": "Trenton",
           "stadium": "TBD",
           "players": []
         },
@@ -2342,8 +2336,14 @@
           "players": []
         },
         {
-          "name": "Commerce",
-          "city": "Commerce",
+          "name": "Rabun County",
+          "city": "Tiger",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Oglethorpe County",
+          "city": "Lexington",
           "stadium": "TBD",
           "players": []
         },
@@ -2354,14 +2354,8 @@
           "players": []
         },
         {
-          "name": "Rabun County",
-          "city": "Tiger",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Banks County",
-          "city": "Homer",
+          "name": "Commerce",
+          "city": "Commerce",
           "stadium": "TBD",
           "players": []
         },
@@ -2372,8 +2366,8 @@
           "players": []
         },
         {
-          "name": "Oglethorpe County",
-          "city": "Lexington",
+          "name": "Banks County",
+          "city": "Homer",
           "stadium": "TBD",
           "players": []
         }
@@ -2383,32 +2377,8 @@
       "name": "Region 1-A Division II",
       "teams": [
         {
-          "name": "Mitchell County",
-          "city": "Camilla",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Early County",
           "city": "Blakely",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Calhoun County",
-          "city": "Edison",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Miller County",
-          "city": "Colquitt",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Pataula Charter",
-          "city": "Edison",
           "stadium": "TBD",
           "players": []
         },
@@ -2419,8 +2389,8 @@
           "players": []
         },
         {
-          "name": "Pelham",
-          "city": "Pelham",
+          "name": "Mitchell County",
+          "city": "Camilla",
           "stadium": "TBD",
           "players": []
         },
@@ -2431,8 +2401,26 @@
           "players": []
         },
         {
+          "name": "Miller County",
+          "city": "Colquitt",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Pelham",
+          "city": "Pelham",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Baconton",
           "city": "Baconton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Pataula Charter",
+          "city": "Edison",
           "stadium": "TBD",
           "players": []
         },
@@ -2443,20 +2431,14 @@
           "players": []
         },
         {
+          "name": "Calhoun County",
+          "city": "Edison",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Terrell County",
           "city": "Dawson",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Baker County",
-          "city": "Newton",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Spring Creek",
-          "city": "Bainbridge",
           "stadium": "TBD",
           "players": []
         }
@@ -2468,12 +2450,6 @@
         {
           "name": "Clinch County",
           "city": "Homerville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Irwin County",
-          "city": "Ocilla",
           "stadium": "TBD",
           "players": []
         },
@@ -2490,6 +2466,12 @@
           "players": []
         },
         {
+          "name": "Lanier County",
+          "city": "Lakeland",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Turner County",
           "city": "Ashburn",
           "stadium": "TBD",
@@ -2502,8 +2484,8 @@
           "players": []
         },
         {
-          "name": "Lanier County",
-          "city": "Lakeland",
+          "name": "Irwin County",
+          "city": "Ocilla",
           "stadium": "TBD",
           "players": []
         }
@@ -2513,20 +2495,8 @@
       "name": "Region 3-A Division II",
       "teams": [
         {
-          "name": "Metter",
-          "city": "Metter",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Jenkins County",
-          "city": "Millen",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "McIntosh County Academy",
-          "city": "Darien",
+          "name": "Screven County",
+          "city": "Sylvania",
           "stadium": "TBD",
           "players": []
         },
@@ -2537,8 +2507,26 @@
           "players": []
         },
         {
+          "name": "Jenkins County",
+          "city": "Millen",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
           "name": "Bryan County",
           "city": "Pembroke",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "McIntosh County Academy",
+          "city": "Darien",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Metter",
+          "city": "Metter",
           "stadium": "TBD",
           "players": []
         },
@@ -2549,20 +2537,14 @@
           "players": []
         },
         {
-          "name": "Screven County",
-          "city": "Sylvania",
+          "name": "Savannah",
+          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Claxton",
           "city": "Claxton",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Savannah",
-          "city": "Savannah",
           "stadium": "TBD",
           "players": []
         }
@@ -2572,20 +2554,14 @@
       "name": "Region 4-A Division II",
       "teams": [
         {
-          "name": "Telfair County",
-          "city": "McRae",
+          "name": "Wheeler County",
+          "city": "Alamo",
           "stadium": "TBD",
           "players": []
         },
         {
           "name": "Hawkinsville",
           "city": "Hawkinsville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Wheeler County",
-          "city": "Alamo",
           "stadium": "TBD",
           "players": []
         },
@@ -2598,6 +2574,12 @@
         {
           "name": "Treutlen",
           "city": "Soperton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Telfair County",
+          "city": "McRae",
           "stadium": "TBD",
           "players": []
         },
@@ -2631,8 +2613,8 @@
           "players": []
         },
         {
-          "name": "Hancock Central",
-          "city": "Sparta",
+          "name": "Georgia Military College",
+          "city": "Milledgeville",
           "stadium": "TBD",
           "players": []
         },
@@ -2643,14 +2625,14 @@
           "players": []
         },
         {
-          "name": "Twiggs County",
-          "city": "Jeffersonville",
+          "name": "Hancock Central",
+          "city": "Sparta",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Georgia Military College",
-          "city": "Milledgeville",
+          "name": "Twiggs County",
+          "city": "Jeffersonville",
           "stadium": "TBD",
           "players": []
         }
@@ -2660,8 +2642,8 @@
       "name": "Region 6-A Division II",
       "teams": [
         {
-          "name": "Macon County",
-          "city": "Montezuma",
+          "name": "Taylor County",
+          "city": "Butler",
           "stadium": "TBD",
           "players": []
         },
@@ -2672,14 +2654,14 @@
           "players": []
         },
         {
-          "name": "Taylor County",
-          "city": "Butler",
+          "name": "Macon County",
+          "city": "Montezuma",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Marion County",
-          "city": "Buena Vista",
+          "name": "Chattahoochee County",
+          "city": "Cusseta",
           "stadium": "TBD",
           "players": []
         },
@@ -2690,8 +2672,8 @@
           "players": []
         },
         {
-          "name": "Chattahoochee County",
-          "city": "Cusseta",
+          "name": "Marion County",
+          "city": "Buena Vista",
           "stadium": "TBD",
           "players": []
         },
@@ -2707,14 +2689,20 @@
       "name": "Region 7-A Division II",
       "teams": [
         {
-          "name": "Manchester",
-          "city": "Manchester",
+          "name": "Bowdon",
+          "city": "Bowdon",
           "stadium": "TBD",
           "players": []
         },
         {
-          "name": "Bowdon",
-          "city": "Bowdon",
+          "name": "Mt. Zion-Carroll",
+          "city": "Carrollton",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Manchester",
+          "city": "Manchester",
           "stadium": "TBD",
           "players": []
         },
@@ -2727,12 +2715,6 @@
         {
           "name": "Greenville",
           "city": "Greenville",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
-          "name": "Mt. Zion-Carroll",
-          "city": "Carrollton",
           "stadium": "TBD",
           "players": []
         }
@@ -2748,12 +2730,6 @@
           "players": []
         },
         {
-          "name": "Greene County",
-          "city": "Greensboro",
-          "stadium": "TBD",
-          "players": []
-        },
-        {
           "name": "Warren County",
           "city": "Warrenton",
           "stadium": "TBD",
@@ -2762,6 +2738,12 @@
         {
           "name": "Washington-Wilkes",
           "city": "Washington",
+          "stadium": "TBD",
+          "players": []
+        },
+        {
+          "name": "Greene County",
+          "city": "Greensboro",
           "stadium": "TBD",
           "players": []
         },

--- a/scripts/ghsa-seed/README.md
+++ b/scripts/ghsa-seed/README.md
@@ -40,7 +40,7 @@ Flags: `--in <path>` (alignment source), `--out <path>` (payload), `--post <base
 
 ### Dashboard "Seed GHSA" button
 
-The web app's `/dashboard/import` page has a **Seed GHSA football (416 teams)**
+The web app's `/dashboard/import` page has a **Seed GHSA football (413 teams)**
 button that loads a prebuilt copy of this payload into the normal import
 preview, so an admin can seed without the CLI. That copy lives at
 `apps/web/public/seed/ghsa-2024-26.json` — regenerate it after editing the
@@ -52,18 +52,21 @@ node scripts/ghsa-seed/build-import.mjs --out ../../apps/web/public/seed/ghsa-20
 
 ## Data provenance
 
-`data/ghsa-2024-26.json` is generated from the **GHSA 2024 football
+`data/ghsa-2024-26.json` is generated from the **GHSA 2025 football
 standings / region alignment** — the *football-specific* regions as actually
 competed, all 7 classifications (6A, 5A, 4A, 3A, 2A, A Division I, A Division
-II): **56 regions, 416 schools**.
+II): **56 regions, 413 schools**.
 
 Source of record (football regions):
-<https://www.ghsa.net/2024-ghsa-football-standings>
+<https://www.ghsa.net/2025-ghsa-football-standings>
 
 Local copies of the GHSA source PDFs live in [`docs/ghsa/`](../../docs/ghsa/).
 
-> ℹ️ The 2024-26 cycle has two football seasons; this is the **2024-season**
-> alignment. The 2025 season may shift a few schools within the same cycle.
+> ℹ️ The 2024-26 cycle has two football seasons. This file now holds the
+> **2025-season** alignment (refreshed from the 2024-season alignment, which had
+> 416 schools). Net change: 3 programs left football (`St. Francis`,
+> `Baker County`, `Spring Creek`) and `Hebron Christian Academy` is listed as
+> `Hebron Christian`; persisting schools kept their curated names and cities.
 
 ### How this was verified (and why 416, not 457)
 
@@ -75,10 +78,12 @@ official GHSA documents:
    *all-sports, enrollment-based* class list and is **organized by class, not by
    football region**, so it's authoritative for **school names/existence** but
    cannot validate regions.
-2. **2024 football standings** — the *football* region alignment. The data file
-   is now generated directly from this.
+2. **Football standings** — the *football* region alignment. The data file is
+   generated directly from this (currently the **2025** standings; first built
+   from 2024).
 
-Reconciling the two explains the count: the football alignment (**416**) excludes
+Reconciling the two explains the count: the football alignment (**413** for 2025,
+416 for 2024) excludes
 the **~44 schools that don't field varsity football** (e.g. Savannah Arts
 Academy, Davidson Fine Arts, Georgia Academy for the Blind, Woody Gap,
 Taliaferro County) plus a stray non-existent entry (`Genesis Innovation`), which
@@ -88,14 +93,16 @@ football though larger by enrollment; Innovation Academy is not in 6A football).
 
 Name fixes carried over from the reconciliation: `Tucker Sub`→`Tucker`,
 `Walton Grove`→`Walnut Grove`, and the mangled `Carroll Griffin` resolved into
-two real schools (`Central-Carroll` + `Griffin`). `Spring Creek` (A-DII) — flagged
-earlier — is **confirmed** in the official football alignment.
+two real schools (`Central-Carroll` + `Griffin`). `Spring Creek` (A-DII) was in
+the 2024 football alignment but is **not** in 2025 (one of the three programs
+that left football for the 2025 season).
 
 ## Extending
 
-1. **2025-season refresh** — regenerate from the 2025 football standings when
-   seeding for the 2025 season (same shape, a few schools move).
-2. **Cities** — all 416 schools have a `city`, enriched from public sources
+1. **Next cycle (2026-28)** — when GHSA publishes the new reclassification,
+   regenerate from that season's football standings (same shape). Within the
+   current 2024-26 cycle, re-run against the latest standings to pick up moves.
+2. **Cities** — all 413 schools have a `city`, enriched from public sources
    (Wikipedia / MaxPreps / school sites), resolved to the municipality (not the
    county). Edit a school's `"city"` to correct any.
 3. **Other states** — the alignment JSON is association-agnostic; point `--in`

--- a/scripts/ghsa-seed/data/ghsa-2024-26.json
+++ b/scripts/ghsa-seed/data/ghsa-2024-26.json
@@ -1,7 +1,7 @@
 {
   "league": "Georgia GHSA Football (2024-26)",
-  "source": "GHSA 2024 football standings / region alignment (https://www.ghsa.net/2024-ghsa-football-standings). These are FOOTBALL regions, not the enrollment-based reclassification. The 2025-season alignment may shift slightly within the same 2024-26 cycle.",
-  "notes": "School-level city is optional; when omitted the importer fills a 'TBD' placeholder a coach corrects on claim. Names are taken from the GHSA football standings with ' (Place)' normalized to '-Place'.",
+  "source": "GHSA 2025 football standings / region alignment (https://www.ghsa.net/2025-ghsa-football-standings, as of 2025-11-01). The 2025 season of the 2024-26 cycle. Names/cities reuse the curated dataset where a school persists from 2024.",
+  "notes": "School-level city is optional; when omitted the importer fills a 'TBD' placeholder a coach corrects on claim. Names carried over from the curated 2024-season dataset by normalized match (apostrophes/spelling preserved); '(Place)' normalized to '-Place' for new entries.",
   "classifications": [
     {
       "name": "6A",
@@ -14,20 +14,20 @@
               "city": "Valdosta"
             },
             {
-              "name": "Colquitt County",
-              "city": "Norman Park"
-            },
-            {
               "name": "Valdosta",
               "city": "Valdosta"
             },
             {
-              "name": "Camden County",
-              "city": "Kingsland"
+              "name": "Colquitt County",
+              "city": "Norman Park"
             },
             {
               "name": "Richmond Hill",
               "city": "Richmond Hill"
+            },
+            {
+              "name": "Camden County",
+              "city": "Kingsland"
             },
             {
               "name": "Tift County",
@@ -47,12 +47,12 @@
               "city": "Douglasville"
             },
             {
-              "name": "Westlake",
-              "city": "Atlanta"
-            },
-            {
               "name": "East Coweta",
               "city": "Sharpsburg"
+            },
+            {
+              "name": "Westlake",
+              "city": "Atlanta"
             },
             {
               "name": "Chapel Hill",
@@ -64,6 +64,10 @@
           "region": 3,
           "schools": [
             {
+              "name": "McEachern",
+              "city": "Powder Springs"
+            },
+            {
               "name": "Harrison",
               "city": "Kennesaw"
             },
@@ -72,20 +76,16 @@
               "city": "Powder Springs"
             },
             {
-              "name": "McEachern",
-              "city": "Powder Springs"
-            },
-            {
-              "name": "Pebblebrook",
-              "city": "Mableton"
+              "name": "Paulding County",
+              "city": "Dallas"
             },
             {
               "name": "Campbell",
               "city": "Smyrna"
             },
             {
-              "name": "Paulding County",
-              "city": "Dallas"
+              "name": "Pebblebrook",
+              "city": "Mableton"
             },
             {
               "name": "Osborne",
@@ -109,12 +109,12 @@
               "city": "Covington"
             },
             {
-              "name": "South Gwinnett",
-              "city": "Snellville"
-            },
-            {
               "name": "Archer",
               "city": "Lawrenceville"
+            },
+            {
+              "name": "South Gwinnett",
+              "city": "Snellville"
             },
             {
               "name": "Rockdale County",
@@ -134,23 +134,19 @@
           "region": 5,
           "schools": [
             {
-              "name": "North Cobb",
-              "city": "Kennesaw"
-            },
-            {
-              "name": "Walton",
-              "city": "Marietta"
-            },
-            {
               "name": "North Paulding",
               "city": "Dallas"
             },
             {
-              "name": "Cherokee",
-              "city": "Canton"
+              "name": "North Cobb",
+              "city": "Kennesaw"
             },
             {
               "name": "Marietta",
+              "city": "Marietta"
+            },
+            {
+              "name": "Walton",
               "city": "Marietta"
             },
             {
@@ -160,20 +156,16 @@
             {
               "name": "Etowah",
               "city": "Woodstock"
+            },
+            {
+              "name": "Cherokee",
+              "city": "Canton"
             }
           ]
         },
         {
           "region": 6,
           "schools": [
-            {
-              "name": "North Atlanta",
-              "city": "Atlanta"
-            },
-            {
-              "name": "Lambert",
-              "city": "Suwanee"
-            },
             {
               "name": "West Forsyth",
               "city": "Cumming"
@@ -183,16 +175,24 @@
               "city": "Alpharetta"
             },
             {
+              "name": "Lambert",
+              "city": "Suwanee"
+            },
+            {
               "name": "North Forsyth",
               "city": "Cumming"
             },
             {
-              "name": "Forsyth Central",
-              "city": "Cumming"
+              "name": "North Atlanta",
+              "city": "Atlanta"
             },
             {
               "name": "Alpharetta",
               "city": "Alpharetta"
+            },
+            {
+              "name": "Forsyth Central",
+              "city": "Cumming"
             },
             {
               "name": "South Forsyth",
@@ -212,12 +212,12 @@
               "city": "Snellville"
             },
             {
-              "name": "Norcross",
-              "city": "Norcross"
-            },
-            {
               "name": "Peachtree Ridge",
               "city": "Suwanee"
+            },
+            {
+              "name": "Norcross",
+              "city": "Norcross"
             },
             {
               "name": "Parkview",
@@ -228,12 +228,12 @@
               "city": "Duluth"
             },
             {
-              "name": "Berkmar",
-              "city": "Lilburn"
-            },
-            {
               "name": "Meadowcreek",
               "city": "Norcross"
+            },
+            {
+              "name": "Berkmar",
+              "city": "Lilburn"
             }
           ]
         },
@@ -245,23 +245,23 @@
               "city": "Buford"
             },
             {
-              "name": "Collins Hill",
-              "city": "Suwanee"
-            },
-            {
               "name": "Mill Creek",
               "city": "Hoschton"
+            },
+            {
+              "name": "Collins Hill",
+              "city": "Suwanee"
             },
             {
               "name": "Dacula",
               "city": "Dacula"
             },
             {
-              "name": "Mountain View",
+              "name": "Central Gwinnett",
               "city": "Lawrenceville"
             },
             {
-              "name": "Central Gwinnett",
+              "name": "Mountain View",
               "city": "Lawrenceville"
             },
             {
@@ -283,36 +283,36 @@
               "city": "Brunswick"
             },
             {
-              "name": "Lakeside-Evans",
-              "city": "Evans"
-            },
-            {
               "name": "Effingham County",
               "city": "Springfield"
-            },
-            {
-              "name": "Glynn Academy",
-              "city": "Brunswick"
-            },
-            {
-              "name": "Evans",
-              "city": "Evans"
-            },
-            {
-              "name": "Greenbrier",
-              "city": "Evans"
             },
             {
               "name": "Statesboro",
               "city": "Statesboro"
             },
             {
-              "name": "Bradwell Institute",
-              "city": "Hinesville"
+              "name": "Glynn Academy",
+              "city": "Brunswick"
             },
             {
               "name": "South Effingham",
               "city": "Guyton"
+            },
+            {
+              "name": "Evans",
+              "city": "Evans"
+            },
+            {
+              "name": "Bradwell Institute",
+              "city": "Hinesville"
+            },
+            {
+              "name": "Greenbrier",
+              "city": "Evans"
+            },
+            {
+              "name": "Lakeside-Evans",
+              "city": "Evans"
             }
           ]
         },
@@ -320,28 +320,28 @@
           "region": 2,
           "schools": [
             {
-              "name": "Lee County",
-              "city": "Leesburg"
-            },
-            {
               "name": "Thomas County Central",
               "city": "Thomasville"
-            },
-            {
-              "name": "Coffee",
-              "city": "Douglas"
             },
             {
               "name": "Houston County",
               "city": "Warner Robins"
             },
             {
-              "name": "Veterans",
-              "city": "Kathleen"
+              "name": "Lee County",
+              "city": "Leesburg"
+            },
+            {
+              "name": "Coffee",
+              "city": "Douglas"
             },
             {
               "name": "Northside-Warner Robins",
               "city": "Warner Robins"
+            },
+            {
+              "name": "Veterans",
+              "city": "Kathleen"
             }
           ]
         },
@@ -353,7 +353,15 @@
               "city": "Fairburn"
             },
             {
+              "name": "Lovejoy",
+              "city": "Hampton"
+            },
+            {
               "name": "Newnan",
+              "city": "Newnan"
+            },
+            {
+              "name": "Northgate",
               "city": "Newnan"
             },
             {
@@ -361,24 +369,16 @@
               "city": "Hampton"
             },
             {
-              "name": "Lovejoy",
-              "city": "Hampton"
-            },
-            {
               "name": "McIntosh",
               "city": "Peachtree City"
             },
             {
-              "name": "Morrow",
-              "city": "Morrow"
-            },
-            {
-              "name": "Northgate",
-              "city": "Newnan"
-            },
-            {
               "name": "Banneker",
               "city": "College Park"
+            },
+            {
+              "name": "Morrow",
+              "city": "Morrow"
             }
           ]
         },
@@ -390,32 +390,32 @@
               "city": "College Park"
             },
             {
-              "name": "Decatur",
-              "city": "Decatur"
-            },
-            {
-              "name": "Tri-Cities",
-              "city": "East Point"
+              "name": "Shiloh",
+              "city": "Snellville"
             },
             {
               "name": "Dunwoody",
               "city": "Dunwoody"
             },
             {
-              "name": "Lakeside-DeKalb",
-              "city": "Atlanta"
-            },
-            {
-              "name": "Shiloh",
-              "city": "Snellville"
-            },
-            {
               "name": "Chamblee",
               "city": "Chamblee"
             },
             {
+              "name": "Decatur",
+              "city": "Decatur"
+            },
+            {
               "name": "Arabia Mountain",
               "city": "Lithonia"
+            },
+            {
+              "name": "Lakeside-DeKalb",
+              "city": "Atlanta"
+            },
+            {
+              "name": "Tri-Cities",
+              "city": "East Point"
             }
           ]
         },
@@ -427,16 +427,16 @@
               "city": "Rome"
             },
             {
-              "name": "East Paulding",
-              "city": "Dallas"
-            },
-            {
               "name": "New Manchester",
               "city": "Douglasville"
             },
             {
               "name": "Villa Rica",
               "city": "Villa Rica"
+            },
+            {
+              "name": "East Paulding",
+              "city": "Dallas"
             },
             {
               "name": "South Paulding",
@@ -468,6 +468,10 @@
               "city": "Marietta"
             },
             {
+              "name": "Creekview",
+              "city": "Canton"
+            },
+            {
               "name": "River Ridge",
               "city": "Woodstock"
             },
@@ -476,8 +480,8 @@
               "city": "Woodstock"
             },
             {
-              "name": "Creekview",
-              "city": "Canton"
+              "name": "Lassiter",
+              "city": "Marietta"
             },
             {
               "name": "Pope",
@@ -486,20 +490,12 @@
             {
               "name": "Riverwood",
               "city": "Sandy Springs"
-            },
-            {
-              "name": "Lassiter",
-              "city": "Marietta"
             }
           ]
         },
         {
           "region": 7,
           "schools": [
-            {
-              "name": "Milton",
-              "city": "Milton"
-            },
             {
               "name": "Roswell",
               "city": "Roswell"
@@ -509,12 +505,16 @@
               "city": "Gainesville"
             },
             {
-              "name": "Lanier",
-              "city": "Sugar Hill"
+              "name": "Milton",
+              "city": "Milton"
             },
             {
               "name": "Seckinger",
               "city": "Buford"
+            },
+            {
+              "name": "Lanier",
+              "city": "Sugar Hill"
             },
             {
               "name": "Chattahoochee",
@@ -530,32 +530,32 @@
           "region": 8,
           "schools": [
             {
-              "name": "Clarke Central",
-              "city": "Athens"
-            },
-            {
               "name": "Jackson County",
               "city": "Hoschton"
-            },
-            {
-              "name": "Winder-Barrow",
-              "city": "Winder"
             },
             {
               "name": "Habersham Central",
               "city": "Mt. Airy"
             },
             {
-              "name": "Loganville",
-              "city": "Loganville"
+              "name": "Clarke Central",
+              "city": "Athens"
+            },
+            {
+              "name": "Winder-Barrow",
+              "city": "Winder"
+            },
+            {
+              "name": "Apalachee",
+              "city": "Winder"
             },
             {
               "name": "Alcovy",
               "city": "Covington"
             },
             {
-              "name": "Apalachee",
-              "city": "Winder"
+              "name": "Loganville",
+              "city": "Loganville"
             }
           ]
         }
@@ -568,20 +568,20 @@
           "region": 1,
           "schools": [
             {
-              "name": "Perry",
-              "city": "Perry"
-            },
-            {
-              "name": "Warner Robins",
-              "city": "Warner Robins"
-            },
-            {
               "name": "Benedictine",
               "city": "Savannah"
             },
             {
               "name": "Ware County",
               "city": "Waycross"
+            },
+            {
+              "name": "Warner Robins",
+              "city": "Warner Robins"
+            },
+            {
+              "name": "Perry",
+              "city": "Perry"
             },
             {
               "name": "New Hampstead",
@@ -597,12 +597,16 @@
           "region": 2,
           "schools": [
             {
+              "name": "Locust Grove",
+              "city": "Locust Grove"
+            },
+            {
               "name": "Ola",
               "city": "McDonough"
             },
             {
-              "name": "Jones County",
-              "city": "Gray"
+              "name": "Stockbridge",
+              "city": "Stockbridge"
             },
             {
               "name": "Hampton",
@@ -613,15 +617,11 @@
               "city": "McDonough"
             },
             {
-              "name": "Locust Grove",
-              "city": "Locust Grove"
+              "name": "Jones County",
+              "city": "Gray"
             },
             {
-              "name": "Union Grove",
-              "city": "McDonough"
-            },
-            {
-              "name": "Eagle's Landing Christian",
+              "name": "McDonough",
               "city": "McDonough"
             },
             {
@@ -629,12 +629,12 @@
               "city": "Stockbridge"
             },
             {
-              "name": "McDonough",
+              "name": "Eagle's Landing Christian",
               "city": "McDonough"
             },
             {
-              "name": "Stockbridge",
-              "city": "Stockbridge"
+              "name": "Union Grove",
+              "city": "McDonough"
             }
           ]
         },
@@ -642,16 +642,20 @@
           "region": 3,
           "schools": [
             {
-              "name": "Starr's Mill",
-              "city": "Fayetteville"
-            },
-            {
               "name": "Central-Carroll",
               "city": "Carrollton"
             },
             {
+              "name": "Griffin",
+              "city": "Griffin"
+            },
+            {
               "name": "Jonesboro",
               "city": "Jonesboro"
+            },
+            {
+              "name": "Starr's Mill",
+              "city": "Fayetteville"
             },
             {
               "name": "Harris County",
@@ -660,10 +664,6 @@
             {
               "name": "Northside-Columbus",
               "city": "Columbus"
-            },
-            {
-              "name": "Griffin",
-              "city": "Griffin"
             },
             {
               "name": "Mundy's Mill",
@@ -679,6 +679,10 @@
               "city": "Fairburn"
             },
             {
+              "name": "M.L. King",
+              "city": "Lithonia"
+            },
+            {
               "name": "Mays",
               "city": "Atlanta"
             },
@@ -687,24 +691,20 @@
               "city": "Atlanta"
             },
             {
-              "name": "Drew",
-              "city": "Riverdale"
-            },
-            {
-              "name": "M.L. King",
-              "city": "Lithonia"
+              "name": "Midtown",
+              "city": "Atlanta"
             },
             {
               "name": "Pace Academy",
               "city": "Atlanta"
             },
             {
-              "name": "Midtown",
-              "city": "Atlanta"
-            },
-            {
               "name": "Forest Park",
               "city": "Forest Park"
+            },
+            {
+              "name": "Drew",
+              "city": "Riverdale"
             }
           ]
         },
@@ -720,36 +720,36 @@
               "city": "Decatur"
             },
             {
-              "name": "St. Pius X",
-              "city": "Atlanta"
+              "name": "Lithonia",
+              "city": "Lithonia"
             },
             {
               "name": "Tucker",
               "city": "Tucker"
             },
             {
-              "name": "Lithonia",
-              "city": "Lithonia"
+              "name": "St. Pius X",
+              "city": "Atlanta"
             },
             {
               "name": "Druid Hills",
               "city": "Atlanta"
             },
             {
-              "name": "North Springs",
-              "city": "Sandy Springs"
-            },
-            {
               "name": "Northview",
               "city": "Johns Creek"
             },
             {
-              "name": "Clarkston",
-              "city": "Clarkston"
+              "name": "North Springs",
+              "city": "Sandy Springs"
             },
             {
               "name": "Cross Keys",
               "city": "Brookhaven"
+            },
+            {
+              "name": "Clarkston",
+              "city": "Clarkston"
             }
           ]
         },
@@ -757,24 +757,24 @@
           "region": 6,
           "schools": [
             {
-              "name": "Blessed Trinity",
-              "city": "Roswell"
+              "name": "Kell",
+              "city": "Marietta"
             },
             {
               "name": "Cambridge",
               "city": "Milton"
             },
             {
-              "name": "Kell",
-              "city": "Marietta"
-            },
-            {
-              "name": "Westminster",
-              "city": "Atlanta"
+              "name": "Blessed Trinity",
+              "city": "Roswell"
             },
             {
               "name": "Centennial",
               "city": "Roswell"
+            },
+            {
+              "name": "Westminster",
+              "city": "Atlanta"
             }
           ]
         },
@@ -786,16 +786,16 @@
               "city": "Cartersville"
             },
             {
-              "name": "Cedartown",
-              "city": "Cedartown"
+              "name": "Cass",
+              "city": "White"
             },
             {
               "name": "Hiram",
               "city": "Hiram"
             },
             {
-              "name": "Cass",
-              "city": "White"
+              "name": "Dalton",
+              "city": "Dalton"
             },
             {
               "name": "Allatoona",
@@ -806,11 +806,11 @@
               "city": "Cartersville"
             },
             {
-              "name": "Southeast Whitfield",
-              "city": "Dalton"
+              "name": "Cedartown",
+              "city": "Cedartown"
             },
             {
-              "name": "Dalton",
+              "name": "Southeast Whitfield",
               "city": "Dalton"
             }
           ]
@@ -823,16 +823,16 @@
               "city": "Bogart"
             },
             {
+              "name": "Flowery Branch",
+              "city": "Flowery Branch"
+            },
+            {
               "name": "Eastside",
               "city": "Covington"
             },
             {
               "name": "East Forsyth",
               "city": "Gainesville"
-            },
-            {
-              "name": "Flowery Branch",
-              "city": "Flowery Branch"
             },
             {
               "name": "Madison County",
@@ -857,6 +857,10 @@
           "region": 1,
           "schools": [
             {
+              "name": "Cairo",
+              "city": "Cairo"
+            },
+            {
               "name": "Peach County",
               "city": "Fort Valley"
             },
@@ -865,20 +869,16 @@
               "city": "Albany"
             },
             {
-              "name": "Cairo",
-              "city": "Cairo"
+              "name": "Monroe",
+              "city": "Albany"
             },
             {
-              "name": "Monroe",
+              "name": "Dougherty",
               "city": "Albany"
             },
             {
               "name": "Bainbridge",
               "city": "Bainbridge"
-            },
-            {
-              "name": "Dougherty",
-              "city": "Albany"
             }
           ]
         },
@@ -890,32 +890,32 @@
               "city": "Tyrone"
             },
             {
-              "name": "LaGrange",
+              "name": "Troup County",
               "city": "LaGrange"
             },
             {
-              "name": "Upson-Lee",
-              "city": "Thomaston"
+              "name": "LaGrange",
+              "city": "LaGrange"
             },
             {
               "name": "Whitewater",
               "city": "Fayetteville"
             },
             {
-              "name": "Spalding",
-              "city": "Griffin"
-            },
-            {
-              "name": "Troup County",
-              "city": "LaGrange"
-            },
-            {
               "name": "Mary Persons",
               "city": "Forsyth"
             },
             {
+              "name": "Upson-Lee",
+              "city": "Thomaston"
+            },
+            {
               "name": "Trinity Christian",
               "city": "Sharpsburg"
+            },
+            {
+              "name": "Spalding",
+              "city": "Griffin"
             },
             {
               "name": "Fayette County",
@@ -927,11 +927,23 @@
           "region": 3,
           "schools": [
             {
+              "name": "Jenkins",
+              "city": "Savannah"
+            },
+            {
               "name": "Calvary Day School",
               "city": "Savannah"
             },
             {
-              "name": "Jenkins",
+              "name": "Liberty County",
+              "city": "Hinesville"
+            },
+            {
+              "name": "Long County",
+              "city": "Ludowici"
+            },
+            {
+              "name": "Beach",
               "city": "Savannah"
             },
             {
@@ -939,15 +951,7 @@
               "city": "Brooklet"
             },
             {
-              "name": "Long County",
-              "city": "Ludowici"
-            },
-            {
-              "name": "Liberty County",
-              "city": "Hinesville"
-            },
-            {
-              "name": "Beach",
+              "name": "Windsor Forest",
               "city": "Savannah"
             },
             {
@@ -955,26 +959,18 @@
               "city": "Savannah"
             },
             {
-              "name": "Windsor Forest",
+              "name": "Islands",
               "city": "Savannah"
             },
             {
               "name": "Groves",
               "city": "Garden City"
-            },
-            {
-              "name": "Islands",
-              "city": "Savannah"
             }
           ]
         },
         {
           "region": 4,
           "schools": [
-            {
-              "name": "Harlem",
-              "city": "Harlem"
-            },
             {
               "name": "West Laurens",
               "city": "Dexter"
@@ -984,24 +980,28 @@
               "city": "Augusta"
             },
             {
-              "name": "Baldwin",
-              "city": "Milledgeville"
-            },
-            {
-              "name": "Aquinas",
-              "city": "Augusta"
-            },
-            {
-              "name": "Howard",
-              "city": "Macon"
+              "name": "Harlem",
+              "city": "Harlem"
             },
             {
               "name": "Richmond Academy",
               "city": "Augusta"
             },
             {
+              "name": "Aquinas",
+              "city": "Augusta"
+            },
+            {
+              "name": "Baldwin",
+              "city": "Milledgeville"
+            },
+            {
               "name": "Hephzibah",
               "city": "Hephzibah"
+            },
+            {
+              "name": "Howard",
+              "city": "Macon"
             },
             {
               "name": "Cross Creek",
@@ -1013,28 +1013,28 @@
           "region": 5,
           "schools": [
             {
-              "name": "Douglass-Atlanta",
-              "city": "Atlanta"
-            },
-            {
               "name": "Stephenson",
               "city": "Stone Mountain"
             },
             {
-              "name": "Luella",
-              "city": "Locust Grove"
+              "name": "North Clayton",
+              "city": "College Park"
+            },
+            {
+              "name": "Douglass-Atlanta",
+              "city": "Atlanta"
             },
             {
               "name": "Cedar Grove",
               "city": "Ellenwood"
             },
             {
-              "name": "Mt. Zion-Jonesboro",
-              "city": "Jonesboro"
+              "name": "Luella",
+              "city": "Locust Grove"
             },
             {
-              "name": "North Clayton",
-              "city": "College Park"
+              "name": "Mt. Zion-Jonesboro",
+              "city": "Jonesboro"
             },
             {
               "name": "Riverdale",
@@ -1054,14 +1054,6 @@
               "city": "Gainesville"
             },
             {
-              "name": "Lumpkin County",
-              "city": "Dahlonega"
-            },
-            {
-              "name": "Chestatee",
-              "city": "Gainesville"
-            },
-            {
               "name": "Greater Atlanta Christian",
               "city": "Norcross"
             },
@@ -1070,12 +1062,20 @@
               "city": "Jasper"
             },
             {
+              "name": "Lumpkin County",
+              "city": "Dahlonega"
+            },
+            {
               "name": "Dawson County",
               "city": "Dawsonville"
             },
             {
               "name": "White County",
               "city": "Cleveland"
+            },
+            {
+              "name": "Chestatee",
+              "city": "Gainesville"
             },
             {
               "name": "Johnson-Gainesville",
@@ -1091,28 +1091,28 @@
               "city": "Calhoun"
             },
             {
-              "name": "Northwest Whitfield",
-              "city": "Tunnel Hill"
-            },
-            {
               "name": "Heritage-Catoosa",
               "city": "Ringgold"
             },
             {
-              "name": "Adairsville",
-              "city": "Adairsville"
+              "name": "Northwest Whitfield",
+              "city": "Tunnel Hill"
             },
             {
               "name": "Gilmer",
               "city": "Ellijay"
             },
             {
-              "name": "Ridgeland",
-              "city": "Rossville"
+              "name": "Adairsville",
+              "city": "Adairsville"
             },
             {
               "name": "LaFayette",
               "city": "LaFayette"
+            },
+            {
+              "name": "Ridgeland",
+              "city": "Rossville"
             }
           ]
         },
@@ -1120,20 +1120,20 @@
           "region": 8,
           "schools": [
             {
-              "name": "Cherokee Bluff",
-              "city": "Flowery Branch"
-            },
-            {
               "name": "Jefferson",
               "city": "Jefferson"
+            },
+            {
+              "name": "Monroe Area",
+              "city": "Monroe"
             },
             {
               "name": "Oconee County",
               "city": "Watkinsville"
             },
             {
-              "name": "Monroe Area",
-              "city": "Monroe"
+              "name": "Cherokee Bluff",
+              "city": "Flowery Branch"
             },
             {
               "name": "East Hall",
@@ -1166,19 +1166,19 @@
               "city": "Columbus"
             },
             {
-              "name": "Shaw",
-              "city": "Columbus"
-            },
-            {
-              "name": "Hardaway",
-              "city": "Columbus"
-            },
-            {
               "name": "Columbus",
               "city": "Columbus"
             },
             {
+              "name": "Shaw",
+              "city": "Columbus"
+            },
+            {
               "name": "Kendrick",
+              "city": "Columbus"
+            },
+            {
+              "name": "Hardaway",
               "city": "Columbus"
             },
             {
@@ -1191,20 +1191,20 @@
           "region": 2,
           "schools": [
             {
-              "name": "Callaway",
-              "city": "Hogansville"
-            },
-            {
               "name": "Morgan County",
               "city": "Madison"
             },
             {
-              "name": "Westside-Macon",
-              "city": "Macon"
+              "name": "Callaway",
+              "city": "Hogansville"
             },
             {
               "name": "Jackson",
               "city": "Jackson"
+            },
+            {
+              "name": "Westside-Macon",
+              "city": "Macon"
             },
             {
               "name": "Pike County",
@@ -1224,12 +1224,12 @@
               "city": "Baxley"
             },
             {
-              "name": "Pierce County",
-              "city": "Blackshear"
-            },
-            {
               "name": "Crisp County",
               "city": "Cordele"
+            },
+            {
+              "name": "Pierce County",
+              "city": "Blackshear"
             },
             {
               "name": "Cook",
@@ -1245,12 +1245,12 @@
           "region": 4,
           "schools": [
             {
-              "name": "Burke County",
-              "city": "Waynesboro"
-            },
-            {
               "name": "Thomson",
               "city": "Thomson"
+            },
+            {
+              "name": "Burke County",
+              "city": "Waynesboro"
             },
             {
               "name": "Laney",
@@ -1261,11 +1261,11 @@
               "city": "Augusta"
             },
             {
-              "name": "Glenn Hills",
+              "name": "Josey",
               "city": "Augusta"
             },
             {
-              "name": "Josey",
+              "name": "Glenn Hills",
               "city": "Augusta"
             }
           ]
@@ -1274,23 +1274,19 @@
           "region": 5,
           "schools": [
             {
-              "name": "Hapeville",
-              "city": "Hapeville"
-            },
-            {
               "name": "Carver-Atlanta",
               "city": "Atlanta"
             },
             {
-              "name": "Lovett",
-              "city": "Atlanta"
+              "name": "Hapeville",
+              "city": "Hapeville"
             },
             {
               "name": "Holy Innocents'",
               "city": "Sandy Springs"
             },
             {
-              "name": "Therrell",
+              "name": "Lovett",
               "city": "Atlanta"
             },
             {
@@ -1299,6 +1295,10 @@
             },
             {
               "name": "Washington",
+              "city": "Atlanta"
+            },
+            {
+              "name": "Therrell",
               "city": "Atlanta"
             }
           ]
@@ -1311,16 +1311,16 @@
               "city": "Decatur"
             },
             {
-              "name": "South Atlanta",
-              "city": "Atlanta"
-            },
-            {
               "name": "Miller Grove",
               "city": "Lithonia"
             },
             {
               "name": "Redan",
               "city": "Stone Mountain"
+            },
+            {
+              "name": "South Atlanta",
+              "city": "Atlanta"
             },
             {
               "name": "Salem",
@@ -1336,28 +1336,28 @@
               "city": "Rockmart"
             },
             {
-              "name": "North Cobb Christian",
-              "city": "Kennesaw"
-            },
-            {
-              "name": "Ringgold",
-              "city": "Ringgold"
-            },
-            {
               "name": "North Murray",
               "city": "Chatsworth"
-            },
-            {
-              "name": "Union County",
-              "city": "Blairsville"
             },
             {
               "name": "Lakeview-Ft. Oglethorpe",
               "city": "Fort Oglethorpe"
             },
             {
+              "name": "Ringgold",
+              "city": "Ringgold"
+            },
+            {
               "name": "Sonoraville",
               "city": "Calhoun"
+            },
+            {
+              "name": "Union County",
+              "city": "Blairsville"
+            },
+            {
+              "name": "North Cobb Christian",
+              "city": "Kennesaw"
             },
             {
               "name": "Coahulla Creek",
@@ -1373,16 +1373,20 @@
           "region": 8,
           "schools": [
             {
+              "name": "Hebron Christian",
+              "city": "Dacula"
+            },
+            {
               "name": "Prince Avenue Christian",
               "city": "Bogart"
             },
             {
-              "name": "Hebron Christian Academy",
-              "city": "Dacula"
-            },
-            {
               "name": "Stephens County",
               "city": "Toccoa"
+            },
+            {
+              "name": "Franklin County",
+              "city": "Carnesville"
             },
             {
               "name": "Hart County",
@@ -1391,10 +1395,6 @@
             {
               "name": "East Jackson",
               "city": "Commerce"
-            },
-            {
-              "name": "Franklin County",
-              "city": "Carnesville"
             }
           ]
         }
@@ -1407,10 +1407,6 @@
           "region": 1,
           "schools": [
             {
-              "name": "Thomasville",
-              "city": "Thomasville"
-            },
-            {
               "name": "Worth County",
               "city": "Sylvester"
             },
@@ -1419,12 +1415,12 @@
               "city": "Fitzgerald"
             },
             {
-              "name": "Jeff Davis",
-              "city": "Hazlehurst"
+              "name": "Thomasville",
+              "city": "Thomasville"
             },
             {
-              "name": "Brantley County",
-              "city": "Nahunta"
+              "name": "Jeff Davis",
+              "city": "Hazlehurst"
             },
             {
               "name": "Bacon County",
@@ -1433,6 +1429,10 @@
             {
               "name": "Berrien",
               "city": "Nashville"
+            },
+            {
+              "name": "Brantley County",
+              "city": "Nahunta"
             }
           ]
         },
@@ -1448,6 +1448,10 @@
               "city": "Macon"
             },
             {
+              "name": "Bleckley County",
+              "city": "Cochran"
+            },
+            {
               "name": "Dodge County",
               "city": "Eastman"
             },
@@ -1460,16 +1464,12 @@
               "city": "Macon"
             },
             {
-              "name": "Southwest",
-              "city": "Macon"
-            },
-            {
-              "name": "Bleckley County",
-              "city": "Cochran"
-            },
-            {
               "name": "East Laurens",
               "city": "East Dublin"
+            },
+            {
+              "name": "Southwest",
+              "city": "Macon"
             },
             {
               "name": "Jefferson County",
@@ -1485,12 +1485,12 @@
           "region": 3,
           "schools": [
             {
-              "name": "Savannah Christian",
-              "city": "Savannah"
-            },
-            {
               "name": "Toombs County",
               "city": "Lyons"
+            },
+            {
+              "name": "Savannah Christian",
+              "city": "Savannah"
             },
             {
               "name": "Swainsboro",
@@ -1514,12 +1514,12 @@
               "city": "Barnesville"
             },
             {
-              "name": "Social Circle",
-              "city": "Social Circle"
-            },
-            {
               "name": "Jasper County",
               "city": "Monticello"
+            },
+            {
+              "name": "Social Circle",
+              "city": "Social Circle"
             },
             {
               "name": "Putnam County",
@@ -1547,36 +1547,36 @@
               "city": "Roswell"
             },
             {
-              "name": "Wesleyan",
-              "city": "Peachtree Corners"
-            },
-            {
               "name": "Whitefield Academy",
               "city": "Mableton"
             },
             {
-              "name": "Mt. Paran Christian",
-              "city": "Kennesaw"
+              "name": "Wesleyan",
+              "city": "Peachtree Corners"
             },
             {
               "name": "Landmark Christian",
               "city": "Fairburn"
             },
             {
-              "name": "King's Ridge",
-              "city": "Alpharetta"
-            },
-            {
               "name": "Mount Vernon",
               "city": "Sandy Springs"
             },
             {
-              "name": "B.E.S.T Academy",
-              "city": "Atlanta"
+              "name": "King's Ridge",
+              "city": "Alpharetta"
+            },
+            {
+              "name": "Mt. Paran Christian",
+              "city": "Kennesaw"
             },
             {
               "name": "Mt. Pisgah Christian",
               "city": "Johns Creek"
+            },
+            {
+              "name": "B.E.S.T Academy",
+              "city": "Atlanta"
             },
             {
               "name": "Mt. Bethel Christian",
@@ -1585,10 +1585,6 @@
             {
               "name": "Walker",
               "city": "Marietta"
-            },
-            {
-              "name": "St. Francis",
-              "city": "Alpharetta"
             }
           ]
         },
@@ -1600,28 +1596,28 @@
               "city": "Franklin"
             },
             {
-              "name": "Temple",
-              "city": "Temple"
+              "name": "Pepperell",
+              "city": "Lindale"
+            },
+            {
+              "name": "Haralson County",
+              "city": "Tallapoosa"
             },
             {
               "name": "Bremen",
               "city": "Bremen"
             },
             {
+              "name": "Temple",
+              "city": "Temple"
+            },
+            {
               "name": "Darlington",
               "city": "Rome"
             },
             {
-              "name": "Pepperell",
-              "city": "Lindale"
-            },
-            {
               "name": "Model",
               "city": "Rome"
-            },
-            {
-              "name": "Haralson County",
-              "city": "Tallapoosa"
             }
           ]
         },
@@ -1629,32 +1625,32 @@
           "region": 7,
           "schools": [
             {
-              "name": "Fannin County",
-              "city": "Blue Ridge"
+              "name": "Gordon Lee",
+              "city": "Chickamauga"
             },
             {
               "name": "Christian Heritage",
               "city": "Dalton"
             },
             {
-              "name": "Gordon Lee",
-              "city": "Chickamauga"
+              "name": "Gordon Central",
+              "city": "Calhoun"
+            },
+            {
+              "name": "Fannin County",
+              "city": "Blue Ridge"
             },
             {
               "name": "Chattooga",
               "city": "Summerville"
             },
             {
-              "name": "Dade County",
-              "city": "Trenton"
-            },
-            {
               "name": "Coosa",
               "city": "Rome"
             },
             {
-              "name": "Gordon Central",
-              "city": "Calhoun"
+              "name": "Dade County",
+              "city": "Trenton"
             },
             {
               "name": "Armuchee",
@@ -1670,28 +1666,28 @@
               "city": "Athens"
             },
             {
-              "name": "Commerce",
-              "city": "Commerce"
+              "name": "Rabun County",
+              "city": "Tiger"
+            },
+            {
+              "name": "Oglethorpe County",
+              "city": "Lexington"
             },
             {
               "name": "Elbert County",
               "city": "Elberton"
             },
             {
-              "name": "Rabun County",
-              "city": "Tiger"
-            },
-            {
-              "name": "Banks County",
-              "city": "Homer"
+              "name": "Commerce",
+              "city": "Commerce"
             },
             {
               "name": "Providence Christian",
               "city": "Lilburn"
             },
             {
-              "name": "Oglethorpe County",
-              "city": "Lexington"
+              "name": "Banks County",
+              "city": "Homer"
             }
           ]
         }
@@ -1704,56 +1700,48 @@
           "region": 1,
           "schools": [
             {
-              "name": "Mitchell County",
-              "city": "Camilla"
-            },
-            {
               "name": "Early County",
               "city": "Blakely"
-            },
-            {
-              "name": "Calhoun County",
-              "city": "Edison"
-            },
-            {
-              "name": "Miller County",
-              "city": "Colquitt"
-            },
-            {
-              "name": "Pataula Charter",
-              "city": "Edison"
             },
             {
               "name": "Seminole County",
               "city": "Donalsonville"
             },
             {
-              "name": "Pelham",
-              "city": "Pelham"
+              "name": "Mitchell County",
+              "city": "Camilla"
             },
             {
               "name": "Randolph-Clay",
               "city": "Cuthbert"
             },
             {
+              "name": "Miller County",
+              "city": "Colquitt"
+            },
+            {
+              "name": "Pelham",
+              "city": "Pelham"
+            },
+            {
               "name": "Baconton",
               "city": "Baconton"
+            },
+            {
+              "name": "Pataula Charter",
+              "city": "Edison"
             },
             {
               "name": "Southwest Georgia STEM",
               "city": "Shellman"
             },
             {
+              "name": "Calhoun County",
+              "city": "Edison"
+            },
+            {
               "name": "Terrell County",
               "city": "Dawson"
-            },
-            {
-              "name": "Baker County",
-              "city": "Newton"
-            },
-            {
-              "name": "Spring Creek",
-              "city": "Bainbridge"
             }
           ]
         },
@@ -1765,16 +1753,16 @@
               "city": "Homerville"
             },
             {
-              "name": "Irwin County",
-              "city": "Ocilla"
-            },
-            {
               "name": "Brooks County",
               "city": "Quitman"
             },
             {
               "name": "Charlton County",
               "city": "Folkston"
+            },
+            {
+              "name": "Lanier County",
+              "city": "Lakeland"
             },
             {
               "name": "Turner County",
@@ -1785,8 +1773,8 @@
               "city": "Pearson"
             },
             {
-              "name": "Lanier County",
-              "city": "Lakeland"
+              "name": "Irwin County",
+              "city": "Ocilla"
             }
           ]
         },
@@ -1794,40 +1782,40 @@
           "region": 3,
           "schools": [
             {
-              "name": "Metter",
-              "city": "Metter"
-            },
-            {
-              "name": "Jenkins County",
-              "city": "Millen"
-            },
-            {
-              "name": "McIntosh County Academy",
-              "city": "Darien"
+              "name": "Screven County",
+              "city": "Sylvania"
             },
             {
               "name": "Emanuel County Institute",
               "city": "Twin City"
             },
             {
+              "name": "Jenkins County",
+              "city": "Millen"
+            },
+            {
               "name": "Bryan County",
               "city": "Pembroke"
+            },
+            {
+              "name": "McIntosh County Academy",
+              "city": "Darien"
+            },
+            {
+              "name": "Metter",
+              "city": "Metter"
             },
             {
               "name": "Portal",
               "city": "Portal"
             },
             {
-              "name": "Screven County",
-              "city": "Sylvania"
+              "name": "Savannah",
+              "city": "Savannah"
             },
             {
               "name": "Claxton",
               "city": "Claxton"
-            },
-            {
-              "name": "Savannah",
-              "city": "Savannah"
             }
           ]
         },
@@ -1835,16 +1823,12 @@
           "region": 4,
           "schools": [
             {
-              "name": "Telfair County",
-              "city": "McRae"
+              "name": "Wheeler County",
+              "city": "Alamo"
             },
             {
               "name": "Hawkinsville",
               "city": "Hawkinsville"
-            },
-            {
-              "name": "Wheeler County",
-              "city": "Alamo"
             },
             {
               "name": "Wilcox County",
@@ -1853,6 +1837,10 @@
             {
               "name": "Treutlen",
               "city": "Soperton"
+            },
+            {
+              "name": "Telfair County",
+              "city": "McRae"
             },
             {
               "name": "Dooly County",
@@ -1876,20 +1864,20 @@
               "city": "Irwinton"
             },
             {
-              "name": "Hancock Central",
-              "city": "Sparta"
+              "name": "Georgia Military College",
+              "city": "Milledgeville"
             },
             {
               "name": "Glascock County",
               "city": "Gibson"
             },
             {
-              "name": "Twiggs County",
-              "city": "Jeffersonville"
+              "name": "Hancock Central",
+              "city": "Sparta"
             },
             {
-              "name": "Georgia Military College",
-              "city": "Milledgeville"
+              "name": "Twiggs County",
+              "city": "Jeffersonville"
             }
           ]
         },
@@ -1897,28 +1885,28 @@
           "region": 6,
           "schools": [
             {
-              "name": "Macon County",
-              "city": "Montezuma"
+              "name": "Taylor County",
+              "city": "Butler"
             },
             {
               "name": "Schley County",
               "city": "Ellaville"
             },
             {
-              "name": "Taylor County",
-              "city": "Butler"
+              "name": "Macon County",
+              "city": "Montezuma"
             },
             {
-              "name": "Marion County",
-              "city": "Buena Vista"
+              "name": "Chattahoochee County",
+              "city": "Cusseta"
             },
             {
               "name": "Crawford County",
               "city": "Roberta"
             },
             {
-              "name": "Chattahoochee County",
-              "city": "Cusseta"
+              "name": "Marion County",
+              "city": "Buena Vista"
             },
             {
               "name": "Central-Talbotton",
@@ -1930,12 +1918,16 @@
           "region": 7,
           "schools": [
             {
-              "name": "Manchester",
-              "city": "Manchester"
-            },
-            {
               "name": "Bowdon",
               "city": "Bowdon"
+            },
+            {
+              "name": "Mt. Zion-Carroll",
+              "city": "Carrollton"
+            },
+            {
+              "name": "Manchester",
+              "city": "Manchester"
             },
             {
               "name": "Trion",
@@ -1944,10 +1936,6 @@
             {
               "name": "Greenville",
               "city": "Greenville"
-            },
-            {
-              "name": "Mt. Zion-Carroll",
-              "city": "Carrollton"
             }
           ]
         },
@@ -1959,16 +1947,16 @@
               "city": "Lincolnton"
             },
             {
-              "name": "Greene County",
-              "city": "Greensboro"
-            },
-            {
               "name": "Warren County",
               "city": "Warrenton"
             },
             {
               "name": "Washington-Wilkes",
               "city": "Washington"
+            },
+            {
+              "name": "Greene County",
+              "city": "Greensboro"
             },
             {
               "name": "Towns County",


### PR DESCRIPTION
## What

Refreshes the GHSA seed from the **2025 football standings** (the second season of the 2024-26 cycle) — the documented one-step refresh noted when the seed first shipped.

**416 → 413 schools** (still 56 regions, 7 classifications).

## Changes vs the 2024-season alignment

- **3 programs left football for 2025** (dropped): `St. Francis` (A-DI), `Baker County` (A-DII), `Spring Creek` (A-DII).
- **1 rename**: `Hebron Christian Academy` → `Hebron Christian` (same school; city `Dacula` carried over).
- **Region membership** updated to the 2025 alignment across all classes.

Persisting schools **keep their curated names and cities** (reused by normalized match), so the only diffs are the genuine moves. Result: **0 TBD cities**, builder validates, dashboard asset regenerated.

## Source

<https://www.ghsa.net/2025-ghsa-football-standings> (as of 2025-11-01). The league name stays `Georgia GHSA Football (2024-26)` since it's the same reclassification cycle.

> Done in an isolated git worktree to avoid colliding with concurrent work in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)