### PR TITLE
feat(web): copy rosters from previous season into a new season (WSM-000163)

### DIFF
--- a/apps/web/convex/__tests__/rosterCarryover.test.ts
+++ b/apps/web/convex/__tests__/rosterCarryover.test.ts
@@ -1,0 +1,219 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/**
+ * Seed a league with two seasons (source older than target), two teams, and a
+ * player per team. The source season gets two roster assignments + two depth
+ * chart entries; the target starts empty.
+ */
+async function seedLeagueWithTwoSeasons(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Carryover League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const teamIds: Id<"teams">[] = [];
+    const playerIds: Id<"players">[] = [];
+    for (let i = 0; i < 2; i++) {
+      const teamId = await ctx.db.insert("teams", {
+        name: `Team ${i}`,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Loc",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+      teamIds.push(teamId);
+      playerIds.push(
+        await ctx.db.insert("players", {
+          name: `Player ${i}`,
+          leagueId,
+          teamId,
+          position: "QB",
+          positionGroup: null,
+          jerseyNumber: null,
+          dateOfBirth: null,
+          status: "active",
+          headshotUrl: null,
+        }),
+      );
+    }
+
+    // Source is the earlier season (2025); target is the later one (2026).
+    const sourceSeasonId = await ctx.db.insert("seasons", {
+      name: "2025",
+      leagueId,
+      startDate: "2025-09-01",
+      endDate: "2025-12-15",
+      status: "completed",
+      rosterLocked: false,
+    });
+    const targetSeasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: "2026-09-01",
+      endDate: "2026-12-15",
+      status: "active",
+      rosterLocked: false,
+    });
+
+    // Two assignments + two depth entries on the source season.
+    for (let i = 0; i < 2; i++) {
+      await ctx.db.insert("rosterAssignments", {
+        seasonId: sourceSeasonId,
+        teamId: teamIds[i],
+        playerId: playerIds[i],
+        leagueId,
+        depthRank: 1,
+        positionSlot: "QB",
+        status: "active",
+        assignedAt: "2025-09-01T00:00:00.000Z",
+        assignedBy: "old_actor",
+      });
+      await ctx.db.insert("depthChartEntries", {
+        teamId: teamIds[i],
+        seasonId: sourceSeasonId,
+        playerId: playerIds[i],
+        positionSlot: "QB",
+        sortOrder: 0,
+        updatedAt: "2025-09-01T00:00:00.000Z",
+      });
+    }
+
+    return { leagueId, teamIds, playerIds, sourceSeasonId, targetSeasonId };
+  });
+}
+
+async function countForSeason(
+  t: ReturnType<typeof convexTest>,
+  seasonId: Id<"seasons">,
+) {
+  return t.run(async (ctx) => {
+    const assignments = (
+      await ctx.db.query("rosterAssignments").collect()
+    ).filter((a) => a.seasonId === seasonId);
+    const depth = (await ctx.db.query("depthChartEntries").collect()).filter(
+      (d) => d.seasonId === seasonId,
+    );
+    return { assignments, depth };
+  });
+}
+
+describe("copySeasonRosters (WSM-000163)", () => {
+  it("clones the most recent prior season's rosters into the target", async () => {
+    const t = convexTest(schema, modules);
+    const { sourceSeasonId, targetSeasonId } =
+      await seedLeagueWithTwoSeasons(t);
+
+    const res = await t.mutation(internal.sports.copySeasonRosters, {
+      targetSeasonId,
+      actorUserId: "new_actor",
+    });
+
+    expect(res.copiedAssignments).toBe(2);
+    expect(res.copiedDepthEntries).toBe(2);
+    expect(res.sourceSeasonId).toBe(sourceSeasonId);
+
+    const target = await countForSeason(t, targetSeasonId);
+    expect(target.assignments).toHaveLength(2);
+    expect(target.depth).toHaveLength(2);
+    // Cloned rows belong to the target season and carry the new actor.
+    for (const a of target.assignments) {
+      expect(a.seasonId).toBe(targetSeasonId);
+      expect(a.assignedBy).toBe("new_actor");
+      expect(a.positionSlot).toBe("QB");
+    }
+    for (const d of target.depth) {
+      expect(d.seasonId).toBe(targetSeasonId);
+    }
+
+    // The source season is untouched.
+    const source = await countForSeason(t, sourceSeasonId);
+    expect(source.assignments).toHaveLength(2);
+    expect(source.depth).toHaveLength(2);
+  });
+
+  it("uses an explicit sourceSeasonId when provided", async () => {
+    const t = convexTest(schema, modules);
+    const { sourceSeasonId, targetSeasonId } =
+      await seedLeagueWithTwoSeasons(t);
+
+    const res = await t.mutation(internal.sports.copySeasonRosters, {
+      targetSeasonId,
+      sourceSeasonId,
+      actorUserId: "new_actor",
+    });
+
+    expect(res.sourceSeasonId).toBe(sourceSeasonId);
+    expect(res.copiedAssignments).toBe(2);
+  });
+
+  it("guards a populated target then succeeds with confirm: true", async () => {
+    const t = convexTest(schema, modules);
+    const { targetSeasonId } = await seedLeagueWithTwoSeasons(t);
+
+    // First copy populates the target.
+    await t.mutation(internal.sports.copySeasonRosters, {
+      targetSeasonId,
+      actorUserId: "new_actor",
+    });
+
+    // Re-running unconfirmed throws the guard.
+    await expect(
+      t.mutation(internal.sports.copySeasonRosters, {
+        targetSeasonId,
+        actorUserId: "new_actor",
+      }),
+    ).rejects.toThrow(/target_has_rosters/);
+
+    // With confirm: true it cleanly replaces — count stays at 2 (not doubled).
+    const res = await t.mutation(internal.sports.copySeasonRosters, {
+      targetSeasonId,
+      actorUserId: "new_actor",
+      confirm: true,
+    });
+    expect(res.copiedAssignments).toBe(2);
+
+    const target = await countForSeason(t, targetSeasonId);
+    expect(target.assignments).toHaveLength(2);
+    expect(target.depth).toHaveLength(2);
+  });
+
+  it("throws no_source_season when there is no prior season", async () => {
+    const t = convexTest(schema, modules);
+    const targetSeasonId = await t.run(async (ctx) => {
+      const leagueId = await ctx.db.insert("leagues", {
+        name: "Lonely League",
+        orgId: "org_1",
+        isPublic: false,
+        inviteToken: null,
+      });
+      return ctx.db.insert("seasons", {
+        name: "2026",
+        leagueId,
+        startDate: null,
+        endDate: null,
+        status: "active",
+        rosterLocked: false,
+      });
+    });
+
+    await expect(
+      t.mutation(internal.sports.copySeasonRosters, {
+        targetSeasonId,
+        actorUserId: "new_actor",
+      }),
+    ).rejects.toThrow(/no_source_season/);
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -3788,6 +3788,125 @@ export const generateSeasonSchedule = internalMutationGeneric({
   },
 });
 
+/*
+ * Roster carryover (WSM-000163). Clone the previous season's rosters into a new
+ * season so a coach doesn't rebuild the depth chart from scratch each year.
+ *
+ * Source resolution: an explicit `sourceSeasonId` (must be in the same league)
+ * wins; otherwise the most recent PRIOR season in the same league — ordered by
+ * `startDate` when present, else `_creationTime`, excluding the target. If none
+ * exists the mutation throws `no_source_season`.
+ *
+ * Like generateSeasonSchedule, this refuses to silently overwrite: if the target
+ * already has any rosterAssignments and the caller hasn't passed `confirm: true`,
+ * it throws `target_has_rosters`. On confirm (or an empty target) it does a clean
+ * replace — the target's existing rosterAssignments + depthChartEntries are
+ * deleted first, then every source row is cloned into the target season.
+ */
+export const copySeasonRosters = internalMutation({
+  args: {
+    targetSeasonId: v.id("seasons"),
+    sourceSeasonId: v.optional(v.id("seasons")),
+    actorUserId: v.string(),
+    confirm: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    copiedAssignments: v.number(),
+    copiedDepthEntries: v.number(),
+    sourceSeasonId: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const target = await ctx.db.get(args.targetSeasonId);
+    if (!target) throw new Error("target_season_not_found");
+
+    // Resolve the source season.
+    let source;
+    if (args.sourceSeasonId) {
+      source = await ctx.db.get(args.sourceSeasonId);
+      if (!source) throw new Error("no_source_season");
+      if (source.leagueId !== target.leagueId) {
+        throw new Error("source_season_league_mismatch");
+      }
+      if (source._id === target._id) throw new Error("no_source_season");
+    } else {
+      // Most recent prior season in the same league. Prefer startDate ordering,
+      // falling back to _creationTime when a season has no start date.
+      const candidates = (
+        await ctx.db
+          .query("seasons")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", target.leagueId))
+          .collect()
+      ).filter((s) => s._id !== target._id);
+      if (candidates.length === 0) throw new Error("no_source_season");
+      const sortKey = (s: (typeof candidates)[number]) =>
+        s.startDate ?? new Date(s._creationTime).toISOString();
+      candidates.sort((a, b) => sortKey(b).localeCompare(sortKey(a)));
+      source = candidates[0];
+    }
+
+    // Load the source rows up front so the target wipe can't affect them.
+    const sourceAssignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) => q.eq("seasonId", source._id))
+      .collect();
+    const sourceDepthEntries = (
+      await ctx.db.query("depthChartEntries").collect()
+    ).filter((d) => d.seasonId === source._id);
+
+    // Results-style guard: refuse to overwrite a populated target unconfirmed.
+    const existingTargetAssignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.targetSeasonId),
+      )
+      .collect();
+    if (existingTargetAssignments.length > 0 && !args.confirm) {
+      throw new Error("target_has_rosters");
+    }
+
+    // Clean replace: clear the target's existing roster + depth-chart rows.
+    for (const ra of existingTargetAssignments) {
+      await ctx.db.delete(ra._id);
+    }
+    for (const d of await ctx.db.query("depthChartEntries").collect()) {
+      if (d.seasonId === args.targetSeasonId) await ctx.db.delete(d._id);
+    }
+
+    const now = new Date().toISOString();
+
+    for (const ra of sourceAssignments) {
+      await ctx.db.insert("rosterAssignments", {
+        seasonId: args.targetSeasonId,
+        teamId: ra.teamId,
+        playerId: ra.playerId,
+        leagueId: ra.leagueId,
+        depthRank: ra.depthRank,
+        positionSlot: ra.positionSlot,
+        status: ra.status,
+        assignedAt: now,
+        assignedBy: args.actorUserId,
+      });
+    }
+
+    for (const d of sourceDepthEntries) {
+      await ctx.db.insert("depthChartEntries", {
+        teamId: d.teamId,
+        seasonId: args.targetSeasonId,
+        playerId: d.playerId,
+        positionSlot: d.positionSlot,
+        sortOrder: d.sortOrder,
+        updatedAt: now,
+      });
+    }
+
+    return {
+      copiedAssignments: sourceAssignments.length,
+      copiedDepthEntries: sourceDepthEntries.length,
+      sourceSeasonId: source._id as string,
+    };
+  },
+});
+
 export const getFixture = queryGeneric({
   args: { fixtureId: v.id("fixtures") },
   returns: v.union(fixtureDtoValidator, v.null()),

--- a/apps/web/src/app/dashboard/seasons/__tests__/copy-rosters-action.test.ts
+++ b/apps/web/src/app/dashboard/seasons/__tests__/copy-rosters-action.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockGetSeasonLeagueId,
+  mockGetLeagueOrgId,
+  mockGetUserRoleInOrg,
+  mockCopySeasonRosters,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockGetSeasonLeagueId: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetUserRoleInOrg: vi.fn(),
+  mockCopySeasonRosters: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  copySeasonRosters: mockCopySeasonRosters,
+  getSeasonLeagueId: mockGetSeasonLeagueId,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  // Imported by the module under test but unused by this action.
+  upsertSeason: vi.fn(),
+  updateSeason: vi.fn(),
+  setActiveSeason: vi.fn(),
+  deleteSeason: vi.fn(),
+  getSeasons: vi.fn(),
+}));
+vi.mock("@/lib/org-context", () => ({
+  getUserRoleInOrg: mockGetUserRoleInOrg,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { copyRostersAction } from "../actions";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+
+/** Put every gate in the "admin allowed" state. */
+function authorize() {
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockGetSeasonLeagueId.mockResolvedValue(LEAGUE);
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockGetUserRoleInOrg.mockResolvedValue("org:admin");
+}
+
+describe("copyRostersAction (WSM-000163)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("copies rosters for an authorized league admin", async () => {
+    authorize();
+    mockCopySeasonRosters.mockResolvedValue({
+      copiedAssignments: 40,
+      copiedDepthEntries: 22,
+      sourceSeasonId: "season_prev",
+    });
+
+    const res = await copyRostersAction({ targetSeasonId: SEASON });
+
+    expect(res).toEqual({
+      ok: true,
+      copiedAssignments: 40,
+      copiedDepthEntries: 22,
+    });
+    expect(mockCopySeasonRosters).toHaveBeenCalledWith({
+      targetSeasonId: SEASON,
+      actorUserId: "user_1",
+      confirm: undefined,
+    });
+  });
+
+  it("returns needsConfirm when the target already has rosters", async () => {
+    authorize();
+    mockCopySeasonRosters.mockRejectedValue(
+      new Error("Uncaught Error: target_has_rosters"),
+    );
+
+    const res = await copyRostersAction({ targetSeasonId: SEASON });
+
+    expect(res).toEqual({ ok: false, needsConfirm: true });
+  });
+
+  it("passes confirm through to the mutation", async () => {
+    authorize();
+    mockCopySeasonRosters.mockResolvedValue({
+      copiedAssignments: 1,
+      copiedDepthEntries: 0,
+      sourceSeasonId: "season_prev",
+    });
+
+    await copyRostersAction({ targetSeasonId: SEASON, confirm: true });
+
+    expect(mockCopySeasonRosters).toHaveBeenCalledWith({
+      targetSeasonId: SEASON,
+      actorUserId: "user_1",
+      confirm: true,
+    });
+  });
+
+  it("maps no_source_season to a friendly error", async () => {
+    authorize();
+    mockCopySeasonRosters.mockRejectedValue(
+      new Error("Uncaught Error: no_source_season"),
+    );
+
+    const res = await copyRostersAction({ targetSeasonId: SEASON });
+
+    expect(res).toEqual({
+      ok: false,
+      error: "This league has no earlier season to copy rosters from.",
+    });
+  });
+
+  it("rejects a non-admin caller", async () => {
+    authorize();
+    mockGetUserRoleInOrg.mockResolvedValue("org:member");
+
+    const res = await copyRostersAction({ targetSeasonId: SEASON });
+
+    expect(res).toEqual({ ok: false, error: "not_admin" });
+    expect(mockCopySeasonRosters).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const res = await copyRostersAction({ targetSeasonId: SEASON });
+
+    expect(res).toEqual({ ok: false, error: "unauthorized" });
+    expect(mockCopySeasonRosters).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -7,6 +7,7 @@ import {
   updateSeason as updateSeasonMutation,
   setActiveSeason as setActiveSeasonMutation,
   deleteSeason as deleteSeasonMutation,
+  copySeasonRosters,
   getSeasonLeagueId,
   getLeagueOrgId,
   getSeasons,
@@ -109,4 +110,53 @@ export async function deleteSeasonAction(seasonId: string): Promise<Result> {
   await deleteSeasonMutation(seasonId);
   revalidatePath("/dashboard/seasons");
   return { ok: true };
+}
+
+/*
+ * Roster carryover (WSM-000163). Clone the most recent prior season's rosters
+ * into the target season. The mutation refuses to overwrite a target that
+ * already has rosters; that surfaces here as `needsConfirm` so the UI can
+ * re-call with `confirm: true`. A league with no prior season maps to a
+ * friendly error.
+ */
+export async function copyRostersAction(input: {
+  targetSeasonId: string;
+  confirm?: boolean;
+}): Promise<
+  | { ok: true; copiedAssignments: number; copiedDepthEntries: number }
+  | { ok: false; needsConfirm: true }
+  | { ok: false; error: string }
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const leagueId = await getSeasonLeagueId(input.targetSeasonId);
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+
+  try {
+    const res = await copySeasonRosters({
+      targetSeasonId: input.targetSeasonId,
+      actorUserId: userId,
+      confirm: input.confirm,
+    });
+    revalidatePath("/dashboard/seasons");
+    return {
+      ok: true,
+      copiedAssignments: res.copiedAssignments,
+      copiedDepthEntries: res.copiedDepthEntries,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("target_has_rosters")) {
+      return { ok: false, needsConfirm: true };
+    }
+    if (message.includes("no_source_season")) {
+      return {
+        ok: false,
+        error: "This league has no earlier season to copy rosters from.",
+      };
+    }
+    return { ok: false, error: message };
+  }
 }

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -5,12 +5,13 @@ import { useRouter } from "next/navigation";
 import type { SeasonDto } from "@sports-management/shared-types";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { Plus, Trash2, Pencil, CheckCircle2 } from "lucide-react";
+import { Plus, Trash2, Pencil, CheckCircle2, Users } from "lucide-react";
 import {
   createSeasonAction,
   updateSeasonAction,
   activateSeasonAction,
   deleteSeasonAction,
+  copyRostersAction,
 } from "./actions";
 
 const inputClass =
@@ -103,6 +104,62 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
         Cancel
       </Button>
     </div>
+  );
+}
+
+/**
+ * Copy rosters from the most recent prior season into this one (WSM-000163).
+ * Mirrors the GenerateScheduleButton confirm flow: a populated target surfaces
+ * `needsConfirm`, and the user is asked before the clean-replace proceeds.
+ */
+export function CopyRostersButton({ season }: { season: SeasonDto }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function run(confirm: boolean) {
+    setBusy(true);
+    const res = await copyRostersAction({
+      targetSeasonId: season.id,
+      confirm,
+    });
+    setBusy(false);
+
+    if (res.ok) {
+      toast.success(
+        `Copied ${res.copiedAssignments} roster ${
+          res.copiedAssignments === 1 ? "player" : "players"
+        } into ${season.name}.`,
+      );
+      router.refresh();
+      return;
+    }
+
+    if ("needsConfirm" in res) {
+      const proceed = window.confirm(
+        `${season.name} already has rosters. Copying replaces them with last season's rosters. This can't be undone. Continue?`,
+      );
+      if (proceed) run(true);
+      return;
+    }
+
+    toast.error(
+      res.error === "not_admin"
+        ? "Only league admins can copy rosters."
+        : res.error,
+    );
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={busy}
+      onClick={() => run(false)}
+      aria-label={`Copy rosters from last season into ${season.name}`}
+    >
+      <Users className="mr-1 h-3.5 w-3.5" />
+      {busy ? "…" : "Copy rosters"}
+    </Button>
   );
 }
 
@@ -218,6 +275,7 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
           Make active
         </Button>
       )}
+      <CopyRostersButton season={season} />
       <Button
         size="sm"
         variant="ghost"

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -481,6 +481,19 @@ const refs = {
     { seasonId: string; actorUserId: string; confirm?: boolean },
     { created: number; weeks: number; teamCount: number }
   >("sports:generateSeasonSchedule"),
+  copySeasonRosters: mutationRef<
+    {
+      targetSeasonId: string;
+      sourceSeasonId?: string;
+      actorUserId: string;
+      confirm?: boolean;
+    },
+    {
+      copiedAssignments: number;
+      copiedDepthEntries: number;
+      sourceSeasonId: string;
+    }
+  >("sports:copySeasonRosters"),
   listFixturesBySeason: queryRef<{ seasonId: string }, FixtureDto[]>(
     "sports:listFixturesBySeason",
   ),
@@ -1597,6 +1610,19 @@ export async function generateSeasonSchedule(input: {
   confirm?: boolean;
 }): Promise<{ created: number; weeks: number; teamCount: number }> {
   return mutateConvex(refs.generateSeasonSchedule, input);
+}
+
+export async function copySeasonRosters(input: {
+  targetSeasonId: string;
+  sourceSeasonId?: string;
+  actorUserId: string;
+  confirm?: boolean;
+}): Promise<{
+  copiedAssignments: number;
+  copiedDepthEntries: number;
+  sourceSeasonId: string;
+}> {
+  return mutateConvex(refs.copySeasonRosters, input);
 }
 
 export async function listFixturesBySeason(


### PR DESCRIPTION
## What

Implements **roster carryover** (#370 / WSM-000163): a coach can copy the previous season's rosters into a new season instead of rebuilding the depth chart from scratch.

## Changes

- **convex/sports.ts** — new `internalMutation` `copySeasonRosters`:
  - Loads the target season; resolves the **source**: explicit `sourceSeasonId` (must be same league) wins, otherwise the most recent **prior** season in the same league (ordered by `startDate` when present, else `_creationTime`, excluding the target). No prior season → throws `no_source_season`.
  - Results-style guard mirroring `generateSeasonSchedule`: a target that already has `rosterAssignments` throws `target_has_rosters` unless `confirm: true`.
  - On confirm (or empty target) it does a clean replace — deletes the target's existing `rosterAssignments` + `depthChartEntries`, then clones every source row into the target season (new `seasonId`, fresh `assignedAt`/`updatedAt`, `assignedBy` = actor).
  - Returns `{ copiedAssignments, copiedDepthEntries, sourceSeasonId }`.
- **lib/data-api.ts** — `copySeasonRosters` `mutationRef` + exported wrapper.
- **seasons/actions.ts** — `copyRostersAction` gated by the existing `requireLeagueAdmin`; maps `target_has_rosters` → `{ ok: false, needsConfirm: true }` and `no_source_season` → a friendly error; `revalidatePath` on success.
- **seasons/season-actions.tsx** — per-season "Copy rosters" control mirroring the `GenerateScheduleButton` confirm flow.

## Tests

- `convex/__tests__/rosterCarryover.test.ts` — clone counts + target `seasonId`, explicit source, the `target_has_rosters` guard then success with `confirm: true` (no doubling), and `no_source_season`.
- `seasons/__tests__/copy-rosters-action.test.ts` — admin gate enforced, `needsConfirm` passthrough, `confirm` forwarding, friendly `no_source_season` mapping.

## Verification (from `apps/web`)

- `tsc --noEmit` — no new errors (pre-existing `player-form` / `local-workspace` `grade`/`squad` errors are on `main`, untouched).
- `eslint` (changed files) — clean.
- `test:unit` — 584 passed (83 files), including the 10 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)