### PR TITLE
fix(web): pricing upgrade CTAs dead-end — resolve Stripe price server-side (WSM-000169/170)

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -2,18 +2,28 @@ import { auth, currentUser, clerkClient } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import { getStripe } from "@/lib/stripe";
 import { getStripeCustomerId } from "@/lib/authorization";
-import { TIER_CONFIGS, TIER_ORDER } from "@/lib/tiers";
+import {
+  TIER_CONFIGS,
+  TIER_ORDER,
+  type Tier,
+  type BillingInterval,
+} from "@/lib/tiers";
 import { handleApiError, ApiError } from "@/lib/api-error";
 
-// Build the set of valid price IDs at module load
-function getValidPriceIds(): Set<string> {
-  const ids = new Set<string>();
-  for (const tier of TIER_ORDER) {
-    const config = TIER_CONFIGS[tier];
-    if (config.monthlyPriceId) ids.add(config.monthlyPriceId);
-    if (config.yearlyPriceId) ids.add(config.yearlyPriceId);
+/**
+ * Resolve a Stripe price id from a (paid) tier + interval. Price ids live in
+ * server-only env (`STRIPE_PRICE_*`), so the CLIENT cannot send them — it sends
+ * the tier and we resolve here (WSM-000169). Returns null for a free/unknown
+ * tier or a plan whose price isn't configured in this environment.
+ */
+function resolvePriceId(tier: unknown, interval: unknown): string | null {
+  if (typeof tier !== "string" || !TIER_ORDER.includes(tier as Tier)) {
+    return null;
   }
-  return ids;
+  if (tier === "free") return null;
+  const billing: BillingInterval = interval === "yearly" ? "yearly" : "monthly";
+  const config = TIER_CONFIGS[tier as Tier];
+  return billing === "yearly" ? config.yearlyPriceId : config.monthlyPriceId;
 }
 
 export async function POST(request: NextRequest) {
@@ -24,17 +34,12 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const priceId = body?.priceId as string | undefined;
 
-    if (!priceId || typeof priceId !== "string") {
-      throw new ApiError({ statusCode: 400, message: "priceId is required" });
-    }
-
-    const validPriceIds = getValidPriceIds();
-    if (!validPriceIds.has(priceId)) {
+    const priceId = resolvePriceId(body?.tier, body?.interval);
+    if (!priceId) {
       throw new ApiError({
         statusCode: 400,
-        message: "Invalid priceId",
+        message: "A valid paid tier is required",
       });
     }
 

--- a/apps/web/src/app/dashboard/billing/_components/billing-actions.tsx
+++ b/apps/web/src/app/dashboard/billing/_components/billing-actions.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PricingTable } from "@/components/pricing-table";
-import type { Tier } from "@/lib/tiers";
+import type { Tier, BillingInterval } from "@/lib/tiers";
 
 interface BillingActionsProps {
   currentTier?: Tier;
@@ -36,12 +36,12 @@ export function BillingActions({
     }
   };
 
-  const handleSelectPlan = async (priceId: string) => {
+  const handleSelectPlan = async (tier: Tier, interval: BillingInterval) => {
     try {
       const res = await fetch("/api/stripe/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ priceId }),
+        body: JSON.stringify({ tier, interval }),
       });
       if (!res.ok) {
         const err = await res.json();

--- a/apps/web/src/components/marketing/pricing-table-marketing.tsx
+++ b/apps/web/src/components/marketing/pricing-table-marketing.tsx
@@ -2,23 +2,28 @@
 
 import { useRouter } from "next/navigation";
 import { PricingTable } from "@/components/pricing-table";
-import type { Tier } from "@/lib/tiers";
+import type { Tier, BillingInterval } from "@/lib/tiers";
 
 /**
  * Marketing-page wrapper for PricingTable.
  *
- * For unauthenticated visitors, clicking a paid tier sends them to
- * /sign-up?priceId=<id> so they can complete signup before checkout.
- * Free tier is the "current plan" by default for visitors.
+ * For unauthenticated visitors, clicking a paid tier sends them into sign-up
+ * with the chosen plan + interval preserved (`/sign-up?plan=<tier>&interval=…`)
+ * so the funnel can resume checkout after auth. We route by tier (not a Stripe
+ * price id) because price ids are server-only and null in this client bundle —
+ * the old code silently no-op'd on the missing id (WSM-000169).
+ *
+ * No `currentTier` is passed: anonymous visitors must not see a "Current Plan"
+ * badge (WSM-000170).
  */
 export function PricingTableMarketing() {
   const router = useRouter();
 
-  const handleSelectPlan = (priceId: string, _tier: Tier) => {
-    router.push(`/sign-up?priceId=${encodeURIComponent(priceId)}`);
+  const handleSelectPlan = (tier: Tier, interval: BillingInterval) => {
+    router.push(
+      `/sign-up?plan=${encodeURIComponent(tier)}&interval=${encodeURIComponent(interval)}`,
+    );
   };
 
-  return (
-    <PricingTable currentTier="free" onSelectPlan={handleSelectPlan} />
-  );
+  return <PricingTable onSelectPlan={handleSelectPlan} />;
 }

--- a/apps/web/src/components/pricing-table.tsx
+++ b/apps/web/src/components/pricing-table.tsx
@@ -10,7 +10,12 @@ import { cn } from "@/lib/utils";
 
 interface PricingTableProps {
   currentTier?: Tier;
-  onSelectPlan?: (priceId: string, tier: Tier) => void | Promise<void>;
+  /**
+   * Called with the chosen tier + interval (NOT a Stripe price id). Stripe price
+   * ids are server-only env vars and are `null` in this client bundle, so the
+   * server resolves the price from the tier — see WSM-000169.
+   */
+  onSelectPlan?: (tier: Tier, interval: BillingInterval) => void | Promise<void>;
   defaultInterval?: BillingInterval;
 }
 
@@ -35,13 +40,9 @@ export function PricingTable({
 
   const handleSelect = async (tier: Tier) => {
     if (!onSelectPlan) return;
-    const config = TIER_CONFIGS[tier];
-    const priceId = interval === "monthly" ? config.monthlyPriceId : config.yearlyPriceId;
-    if (!priceId) return;
-
     setLoadingTier(tier);
     try {
-      await onSelectPlan(priceId, tier);
+      await onSelectPlan(tier, interval);
     } finally {
       setLoadingTier(null);
     }


### PR DESCRIPTION
Closes #387 (WSM-000169) · Closes #388 (WSM-000170) · found in the launch-readiness funnel audit

## Root cause
`TIER_CONFIGS` reads **server-only** `STRIPE_PRICE_*` env vars, but `pricing-table.tsx` is a **client** component — so `monthlyPriceId`/`yearlyPriceId` are `null` in the browser. `handleSelect` bailed on `if (!priceId) return`, so the **"Upgrade to <tier>" buttons silently did nothing**. This dead-ended both:
- the **logged-out marketing** funnel (#387, the audit finding), and
- the **authenticated in-app upgrade** (`billing-actions.tsx` posted `{ priceId }` = null) — same root cause.

## Fix
Switch the client→server contract from a price id to **`{ tier, interval }`** (values that exist client-side); resolve the Stripe price **server-side** where the env vars live.
- `pricing-table.tsx`: `onSelectPlan(tier, interval)` — never a price id.
- `api/stripe/checkout`: new `resolvePriceId(tier, interval)` resolves + validates server-side.
- `pricing-table-marketing.tsx`: logged-out clicks route to `/sign-up?plan=<tier>&interval=…` (intent preserved); **no `currentTier`** passed, so anonymous visitors no longer see a false **"Current Plan"** badge on Free (#388).
- `billing-actions.tsx`: posts `{ tier, interval }`.

## Verification
- Local browser: clicking **"Upgrade to Plus"** navigates to `/sign-up?plan=plus&interval=monthly`; `/sign-up?plan=…` renders (200). No "Current Plan" badge when logged out.
- `tsc` + `eslint` clean, **634 tests pass**.

## Follow-up (not this PR)
The `/sign-up?plan=…&interval=…` params are preserved but **not yet consumed** to auto-resume Stripe checkout after sign-up — a coach still lands in the app and would re-pick the plan in billing. Worth a small follow-up to read those params post-auth and kick off checkout. (And #386 — Clerk prod keys — remains the hard launch blocker, ops-side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)