### PR TITLE
fix(web): anchor generated kickoff dates at noon UTC (WSM-000160)

### DIFF
--- a/apps/web/convex/__tests__/roundRobin.test.ts
+++ b/apps/web/convex/__tests__/roundRobin.test.ts
@@ -128,18 +128,28 @@ describe("weekKickoff (WSM-000158)", () => {
     expect(weekKickoff("not-a-date", 1)).toBeNull();
   });
 
-  it("puts week 1 on the season start date and adds 7 days per week (UTC)", () => {
-    expect(weekKickoff("2026-09-01", 1)).toBe("2026-09-01T00:00:00.000Z");
-    expect(weekKickoff("2026-09-01", 2)).toBe("2026-09-08T00:00:00.000Z");
-    expect(weekKickoff("2026-09-01", 3)).toBe("2026-09-15T00:00:00.000Z");
+  it("anchors a date-only start at noon UTC and adds 7 days per week (WSM-000160)", () => {
+    // Noon UTC, not midnight, so the date renders correctly in the Americas.
+    expect(weekKickoff("2026-09-01", 1)).toBe("2026-09-01T12:00:00.000Z");
+    expect(weekKickoff("2026-09-01", 2)).toBe("2026-09-08T12:00:00.000Z");
+    expect(weekKickoff("2026-09-01", 3)).toBe("2026-09-15T12:00:00.000Z");
+  });
+
+  it("renders the intended calendar day in a US-Eastern timezone", () => {
+    // The bug: midnight UTC showed as the previous day. Noon UTC fixes it.
+    const iso = weekKickoff("2026-09-05", 1)!;
+    const shown = new Date(iso).toLocaleDateString("en-US", {
+      timeZone: "America/New_York",
+    });
+    expect(shown).toBe("9/5/2026");
   });
 
   it("adds whole weeks without DST drift across a US fall-back", () => {
     // US DST ends 2026-11-01; whole-week UTC math keeps the same wall offset.
     const w1 = weekKickoff("2026-10-25", 1);
     const w2 = weekKickoff("2026-10-25", 2);
-    expect(w1).toBe("2026-10-25T00:00:00.000Z");
-    expect(w2).toBe("2026-11-01T00:00:00.000Z");
+    expect(w1).toBe("2026-10-25T12:00:00.000Z");
+    expect(w2).toBe("2026-11-01T12:00:00.000Z");
     expect(Date.parse(w2!) - Date.parse(w1!)).toBe(7 * 24 * 60 * 60 * 1000);
   });
 

--- a/apps/web/convex/__tests__/scheduleGeneration.test.ts
+++ b/apps/web/convex/__tests__/scheduleGeneration.test.ts
@@ -98,9 +98,9 @@ describe("generateSeasonSchedule (WSM-000153)", () => {
       ctx.db.query("fixtures").collect(),
     );
     const dateByWeek: Record<number, string> = {
-      1: "2026-09-05T00:00:00.000Z",
-      2: "2026-09-12T00:00:00.000Z",
-      3: "2026-09-19T00:00:00.000Z",
+      1: "2026-09-05T12:00:00.000Z",
+      2: "2026-09-12T12:00:00.000Z",
+      3: "2026-09-19T12:00:00.000Z",
     };
     for (const f of fixtures) {
       expect(f.scheduledAt).toBe(dateByWeek[f.week as number]);

--- a/apps/web/convex/lib/roundRobin.ts
+++ b/apps/web/convex/lib/roundRobin.ts
@@ -88,6 +88,13 @@ const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
  * every game in a week shares one date. Returns null when the season has no
  * start date (the generator then leaves `scheduledAt` null — week numbers only).
  *
+ * A date-only start (`YYYY-MM-DD`) has no meaningful kickoff time, so it is
+ * anchored at **noon UTC** rather than the midnight UTC that `Date.parse` would
+ * give it. Midnight UTC renders as the *previous* day under `toLocaleString()`
+ * in any negative-offset timezone (the Americas) — WSM-000160. Noon UTC lands
+ * on the intended calendar day across the Americas and Europe. A start that
+ * already carries an explicit time keeps it.
+ *
  * Date math is done in UTC off the parsed start, so adding whole weeks never
  * drifts across DST and the result is deterministic (no `Date.now()`).
  *
@@ -100,7 +107,8 @@ export function weekKickoff(
   week: number,
 ): string | null {
   if (!seasonStart) return null;
-  const startMs = Date.parse(seasonStart);
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(seasonStart);
+  const startMs = Date.parse(dateOnly ? `${seasonStart}T12:00:00.000Z` : seasonStart);
   if (Number.isNaN(startMs)) return null;
   return new Date(startMs + (week - 1) * MS_PER_WEEK).toISOString();
 }


### PR DESCRIPTION
Closes #366 · follow-up to #363 (WSM-000158)

## Problem
A schedule generated from a season starting **2026-09-05** displayed week-1 games as **"9/4/2026, 8:00:00 PM"** — one day early. `weekKickoff` parsed the date-only `startDate` as **midnight UTC**, which `toLocaleString()` renders as the previous evening in any negative-offset timezone (the Americas). Observed live in the browser while verifying #363.

## Fix
Anchor **date-only** generated kickoffs at **noon UTC** (`T12:00:00.000Z`). Noon UTC lands on the intended calendar day across the Americas and Europe, so the date renders correctly. Season starts that already carry an explicit time are untouched. One-line change in `weekKickoff` — fixes it at the source, so every surface that renders `scheduledAt` is corrected.

## Tests (574 passing)
- New: `weekKickoff("2026-09-05", 1)` renders as **9/5/2026** in `America/New_York`.
- Updated date-only expectations to noon UTC; convex-test expectations updated.

## Follow-up (not this PR)
The When column still shows a placeholder time (e.g. 8:00 AM) for date-only fixtures; a date-only display would be cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)