### PR TITLE
fix(web): wrap player-development & season-attributes tables for mobile (WSM-000155)

### DIFF
--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -71,7 +71,7 @@ export default async function PlayerDevelopmentPage({
         &larr; Back to Players
       </Link>
 
-      <header className="mb-6 flex items-start justify-between gap-4">
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1">
           <h2 className="text-2xl font-bold text-foreground">
             {player.name}
@@ -115,7 +115,8 @@ export default async function PlayerDevelopmentPage({
 
       <Card>
         <CardContent className="p-0">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
             <thead>
               <tr className="border-b-2 border-border bg-muted text-left text-foreground">
                 <th className="px-4 py-2 font-mono text-xs uppercase">
@@ -174,6 +175,7 @@ export default async function PlayerDevelopmentPage({
               )}
             </tbody>
           </table>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/apps/web/src/app/dashboard/seasons/[id]/attributes/[positionGroup]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/attributes/[positionGroup]/page.tsx
@@ -90,7 +90,8 @@ export default async function SeasonAttributesByPositionPage({
 
       <Card>
         <CardContent className="p-0">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
             <thead>
               <tr className="border-b-2 border-border bg-muted text-left text-foreground">
                 <th className="px-4 py-2 font-mono text-xs uppercase">
@@ -147,6 +148,7 @@ export default async function SeasonAttributesByPositionPage({
               )}
             </tbody>
           </table>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Closes #353

## Root cause (re-confirmed)
Two dashboard pages render a bare `<table className="w-full text-sm">` with **no** `overflow-x-auto` wrapper, so on a ~390px phone viewport the table's min-content width pushes the whole page sideways. This is the same class of defect just fixed on the league Schedule page in #352 (WSM-000154).

Confirmed at file:line before changing code:
- `apps/web/src/app/dashboard/players/[id]/development/page.tsx:118` — 4-col table (Season, Position group, Overall, Δ); header at `:74` was also a non-wrapping `flex items-start justify-between`.
- `apps/web/src/app/dashboard/seasons/[id]/attributes/[positionGroup]/page.tsx:93` — 4-col table (Rank, Player, Overall, Top attributes); the position-group nav at `:72` already uses `flex flex-wrap`, so only the table needed wrapping.

## Fix (Tailwind only — mirrors PR #352 exactly)
- Wrap each `<table>` in `<div className="overflow-x-auto">` so it scrolls **within its card** instead of breaking the page, and add `min-w-[640px]` so columns aren't crushed.
- Player-development header now stacks on mobile and becomes a row from `sm:` up: `flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between` — matching the Schedule header fix and the ticket's acceptance criteria.
- No desktop / `sm:+` behavior change. Two files touched, nothing else.

## Verification (from `apps/web`)
- `pnpm -C apps/web run type-check` (`tsc --noEmit`) — **clean, exit 0**.
- `pnpm -C apps/web run lint` (`eslint .`) — **clean, exit 0**.
- This repo's vitest env is `node` (no jsdom/Testing Library), so a DOM/visual unit test isn't feasible here; per the #352 precedent this CSS-only wrapper fix is verified by type-check + lint + code inspection confirming both tables now have the `overflow-x-auto` + `min-w-[640px]` wrapper identical to #352.

## Notes
- Scope held to the two tables named in the ticket. The ticket's "Not affected" list (Standings, shared `ui/Table` DataTable, card/timeline layouts) was respected — none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls9N5DBiXh7esUP3jTCHHq