### PR TITLE
feat(web): token-based design system foundation (WSM-000166)

### DIFF
--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -47,9 +47,9 @@ export default async function BillingPage({
       </div>
 
       {params.success && (
-        <Card className="border-green-500/30 bg-green-500/10">
+        <Card className="border-accent/30 bg-accent/10">
           <CardContent className="py-4">
-            <p className="text-sm text-green-400">
+            <p className="text-sm text-accent">
               ✓ Subscription activated. Welcome to {config.name}!
             </p>
           </CardContent>

--- a/apps/web/src/app/dashboard/discover/discover-leagues.tsx
+++ b/apps/web/src/app/dashboard/discover/discover-leagues.tsx
@@ -353,7 +353,7 @@ function LeagueCatalogCard({ league }: { league: DiscoverLeague }) {
 function StateBadge({ state }: { state: AddState }) {
   if (state === "all") {
     return (
-      <span className="flex shrink-0 items-center gap-1 text-xs text-green-500">
+      <span className="flex shrink-0 items-center gap-1 text-xs text-accent">
         <CheckCircle2 className="h-3.5 w-3.5" />
         All added
       </span>
@@ -494,7 +494,7 @@ function DivisionSection({
                 </span>
                 {isAdded ? (
                   <div className="flex shrink-0 items-center gap-1">
-                    <span className="flex items-center gap-1 text-xs text-green-500">
+                    <span className="flex items-center gap-1 text-xs text-accent">
                       <CheckCircle2 className="h-3.5 w-3.5" />
                       Added
                     </span>

--- a/apps/web/src/app/dashboard/import/_components/import-form.tsx
+++ b/apps/web/src/app/dashboard/import/_components/import-form.tsx
@@ -392,9 +392,9 @@ export function ImportForm() {
 
       {/* Result */}
       {state.step === "done" && (
-        <Card className="border-green-500/30">
+        <Card className="border-accent/30">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-green-500">
+            <CardTitle className="flex items-center gap-2 text-accent">
               <CheckCircle2 className="h-5 w-5" />
               Import Complete
             </CardTitle>
@@ -408,7 +408,7 @@ export function ImportForm() {
                       {entity}
                     </p>
                     <p className="text-sm">
-                      <span className="font-semibold text-green-500">
+                      <span className="font-semibold text-accent">
                         {state.result.created[entity]} created
                       </span>
                       {", "}

--- a/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
+++ b/apps/web/src/app/dashboard/import/_components/nfl-sync-card.tsx
@@ -64,7 +64,7 @@ function SyncReportDisplay({ report }: { report: SyncReport }) {
                   {entity}
                 </p>
                 <p className="text-sm">
-                  <span className="font-semibold text-green-500">
+                  <span className="font-semibold text-accent">
                     {report.importResult!.created[entity]}
                   </span>
                   {" / "}
@@ -302,7 +302,7 @@ export function NflSyncCard() {
         {config.lastSyncReport ? (
           <div>
             <h4 className="mb-2 flex items-center gap-1 text-sm font-medium text-foreground">
-              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              <CheckCircle2 className="h-4 w-4 text-accent" />
               Last Sync
             </h4>
             <SyncReportDisplay report={config.lastSyncReport} />

--- a/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/invite-form.tsx
@@ -62,7 +62,7 @@ export default function InviteForm({ orgId }: { orgId: string }) {
       </form>
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       {success && (
-        <p className="mt-2 text-sm text-green-500">Invitation sent successfully!</p>
+        <p className="mt-2 text-sm text-accent">Invitation sent successfully!</p>
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -98,7 +98,7 @@ export default async function PlayerDevelopmentPage({
             {headlineDelta !== null ? (
               <span
                 className={`font-mono text-sm ${
-                  headlineDelta >= 0 ? "text-green-500" : "text-destructive"
+                  headlineDelta >= 0 ? "text-accent" : "text-destructive"
                 }`}
               >
                 {headlineDelta >= 0 ? "+" : ""}
@@ -162,7 +162,7 @@ export default async function PlayerDevelopmentPage({
                         row.delta === null
                           ? "text-muted-foreground"
                           : row.delta >= 0
-                            ? "text-green-500"
+                            ? "text-accent"
                             : "text-destructive"
                       }`}
                     >

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -227,7 +227,7 @@ export default async function PlayerProfilePage({
                 SPRT Rating
               </h3>
               {rating.weightedOverall != null && (
-                <span className="font-mono text-2xl font-bold text-green-500">
+                <span className="font-mono text-2xl font-bold text-accent">
                   {Math.round(rating.weightedOverall)}
                   <span className="ml-1 text-xs font-normal text-muted-foreground">
                     OVR
@@ -299,7 +299,7 @@ export default async function PlayerProfilePage({
                     </dt>
                     <dd
                       className={`shrink-0 font-mono text-sm font-semibold ${
-                        a.value >= 90 ? "text-green-500" : "text-foreground"
+                        a.value >= 90 ? "text-accent" : "text-foreground"
                       }`}
                     >
                       {a.value}

--- a/apps/web/src/app/dashboard/roles/page.tsx
+++ b/apps/web/src/app/dashboard/roles/page.tsx
@@ -88,7 +88,7 @@ export default function RolesPage() {
                   <TableCell key={role} className="text-center">
                     {row.allowed[role] ? (
                       <Check
-                        className="mx-auto h-4 w-4 text-green-500"
+                        className="mx-auto h-4 w-4 text-accent"
                         aria-label="Allowed"
                       />
                     ) : (

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -164,7 +164,7 @@ export default function TeamManagement({
               render: (p: RosterRow) => {
                 const ovr = snapshots.get(p.id as string)?.weightedOverall;
                 return ovr != null ? (
-                  <span className="font-mono font-semibold text-green-500">
+                  <span className="font-mono font-semibold text-accent">
                     {Math.round(ovr)}
                   </span>
                 ) : (

--- a/apps/web/src/app/dev/ui/page.tsx
+++ b/apps/web/src/app/dev/ui/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 /*
- * WSM-000136 — Design system kitchen sink.
+ * Design system kitchen sink + token reference.
  *
- * Renders the base shadcn `ui/*` primitives in the app's standard theme for
- * quick visual review. Dev-only; not linked from nav.
+ * The living reference for the Sports League design system: the 12 semantic
+ * color tokens, the type scale, the radius family, and the shadcn `ui/*`
+ * primitives that consume them — rendered in whichever theme is active (toggle
+ * top-right). Dev-only; not linked from nav.
  */
 import { Button } from "@/components/ui/button";
 import {
@@ -45,7 +47,7 @@ function Section({
 }) {
   return (
     <section className="space-y-4">
-      <h2 className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+      <h2 className="font-mono text-xs font-medium uppercase tracking-widest text-text-muted">
         {title}
       </h2>
       {children}
@@ -53,24 +55,110 @@ function Section({
   );
 }
 
+// The 12 semantic color tokens — each resolves to a light and a dark value;
+// components reference the name, never the hex.
+const COLOR_TOKENS: { name: string; cls: string; role: string }[] = [
+  { name: "--bg", cls: "bg-bg", role: "App background" },
+  { name: "--surface", cls: "bg-surface", role: "Card surface" },
+  { name: "--surface-2", cls: "bg-surface-2", role: "Inset / secondary fill" },
+  { name: "--surface-3", cls: "bg-surface-3", role: "Hover / pressed" },
+  { name: "--border", cls: "bg-border", role: "Hairline border" },
+  { name: "--border-strong", cls: "bg-border-strong", role: "Control border" },
+  { name: "--text", cls: "bg-text", role: "Primary text" },
+  { name: "--text-muted", cls: "bg-text-muted", role: "Secondary text" },
+  { name: "--text-subtle", cls: "bg-text-subtle", role: "Hint / disabled" },
+  { name: "--primary", cls: "bg-primary", role: "High-contrast action" },
+  { name: "--accent", cls: "bg-accent", role: "Success / live data" },
+  { name: "--danger", cls: "bg-danger", role: "Destructive" },
+];
+
+// name · size/line-height · the Tailwind text-* utility that carries all three.
+const TYPE_SCALE: { name: string; cls: string; sample: string }[] = [
+  { name: "display-32 · 32/38 · 700", cls: "text-display-32", sample: "Discover Leagues" },
+  { name: "stat-30 · 30/32 · 700", cls: "text-stat-30", sample: "413 Teams" },
+  { name: "title-22 · 22/28 · 700", cls: "text-title-22", sample: "Cobb County Football" },
+  { name: "heading-18 · 18/24 · 600", cls: "text-heading-18", sample: "Player Roster" },
+  { name: "body-15 · 15/23 · 400", cls: "text-body-15", sample: "Browse leagues and add teams to your dashboard." },
+  { name: "label-14 · 14/20 · 500", cls: "text-label-14", sample: "Add Player" },
+  { name: "caption-12 · 12/16 · 500", cls: "text-caption-12", sample: "City · Acworth" },
+  { name: "mono-13 · 13/18 · 500", cls: "text-mono-13 font-mono", sample: "sprtsmng.dev ⌘K" },
+];
+
+const RADII: { name: string; cls: string; px: string }[] = [
+  { name: "control", cls: "rounded-control", px: "10px" },
+  { name: "card", cls: "rounded-card", px: "14px" },
+  { name: "pill", cls: "rounded-full", px: "full" },
+];
+
 export default function UiKitchenSinkPage() {
   return (
     <div className="min-h-screen px-6 py-10 font-sans">
       <div className="mx-auto max-w-4xl space-y-12">
         <header className="flex items-start justify-between gap-4">
           <div className="space-y-2">
-            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-              Design system — professional theme
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              WSM-000136 · standard shadcn/ui · dark-first. Toggle to review the
-              light theme →
+            <h1 className="text-display-32 text-foreground">The design system</h1>
+            <p className="text-body-15 text-text-muted">
+              One token set, two themes · Hanken Grotesk / JetBrains Mono · 4px
+              grid. Toggle the theme top-right →
             </p>
           </div>
           <ThemeToggle />
         </header>
 
-        <Section title="Buttons">
+        <Section title="01 — Color tokens">
+          <div className="overflow-hidden rounded-card border border-border">
+            {COLOR_TOKENS.map((t) => (
+              <div
+                key={t.name}
+                className="flex items-center gap-4 border-b border-border px-4 py-2.5 last:border-b-0"
+              >
+                <span
+                  className={`h-7 w-7 shrink-0 rounded-md border border-border ${t.cls}`}
+                />
+                <span className="w-40 font-mono text-mono-13 text-foreground">
+                  {t.name}
+                </span>
+                <span className="text-label-14 text-text-muted">{t.role}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="02 — Typography">
+          <div className="space-y-4">
+            {TYPE_SCALE.map((t) => (
+              <div
+                key={t.name}
+                className="flex items-baseline justify-between gap-6 border-b border-border pb-3 last:border-b-0"
+              >
+                <span className={`${t.cls} text-foreground`}>{t.sample}</span>
+                <span className="shrink-0 font-mono text-caption-12 text-text-subtle">
+                  {t.name}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="03 — Radius">
+          <div className="flex flex-wrap gap-6">
+            {RADII.map((r) => (
+              <div key={r.name} className="space-y-2 text-center">
+                <div
+                  className={`h-20 w-20 border border-border-strong bg-surface-2 ${r.cls}`}
+                />
+                <div className="font-mono text-mono-13 text-foreground">
+                  {r.name}
+                </div>
+                <div className="font-mono text-caption-12 text-text-subtle">
+                  {r.px}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="04 — Buttons">
           <div className="flex flex-wrap items-center gap-3">
             <Button>Primary</Button>
             <Button variant="secondary">Secondary</Button>
@@ -87,16 +175,17 @@ export default function UiKitchenSinkPage() {
           </div>
         </Section>
 
-        <Section title="Badges (status uses semantic color only)">
+        <Section title="05 — Badges & status">
           <div className="flex flex-wrap items-center gap-2">
             <Badge>Default</Badge>
             <Badge variant="secondary">Secondary</Badge>
             <Badge variant="outline">Outline</Badge>
+            <Badge variant="success">Active</Badge>
             <Badge variant="destructive">Destructive</Badge>
           </div>
         </Section>
 
-        <Section title="Form controls">
+        <Section title="06 — Form controls">
           <div className="grid max-w-md gap-4">
             <div className="grid gap-2">
               <Label htmlFor="ks-name">Team name</Label>
@@ -118,7 +207,7 @@ export default function UiKitchenSinkPage() {
           </div>
         </Section>
 
-        <Section title="Card">
+        <Section title="07 — Card">
           <Card className="max-w-md">
             <CardHeader>
               <CardTitle>Cobb County Football</CardTitle>
@@ -131,7 +220,7 @@ export default function UiKitchenSinkPage() {
           </Card>
         </Section>
 
-        <Section title="Table">
+        <Section title="08 — Table">
           <Card>
             <Table>
               <TableHeader>
@@ -158,7 +247,7 @@ export default function UiKitchenSinkPage() {
           </Card>
         </Section>
 
-        <Section title="Skeleton & separator">
+        <Section title="09 — Skeleton & separator">
           <div className="space-y-3">
             <Skeleton className="h-4 w-48" />
             <Skeleton className="h-4 w-72" />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,88 +1,124 @@
 @import "tailwindcss";
 
 /*
- * Standard shadcn/ui theme (WSM-000136 — UI overhaul global cutover).
+ * Sports League design system — semantic tokens (one set, two themes).
  *
- * Neutral, token-driven shadcn theme. Tokens live in :root (light) and .dark
- * (dark) as `--<name>`; `@theme inline` maps them to the Tailwind v4
- * `--color-<name>` namespace that powers the bg, text and border utilities, so
- * every shadcn `ui/*` primitive inherits the palette. The app renders dark-first
- * (`.dark` is set on <html>); the light set is retained for a future toggle.
+ * 12 semantic tokens live in :root (light) and .dark (dark) as `--<name>`.
+ * `@theme inline` maps them to the Tailwind v4 `--color-<name>` namespace AND
+ * keeps the legacy shadcn aliases (--color-background, --color-card, …) so the
+ * existing `ui/*` primitives and ~600 call sites inherit the palette unchanged.
+ * Components reference token names, never the hex. Theme follows the OS by
+ * default (next-themes); `.dark` is toggled on <html>.
+ *
+ * `--accent` is GREEN (success / live data); the neutral hover/pressed fill is
+ * `--surface-3` (shadcn's old neutral `accent` was rewired to it). `--primary`
+ * intentionally inverts: near-black in light, near-white in dark.
  */
 :root {
-  --radius: 0.625rem;
+  --bg: #fbfbfc;
+  --surface: #ffffff;
+  --surface-2: #f4f4f5;
+  --surface-3: #eaeaec;
+  --border: #e6e6e9;
+  --border-strong: #d6d6da;
+  --text: #0c0c0d;
+  --text-muted: #5b5b61;
+  --text-subtle: #9a9aa1;
+  --primary: #0c0c0d;
+  --accent: #18a558;
+  --danger: #e5484d;
 
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --radius-control: 10px;
+  --radius-card: 14px;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --bg: #0a0a0b;
+  --surface: #161618;
+  --surface-2: #1d1d20;
+  --surface-3: #26262a;
+  --border: #2a2a2e;
+  --border-strong: #3a3a40;
+  --text: #fafafa;
+  --text-muted: #9b9ba3;
+  --text-subtle: #67676f;
+  --primary: #fafafa;
+  --accent: #46c964;
+  --danger: #ff6166;
 }
 
 @theme inline {
-  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
-  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, monospace;
+  --font-sans: var(--font-hanken), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular,
+    monospace;
 
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
+  /* Design-system semantic color utilities */
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
   --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
+  --color-border-strong: var(--border-strong);
+  --color-text: var(--text);
+  --color-text-muted: var(--text-muted);
+  --color-text-subtle: var(--text-subtle);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--bg);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--bg);
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--bg);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* Legacy shadcn aliases → semantic tokens (keep existing call sites working) */
+  --color-background: var(--bg);
+  --color-foreground: var(--text);
+  --color-card: var(--surface);
+  --color-card-foreground: var(--text);
+  --color-popover: var(--surface);
+  --color-popover-foreground: var(--text);
+  --color-secondary: var(--surface-2);
+  --color-secondary-foreground: var(--text);
+  --color-muted: var(--surface-2);
+  --color-muted-foreground: var(--text-muted);
+  --color-destructive: var(--danger);
+  --color-destructive-foreground: var(--bg);
+  --color-input: var(--border-strong);
+  --color-ring: var(--border-strong);
+
+  /* Type scale — size / line-height · weight */
+  --text-display-32: 32px;
+  --text-display-32--line-height: 38px;
+  --text-display-32--font-weight: 700;
+  --text-stat-30: 30px;
+  --text-stat-30--line-height: 32px;
+  --text-stat-30--font-weight: 700;
+  --text-title-22: 22px;
+  --text-title-22--line-height: 28px;
+  --text-title-22--font-weight: 700;
+  --text-heading-18: 18px;
+  --text-heading-18--line-height: 24px;
+  --text-heading-18--font-weight: 600;
+  --text-body-15: 15px;
+  --text-body-15--line-height: 23px;
+  --text-body-15--font-weight: 400;
+  --text-label-14: 14px;
+  --text-label-14--line-height: 20px;
+  --text-label-14--font-weight: 500;
+  --text-caption-12: 12px;
+  --text-caption-12--line-height: 16px;
+  --text-caption-12--font-weight: 500;
+  --text-mono-13: 13px;
+  --text-mono-13--line-height: 18px;
+  --text-mono-13--font-weight: 500;
+
+  /* Radius — control / card / pill (+ shadcn aliases).
+   * rounded-md (buttons/inputs/menus) → 10px; rounded-xl (cards) → 14px. */
+  --radius-control: 10px;
+  --radius-card: 14px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
 
   --animate-in: enter 0.2s ease-out;
   --animate-out: exit 0.2s ease-in;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
-import { Pixelify_Sans } from "next/font/google";
-import { GeistSans } from "geist/font/sans";
-import { GeistMono } from "geist/font/mono";
+import { Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -11,12 +9,20 @@ import "./globals.css";
 
 export const dynamic = "force-dynamic";
 
-// Display font for headings + 8-bit retro accents.
-const pixelifySans = Pixelify_Sans({
+// Design system type: Hanken Grotesk carries UI + prose; JetBrains Mono sets
+// keys, paths, and data (numerics, IDs, ⌘K).
+const hanken = Hanken_Grotesk({
   subsets: ["latin"],
-  variable: "--font-pixelify-sans",
+  variable: "--font-hanken",
   display: "swap",
   weight: ["400", "500", "600", "700"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+  weight: ["400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -62,11 +68,11 @@ export default function RootLayout({
 }) {
   return (
     <ClerkProvider>
-      {/* dark-first (WSM-000136); next-themes sets the class, light via toggle. */}
+      {/* Theme follows the OS by default (next-themes); a top-bar toggle overrides. */}
       <html
         lang="en"
         suppressHydrationWarning
-        className={`${GeistSans.variable} ${GeistMono.variable} ${pixelifySans.variable}`}
+        className={`${hanken.variable} ${jetbrainsMono.variable}`}
       >
         <body className="bg-background text-foreground font-sans antialiased">
           <script
@@ -75,8 +81,8 @@ export default function RootLayout({
           />
           <ThemeProvider
             attribute="class"
-            defaultTheme="dark"
-            enableSystem={false}
+            defaultTheme="system"
+            enableSystem
             disableTransitionOnChange
           >
             {children}

--- a/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
+++ b/apps/web/src/app/leagues/[id]/players/[playerId]/development/page.tsx
@@ -73,7 +73,7 @@ export default async function PublicPlayerDevelopmentPage({
             {headlineDelta !== null ? (
               <span
                 className={`font-mono text-sm ${
-                  headlineDelta >= 0 ? "text-green-500" : "text-destructive"
+                  headlineDelta >= 0 ? "text-accent" : "text-destructive"
                 }`}
               >
                 {headlineDelta >= 0 ? "+" : ""}
@@ -136,7 +136,7 @@ export default async function PublicPlayerDevelopmentPage({
                         row.delta === null
                           ? "text-muted-foreground"
                           : row.delta >= 0
-                            ? "text-green-500"
+                            ? "text-accent"
                             : "text-destructive"
                       }`}
                     >

--- a/apps/web/src/app/local/import/page.tsx
+++ b/apps/web/src/app/local/import/page.tsx
@@ -268,9 +268,9 @@ export default function LocalImportPage() {
       )}
 
       {state.step === "done" && (
-        <Card className="border-green-500/30">
+        <Card className="border-accent/30">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base text-green-500">
+            <CardTitle className="flex items-center gap-2 text-base text-accent">
               <CheckCircle2 className="h-5 w-5" />
               Import complete
             </CardTitle>

--- a/apps/web/src/components/pricing-table.tsx
+++ b/apps/web/src/components/pricing-table.tsx
@@ -115,14 +115,14 @@ export function PricingTable({
                     </span>
                   )}
                   {!isFree && interval === "yearly" && savings > 0 && (
-                    <p className="mt-1 text-xs text-green-500">Save {savings}% vs monthly</p>
+                    <p className="mt-1 text-xs text-accent">Save {savings}% vs monthly</p>
                   )}
                 </div>
 
                 <ul className="mb-6 space-y-2 text-sm">
                   {config.highlights.map((feature) => (
                     <li key={feature} className="flex items-start gap-2">
-                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" />
+                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent" />
                       <span>{feature}</span>
                     </li>
                   ))}

--- a/apps/web/src/components/roster/RosterAuditTimeline.tsx
+++ b/apps/web/src/components/roster/RosterAuditTimeline.tsx
@@ -24,7 +24,7 @@ const ACTION_FILTERS: Array<{
 ];
 
 const ACTION_COLORS: Record<RosterAuditAction, string> = {
-  assign: "bg-green-500/15 text-green-400 border-green-500/30",
+  assign: "bg-accent/15 text-accent border-accent/30",
   remove: "bg-destructive/15 text-destructive border-destructive/30",
   status_change: "bg-amber-500/15 text-amber-400 border-amber-500/30",
   depth_reorder: "bg-blue-500/15 text-blue-400 border-blue-500/30",

--- a/apps/web/src/components/schedule/StandingsTable.tsx
+++ b/apps/web/src/components/schedule/StandingsTable.tsx
@@ -58,7 +58,7 @@ export default function StandingsTable({ rows }: StandingsTableProps) {
                 <td
                   className={`px-4 py-2 text-right font-mono ${
                     diff > 0
-                      ? "text-green-500"
+                      ? "text-accent"
                       : diff < 0
                         ? "text-destructive"
                         : "text-muted-foreground"

--- a/apps/web/src/components/stats/HsRatingCard.tsx
+++ b/apps/web/src/components/stats/HsRatingCard.tsx
@@ -43,7 +43,7 @@ export function HsRatingCard({
               from game stats
             </span>
           </h3>
-          <span className="font-mono text-2xl font-bold text-green-500">
+          <span className="font-mono text-2xl font-bold text-accent">
             {overall}
             <span className="ml-1 text-xs font-normal text-muted-foreground">
               OVR

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         secondary: "border-transparent bg-secondary text-secondary-foreground",
         destructive: "border-transparent bg-destructive/15 text-destructive",
         outline: "text-foreground",
-        success: "border-transparent bg-green-500/15 text-green-400",
+        success: "border-transparent bg-accent/15 text-accent",
         warning: "border-transparent bg-yellow-500/15 text-yellow-400",
       },
     },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -16,10 +16,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-surface-3 hover:text-text",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-surface-3 hover:text-text",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -140,7 +140,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-surface-3 data-[selected=true]:text-text [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -73,7 +73,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none data-[state=open]:bg-surface-3 data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none focus:bg-surface-3 focus:text-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-surface-3 focus:text-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-surface-3 focus:text-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-surface-3 focus:text-text data-[inset]:pl-8 data-[state=open]:bg-surface-3 data-[state=open]:text-text [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -109,7 +109,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden transition-colors select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden transition-colors select-none focus:bg-surface-3 focus:text-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Token-based design system — foundation cutover (WSM-000166)

Adopts the **Sports League design system** (the spec shared as a Claude artifact) as the single source of truth and restyles the whole app in one PR. Everything funnels through `@theme` + the shadcn `ui/*` primitives, so swapping the token + font layer restyles every surface; subsequent PRs polish individual components to match the mockups.

### What changed
- **`globals.css`** — the 12 semantic tokens (`--bg, --surface, --surface-2, --surface-3, --border, --border-strong, --text, --text-muted, --text-subtle, --primary, --accent, --danger`) in `:root` (light) + `.dark` (dark), mapped to `--color-*` utilities. **Legacy shadcn aliases** (`--color-background→--bg`, `--color-card→--surface`, `--color-muted→--surface-2`, `--color-muted-foreground→--text-muted`, `--color-input/ring→--border-strong`, `--color-destructive→--danger`, …) keep ~600 existing call sites working with zero churn. Plus the **type scale** (`display-32`…`mono-13`, size/line-height/weight) and **radius** family (control 10 / card 14 / pill) as Tailwind v4 utilities.
- **Fonts** — Hanken Grotesk (UI + prose) + JetBrains Mono (data/keys) via `next/font/google`; removed the unused Pixelify and Geist imports.
- **Theme = system** — `next-themes` now `defaultTheme="system"` + `enableSystem`; the top-bar toggle (already present in desktop + mobile headers) overrides.
- **`--accent` is GREEN** (success/live). Resolved the shadcn collision by rewiring the **8 neutral hover/focus spots** (`button` outline/ghost, `dropdown-menu`, `select`, `command`, `dialog`) from `bg-accent`→`bg-surface-3`, then pointing the badge `success` variant + **~20 hardcoded `text-green-500`** across 15 files at the accent token — consolidating "green = success" onto one token.
- **`/dev/ui`** rebuilt as the living reference: 12 color swatches, all 8 type specimens, radius samples, and the primitives — verify light + dark via the toggle.

**Left untouched** (intentional non-token color): the video score overlay, modal scrims, brand/OG hex, user team colors, and `PixelLineChart` (already token-wired).

### Verification
- `tsc --noEmit` clean · `eslint` clean · `vitest` **631 passed** · `next build` compiles.
- 👀 **Please eyeball the Vercel preview** (link below) at `/dev/ui` and the dashboard, in both light and dark, before merge.

### Follow-ups (this is the foundation; polish PRs next, autonomous)
PR2 nav/controls · PR3 surfaces/stat cards · PR4 toast/banner/dialog · PR5 LIVE badge→green · PR6 type-scale adoption sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
