### PR TITLE
feat(web): single-elimination playoffs backend (WSM-000164)

### DIFF
--- a/apps/web/convex/__tests__/bracket.test.ts
+++ b/apps/web/convex/__tests__/bracket.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { seedOrder, buildBracket } from "../lib/bracket";
+
+describe("seedOrder (WSM-000164)", () => {
+  it("rejects non-powers-of-two", () => {
+    expect(() => seedOrder(6)).toThrow("bracket_size_must_be_power_of_two");
+    expect(() => seedOrder(1)).toThrow();
+  });
+
+  it("produces the standard order for 4 and 8", () => {
+    expect(seedOrder(4)).toEqual([1, 4, 2, 3]);
+    expect(seedOrder(8)).toEqual([1, 8, 4, 5, 2, 7, 3, 6]);
+  });
+
+  it.each([4, 8, 16])("uses every seed once and pairs to N+1 (size %i)", (n) => {
+    const order = seedOrder(n);
+    expect([...order].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: n }, (_, i) => i + 1),
+    );
+    for (let i = 0; i < n; i += 2) {
+      expect(order[i] + order[i + 1]).toBe(n + 1); // round-1 opponents
+    }
+  });
+});
+
+describe("buildBracket (WSM-000164)", () => {
+  it.each([
+    [4, 2, 3],
+    [8, 3, 7],
+    [16, 4, 15],
+  ])("size %i → %i rounds and N-1 total matchups", (size, rounds, total) => {
+    const b = buildBracket(size);
+    expect(b.rounds).toBe(rounds);
+    expect(b.matchups).toHaveLength(total);
+    // Matchups per round halve each round.
+    for (let r = 1; r <= rounds; r++) {
+      expect(b.matchups.filter((m) => m.round === r)).toHaveLength(
+        size / 2 ** r,
+      );
+    }
+  });
+
+  it("seeds only round 1; higher seed hosts; later rounds are TBD", () => {
+    const b = buildBracket(8);
+    const r1 = b.matchups.filter((m) => m.round === 1);
+    for (const m of r1) {
+      expect(m.homeSeed).not.toBeNull();
+      expect(m.awaySeed).not.toBeNull();
+      expect(m.homeSeed!).toBeLessThan(m.awaySeed!); // higher seed hosts
+    }
+    for (const m of b.matchups.filter((m) => m.round > 1)) {
+      expect(m.homeSeed).toBeNull();
+      expect(m.awaySeed).toBeNull();
+    }
+  });
+
+  it("keeps seeds 1 and 2 in opposite halves (meet only in the final)", () => {
+    const b = buildBracket(8);
+    const r1 = b.matchups.filter((m) => m.round === 1).sort((a, z) => a.slot - z.slot);
+    const half = r1.length / 2;
+    const seed1Slot = r1.findIndex((m) => m.homeSeed === 1 || m.awaySeed === 1);
+    const seed2Slot = r1.findIndex((m) => m.homeSeed === 2 || m.awaySeed === 2);
+    expect(seed1Slot < half).toBe(true);
+    expect(seed2Slot >= half).toBe(true);
+  });
+
+  it("wires each non-final matchup to the correct parent slot/side", () => {
+    const b = buildBracket(8);
+    const final = b.matchups.find((m) => m.round === b.rounds)!;
+    expect(final.parentSlot).toBeNull();
+    expect(final.parentSide).toBeNull();
+    for (const m of b.matchups.filter((m) => m.round < b.rounds)) {
+      expect(m.parentSlot).toBe(Math.floor(m.slot / 2));
+      expect(m.parentSide).toBe(m.slot % 2 === 0 ? "home" : "away");
+    }
+    // Both round-1 slots 0 and 1 feed round-2 slot 0 (home + away).
+    const feeders = b.matchups.filter((m) => m.round === 1 && m.parentSlot === 0);
+    expect(feeders.map((m) => m.parentSide).sort()).toEqual(["away", "home"]);
+  });
+});

--- a/apps/web/convex/__tests__/playoffBracket.test.ts
+++ b/apps/web/convex/__tests__/playoffBracket.test.ts
@@ -1,0 +1,238 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedLeague(t: ReturnType<typeof convexTest>, teamCount: number) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Playoff League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "Div 1",
+      leagueId,
+    });
+    const teamIds: Id<"teams">[] = [];
+    for (let i = 0; i < teamCount; i++) {
+      teamIds.push(
+        await ctx.db.insert("teams", {
+          name: `Team ${i}`,
+          leagueId,
+          divisionId,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Loc",
+          logoUrl: null,
+          rosterLimit: 53,
+        }),
+      );
+    }
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    return { leagueId, seasonId, teamIds };
+  });
+}
+
+// NB: query the new playoff tables WITHOUT `.withIndex` here. With ~21 tables,
+// TS truncates DataModelFromSchemaDefinition's per-table index map for the
+// last-defined tables under convex-test's strict ctx, so `.withIndex("by_…")`
+// won't type-check (runtime + production `*Generic` handlers are unaffected).
+function allMatchups(t: ReturnType<typeof convexTest>, seasonId: Id<"seasons">) {
+  return t.run(async (ctx) =>
+    (await ctx.db.query("playoffMatchups").collect()).filter(
+      (m) => m.seasonId === seasonId,
+    ),
+  );
+}
+
+async function roundOneMatchups(
+  t: ReturnType<typeof convexTest>,
+  seasonId: Id<"seasons">,
+) {
+  const ms = await allMatchups(t, seasonId);
+  return ms.filter((m) => m.round === 1).sort((a, b) => a.slot - b.slot);
+}
+
+describe("playoff bracket (WSM-000164)", () => {
+  it("generates a size-4 bracket: 3 matchups, round-1 fixtures spawned (stage=playoff)", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    const res = await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+    });
+    expect(res).toMatchObject({ size: 4, rounds: 2, matchups: 3 });
+
+    const state = await t.run(async (ctx) => {
+      const ms = (await ctx.db.query("playoffMatchups").collect()).filter(
+        (m) => m.seasonId === seasonId,
+      );
+      const fixtures = await ctx.db
+        .query("fixtures")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect();
+      return { ms, fixtures };
+    });
+
+    const r1 = state.ms.filter((m) => m.round === 1);
+    const final = state.ms.find((m) => m.round === 2)!;
+    expect(r1).toHaveLength(2);
+    // Round-1 matchups have both teams + a spawned fixture; final is TBD.
+    for (const m of r1) {
+      expect(m.homeTeamId).not.toBeNull();
+      expect(m.awayTeamId).not.toBeNull();
+      expect(m.fixtureId).not.toBeNull();
+      expect(m.nextMatchupId).toBe(final._id);
+    }
+    expect(final.homeTeamId).toBeNull();
+    expect(final.fixtureId).toBeNull();
+    // Exactly the 2 round-1 fixtures exist, all stage=playoff.
+    expect(state.fixtures).toHaveLength(2);
+    expect(state.fixtures.every((f) => f.stage === "playoff")).toBe(true);
+  });
+
+  it("auto-advances winners and spawns the final once both semis are decided", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+    });
+
+    const semis = await roundOneMatchups(t, seasonId);
+    // Home team wins each semifinal.
+    for (const m of semis) {
+      await t.mutation(internal.sports.recordGameResult, {
+        fixtureId: m.fixtureId as Id<"fixtures">,
+        homeScore: 28,
+        awayScore: 14,
+        actorUserId: "user_1",
+      });
+    }
+
+    const allFinal = await allMatchups(t, seasonId);
+    const final = allFinal.find((m) => m.round === 2)!;
+    // Both semifinal home teams advanced; the final now has both teams + fixture.
+    expect(final.homeTeamId).toBe(semis[0].homeTeamId);
+    expect(final.awayTeamId).toBe(semis[1].homeTeamId);
+    expect(final.fixtureId).not.toBeNull();
+  });
+
+  it("a tie does not advance a winner", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+    });
+    const semis = await roundOneMatchups(t, seasonId);
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: semis[0].fixtureId as Id<"fixtures">,
+      homeScore: 21,
+      awayScore: 21,
+      actorUserId: "user_1",
+    });
+    const m0 = (await allMatchups(t, seasonId)).find(
+      (m) => m._id === semis[0]._id,
+    )!;
+    expect(m0.winnerTeamId).toBeNull();
+  });
+
+  it("playoff results never affect regular-season standings", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+    });
+    const semis = await roundOneMatchups(t, seasonId);
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: semis[0].fixtureId as Id<"fixtures">,
+      homeScore: 35,
+      awayScore: 0,
+      actorUserId: "user_1",
+    });
+    const standings = await t.query(api.sports.computeStandings, {
+      seasonId,
+    });
+    // No regular-season games → everyone 0-0 despite the playoff blowout.
+    expect(standings.every((s) => s.wins === 0 && s.losses === 0)).toBe(true);
+  });
+
+  it("guards: invalid size, not enough teams, and regen with a played game", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    await expect(
+      t.mutation(internal.sports.generatePlayoffBracket, {
+        seasonId,
+        size: 6,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("invalid_bracket_size");
+
+    await expect(
+      t.mutation(internal.sports.generatePlayoffBracket, {
+        seasonId,
+        size: 8,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("not_enough_teams");
+
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+    });
+    const semis = await roundOneMatchups(t, seasonId);
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: semis[0].fixtureId as Id<"fixtures">,
+      homeScore: 10,
+      awayScore: 3,
+      actorUserId: "user_1",
+    });
+
+    // Regenerating now is blocked unless confirmed.
+    await expect(
+      t.mutation(internal.sports.generatePlayoffBracket, {
+        seasonId,
+        size: 4,
+        actorUserId: "user_1",
+      }),
+    ).rejects.toThrow("bracket_has_results");
+
+    const res = await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+      confirm: true,
+    });
+    expect(res.matchups).toBe(3);
+    // Old playoff fixtures + results were wiped; only fresh round-1 remain.
+    const counts = await t.run(async (ctx) => ({
+      results: (await ctx.db.query("gameResults").collect()).length,
+      fixtures: (await ctx.db.query("fixtures").collect()).length,
+    }));
+    expect(counts.results).toBe(0);
+    expect(counts.fixtures).toBe(2);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -134,6 +134,7 @@ type AllowedPublicSportsReads =
   | "getOrgForkedSourceTeamIds"
   | "getOrgMemberRole"
   | "getPlayer"
+  | "getPlayoffBracket"
   | "getPlayerDevelopment"
   | "getPlayerDevelopmentPublic"
   | "getPlayerGameStatsByFixture"

--- a/apps/web/convex/lib/bracket.ts
+++ b/apps/web/convex/lib/bracket.ts
@@ -1,0 +1,91 @@
+/*
+ * WSM-000164 — Single-elimination bracket construction.
+ *
+ * Pure functions isolated from Convex `db` so they can be unit-tested directly.
+ * `generatePlayoffBracket` in `sports.ts` calls `buildBracket(size)` to lay out
+ * the matchup tree, then inserts rows + wires `nextMatchupId` pointers from the
+ * (round, slot) structure here.
+ *
+ * Sizes are powers of two ≥ 2 (the product restricts to 4/8/16). No byes.
+ */
+
+/** Side of a parent matchup a winner advances into. */
+export type BracketSide = "home" | "away";
+
+export interface BracketMatchupPlan {
+  round: number; // 1-based; round === rounds is the final
+  slot: number; // 0-based position within the round
+  /** Round-1 seeds (1 = top seed). null for later rounds (TBD until played). */
+  homeSeed: number | null;
+  awaySeed: number | null;
+  /** The (round+1) slot this winner feeds, and which side. null for the final. */
+  parentSlot: number | null;
+  parentSide: BracketSide | null;
+}
+
+export interface BracketPlan {
+  size: number;
+  rounds: number;
+  matchups: BracketMatchupPlan[];
+}
+
+function isPowerOfTwo(n: number): boolean {
+  return n >= 2 && (n & (n - 1)) === 0;
+}
+
+/**
+ * Standard single-elimination seed order for round 1. Returns the seed sitting
+ * at each round-1 position, arranged so the top two seeds land in opposite
+ * halves and seed `i` meets seed `N+1-i` first. E.g. size 8 → [1,8,4,5,2,7,3,6].
+ */
+export function seedOrder(size: number): number[] {
+  if (!isPowerOfTwo(size)) throw new Error("bracket_size_must_be_power_of_two");
+  let order = [1];
+  while (order.length < size) {
+    const n = order.length * 2;
+    const next: number[] = [];
+    for (const s of order) {
+      next.push(s, n + 1 - s);
+    }
+    order = next;
+  }
+  return order;
+}
+
+/**
+ * Build the full bracket tree for `size` seeds. Round 1 carries the seeded
+ * pairings (home = the higher/lower-numbered seed); later rounds are empty
+ * placeholders whose teams resolve as games are played.
+ */
+export function buildBracket(size: number): BracketPlan {
+  if (!isPowerOfTwo(size)) throw new Error("bracket_size_must_be_power_of_two");
+  const rounds = Math.log2(size);
+  const order = seedOrder(size);
+  const matchups: BracketMatchupPlan[] = [];
+
+  for (let round = 1; round <= rounds; round++) {
+    const count = size / 2 ** round; // matchups in this round
+    for (let slot = 0; slot < count; slot++) {
+      const isFinal = round === rounds;
+      let homeSeed: number | null = null;
+      let awaySeed: number | null = null;
+      if (round === 1) {
+        const a = order[slot * 2];
+        const b = order[slot * 2 + 1];
+        // Higher seed (smaller number) hosts.
+        homeSeed = Math.min(a, b);
+        awaySeed = Math.max(a, b);
+      }
+      matchups.push({
+        round,
+        slot,
+        homeSeed,
+        awaySeed,
+        parentSlot: isFinal ? null : Math.floor(slot / 2),
+        parentSide: isFinal ? null : slot % 2 === 0 ? "home" : "away",
+      });
+    }
+  }
+
+  return { size, rounds, matchups };
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -262,6 +262,9 @@ export default defineSchema({
     week: v.union(v.number(), v.null()),
     venue: v.union(v.string(), v.null()),
     status: v.string(),
+    // "regular" (default when absent) | "playoff" (WSM-000164). Playoff fixtures
+    // are spawned by the bracket and excluded from standings computation.
+    stage: v.optional(v.string()),
     createdAt: v.string(),
     createdBy: v.string(),
   })
@@ -346,4 +349,47 @@ export default defineSchema({
     startedAt: v.string(),
     updatedAt: v.string(),
   }).index("by_fixtureId", ["fixtureId"]),
+
+  /*
+   * Single-elimination playoffs (WSM-000164). One bracket per season; sizes
+   * 4/8/16 (powers of two, no byes). Seeds are snapshotted from standings at
+   * generation time onto the matchups.
+   */
+  playoffBrackets: defineTable({
+    seasonId: v.id("seasons"),
+    leagueId: v.id("leagues"),
+    size: v.number(), // 4 | 8 | 16
+    rounds: v.number(), // log2(size)
+    createdAt: v.string(),
+    createdBy: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  /*
+   * One node of the bracket tree. round 1 = first round … round = `rounds` is
+   * the final. `slot` is the 0-based position within the round. Team/seed ids
+   * are null until both feeders resolve. `nextMatchupId`/`nextSlot` point at the
+   * parent node the winner advances into (null for the final). `fixtureId` is
+   * set once both teams are known and a playable fixture is spawned.
+   */
+  playoffMatchups: defineTable({
+    bracketId: v.id("playoffBrackets"),
+    seasonId: v.id("seasons"),
+    round: v.number(),
+    slot: v.number(),
+    homeSeed: v.union(v.number(), v.null()),
+    awaySeed: v.union(v.number(), v.null()),
+    homeTeamId: v.union(v.id("teams"), v.null()),
+    awayTeamId: v.union(v.id("teams"), v.null()),
+    // Self-referential id stored as a string: v.id("playoffMatchups") here would
+    // make DataModelFromSchemaDefinition circular and silently drop this table's
+    // indexes. Cast back to Id<"playoffMatchups"> at the (few) use sites.
+    nextMatchupId: v.union(v.string(), v.null()),
+    nextSlot: v.union(v.string(), v.null()), // "home" | "away" | null
+    winnerTeamId: v.union(v.id("teams"), v.null()),
+    fixtureId: v.union(v.id("fixtures"), v.null()),
+  })
+    .index("by_bracketId", ["bracketId"])
+    .index("by_seasonId", ["seasonId"]),
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -21,6 +21,7 @@ import {
   doubleRoundRobinSchedule,
   weekKickoff,
 } from "./lib/roundRobin";
+import { buildBracket } from "./lib/bracket";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -4000,6 +4001,12 @@ export const recordGameResult = internalMutationGeneric({
       await ctx.db.patch(args.fixtureId, { status: "final" });
     }
 
+    // Playoff games advance the winner up the bracket atomically with the
+    // result (WSM-000164). Idempotent: re-recording recomputes the same tree.
+    if (fixture.stage === "playoff") {
+      await advanceBracketForSeason(ctx as MutationCtx, fixture.seasonId);
+    }
+
     return {
       id: resultId,
       fixtureId: args.fixtureId,
@@ -4071,7 +4078,7 @@ export const computeStandings = query({
       .collect();
 
     const finalFixtureIds = fixtureRows
-      .filter((f) => f.status === "final")
+      .filter((f) => f.status === "final" && f.stage !== "playoff")
       .map((f) => f._id);
 
     const resultRows = (
@@ -4091,13 +4098,15 @@ export const computeStandings = query({
         name: t.name,
         divisionId: t.divisionId,
       })),
-      fixtures: fixtureRows.map((f) => ({
-        _id: f._id,
-        seasonId: f.seasonId,
-        homeTeamId: f.homeTeamId,
-        awayTeamId: f.awayTeamId,
-        status: f.status,
-      })),
+      fixtures: fixtureRows
+        .filter((f) => f.stage !== "playoff")
+        .map((f) => ({
+          _id: f._id,
+          seasonId: f.seasonId,
+          homeTeamId: f.homeTeamId,
+          awayTeamId: f.awayTeamId,
+          status: f.status,
+        })),
       results: resultRows.map((r) => ({
         fixtureId: r.fixtureId,
         homeScore: r.homeScore,
@@ -4128,7 +4137,7 @@ export const computeDivisionStandings = query({
       .collect();
 
     const finalFixtureIds = fixtureRows
-      .filter((f) => f.status === "final")
+      .filter((f) => f.status === "final" && f.stage !== "playoff")
       .map((f) => f._id);
 
     const resultRows = (
@@ -4148,13 +4157,15 @@ export const computeDivisionStandings = query({
         name: t.name,
         divisionId: t.divisionId,
       })),
-      fixtures: fixtureRows.map((f) => ({
-        _id: f._id,
-        seasonId: f.seasonId,
-        homeTeamId: f.homeTeamId,
-        awayTeamId: f.awayTeamId,
-        status: f.status,
-      })),
+      fixtures: fixtureRows
+        .filter((f) => f.stage !== "playoff")
+        .map((f) => ({
+          _id: f._id,
+          seasonId: f.seasonId,
+          homeTeamId: f.homeTeamId,
+          awayTeamId: f.awayTeamId,
+          status: f.status,
+        })),
       results: resultRows.map((r) => ({
         fixtureId: r.fixtureId,
         homeScore: r.homeScore,
@@ -4205,7 +4216,7 @@ export const computeStandingsPublic = query({
       .collect();
 
     const finalFixtureIds = fixtureRows
-      .filter((f) => f.status === "final")
+      .filter((f) => f.status === "final" && f.stage !== "playoff")
       .map((f) => f._id);
 
     const resultRows = (
@@ -4225,13 +4236,15 @@ export const computeStandingsPublic = query({
         name: t.name,
         divisionId: t.divisionId,
       })),
-      fixtures: fixtureRows.map((f) => ({
-        _id: f._id,
-        seasonId: f.seasonId,
-        homeTeamId: f.homeTeamId,
-        awayTeamId: f.awayTeamId,
-        status: f.status,
-      })),
+      fixtures: fixtureRows
+        .filter((f) => f.stage !== "playoff")
+        .map((f) => ({
+          _id: f._id,
+          seasonId: f.seasonId,
+          homeTeamId: f.homeTeamId,
+          awayTeamId: f.awayTeamId,
+          status: f.status,
+        })),
       results: resultRows.map((r) => ({
         fixtureId: r.fixtureId,
         homeScore: r.homeScore,
@@ -4841,6 +4854,385 @@ export const getLiveGameState = query({
       period: row.period,
       clock: row.clock,
       status: row.status,
+    };
+  },
+});
+
+/* ───────────────────────── Playoffs (WSM-000164) ───────────────────────── */
+
+/** Ordered team ids by league standings (regular season only), seeds 1..N. */
+async function seasonStandingTeamIds(
+  ctx: MutationCtx,
+  season: { _id: Id<"seasons">; leagueId: Id<"leagues"> },
+): Promise<string[]> {
+  const teamRows = await ctx.db
+    .query("teams")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+    .collect();
+  const fixtureRows = (
+    await ctx.db
+      .query("fixtures")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", season._id))
+      .collect()
+  ).filter((f) => f.stage !== "playoff");
+  const finalIds = fixtureRows
+    .filter((f) => f.status === "final")
+    .map((f) => f._id);
+  const results = (
+    await Promise.all(
+      finalIds.map((fid) =>
+        ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", fid))
+          .first(),
+      ),
+    )
+  ).filter((r): r is NonNullable<typeof r> => r !== null);
+  return computeStandingsPure({
+    teams: teamRows.map((t) => ({
+      _id: t._id,
+      name: t.name,
+      divisionId: t.divisionId,
+    })),
+    fixtures: fixtureRows.map((f) => ({
+      _id: f._id,
+      seasonId: f.seasonId,
+      homeTeamId: f.homeTeamId,
+      awayTeamId: f.awayTeamId,
+      status: f.status,
+    })),
+    results: results.map((r) => ({
+      fixtureId: r.fixtureId,
+      homeScore: r.homeScore,
+      awayScore: r.awayScore,
+    })),
+  }).map((r) => r.teamId);
+}
+
+/** Insert a playoff fixture for a matchup whose two teams are known. */
+async function spawnPlayoffFixture(
+  ctx: MutationCtx,
+  m: {
+    seasonId: Id<"seasons">;
+    homeTeamId: Id<"teams"> | null;
+    awayTeamId: Id<"teams"> | null;
+  },
+  createdBy: string,
+): Promise<Id<"fixtures">> {
+  if (!m.homeTeamId || !m.awayTeamId) throw new Error("matchup_teams_unknown");
+  return ctx.db.insert("fixtures", {
+    seasonId: m.seasonId,
+    homeTeamId: m.homeTeamId,
+    awayTeamId: m.awayTeamId,
+    scheduledAt: null,
+    week: null,
+    venue: null,
+    status: "scheduled",
+    stage: "playoff",
+    createdAt: new Date().toISOString(),
+    createdBy,
+  });
+}
+
+/**
+ * Idempotent bracket recompute. In round order: spawn a fixture when both teams
+ * are known, resolve a decisive game's winner, and propagate that winner into
+ * its parent matchup's slot. A tie leaves the matchup unresolved (no advance).
+ */
+async function advanceBracketForSeason(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+): Promise<void> {
+  const bracket = await ctx.db
+    .query("playoffBrackets")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .first();
+  if (!bracket) return;
+
+  const matchups = await ctx.db
+    .query("playoffMatchups")
+    .withIndex("by_bracketId", (q) => q.eq("bracketId", bracket._id))
+    .collect();
+  const byId = new Map(matchups.map((m) => [m._id, m]));
+  const ordered = [...matchups].sort(
+    (a, b) => a.round - b.round || a.slot - b.slot,
+  );
+
+  for (const m of ordered) {
+    // 1. Spawn this matchup's fixture once both teams are known.
+    if (m.homeTeamId && m.awayTeamId && !m.fixtureId) {
+      const fid = await spawnPlayoffFixture(ctx, m, "system");
+      await ctx.db.patch(m._id, { fixtureId: fid });
+      m.fixtureId = fid;
+    }
+    // 2. Resolve a decisive winner from the played fixture.
+    if (m.fixtureId && !m.winnerTeamId) {
+      const fx = await ctx.db.get(m.fixtureId);
+      if (fx && fx.status === "final") {
+        const res = await ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+          .first();
+        if (res && res.homeScore !== res.awayScore) {
+          const winner =
+            res.homeScore > res.awayScore ? fx.homeTeamId : fx.awayTeamId;
+          await ctx.db.patch(m._id, { winnerTeamId: winner });
+          m.winnerTeamId = winner;
+        }
+      }
+    }
+    // 3. Propagate the winner into the parent slot.
+    if (m.winnerTeamId && m.nextMatchupId && m.nextSlot) {
+      const parent = byId.get(m.nextMatchupId as Id<"playoffMatchups">);
+      if (parent) {
+        if (m.nextSlot === "home" && parent.homeTeamId !== m.winnerTeamId) {
+          await ctx.db.patch(parent._id, { homeTeamId: m.winnerTeamId });
+          parent.homeTeamId = m.winnerTeamId;
+        } else if (
+          m.nextSlot === "away" &&
+          parent.awayTeamId !== m.winnerTeamId
+        ) {
+          await ctx.db.patch(parent._id, { awayTeamId: m.winnerTeamId });
+          parent.awayTeamId = m.winnerTeamId;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Generate a single-elimination bracket from the season's standings. Sizes
+ * 4/8/16. Re-running re-snapshots seeds, but refuses to wipe a bracket that has
+ * a played/in-progress game unless `confirm` is set.
+ */
+export const generatePlayoffBracket = internalMutationGeneric({
+  args: {
+    seasonId: v.id("seasons"),
+    size: v.number(),
+    actorUserId: v.string(),
+    confirm: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    bracketId: v.string(),
+    size: v.number(),
+    rounds: v.number(),
+    matchups: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    if (![4, 8, 16].includes(args.size)) {
+      throw new Error("invalid_bracket_size");
+    }
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+
+    // Existing bracket: results-guard, then clean wipe.
+    const existing = await ctx.db
+      .query("playoffBrackets")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (existing) {
+      const existingMatchups = await ctx.db
+        .query("playoffMatchups")
+        .withIndex("by_bracketId", (q) => q.eq("bracketId", existing._id))
+        .collect();
+      if (!args.confirm) {
+        for (const m of existingMatchups) {
+          if (!m.fixtureId) continue;
+          const res = await ctx.db
+            .query("gameResults")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+            .first();
+          if (res) throw new Error("bracket_has_results");
+          const live = await ctx.db
+            .query("liveGameState")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+            .first();
+          if (live) throw new Error("bracket_has_results");
+        }
+      }
+      for (const m of existingMatchups) {
+        if (m.fixtureId) {
+          for (const gr of await ctx.db
+            .query("gameResults")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+            .collect())
+            await ctx.db.delete(gr._id);
+          for (const lg of await ctx.db
+            .query("liveGameState")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+            .collect())
+            await ctx.db.delete(lg._id);
+          await ctx.db.delete(m.fixtureId);
+        }
+        await ctx.db.delete(m._id);
+      }
+      await ctx.db.delete(existing._id);
+    }
+
+    const seeds = await seasonStandingTeamIds(ctx as MutationCtx, season);
+    if (seeds.length < args.size) throw new Error("not_enough_teams");
+
+    const plan = buildBracket(args.size);
+    const createdAt = new Date().toISOString();
+    const bracketId = await ctx.db.insert("playoffBrackets", {
+      seasonId: args.seasonId,
+      leagueId: season.leagueId,
+      size: args.size,
+      rounds: plan.rounds,
+      createdAt,
+      createdBy: args.actorUserId,
+    });
+
+    // Insert matchups, then wire parent pointers, then spawn round-1 fixtures.
+    const idByKey = new Map<string, Id<"playoffMatchups">>();
+    for (const mp of plan.matchups) {
+      const homeTeamId =
+        mp.homeSeed != null
+          ? (seeds[mp.homeSeed - 1] as Id<"teams">)
+          : null;
+      const awayTeamId =
+        mp.awaySeed != null
+          ? (seeds[mp.awaySeed - 1] as Id<"teams">)
+          : null;
+      const id = await ctx.db.insert("playoffMatchups", {
+        bracketId,
+        seasonId: args.seasonId,
+        round: mp.round,
+        slot: mp.slot,
+        homeSeed: mp.homeSeed,
+        awaySeed: mp.awaySeed,
+        homeTeamId,
+        awayTeamId,
+        nextMatchupId: null,
+        nextSlot: null,
+        winnerTeamId: null,
+        fixtureId: null,
+      });
+      idByKey.set(`${mp.round}:${mp.slot}`, id);
+    }
+    for (const mp of plan.matchups) {
+      if (mp.parentSlot == null || mp.parentSide == null) continue;
+      await ctx.db.patch(idByKey.get(`${mp.round}:${mp.slot}`)!, {
+        nextMatchupId: idByKey.get(`${mp.round + 1}:${mp.parentSlot}`)!,
+        nextSlot: mp.parentSide,
+      });
+    }
+    for (const mp of plan.matchups) {
+      if (mp.round !== 1) continue;
+      const id = idByKey.get(`1:${mp.slot}`)!;
+      const m = (await ctx.db.get(id))!;
+      const fid = await spawnPlayoffFixture(ctx as MutationCtx, m, args.actorUserId);
+      await ctx.db.patch(id, { fixtureId: fid });
+    }
+
+    return {
+      bracketId,
+      size: args.size,
+      rounds: plan.rounds,
+      matchups: plan.matchups.length,
+    };
+  },
+});
+
+/** Manual/repair recompute of a season's bracket (advancement is otherwise
+ * automatic on result recording). */
+export const advancePlayoffBracket = internalMutationGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await advanceBracketForSeason(ctx as MutationCtx, args.seasonId);
+    return null;
+  },
+});
+
+const playoffMatchupDtoValidator = v.object({
+  id: v.string(),
+  round: v.number(),
+  slot: v.number(),
+  homeSeed: v.union(v.number(), v.null()),
+  awaySeed: v.union(v.number(), v.null()),
+  homeTeamId: v.union(v.string(), v.null()),
+  awayTeamId: v.union(v.string(), v.null()),
+  homeTeamName: v.union(v.string(), v.null()),
+  awayTeamName: v.union(v.string(), v.null()),
+  winnerTeamId: v.union(v.string(), v.null()),
+  fixtureId: v.union(v.string(), v.null()),
+  status: v.union(v.string(), v.null()),
+  homeScore: v.union(v.number(), v.null()),
+  awayScore: v.union(v.number(), v.null()),
+});
+
+/** Bracket tree DTO for the UI (WSM-000165). Null when no bracket exists. */
+export const getPlayoffBracket = queryGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.union(
+    v.object({
+      bracketId: v.string(),
+      size: v.number(),
+      rounds: v.number(),
+      matchups: v.array(playoffMatchupDtoValidator),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const bracket = await ctx.db
+      .query("playoffBrackets")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (!bracket) return null;
+
+    const matchups = await ctx.db
+      .query("playoffMatchups")
+      .withIndex("by_bracketId", (q) => q.eq("bracketId", bracket._id))
+      .collect();
+
+    const dtos = await Promise.all(
+      matchups
+        .sort((a, b) => a.round - b.round || a.slot - b.slot)
+        .map(async (m) => {
+          const home = m.homeTeamId ? await ctx.db.get(m.homeTeamId) : null;
+          const away = m.awayTeamId ? await ctx.db.get(m.awayTeamId) : null;
+          let status: string | null = null;
+          let homeScore: number | null = null;
+          let awayScore: number | null = null;
+          if (m.fixtureId) {
+            const fx = await ctx.db.get(m.fixtureId);
+            status = fx?.status ?? null;
+            if (fx?.status === "final") {
+              const res = await ctx.db
+                .query("gameResults")
+                .withIndex("by_fixtureId", (q) =>
+                  q.eq("fixtureId", m.fixtureId!),
+                )
+                .first();
+              homeScore = res?.homeScore ?? null;
+              awayScore = res?.awayScore ?? null;
+            }
+          }
+          return {
+            id: m._id,
+            round: m.round,
+            slot: m.slot,
+            homeSeed: m.homeSeed,
+            awaySeed: m.awaySeed,
+            homeTeamId: m.homeTeamId,
+            awayTeamId: m.awayTeamId,
+            homeTeamName: home?.name ?? null,
+            awayTeamName: away?.name ?? null,
+            winnerTeamId: m.winnerTeamId,
+            fixtureId: m.fixtureId,
+            status,
+            homeScore,
+            awayScore,
+          };
+        }),
+    );
+
+    return {
+      bracketId: bracket._id,
+      size: bracket.size,
+      rounds: bracket.rounds,
+      matchups: dtos,
     };
   },
 });

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPlayoffsV1,
+  mockAuth,
+  mockGetLeague,
+  mockGetLeagueOrgId,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockCanManageRoster,
+  mockGeneratePlayoffBracket,
+} = vi.hoisted(() => ({
+  mockPlayoffsV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetLeague: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockCanManageRoster: vi.fn(),
+  mockGeneratePlayoffBracket: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ playoffsV1: mockPlayoffsV1 }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  generatePlayoffBracket: mockGeneratePlayoffBracket,
+  getLeague: mockGetLeague,
+  getLeagueOrgId: mockGetLeagueOrgId,
+}));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/permissions", () => ({ canManageRoster: mockCanManageRoster }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { generatePlayoffsAction } from "../actions";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+
+function authorize() {
+  mockPlayoffsV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
+  mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue("org:admin");
+  mockCanManageRoster.mockReturnValue(true);
+}
+
+describe("generatePlayoffsAction (WSM-000164)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("generates a bracket for an authorized manager", async () => {
+    authorize();
+    mockGeneratePlayoffBracket.mockResolvedValue({
+      bracketId: "b1",
+      size: 8,
+      rounds: 3,
+      matchups: 7,
+    });
+
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 8,
+    });
+
+    expect(res).toEqual({
+      ok: true,
+      bracketId: "b1",
+      size: 8,
+      rounds: 3,
+      matchups: 7,
+    });
+    expect(mockGeneratePlayoffBracket).toHaveBeenCalledWith({
+      seasonId: SEASON,
+      size: 8,
+      actorUserId: "user_1",
+      confirm: undefined,
+    });
+  });
+
+  it("returns needsConfirm when the bracket already has a played game", async () => {
+    authorize();
+    mockGeneratePlayoffBracket.mockRejectedValue(
+      new Error("Uncaught Error: bracket_has_results"),
+    );
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 4,
+    });
+    expect(res).toEqual({ ok: false, needsConfirm: true });
+  });
+
+  it("passes confirm through", async () => {
+    authorize();
+    mockGeneratePlayoffBracket.mockResolvedValue({
+      bracketId: "b1",
+      size: 4,
+      rounds: 2,
+      matchups: 3,
+    });
+    await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 4,
+      confirm: true,
+    });
+    expect(mockGeneratePlayoffBracket).toHaveBeenCalledWith(
+      expect.objectContaining({ confirm: true }),
+    );
+  });
+
+  it("maps not_enough_teams to a friendly error", async () => {
+    authorize();
+    mockGeneratePlayoffBracket.mockRejectedValue(
+      new Error("Uncaught Error: not_enough_teams"),
+    );
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 16,
+    });
+    expect(res).toMatchObject({ ok: false });
+    expect("error" in res && res.error).toMatch(/Not enough teams/);
+  });
+
+  it("rejects a non-manager", async () => {
+    authorize();
+    mockCanManageRoster.mockReturnValue(false);
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 4,
+    });
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the flag is off", async () => {
+    authorize();
+    mockPlayoffsV1.mockResolvedValue(false);
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 4,
+    });
+    expect(res).toEqual({ ok: false, error: "flag_disabled" });
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { playoffsV1 } from "@/lib/flags";
+import { generatePlayoffBracket, getLeague, getLeagueOrgId } from "@/lib/data-api";
+import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
+
+/*
+ * Auth chain for playoff actions (mirrors the schedule manager gate):
+ *   1. playoffsV1 flag enabled
+ *   2. Clerk session present
+ *   3. league visible to the user
+ *   4. caller can manage rosters (admin or coach) of the league's org
+ */
+async function authorizePlayoffAction(
+  leagueId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const enabled = await playoffsV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) return { ok: false, error: "league_not_found" };
+
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "league_not_owned" };
+
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) return { ok: false, error: "not_authorized" };
+
+  return { ok: true };
+}
+
+function friendlyError(code: string): string {
+  if (code.includes("not_enough_teams")) {
+    return "Not enough teams in the standings for a bracket of this size.";
+  }
+  if (code.includes("invalid_bracket_size")) {
+    return "Bracket size must be 4, 8, or 16.";
+  }
+  if (code.includes("season_not_found")) {
+    return "This season no longer exists.";
+  }
+  return "Could not generate the bracket.";
+}
+
+/*
+ * Seed a single-elimination bracket from the season's standings (WSM-000164).
+ * The mutation refuses to overwrite a bracket that already has a played game;
+ * that surfaces here as `needsConfirm` so the UI can re-call with confirm.
+ */
+export async function generatePlayoffsAction(input: {
+  leagueId: string;
+  seasonId: string;
+  size: number;
+  confirm?: boolean;
+}): Promise<
+  | { ok: true; bracketId: string; size: number; rounds: number; matchups: number }
+  | { ok: false; needsConfirm: true }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizePlayoffAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  try {
+    const res = await generatePlayoffBracket({
+      seasonId: input.seasonId,
+      size: input.size,
+      actorUserId: userId,
+      confirm: input.confirm,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/playoffs`);
+    return { ok: true, ...res };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("bracket_has_results")) {
+      return { ok: false, needsConfirm: true };
+    }
+    return { ok: false, error: friendlyError(message) };
+  }
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -67,6 +67,31 @@ function mutationRef<Args extends object, Return>(name: string) {
   return makeFunctionReference<"mutation", any, Return>(name);
 }
 
+/** A single bracket node (WSM-000164). Team/score fields are null until played. */
+export interface PlayoffMatchupDto {
+  id: string;
+  round: number;
+  slot: number;
+  homeSeed: number | null;
+  awaySeed: number | null;
+  homeTeamId: string | null;
+  awayTeamId: string | null;
+  homeTeamName: string | null;
+  awayTeamName: string | null;
+  winnerTeamId: string | null;
+  fixtureId: string | null;
+  status: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+}
+
+export interface PlayoffBracketDto {
+  bracketId: string;
+  size: number;
+  rounds: number;
+  matchups: PlayoffMatchupDto[];
+}
+
 const refs = {
   getVisibleLeagueContext: queryRef<
     { orgIds: string[]; userId: string },
@@ -499,6 +524,13 @@ const refs = {
       sourceSeasonId: string;
     }
   >("sports:copySeasonRosters"),
+  generatePlayoffBracket: mutationRef<
+    { seasonId: string; size: number; actorUserId: string; confirm?: boolean },
+    { bracketId: string; size: number; rounds: number; matchups: number }
+  >("sports:generatePlayoffBracket"),
+  getPlayoffBracket: queryRef<{ seasonId: string }, PlayoffBracketDto | null>(
+    "sports:getPlayoffBracket",
+  ),
   listFixturesBySeason: queryRef<{ seasonId: string }, FixtureDto[]>(
     "sports:listFixturesBySeason",
   ),
@@ -1629,6 +1661,26 @@ export async function copySeasonRosters(input: {
   sourceSeasonId: string;
 }> {
   return mutateConvex(refs.copySeasonRosters, input);
+}
+
+export async function generatePlayoffBracket(input: {
+  seasonId: string;
+  size: number;
+  actorUserId: string;
+  confirm?: boolean;
+}): Promise<{
+  bracketId: string;
+  size: number;
+  rounds: number;
+  matchups: number;
+}> {
+  return mutateConvex(refs.generatePlayoffBracket, input);
+}
+
+export async function getPlayoffBracket(
+  seasonId: string,
+): Promise<PlayoffBracketDto | null> {
+  return queryConvex(refs.getPlayoffBracket, { seasonId });
 }
 
 export async function listFixturesBySeason(

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -137,6 +137,22 @@ export const liveScoringV1 = flag<boolean>({
   },
 });
 
+export const playoffsV1 = flag<boolean>({
+  key: "playoffs_v1",
+  description:
+    "Single-elimination playoffs: seeded bracket generation + auto-advancement (WSM-000164)",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_PLAYOFFS_V1");
+    void trackFlagExposure("playoffs_v1", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
Closes #374 · part 1 of 2 (UI is #375, WSM-000165)

## What
Backend for seeded **single-elimination** playoffs. A dedicated bracket tree spawns real `fixtures`, so game results / live scoring / streaming all reuse the existing fixture machinery; recording a playoff result advances the winner up the bracket **atomically**.

## Design (per the grilled spec)
- **Seeding:** league-wide top-N from `computeStandings`; sizes **4/8/16** (no byes); higher seed hosts; standard bracket order so seeds 1 & 2 meet only in the final.
- **Data model:** `playoffBrackets` + `playoffMatchups` tables; each ready matchup spawns a `fixture` tagged `stage:"playoff"`.
- **Standings:** all three `computeStandings*` queries exclude `stage:"playoff"` — playoff games never affect regular-season records.
- **Advancement:** `advanceBracketForSeason` is an idempotent recompute (spawn → resolve decisive winner → propagate to parent slot); a **tie doesn't advance**. Hooked into `recordGameResult` for playoff fixtures.
- **Generate/regen:** anytime (snapshots standings); regenerate **results-guarded** (`bracket_has_results`) and confirm-gated; `not_enough_teams`/`invalid_bracket_size` rejected.
- **Surface:** `getPlayoffBracket` query (bracket DTO), data-api refs + wrappers, `generatePlayoffsAction` (manager gate, `needsConfirm`), behind the **`playoffsV1`** flag.

## Tests (626 passing)
- `bracket.ts` pure logic (seed order, tree shape, 1-vs-2 halves, parent wiring).
- convex-test: generation, auto-advance + final spawn, tie blocks, **standings exclusion**, guards (invalid size / not enough teams / regen with a played game).
- `generatePlayoffsAction` (gate, needsConfirm, error mapping).

## Notes for review
- `playoffMatchups.nextMatchupId` is stored as a **string**, not `v.id("playoffMatchups")`: a self-referential id makes `DataModelFromSchemaDefinition` circular and silently drops the table's index types. Cast back to `Id` at the few use sites.
- The convex-test for the new tables queries via `.collect()` rather than `.withIndex(...)`: with ~21 tables, TS truncates the per-table index map for the last-defined table under convex-test's strict ctx. Production uses the loose `*Generic` handlers and is unaffected (runtime verified by the passing tests).

## Next (PR #375)
Visual bracket tree UI consuming `getPlayoffBracket`, with the `generatePlayoffsAction` control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)