### PR TITLE
feat(web): visual playoff bracket UI (WSM-000165)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -1,0 +1,107 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { playoffsV1 } from "@/lib/flags";
+import {
+  getLeague,
+  getLeagueOrgId,
+  getSeasons,
+  getPlayoffBracket,
+} from "@/lib/data-api";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import PlayoffBracket from "@/components/playoffs/PlayoffBracket";
+import GeneratePlayoffsButton from "@/components/playoffs/GeneratePlayoffsButton";
+
+export default async function LeaguePlayoffsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await playoffsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: leagueId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  // Manager gate (admins + coaches), consistent with the schedule page.
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  const isAdmin = canManageRoster(role);
+
+  const allSeasons = await getSeasons([leagueId]);
+  const activeSeason =
+    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+
+  const bracket = activeSeason
+    ? await getPlayoffBracket(activeSeason.id)
+    : null;
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">{league.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Playoffs {activeSeason ? `· ${activeSeason.name}` : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/dashboard/leagues/${leagueId}/schedule`}
+            className="text-sm text-primary hover:underline"
+          >
+            &larr; Schedule
+          </Link>
+          {isAdmin && activeSeason ? (
+            <GeneratePlayoffsButton
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+              seasonName={activeSeason.name}
+              hasBracket={bracket !== null}
+            />
+          ) : null}
+        </div>
+      </header>
+
+      {!activeSeason ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Playoffs need a season. Create one and play some games so standings
+              can seed the bracket.
+            </p>
+            <Button asChild size="sm">
+              <Link href="/dashboard/seasons">Go to Seasons</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : !bracket ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            No bracket yet for {activeSeason.name}.
+            {isAdmin
+              ? " Pick a size and generate one — seeds come from the current standings."
+              : ""}
+          </CardContent>
+        </Card>
+      ) : (
+        <PlayoffBracket bracket={bracket} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -7,6 +7,7 @@ import {
   liveStreamingV1,
   statKeepingV1,
   liveScoringV1,
+  playoffsV1,
 } from "@/lib/flags";
 import {
   getLeague,
@@ -63,6 +64,8 @@ export default async function LeagueSchedulePage({
   // Live scoring (WSM-000152): operator-driven running scoreboard. Same
   // admin/coach surface as stats; the live page re-checks canManageTeam.
   const liveEnabled = await liveScoringV1();
+  // Playoffs (WSM-000164/165): bracket lives on its own page; link when enabled.
+  const playoffsEnabled = await playoffsV1();
 
   // Pick the active season — fall back to whichever exists if none flagged active.
   const allSeasons = await getSeasons([leagueId]);
@@ -133,6 +136,14 @@ export default async function LeagueSchedulePage({
           >
             Standings &rarr;
           </Link>
+          {playoffsEnabled ? (
+            <Link
+              href={`/dashboard/leagues/${leagueId}/playoffs`}
+              className="text-sm text-primary hover:underline"
+            >
+              Playoffs &rarr;
+            </Link>
+          ) : null}
           {isAdmin && activeSeason && teams.length >= 2 ? (
             <GenerateScheduleButton
               leagueId={leagueId}

--- a/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { generatePlayoffsAction } from "@/app/dashboard/leagues/[id]/playoffs/actions";
+
+export interface GeneratePlayoffsButtonProps {
+  leagueId: string;
+  seasonId: string;
+  seasonName: string;
+  /** Whether a bracket already exists (changes the button label + confirm copy). */
+  hasBracket: boolean;
+}
+
+const SIZES = [4, 8, 16] as const;
+
+export default function GeneratePlayoffsButton({
+  leagueId,
+  seasonId,
+  seasonName,
+  hasBracket,
+}: GeneratePlayoffsButtonProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [size, setSize] = useState<number>(8);
+
+  function run(confirm: boolean) {
+    startTransition(async () => {
+      const res = await generatePlayoffsAction({
+        leagueId,
+        seasonId,
+        size,
+        confirm,
+      });
+
+      if (res.ok) {
+        toast.success(`Generated a ${res.size}-team bracket (${res.rounds} rounds).`);
+        router.refresh();
+        return;
+      }
+
+      if ("needsConfirm" in res) {
+        const proceed = window.confirm(
+          `${seasonName} already has a bracket with recorded results or a live game. Regenerating deletes the bracket and those results. This can't be undone. Continue?`,
+        );
+        if (proceed) run(true);
+        return;
+      }
+
+      toast.error(res.error);
+    });
+  }
+
+  function onClick() {
+    if (
+      hasBracket &&
+      !window.confirm(
+        `Replace the current bracket for ${seasonName} with a fresh ${size}-team bracket? Existing playoff games will be removed.`,
+      )
+    ) {
+      return;
+    }
+    run(false);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <label className="sr-only" htmlFor="bracket-size">
+        Bracket size
+      </label>
+      <select
+        id="bracket-size"
+        value={size}
+        disabled={pending}
+        onChange={(e) => setSize(Number(e.target.value))}
+        className="h-9 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {SIZES.map((s) => (
+          <option key={s} value={s}>
+            {s} teams
+          </option>
+        ))}
+      </select>
+      <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
+        <Trophy className="mr-1.5 h-4 w-4" />
+        {pending
+          ? "Generating…"
+          : hasBracket
+            ? "Regenerate bracket"
+            : "Generate bracket"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@/lib/utils";
+import type { PlayoffBracketDto, PlayoffMatchupDto } from "@/lib/data-api";
+import { groupMatchupsByRound, winnerSide } from "@/lib/playoffs";
+
+function Side({
+  seed,
+  name,
+  score,
+  won,
+  dim,
+}: {
+  seed: number | null;
+  name: string | null;
+  score: number | null;
+  won: boolean;
+  dim: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 px-2 py-1 text-sm",
+        won && "font-semibold text-foreground",
+        dim && !won && "text-muted-foreground",
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        {seed != null ? (
+          <span className="shrink-0 rounded bg-muted px-1 font-mono text-[10px] text-muted-foreground">
+            {seed}
+          </span>
+        ) : null}
+        <span className="truncate">{name ?? "TBD"}</span>
+      </span>
+      <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
+        {score ?? ""}
+      </span>
+    </div>
+  );
+}
+
+function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
+  const side = winnerSide(m);
+  const decided = side !== null;
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-card">
+      <Side
+        seed={m.homeSeed}
+        name={m.homeTeamName}
+        score={m.homeScore}
+        won={side === "home"}
+        dim={decided}
+      />
+      <div className="border-t border-border" />
+      <Side
+        seed={m.awaySeed}
+        name={m.awayTeamName}
+        score={m.awayScore}
+        won={side === "away"}
+        dim={decided}
+      />
+    </div>
+  );
+}
+
+/**
+ * Read-only single-elimination bracket (WSM-000165). Renders one column per
+ * round left→right; columns scroll horizontally on small screens. Winners are
+ * bolded, the loser dimmed, and unresolved slots show "TBD".
+ */
+export default function PlayoffBracket({
+  bracket,
+}: {
+  bracket: PlayoffBracketDto;
+}) {
+  const rounds = groupMatchupsByRound(bracket.matchups, bracket.rounds);
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex min-w-max gap-6 pb-2">
+        {rounds.map((r) => (
+          <div key={r.round} className="flex w-56 shrink-0 flex-col">
+            <h3 className="mb-3 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+              {r.label}
+            </h3>
+            <div className="flex flex-1 flex-col justify-around gap-4">
+              {r.matchups.map((m) => (
+                <MatchupCard key={m.id} m={m} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/playoffs.test.ts
+++ b/apps/web/src/lib/__tests__/playoffs.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  roundLabel,
+  groupMatchupsByRound,
+  winnerSide,
+} from "../playoffs";
+import type { PlayoffMatchupDto } from "@/lib/data-api";
+
+function m(partial: Partial<PlayoffMatchupDto>): PlayoffMatchupDto {
+  return {
+    id: "m",
+    round: 1,
+    slot: 0,
+    homeSeed: null,
+    awaySeed: null,
+    homeTeamId: null,
+    awayTeamId: null,
+    homeTeamName: null,
+    awayTeamName: null,
+    winnerTeamId: null,
+    fixtureId: null,
+    status: null,
+    homeScore: null,
+    awayScore: null,
+    ...partial,
+  };
+}
+
+describe("roundLabel (WSM-000165)", () => {
+  it("names rounds from the end for a size-16 bracket (4 rounds)", () => {
+    expect(roundLabel(4, 4)).toBe("Final");
+    expect(roundLabel(3, 4)).toBe("Semifinals");
+    expect(roundLabel(2, 4)).toBe("Quarterfinals");
+    expect(roundLabel(1, 4)).toBe("Round of 16");
+  });
+  it("uses Final/Semifinals for a size-4 bracket (2 rounds)", () => {
+    expect(roundLabel(2, 2)).toBe("Final");
+    expect(roundLabel(1, 2)).toBe("Semifinals");
+  });
+  it("falls back to Round N beyond the named rounds", () => {
+    expect(roundLabel(1, 5)).toBe("Round 1"); // 32-team first round
+  });
+});
+
+describe("groupMatchupsByRound", () => {
+  it("groups into ordered rounds, each sorted by slot, with labels", () => {
+    const matchups = [
+      m({ id: "f", round: 2, slot: 0 }),
+      m({ id: "s1", round: 1, slot: 1 }),
+      m({ id: "s0", round: 1, slot: 0 }),
+    ];
+    const rounds = groupMatchupsByRound(matchups, 2);
+    expect(rounds.map((r) => r.label)).toEqual(["Semifinals", "Final"]);
+    expect(rounds[0].matchups.map((x) => x.id)).toEqual(["s0", "s1"]);
+    expect(rounds[1].matchups.map((x) => x.id)).toEqual(["f"]);
+  });
+});
+
+describe("winnerSide", () => {
+  it("returns the side matching winnerTeamId, else null", () => {
+    expect(winnerSide(m({ winnerTeamId: null }))).toBeNull();
+    expect(
+      winnerSide(m({ winnerTeamId: "t1", homeTeamId: "t1", awayTeamId: "t2" })),
+    ).toBe("home");
+    expect(
+      winnerSide(m({ winnerTeamId: "t2", homeTeamId: "t1", awayTeamId: "t2" })),
+    ).toBe("away");
+  });
+});

--- a/apps/web/src/lib/playoffs.ts
+++ b/apps/web/src/lib/playoffs.ts
@@ -1,0 +1,56 @@
+/*
+ * WSM-000165 — presentation helpers for the playoff bracket UI.
+ *
+ * Pure functions (node-testable) split out from the React component so the
+ * round-grouping and labelling logic has direct unit coverage; the visual
+ * layout itself is verified in the browser.
+ */
+import type { PlayoffMatchupDto } from "@/lib/data-api";
+
+/**
+ * Human label for a round. The last round is the Final; earlier rounds are
+ * named by how many teams they contain (2^(R-r+1)): Semifinals (4),
+ * Quarterfinals (8), Round of 16 (16); anything earlier falls back to "Round N".
+ */
+export function roundLabel(round: number, totalRounds: number): string {
+  const fromEnd = totalRounds - round; // 0 = final
+  if (fromEnd === 0) return "Final";
+  if (fromEnd === 1) return "Semifinals";
+  if (fromEnd === 2) return "Quarterfinals";
+  if (fromEnd === 3) return "Round of 16";
+  return `Round ${round}`;
+}
+
+export interface BracketRound {
+  round: number;
+  label: string;
+  matchups: PlayoffMatchupDto[];
+}
+
+/** Group matchups into ordered rounds (1..totalRounds), each sorted by slot. */
+export function groupMatchupsByRound(
+  matchups: PlayoffMatchupDto[],
+  totalRounds: number,
+): BracketRound[] {
+  const rounds: BracketRound[] = [];
+  for (let round = 1; round <= totalRounds; round++) {
+    rounds.push({
+      round,
+      label: roundLabel(round, totalRounds),
+      matchups: matchups
+        .filter((m) => m.round === round)
+        .sort((a, b) => a.slot - b.slot),
+    });
+  }
+  return rounds;
+}
+
+/** Which side won, for highlighting. null until the game is final + decisive. */
+export function winnerSide(
+  m: PlayoffMatchupDto,
+): "home" | "away" | null {
+  if (!m.winnerTeamId) return null;
+  if (m.winnerTeamId === m.homeTeamId) return "home";
+  if (m.winnerTeamId === m.awayTeamId) return "away";
+  return null;
+}


### PR DESCRIPTION
Closes #375 · part 2 of 2 (backend was #377, WSM-000164)

## What
The playoff bracket UI on top of the WSM-000164 backend.

- **`/dashboard/leagues/[id]/playoffs`** — flag-gated (`playoffsV1`) page; picks the active season and renders the bracket or an empty state. A manager (admin/coach) gets a **size selector (4/8/16)** + **Generate/Regenerate** with the `needsConfirm` confirm flow (mirrors `GenerateScheduleButton`).
- **`PlayoffBracket`** — round columns left→right (horizontal scroll on mobile), seed badges, scores, **TBD** slots for pending matchups, winner **bolded** / loser dimmed. Round labels derive from size (Final / Semifinals / Quarterfinals / Round of 16).
- **Pure helpers** in `src/lib/playoffs.ts` (`roundLabel`, `groupMatchupsByRound`, `winnerSide`) — node-unit-tested, matching the repo's convention (vitest is node-env, no RTL); the visual layout is verified in-browser.
- The **schedule page** header links to Playoffs when the flag is on.

## Tests (631 passing)
5 new unit tests for the presentation helpers (round labelling for 4/8/16, grouping/sorting, winner side).

## Verification
Pure logic is unit-tested; the bracket layout is intended for browser verification (now that local dev renders). Recording a playoff result auto-advances the winner (backend, #377), so the tree updates on `router.refresh()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)