### PR TITLE
fix(web): unbreak local next dev — stray `*/` in globals.css comment (WSM-000156)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,7 +5,7 @@
  *
  * Neutral, token-driven shadcn theme. Tokens live in :root (light) and .dark
  * (dark) as `--<name>`; `@theme inline` maps them to the Tailwind v4
- * `--color-<name>` namespace that powers bg-*/text-*/border-* utilities, so
+ * `--color-<name>` namespace that powers the bg, text and border utilities, so
  * every shadcn `ui/*` primitive inherits the palette. The app renders dark-first
  * (`.dark` is set on <html>); the light set is retained for a future toggle.
  */


### PR DESCRIPTION
Closes #355

## Problem
`apps/web/src/app/globals.css:8` had `bg-*/text-*/border-*` inside the theme block comment. `*/` ends a CSS comment, so the rest of the comment parsed as declarations and Turbopack threw `Unexpected token Delim('*')`. Because `globals.css` is imported by the root layout, **every route 500'd under `next dev`** on `main`. Production builds tolerate it (different CSS path), so deploys stayed green and it slipped through.

## Fix
Reword the one comment line to drop the slashes (`the bg, text and border utilities`). Comment intent preserved; zero behavior change.

## Verification
- `pnpm dev` on this branch → `/` returns **200** in ~2s (was 500), no CSS/PostCSS error in the log.
- Only the legitimate closing `*/` remains in the comment block.

Introduced in a25e983 (WSM-000136, #257). Found while verifying #348 (WSM-000153), where it blocked local browser verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)