### PR TITLE
feat(web): render date-only fixtures without placeholder time (WSM-000161)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
+import { formatFixtureWhen } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
@@ -210,9 +211,7 @@ export default async function LeagueSchedulePage({
                       {rows.map(({ fixture, result }) => (
                         <tr key={fixture.id} className="border-b border-border">
                           <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-                            {fixture.scheduledAt
-                              ? new Date(fixture.scheduledAt).toLocaleString()
-                              : "TBD"}
+                            {formatFixtureWhen(fixture.scheduledAt)}
                           </td>
                           <td className="px-4 py-2 text-foreground">
                             {fixture.homeTeamName}

--- a/apps/web/src/lib/__tests__/format.test.ts
+++ b/apps/web/src/lib/__tests__/format.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { formatFixtureWhen } from "../format";
+
+describe("formatFixtureWhen (WSM-000161)", () => {
+  it("returns TBD for a null scheduledAt", () => {
+    expect(formatFixtureWhen(null)).toBe("TBD");
+  });
+
+  it("renders a date-only fixture (noon-UTC anchor) as a date with no time", () => {
+    // Generator anchors date-only kickoffs to noon UTC.
+    const out = formatFixtureWhen("2026-09-05T12:00:00.000Z");
+    // No clock time should leak through (no ":" from H:MM, no AM/PM marker).
+    expect(out).not.toMatch(/\d:\d/);
+    expect(out).not.toMatch(/[AP]M/i);
+    // The UTC calendar day must be preserved.
+    expect(out).toContain("Sep");
+    expect(out).toContain("5");
+    expect(out).toContain("2026");
+  });
+
+  it("uses the UTC calendar day so the date does not shift across timezones", () => {
+    // Noon UTC is the same calendar day everywhere on Earth, so regardless of
+    // the test runner's local timezone the day must read as Sep 5.
+    const out = formatFixtureWhen("2026-09-05T12:00:00.000Z");
+    // "Sep 5, 2026" with a weekday prefix; assert the day number is 5 and not
+    // a neighboring day that a TZ offset could have produced.
+    expect(out).toMatch(/\bSep\b/);
+    expect(out).toMatch(/\b5\b/);
+    expect(out).not.toMatch(/\b4\b/);
+    expect(out).not.toMatch(/\b6\b/);
+  });
+
+  it("renders a real kickoff time as date + time", () => {
+    // A non-noon-UTC time is a real kickoff and must keep the time component.
+    const out = formatFixtureWhen("2026-09-05T19:30:00.000Z");
+    // toLocaleString() includes a clock time (H:MM somewhere in the string).
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("treats a non-zero seconds/ms value as a real time, not date-only", () => {
+    const out = formatFixtureWhen("2026-09-05T12:00:30.000Z");
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+});

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -8,6 +8,43 @@ export function formatDate(dateString: string | null | undefined): string {
   });
 }
 
+/**
+ * Render a fixture's "When" value (WSM-000161).
+ *
+ * The schedule generator anchors date-only kickoffs to noon UTC
+ * (e.g. "2026-09-05T12:00:00.000Z") so the calendar day is stable across
+ * timezones. Rendering that with `toLocaleString()` shows a misleading
+ * placeholder time, so we detect the noon-UTC anchor and render a date only.
+ *
+ * Heuristic: treat the fixture as date-only when its UTC time-of-day is exactly
+ * 12:00:00.000. We render that date in UTC so the calendar day matches what was
+ * scheduled (not the viewer's local day). Fixtures with any other time keep the
+ * existing date + time rendering in the viewer's local timezone.
+ *
+ * Limitation: a genuine kickoff at exactly 12:00:00.000Z would be treated as
+ * date-only and lose its time. That collision is acceptable — real kickoffs land
+ * on the hour/half-hour in local time and almost never on the noon-UTC anchor.
+ */
+export function formatFixtureWhen(scheduledAt: string | null): string {
+  if (!scheduledAt) return "TBD";
+  const date = new Date(scheduledAt);
+  const isDateOnly =
+    date.getUTCHours() === 12 &&
+    date.getUTCMinutes() === 0 &&
+    date.getUTCSeconds() === 0 &&
+    date.getUTCMilliseconds() === 0;
+  if (isDateOnly) {
+    return date.toLocaleDateString(undefined, {
+      timeZone: "UTC",
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+  return date.toLocaleString();
+}
+
 export function calculateAge(dateOfBirth: string | null | undefined): number | null {
   if (!dateOfBirth) return null;
   const birth = new Date(dateOfBirth + "T00:00:00");


### PR DESCRIPTION
## Problem

Generated schedule fixtures store `scheduledAt` as **noon UTC** for date-only kickoffs (e.g. `2026-09-05T12:00:00.000Z`). The league schedule "When" column rendered `new Date(fixture.scheduledAt).toLocaleString()`, which showed a misleading placeholder time (e.g. "8:00 AM"). Closes #368.

## Change

- Added a shared `formatFixtureWhen(scheduledAt: string | null): string` helper in `apps/web/src/lib/format.ts`:
  - `null` → `"TBD"`.
  - Date-only (UTC time-of-day exactly `12:00:00.000`, the generator's noon-UTC anchor) → date only, rendered **in UTC** so the calendar day is correct (`{ timeZone: "UTC", weekday, month, day, year }`).
  - Otherwise → date + time in the viewer's local tz via `toLocaleString()` (unchanged behavior).
  - Code comment documents the noon-UTC heuristic and its one limitation (a genuine `12:00:00Z` kickoff is treated as date-only).
- Used the helper in the dashboard schedule "When" column.
- Added Vitest coverage in `apps/web/src/lib/__tests__/format.test.ts` (null → TBD, noon-UTC → date-only with correct UTC day and no time, real time → includes time, non-zero seconds → real time).

## Scope notes

- The public game page (`/leagues/[id]/games/[gameId]`) uses a separate `formatKickoff` formatter (`dateStyle: full` / `timeStyle: short`, null → "Date TBD") with different semantics, so it does **not** match the `toLocaleString()`/"TBD" pattern and was left unchanged. The public league page only **sorts** by `scheduledAt` and never renders it as text. No other surface renders a fixture date with the targeted pattern.

## Verification (from `apps/web`)

- `pnpm exec tsc --noEmit` — passes
- `pnpm exec eslint` on changed files — passes
- `pnpm run test:unit` — 82 files, 579 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)