### PR TITLE
feat(web): design-system polish — stat surfaces (WSM-000168)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -213,8 +213,10 @@ export default async function DashboardPage() {
                 <CardContent className="flex items-center gap-3 p-4">
                   <Icon className="h-4 w-4 text-muted-foreground" />
                   <div>
-                    <p className="text-xs text-muted-foreground">{card.label}</p>
-                    <p className="text-xl font-bold text-foreground">
+                    <p className="text-caption-12 uppercase tracking-wide text-text-muted">
+                      {card.label}
+                    </p>
+                    <p className="text-stat-30 font-mono tabular-nums text-foreground">
                       {counts[card.key]}
                     </p>
                   </div>
@@ -245,7 +247,7 @@ export default async function DashboardPage() {
           <BentoCard title="This league" className="lg:col-span-2">
             <div className="flex flex-1 flex-col justify-between gap-4">
               <div>
-                <p className="text-2xl font-semibold text-foreground">
+                <p className="text-title-22 text-foreground">
                   {activeLeague!.name}
                 </p>
                 <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -227,9 +227,9 @@ export default async function PlayerProfilePage({
                 SPRT Rating
               </h3>
               {rating.weightedOverall != null && (
-                <span className="font-mono text-2xl font-bold text-accent">
+                <span className="font-mono text-stat-30 tabular-nums text-accent">
                   {Math.round(rating.weightedOverall)}
-                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  <span className="ml-1 text-caption-12 font-normal text-text-muted">
                     OVR
                   </span>
                 </span>

--- a/apps/web/src/components/stats/HsRatingCard.tsx
+++ b/apps/web/src/components/stats/HsRatingCard.tsx
@@ -43,9 +43,9 @@ export function HsRatingCard({
               from game stats
             </span>
           </h3>
-          <span className="font-mono text-2xl font-bold text-accent">
+          <span className="font-mono text-stat-30 tabular-nums text-accent">
             {overall}
-            <span className="ml-1 text-xs font-normal text-muted-foreground">
+            <span className="ml-1 text-caption-12 font-normal text-text-muted">
               OVR
             </span>
           </span>


### PR DESCRIPTION
Aligns prominent stat numerals to the mockup's big-mono treatment (stat-30 + JetBrains Mono + tabular-nums) with caption-12 uppercase labels: dashboard quick-nav stat strip, hero league name → title-22, SPRT rating on HsRatingCard + player page. Builds on #381/#382. Verified: tsc/eslint clean, vitest 634, build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)