### PR TITLE
refactor(web): single playerDtoValidator + Infer-pinned toPlayerDto (WSM-000167)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -3,7 +3,7 @@ import {
   internalQueryGeneric,
   queryGeneric,
 } from "convex/server";
-import { v } from "convex/values";
+import { v, type Infer } from "convex/values";
 import { internalMutation, query } from "./_generated/server";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
@@ -113,6 +113,28 @@ function toTeamDto(doc: {
   };
 }
 
+/*
+ * Single source of truth for the player DTO shape (WSM-000167). Reused by every
+ * player query/mutation `returns` validator, and `toPlayerDto`'s return type is
+ * pinned to it via `Infer` below — so the mapper and the validators can't drift.
+ * The WSM-000166 prod outage was exactly that drift (the DTO grew grade/squad
+ * but the read validators didn't); this turns that class of bug into a tsc error.
+ */
+export const playerDtoValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  teamId: v.string(),
+  position: v.string(),
+  positionGroup: v.union(v.string(), v.null()),
+  jerseyNumber: v.union(v.number(), v.null()),
+  dateOfBirth: v.union(v.string(), v.null()),
+  status: v.string(),
+  headshotUrl: v.union(v.string(), v.null()),
+  experienceYears: v.union(v.number(), v.null()),
+  grade: v.union(v.number(), v.null()),
+  squad: v.union(v.string(), v.null()),
+});
+
 function toPlayerDto(doc: {
   _id: string;
   name: string;
@@ -126,7 +148,7 @@ function toPlayerDto(doc: {
   experienceYears?: number | null;
   grade?: number | null;
   squad?: string | null;
-}) {
+}): Infer<typeof playerDtoValidator> {
   return {
     id: doc._id,
     name: doc.name,
@@ -631,20 +653,7 @@ export const getTeamOwnerOrgId = queryGeneric({
 export const listPlayers = queryGeneric({
   args: { leagueIds: v.array(v.id("leagues")) },
   returns: v.array(
-    v.object({
-      id: v.string(),
-      name: v.string(),
-      teamId: v.string(),
-      position: v.string(),
-      positionGroup: v.union(v.string(), v.null()),
-      jerseyNumber: v.union(v.number(), v.null()),
-      dateOfBirth: v.union(v.string(), v.null()),
-      status: v.string(),
-      headshotUrl: v.union(v.string(), v.null()),
-      experienceYears: v.union(v.number(), v.null()),
-      grade: v.union(v.number(), v.null()),
-      squad: v.union(v.string(), v.null()),
-    }),
+    playerDtoValidator,
   ),
   handler: async (ctx, args) => {
     const docs = await Promise.all(
@@ -662,20 +671,7 @@ export const listPlayers = queryGeneric({
 export const listPlayersByTeam = queryGeneric({
   args: { teamId: v.id("teams") },
   returns: v.array(
-    v.object({
-      id: v.string(),
-      name: v.string(),
-      teamId: v.string(),
-      position: v.string(),
-      positionGroup: v.union(v.string(), v.null()),
-      jerseyNumber: v.union(v.number(), v.null()),
-      dateOfBirth: v.union(v.string(), v.null()),
-      status: v.string(),
-      headshotUrl: v.union(v.string(), v.null()),
-      experienceYears: v.union(v.number(), v.null()),
-      grade: v.union(v.number(), v.null()),
-      squad: v.union(v.string(), v.null()),
-    }),
+    playerDtoValidator,
   ),
   handler: async (ctx, args) => {
     const docs = await ctx.db
@@ -689,20 +685,7 @@ export const listPlayersByTeam = queryGeneric({
 export const getPlayer = queryGeneric({
   args: { playerId: v.id("players") },
   returns: v.union(
-    v.object({
-      id: v.string(),
-      name: v.string(),
-      teamId: v.string(),
-      position: v.string(),
-      positionGroup: v.union(v.string(), v.null()),
-      jerseyNumber: v.union(v.number(), v.null()),
-      dateOfBirth: v.union(v.string(), v.null()),
-      status: v.string(),
-      headshotUrl: v.union(v.string(), v.null()),
-      experienceYears: v.union(v.number(), v.null()),
-      grade: v.union(v.number(), v.null()),
-      squad: v.union(v.string(), v.null()),
-    }),
+    playerDtoValidator,
     v.null(),
   ),
   handler: async (ctx, args) => {
@@ -1244,20 +1227,7 @@ export const upsertPlayer = internalMutationGeneric({
     squad: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.object({
-    dto: v.object({
-      id: v.string(),
-      name: v.string(),
-      teamId: v.string(),
-      position: v.string(),
-      positionGroup: v.union(v.string(), v.null()),
-      jerseyNumber: v.union(v.number(), v.null()),
-      dateOfBirth: v.union(v.string(), v.null()),
-      status: v.string(),
-      headshotUrl: v.union(v.string(), v.null()),
-      experienceYears: v.union(v.number(), v.null()),
-      grade: v.union(v.number(), v.null()),
-      squad: v.union(v.string(), v.null()),
-    }),
+    dto: playerDtoValidator,
     created: v.boolean(),
   }),
   handler: async (ctx, args) => {
@@ -1556,20 +1526,7 @@ export const updatePlayer = internalMutationGeneric({
     squad: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.union(
-    v.object({
-      id: v.string(),
-      name: v.string(),
-      teamId: v.string(),
-      position: v.string(),
-      positionGroup: v.union(v.string(), v.null()),
-      jerseyNumber: v.union(v.number(), v.null()),
-      dateOfBirth: v.union(v.string(), v.null()),
-      status: v.string(),
-      headshotUrl: v.union(v.string(), v.null()),
-      experienceYears: v.union(v.number(), v.null()),
-      grade: v.union(v.number(), v.null()),
-      squad: v.union(v.string(), v.null()),
-    }),
+    playerDtoValidator,
     v.null(),
   ),
   handler: async (ctx, args) => {


### PR DESCRIPTION
Closes #383 · prevents recurrence of #379 (WSM-000166)

## Why
The WSM-000166 prod outage came from validator drift: `toPlayerDto` and its `returns` validator were duplicated across 5 sites, and #351 added `grade`/`squad` to the mapper + 2 mutation validators but not the 3 read-query validators. Convex strict-validates returns → 500s on any populated roster.

## Change
- One `playerDtoValidator` (`v.object`), reused by all 5 player query/mutation return validators (`listPlayers`, `listPlayersByTeam`, `getPlayer`, `upsertPlayer.dto`, `createPlayer`/`updatePlayer`).
- `toPlayerDto` return type pinned to `Infer<typeof playerDtoValidator>`.

Net: the mapper and validators are now mechanically forced to agree — **the WSM-000166 class of bug becomes a `tsc` error instead of a prod 500.**

## Verification
- Pure refactor; validators byte-identical to post-#380. tsc + eslint clean, **634 tests pass**.
- Proved the guard: temporarily dropping `grade` from `playerDtoValidator` fails the build with `TS2353: 'grade' does not exist in type …` at `toPlayerDto` — i.e. it would have caught #351 before merge.

No schema/data change; no Convex deploy needed (return validators are bundled with the functions on the next deploy, but behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)