### PR TITLE
fix(web): actionable Convex admin-key error + document cloud-dev setup (WSM-000159)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -49,6 +49,23 @@ NEXT_PUBLIC_APP_URL=https://sprtsmng.andrewsolomon.dev
 # MUX_TOKEN_SECRET=...
 # MUX_WEBHOOK_SECRET=...           # signing secret from the Mux dashboard webhook
 
+# Convex backend — pick ONE of two local setups:
+#
+#   A) Local backend (no key). Run `convex dev` (local) and point at it:
+#        NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
+#      A 127.0.0.1/localhost URL is treated as local, so CONVEX_ADMIN_KEY is
+#      not required. Fresh, empty DB — seed locally as needed.
+#
+#   B) Cloud dev deployment (shared data). Point at your cloud dev URL AND set
+#      CONVEX_ADMIN_KEY — server components call admin-keyed internal functions,
+#      so without it every dashboard page 500s (WSM-000159):
+#        NEXT_PUBLIC_CONVEX_URL=https://<your-dev>.convex.cloud
+#        CONVEX_ADMIN_KEY=<deploy key>
+#      Generate the deploy key in the Convex dashboard:
+#        Settings → Deploy Keys → Create Deploy Key (value is shown once).
+NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
+# CONVEX_ADMIN_KEY=
+
 # E2E Test Harness (Playwright + Convex)
 # Required only when running e2e specs that use apps/web/e2e/helpers/seed-roster.ts.
 # Enable the seed mutations on the target Convex deployment via:
@@ -56,11 +73,9 @@ NEXT_PUBLIC_APP_URL=https://sprtsmng.andrewsolomon.dev
 # E2E_CLERK_USER_ID / _B and E2E_CLERK_ORG_ID / _B identify the two Clerk
 # test users + orgs the harness uses. User A must be a member of Org A only;
 # User B must be a member of Org B only (cross-org isolation specs depend on
-# this asymmetry). CONVEX_ADMIN_KEY is only required for non-local
-# (preview/prod) Convex deployments.
-NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
+# this asymmetry). CONVEX_ADMIN_KEY (above) is also required here for non-local
+# (cloud dev/preview/prod) Convex deployments.
 E2E_CLERK_USER_ID=user_...
 E2E_CLERK_ORG_ID=org_...
 E2E_CLERK_USER_ID_B=user_...
 E2E_CLERK_ORG_ID_B=org_...
-# CONVEX_ADMIN_KEY=

--- a/apps/web/src/lib/convex-client.ts
+++ b/apps/web/src/lib/convex-client.ts
@@ -14,7 +14,16 @@ export function getConvexClient(): ConvexHttpClient {
     url.includes("127.0.0.1") || url.includes("localhost");
 
   if (!adminKey && !isLocalDeployment) {
-    throw new Error("Missing Convex admin key. Set CONVEX_ADMIN_KEY.");
+    throw new Error(
+      `Missing Convex admin key. NEXT_PUBLIC_CONVEX_URL points at a cloud ` +
+        `deployment (${url}), which needs CONVEX_ADMIN_KEY to authorize ` +
+        `server-side reads/writes. Fix one of two ways:\n` +
+        `  • Cloud dev: set CONVEX_ADMIN_KEY in apps/web/.env.local to a deploy ` +
+        `key (Convex dashboard → Settings → Deploy Keys → Create Deploy Key).\n` +
+        `  • Local backend: point NEXT_PUBLIC_CONVEX_URL at http://127.0.0.1:3210 ` +
+        `and run \`convex dev\` — a local deployment needs no key.\n` +
+        `See apps/web/.env.local.example.`,
+    );
   }
 
   const client = new ConvexHttpClient(url);


### PR DESCRIPTION
Closes #364

## Problem
With `NEXT_PUBLIC_CONVEX_URL` pointed at a **cloud** Convex deployment and `CONVEX_ADMIN_KEY` unset, `getConvexClient` threw `Missing Convex admin key. Set CONVEX_ADMIN_KEY.` and **every dashboard page 500'd** server-side — with no hint where to set it, what value it wants, or that a local backend avoids it. `.env.local.example` only documented the local-backend path. (Found while verifying #348.)

## Fix
- **Actionable error** (`src/lib/convex-client.ts`): names the offending URL and gives both fixes — a deploy key for cloud dev (Dashboard → Settings → Deploy Keys → Create Deploy Key), or `http://127.0.0.1:3210` + `convex dev` for a local backend (no key).
- **Docs** (`.env.local.example`): both local setups (A: local backend, no key · B: cloud dev + deploy key) spelled out.

Per-developer keys stay in local `.env.local` (gitignored) — not in this PR.

## Tests
`convex-client.test.ts` asserts `/Missing Convex admin key/` (substring) — still green. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)