### PR TITLE
feat(web): derive fixture kickoff dates from season start (WSM-000158)

### DIFF
--- a/apps/web/convex/__tests__/roundRobin.test.ts
+++ b/apps/web/convex/__tests__/roundRobin.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   roundRobinSchedule,
+  weekKickoff,
   type RoundRobinPairing,
 } from "../lib/roundRobin";
 
@@ -115,4 +116,36 @@ describe("roundRobinSchedule (WSM-000153)", () => {
       }
     },
   );
+});
+
+describe("weekKickoff (WSM-000158)", () => {
+  it("returns null when the season has no start date", () => {
+    expect(weekKickoff(null, 1)).toBeNull();
+    expect(weekKickoff("", 3)).toBeNull();
+  });
+
+  it("returns null for an unparseable start date", () => {
+    expect(weekKickoff("not-a-date", 1)).toBeNull();
+  });
+
+  it("puts week 1 on the season start date and adds 7 days per week (UTC)", () => {
+    expect(weekKickoff("2026-09-01", 1)).toBe("2026-09-01T00:00:00.000Z");
+    expect(weekKickoff("2026-09-01", 2)).toBe("2026-09-08T00:00:00.000Z");
+    expect(weekKickoff("2026-09-01", 3)).toBe("2026-09-15T00:00:00.000Z");
+  });
+
+  it("adds whole weeks without DST drift across a US fall-back", () => {
+    // US DST ends 2026-11-01; whole-week UTC math keeps the same wall offset.
+    const w1 = weekKickoff("2026-10-25", 1);
+    const w2 = weekKickoff("2026-10-25", 2);
+    expect(w1).toBe("2026-10-25T00:00:00.000Z");
+    expect(w2).toBe("2026-11-01T00:00:00.000Z");
+    expect(Date.parse(w2!) - Date.parse(w1!)).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("preserves the time-of-day when the start is a full ISO timestamp", () => {
+    expect(weekKickoff("2026-09-01T19:30:00.000Z", 2)).toBe(
+      "2026-09-08T19:30:00.000Z",
+    );
+  });
 });

--- a/apps/web/convex/__tests__/scheduleGeneration.test.ts
+++ b/apps/web/convex/__tests__/scheduleGeneration.test.ts
@@ -11,6 +11,7 @@ const modules = import.meta.glob("../**/*.*s");
 async function seedLeague(
   t: ReturnType<typeof convexTest>,
   teamCount: number,
+  startDate: string | null = null,
 ) {
   return t.run(async (ctx) => {
     const leagueId = await ctx.db.insert("leagues", {
@@ -42,7 +43,7 @@ async function seedLeague(
     const seasonId = await ctx.db.insert("seasons", {
       name: "2026",
       leagueId,
-      startDate: null,
+      startDate,
       endDate: null,
       status: "active",
       rosterLocked: false,
@@ -82,6 +83,31 @@ describe("generateSeasonSchedule (WSM-000153)", () => {
       expect(f.week).toBeGreaterThanOrEqual(1);
       expect(f.createdBy).toBe("user_1");
     }
+  });
+
+  it("dates fixtures off the season start (+7d/week) when startDate is set", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4, "2026-09-05");
+
+    await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+    });
+
+    const fixtures = await t.run((ctx) =>
+      ctx.db.query("fixtures").collect(),
+    );
+    const dateByWeek: Record<number, string> = {
+      1: "2026-09-05T00:00:00.000Z",
+      2: "2026-09-12T00:00:00.000Z",
+      3: "2026-09-19T00:00:00.000Z",
+    };
+    for (const f of fixtures) {
+      expect(f.scheduledAt).toBe(dateByWeek[f.week as number]);
+    }
+    // All games in a week share one date.
+    const wk1 = fixtures.filter((f) => f.week === 1).map((f) => f.scheduledAt);
+    expect(new Set(wk1).size).toBe(1);
   });
 
   it("throws when the league has fewer than two teams", async () => {

--- a/apps/web/convex/lib/roundRobin.ts
+++ b/apps/web/convex/lib/roundRobin.ts
@@ -78,3 +78,29 @@ export function roundRobinSchedule(teamIds: string[]): RoundRobinPairing[] {
 
   return pairings;
 }
+
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Kickoff timestamp for a given week of a generated schedule (WSM-000158).
+ *
+ * Week 1 sits on the season's start date; each subsequent week is +7 days, so
+ * every game in a week shares one date. Returns null when the season has no
+ * start date (the generator then leaves `scheduledAt` null — week numbers only).
+ *
+ * Date math is done in UTC off the parsed start, so adding whole weeks never
+ * drifts across DST and the result is deterministic (no `Date.now()`).
+ *
+ * @param seasonStart the season's startDate (`YYYY-MM-DD` or ISO), or null
+ * @param week 1-based week number
+ * @returns ISO timestamp string, or null if no start date
+ */
+export function weekKickoff(
+  seasonStart: string | null,
+  week: number,
+): string | null {
+  if (!seasonStart) return null;
+  const startMs = Date.parse(seasonStart);
+  if (Number.isNaN(startMs)) return null;
+  return new Date(startMs + (week - 1) * MS_PER_WEEK).toISOString();
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -16,7 +16,7 @@ import {
   type HsRatingInput,
 } from "./lib/hsSprt";
 import { applyScore, isLiveStatus, isNonNegInt } from "./lib/liveScore";
-import { roundRobinSchedule } from "./lib/roundRobin";
+import { roundRobinSchedule, weekKickoff } from "./lib/roundRobin";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -3772,7 +3772,9 @@ export const generateSeasonSchedule = internalMutationGeneric({
         seasonId: args.seasonId,
         homeTeamId: p.homeTeamId as Id<"teams">,
         awayTeamId: p.awayTeamId as Id<"teams">,
-        scheduledAt: null,
+        // Week 1 on the season start, +7 days per week; null when the season
+        // has no start date (week-numbers-only). Admins fine-tune per game.
+        scheduledAt: weekKickoff(season.startDate, p.week),
         week: p.week,
         venue: null,
         status: "scheduled",


### PR DESCRIPTION
Closes #362 · follow-up to #348 (WSM-000153)

## What
`generateSeasonSchedule` now seeds each fixture's `scheduledAt` instead of leaving it null:
- **week 1 = `season.startDate`**, each later week **+7 days**; all games in a week share one date.
- Seasons with **no** `startDate` keep `scheduledAt = null` (week-numbers-only — unchanged). `venue` still null.

## How
- New pure helper `weekKickoff(seasonStart, week)` in `convex/lib/roundRobin.ts` — UTC math off the parsed start, so whole-week additions never drift across DST and stay deterministic (no `Date.now()`).
- The mutation maps each pairing's week through it.
- No new UI: the schedule page already renders `scheduledAt` (or "TBD").

## Tests (573 passing)
- `weekKickoff`: null/empty/unparseable start → null; week 1/2/3 spacing; DST-boundary week add; ISO time-of-day preserved.
- convex-test: a season with `startDate` produces dated fixtures (start + (week-1)·7d, one date per week); null-start season still null.

## Out of scope
Per-day staggering within a week, configurable kickoff time-of-day, biweekly/custom cadence (future cadence-form story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)