### PR TITLE
feat(web): double round-robin schedule format (WSM-000162)

### DIFF
--- a/apps/web/convex/__tests__/roundRobin.test.ts
+++ b/apps/web/convex/__tests__/roundRobin.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   roundRobinSchedule,
+  doubleRoundRobinSchedule,
   weekKickoff,
   type RoundRobinPairing,
 } from "../lib/roundRobin";
@@ -116,6 +117,98 @@ describe("roundRobinSchedule (WSM-000153)", () => {
       }
     },
   );
+});
+
+describe("doubleRoundRobinSchedule (WSM-000162)", () => {
+  it("inherits the input guards from the single round-robin", () => {
+    expect(() => doubleRoundRobinSchedule([])).toThrow(
+      "need_at_least_two_teams",
+    );
+    expect(() => doubleRoundRobinSchedule(["t1", "t1"])).toThrow(
+      "duplicate_team_ids",
+    );
+  });
+
+  it("schedules two teams as a home-and-away pair across two weeks", () => {
+    const p = doubleRoundRobinSchedule(ids(2));
+    expect(p).toHaveLength(2);
+    expect(p[0].week).toBe(1);
+    expect(p[1].week).toBe(2);
+    // Same matchup, home/away swapped.
+    expect(p[1].homeTeamId).toBe(p[0].awayTeamId);
+    expect(p[1].awayTeamId).toBe(p[0].homeTeamId);
+  });
+
+  it.each([2, 4, 6, 8])(
+    "with %i teams: every pair meets exactly twice — once home each (N(N-1) games)",
+    (n) => {
+      const pairings = doubleRoundRobinSchedule(ids(n));
+      const expectedGames = n * (n - 1);
+      expect(pairings).toHaveLength(expectedGames);
+
+      // No duplicate ordered (home, away) directed fixtures: each appears once.
+      const directed = pairings.map((p) => `${p.homeTeamId}>${p.awayTeamId}`);
+      expect(new Set(directed).size).toBe(expectedGames);
+
+      // Every unordered pair meets exactly twice.
+      const meetings = new Map<string, number>();
+      for (const p of pairings) {
+        const key = matchupKey(p);
+        meetings.set(key, (meetings.get(key) ?? 0) + 1);
+      }
+      for (const count of meetings.values()) {
+        expect(count).toBe(2);
+      }
+
+      // Each pair plays once with each team home (both directed fixtures exist).
+      const teams = ids(n);
+      for (let i = 0; i < n; i++) {
+        for (let j = i + 1; j < n; j++) {
+          expect(directed).toContain(`${teams[i]}>${teams[j]}`);
+          expect(directed).toContain(`${teams[j]}>${teams[i]}`);
+        }
+      }
+    },
+  );
+
+  it.each([
+    [2, 2],
+    [4, 6],
+    [6, 10],
+    [8, 14],
+  ])("even count (%i teams) spans 2(N-1) weeks", (n, weeks) => {
+    const pairings = doubleRoundRobinSchedule(ids(n));
+    const maxWeek = Math.max(...pairings.map((p) => p.week));
+    expect(maxWeek).toBe(weeks);
+  });
+
+  it("continues second-leg weeks after the first leg (no overlap)", () => {
+    const n = 4;
+    const single = roundRobinSchedule(ids(n));
+    const firstLegMaxWeek = Math.max(...single.map((p) => p.week));
+    const pairings = doubleRoundRobinSchedule(ids(n));
+
+    // First leg occupies weeks 1..firstLegMaxWeek; second leg the next block.
+    const minSecondLegWeek = Math.min(
+      ...pairings
+        .filter((p) => p.week > firstLegMaxWeek)
+        .map((p) => p.week),
+    );
+    expect(minSecondLegWeek).toBe(firstLegMaxWeek + 1);
+  });
+
+  it("never schedules a team twice in the same week", () => {
+    const pairings = doubleRoundRobinSchedule(ids(6));
+    const byWeek = new Map<number, string[]>();
+    for (const p of pairings) {
+      const arr = byWeek.get(p.week) ?? [];
+      arr.push(p.homeTeamId, p.awayTeamId);
+      byWeek.set(p.week, arr);
+    }
+    for (const teams of byWeek.values()) {
+      expect(new Set(teams).size).toBe(teams.length);
+    }
+  });
 });
 
 describe("weekKickoff (WSM-000158)", () => {

--- a/apps/web/convex/__tests__/scheduleGeneration.test.ts
+++ b/apps/web/convex/__tests__/scheduleGeneration.test.ts
@@ -110,6 +110,53 @@ describe("generateSeasonSchedule (WSM-000153)", () => {
     expect(new Set(wk1).size).toBe(1);
   });
 
+  it("defaults to a single round-robin (6 fixtures for 4 teams)", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    const res = await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+      format: "single",
+    });
+
+    expect(res.created).toBe(6); // C(4,2)
+    expect(res.weeks).toBe(3); // n-1
+    expect(await countFixtures(t)).toBe(6);
+  });
+
+  it("double format generates 12 fixtures spanning 6 weeks for 4 teams (WSM-000162)", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    const res = await t.mutation(internal.sports.generateSeasonSchedule, {
+      seasonId,
+      actorUserId: "user_1",
+      format: "double",
+    });
+
+    expect(res.teamCount).toBe(4);
+    expect(res.created).toBe(12); // N(N-1)
+    expect(res.weeks).toBe(6); // 2(N-1)
+    expect(await countFixtures(t)).toBe(12);
+
+    const fixtures = await t.run((ctx) =>
+      ctx.db.query("fixtures").collect(),
+    );
+    const weeks = fixtures.map((f) => f.week as number);
+    expect(Math.min(...weeks)).toBe(1);
+    expect(Math.max(...weeks)).toBe(6);
+
+    // Every unordered pair meets exactly twice.
+    const meetings = new Map<string, number>();
+    for (const f of fixtures) {
+      const key = [f.homeTeamId, f.awayTeamId].sort().join("|");
+      meetings.set(key, (meetings.get(key) ?? 0) + 1);
+    }
+    expect(meetings.size).toBe(6); // C(4,2) distinct pairs
+    for (const count of meetings.values()) expect(count).toBe(2);
+  });
+
   it("throws when the league has fewer than two teams", async () => {
     const t = convexTest(schema, modules);
     const { seasonId } = await seedLeague(t, 1);

--- a/apps/web/convex/lib/roundRobin.ts
+++ b/apps/web/convex/lib/roundRobin.ts
@@ -79,6 +79,34 @@ export function roundRobinSchedule(teamIds: string[]): RoundRobinPairing[] {
   return pairings;
 }
 
+/**
+ * Build a double round-robin: every team plays every other team exactly twice,
+ * once at home and once away (WSM-000162).
+ *
+ * The first leg is a plain {@link roundRobinSchedule}. The second leg replays
+ * those same pairings with home/away swapped, on weeks that continue after the
+ * first leg (second-leg week = firstLegMaxWeek + originalWeek). For an even
+ * team count this spans 2(N-1) weeks and yields N(N-1) games.
+ *
+ * @param teamIds distinct team ids (order is preserved as seeded)
+ * @returns pairings across both legs, weeks continuing 1..2(N-1) for even N
+ * @throws if fewer than two teams, or ids are not distinct
+ */
+export function doubleRoundRobinSchedule(
+  teamIds: string[],
+): RoundRobinPairing[] {
+  const firstLeg = roundRobinSchedule(teamIds);
+  const firstLegMaxWeek = firstLeg.reduce((max, p) => Math.max(max, p.week), 0);
+
+  const secondLeg = firstLeg.map((p) => ({
+    week: firstLegMaxWeek + p.week,
+    homeTeamId: p.awayTeamId,
+    awayTeamId: p.homeTeamId,
+  }));
+
+  return [...firstLeg, ...secondLeg];
+}
+
 const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
 /**

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -16,7 +16,11 @@ import {
   type HsRatingInput,
 } from "./lib/hsSprt";
 import { applyScore, isLiveStatus, isNonNegInt } from "./lib/liveScore";
-import { roundRobinSchedule, weekKickoff } from "./lib/roundRobin";
+import {
+  roundRobinSchedule,
+  doubleRoundRobinSchedule,
+  weekKickoff,
+} from "./lib/roundRobin";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -3713,6 +3717,9 @@ export const generateSeasonSchedule = internalMutationGeneric({
     seasonId: v.id("seasons"),
     actorUserId: v.string(),
     confirm: v.optional(v.boolean()),
+    // "single" (default) plays each pair once; "double" plays a home-and-away
+    // double round-robin (WSM-000162).
+    format: v.optional(v.union(v.literal("single"), v.literal("double"))),
   },
   returns: v.object({
     created: v.number(),
@@ -3765,7 +3772,11 @@ export const generateSeasonSchedule = internalMutationGeneric({
       await ctx.db.delete(f._id);
     }
 
-    const pairings = roundRobinSchedule(teams.map((t) => t._id));
+    const teamIds = teams.map((t) => t._id);
+    const pairings =
+      args.format === "double"
+        ? doubleRoundRobinSchedule(teamIds)
+        : roundRobinSchedule(teamIds);
     const createdAt = new Date().toISOString();
     for (const p of pairings) {
       await ctx.db.insert("fixtures", {

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
@@ -85,6 +85,7 @@ describe("generateScheduleAction (WSM-000153)", () => {
       seasonId: SEASON,
       actorUserId: "user_1",
       confirm: undefined,
+      format: undefined,
     });
   });
 
@@ -120,6 +121,29 @@ describe("generateScheduleAction (WSM-000153)", () => {
       seasonId: SEASON,
       actorUserId: "user_1",
       confirm: true,
+      format: undefined,
+    });
+  });
+
+  it("forwards the chosen format to the mutation (WSM-000162)", async () => {
+    authorize();
+    mockGenerateSeasonSchedule.mockResolvedValue({
+      created: 12,
+      weeks: 6,
+      teamCount: 4,
+    });
+
+    await generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      format: "double",
+    });
+
+    expect(mockGenerateSeasonSchedule).toHaveBeenCalledWith({
+      seasonId: SEASON,
+      actorUserId: "user_1",
+      confirm: undefined,
+      format: "double",
     });
   });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -95,15 +95,17 @@ export async function createFixtureAction(
 }
 
 /*
- * Generate a single round-robin schedule for the league's active season
- * (WSM-000153). The mutation refuses to overwrite a slate that already has
- * recorded results / live state; that surfaces here as `needsConfirm` so the
- * UI can re-call with `confirm: true`.
+ * Generate a round-robin schedule for the league's active season (WSM-000153).
+ * `format` chooses a single round-robin (default) or a home-and-away double
+ * round-robin (WSM-000162). The mutation refuses to overwrite a slate that
+ * already has recorded results / live state; that surfaces here as
+ * `needsConfirm` so the UI can re-call with `confirm: true`.
  */
 export async function generateScheduleAction(input: {
   leagueId: string;
   seasonId: string;
   confirm?: boolean;
+  format?: "single" | "double";
 }): Promise<
   | { ok: true; created: number; weeks: number; teamCount: number }
   | { ok: false; needsConfirm: true }
@@ -120,6 +122,7 @@ export async function generateScheduleAction(input: {
       seasonId: input.seasonId,
       actorUserId: userId,
       confirm: input.confirm,
+      format: input.format,
     });
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);

--- a/apps/web/src/components/schedule/GenerateScheduleButton.tsx
+++ b/apps/web/src/components/schedule/GenerateScheduleButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarPlus } from "lucide-react";
@@ -25,6 +25,8 @@ function friendlyError(code: string): string {
   return "Could not generate the schedule.";
 }
 
+type ScheduleFormat = "single" | "double";
+
 export default function GenerateScheduleButton({
   leagueId,
   seasonId,
@@ -32,15 +34,24 @@ export default function GenerateScheduleButton({
   hasFixtures,
 }: GenerateScheduleButtonProps) {
   const router = useRouter();
+  const formatId = useId();
+  const [format, setFormat] = useState<ScheduleFormat>("single");
   const [pending, startTransition] = useTransition();
 
   function run(confirm: boolean) {
     startTransition(async () => {
-      const res = await generateScheduleAction({ leagueId, seasonId, confirm });
+      const res = await generateScheduleAction({
+        leagueId,
+        seasonId,
+        confirm,
+        format,
+      });
 
       if (res.ok) {
         toast.success(
-          `Generated ${res.created} games across ${res.weeks} weeks for ${res.teamCount} teams.`,
+          `Generated ${res.created} ${
+            format === "double" ? "home-and-away " : ""
+          }games across ${res.weeks} weeks for ${res.teamCount} teams.`,
         );
         router.refresh();
         return;
@@ -73,13 +84,28 @@ export default function GenerateScheduleButton({
   }
 
   return (
-    <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
-      <CalendarPlus className="mr-1.5 h-4 w-4" />
-      {pending
-        ? "Generating…"
-        : hasFixtures
-          ? "Regenerate schedule"
-          : "Generate schedule"}
-    </Button>
+    <div className="flex items-center gap-2">
+      <label htmlFor={formatId} className="sr-only">
+        Schedule format
+      </label>
+      <select
+        id={formatId}
+        value={format}
+        disabled={pending}
+        onChange={(e) => setFormat(e.target.value as ScheduleFormat)}
+        className="h-8 rounded-md border border-input bg-background px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <option value="single">Single round-robin</option>
+        <option value="double">Double (home &amp; away)</option>
+      </select>
+      <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
+        <CalendarPlus className="mr-1.5 h-4 w-4" />
+        {pending
+          ? "Generating…"
+          : hasFixtures
+            ? "Regenerate schedule"
+            : "Generate schedule"}
+      </Button>
+    </div>
   );
 }

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -478,7 +478,12 @@ const refs = {
     "sports:deleteFixture",
   ),
   generateSeasonSchedule: mutationRef<
-    { seasonId: string; actorUserId: string; confirm?: boolean },
+    {
+      seasonId: string;
+      actorUserId: string;
+      confirm?: boolean;
+      format?: "single" | "double";
+    },
     { created: number; weeks: number; teamCount: number }
   >("sports:generateSeasonSchedule"),
   listFixturesBySeason: queryRef<{ seasonId: string }, FixtureDto[]>(
@@ -1595,6 +1600,7 @@ export async function generateSeasonSchedule(input: {
   seasonId: string;
   actorUserId: string;
   confirm?: boolean;
+  format?: "single" | "double";
 }): Promise<{ created: number; weeks: number; teamCount: number }> {
   return mutateConvex(refs.generateSeasonSchedule, input);
 }


### PR DESCRIPTION
## What

Adds a **double round-robin** (home-and-away) option to season schedule generation. Closes #369.

## Changes

- **`convex/lib/roundRobin.ts`** — new pure `doubleRoundRobinSchedule(teamIds)`. Runs the existing single round-robin once, then appends a second leg with home/away swapped on continued weeks (`secondLegWeek = firstLegMaxWeek + originalWeek`). Every pair meets twice — once at each ground. `roundRobinSchedule` is unchanged.
- **`convex/sports.ts`** — `generateSeasonSchedule` gains `format: v.optional(v.union(v.literal("single"), v.literal("double")))` (default `"single"`). Picks the double generator when `"double"`. Stays an `internalMutation`; the results-guard, fixture deletion, and `weekKickoff` dating are untouched (they key off week numbers, which work for any week).
- **`src/lib/data-api.ts`** — `format?: "single" | "double"` added to the `refs.generateSeasonSchedule` ref type and the exported wrapper.
- **`schedule/actions.ts`** — `generateScheduleAction` accepts and forwards `format`; `needsConfirm` mapping preserved.
- **`GenerateScheduleButton.tsx`** — minimal native `<select>` (Single round-robin / Double home & away) next to the button, with an `sr-only` label; success toast notes "home-and-away" for double.

## Tests

- `roundRobin.test.ts` — double round-robin: each pair meets exactly twice (once each home), N(N-1) games, 2(N-1) weeks for even N; covers N=2,4,6,8 plus guard inheritance and second-leg week continuation.
- `scheduleGeneration.test.ts` — `format: "double"` for 4 teams creates 12 fixtures across 6 weeks; `"single"`/default stays 6.
- `generate-schedule-action.test.ts` — new test asserting `format` is forwarded; existing assertions updated.

## Verification (from `apps/web`)

- `tsc --noEmit` — no new errors (the only errors are pre-existing `grade`/`squad` `PlayerDto` issues on `main`, unrelated).
- `eslint` on all changed files — clean.
- `pnpm run test:unit` — **589 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)