### PR TITLE
feat(web): design-system polish — nav, segmented control, live=green (WSM-000167)

### DIFF
--- a/apps/web/src/app/dashboard/_components/nav-link.tsx
+++ b/apps/web/src/app/dashboard/_components/nav-link.tsx
@@ -27,10 +27,10 @@ export default function NavLink({
       href={href}
       onClick={onClick}
       className={cn(
-        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+        "flex items-center gap-3 rounded-control px-3 py-2 text-label-14 transition-colors",
         isActive
           ? "bg-primary text-primary-foreground"
-          : "text-foreground hover:bg-card",
+          : "text-text-muted hover:bg-surface-3 hover:text-text",
       )}
     >
       {Icon && <Icon className="h-4 w-4" />}

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -176,7 +176,7 @@ export default async function PublicGamePage({
             <CardTitle className="flex items-center gap-2">
               {liveActive ? (
                 <>
-                  <Badge variant="destructive">LIVE</Badge>
+                  <Badge variant="success">LIVE</Badge>
                   <span>Watch live</span>
                 </>
               ) : (

--- a/apps/web/src/components/games/PublicLiveScore.tsx
+++ b/apps/web/src/components/games/PublicLiveScore.tsx
@@ -35,7 +35,7 @@ export default function PublicLiveScore({
     <Card className="mb-6">
       <CardContent className="py-6">
         <div className="mb-3 flex justify-center">
-          <Badge variant="destructive" className="gap-1.5">
+          <Badge variant="success" className="gap-1.5">
             <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-current" />
             LIVE
           </Badge>

--- a/apps/web/src/components/roster/PositionGroupTabs.tsx
+++ b/apps/web/src/components/roster/PositionGroupTabs.tsx
@@ -66,10 +66,10 @@ export function PositionGroupTabs<T extends Positioned>({
               role="tab"
               aria-selected={isActive}
               onClick={() => setActiveTab(tab)}
-              className={`shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+              className={`shrink-0 whitespace-nowrap rounded-control px-3 py-2 text-label-14 transition-colors ${
                 isActive
                   ? "bg-primary text-primary-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+                  : "bg-surface-2 text-text-muted hover:bg-surface-3 hover:text-text"
               }`}
             >
               {tab === OTHER_GROUP ? "Other" : tab}


### PR DESCRIPTION
Builds on the design-system foundation (#381). Sidebar nav muted-idle/solid-active, position-group segmented control on the token ladder, and the public LIVE badges move destructive→success (green=live per spec; on-video overlay keeps its red dot). Verified: tsc clean, eslint clean, vitest 634 passed, build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)