### PR TITLE
feat(web): resume Stripe checkout after sign-up (WSM-000171)

### DIFF
--- a/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -8,10 +8,24 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
-export default function SignUpPage() {
+export default async function SignUpPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ plan?: string; interval?: string }>;
+}) {
+  // When a marketing pricing CTA carried a plan, resume Stripe checkout right
+  // after sign-up by sending the new account through /checkout/start (WSM-000171).
+  const { plan, interval } = await searchParams;
+  const redirectUrl = plan
+    ? `/checkout/start?plan=${encodeURIComponent(plan)}&interval=${encodeURIComponent(interval ?? "monthly")}`
+    : undefined;
+
   return (
     <main className="flex min-h-screen items-center justify-center">
-      <SignUp />
+      <SignUp
+        forceRedirectUrl={redirectUrl}
+        fallbackRedirectUrl={redirectUrl}
+      />
     </main>
   );
 }

--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -1,30 +1,8 @@
-import { auth, currentUser, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { getStripe } from "@/lib/stripe";
-import { getStripeCustomerId } from "@/lib/authorization";
-import {
-  TIER_CONFIGS,
-  TIER_ORDER,
-  type Tier,
-  type BillingInterval,
-} from "@/lib/tiers";
+import { resolvePriceId } from "@/lib/tiers";
+import { createSubscriptionCheckoutUrl } from "@/lib/stripe-checkout";
 import { handleApiError, ApiError } from "@/lib/api-error";
-
-/**
- * Resolve a Stripe price id from a (paid) tier + interval. Price ids live in
- * server-only env (`STRIPE_PRICE_*`), so the CLIENT cannot send them — it sends
- * the tier and we resolve here (WSM-000169). Returns null for a free/unknown
- * tier or a plan whose price isn't configured in this environment.
- */
-function resolvePriceId(tier: unknown, interval: unknown): string | null {
-  if (typeof tier !== "string" || !TIER_ORDER.includes(tier as Tier)) {
-    return null;
-  }
-  if (tier === "free") return null;
-  const billing: BillingInterval = interval === "yearly" ? "yearly" : "monthly";
-  const config = TIER_CONFIGS[tier as Tier];
-  return billing === "yearly" ? config.yearlyPriceId : config.monthlyPriceId;
-}
 
 export async function POST(request: NextRequest) {
   const { userId } = await auth();
@@ -34,7 +12,6 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-
     const priceId = resolvePriceId(body?.tier, body?.interval);
     if (!priceId) {
       throw new ApiError({
@@ -43,42 +20,8 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const stripe = getStripe();
-    const user = await currentUser();
-    const email = user?.emailAddresses?.[0]?.emailAddress;
-
-    // Find or create the Stripe customer
-    let customerId = await getStripeCustomerId();
-    if (!customerId) {
-      const customer = await stripe.customers.create({
-        email,
-        metadata: { clerkUserId: userId },
-      });
-      customerId = customer.id;
-
-      // Persist customer ID to Clerk privateMetadata
-      const client = await clerkClient();
-      await client.users.updateUserMetadata(userId, {
-        privateMetadata: { stripeCustomerId: customerId },
-      });
-    }
-
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      customer: customerId,
-      line_items: [{ price: priceId, quantity: 1 }],
-      success_url: `${appUrl}/dashboard/billing?success=true&session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${appUrl}/dashboard/billing?cancelled=true`,
-      client_reference_id: userId,
-      metadata: { clerkUserId: userId },
-      subscription_data: {
-        metadata: { clerkUserId: userId },
-      },
-    });
-
-    return NextResponse.json({ url: session.url });
+    const url = await createSubscriptionCheckoutUrl(userId, priceId);
+    return NextResponse.json({ url });
   } catch (error) {
     return handleApiError(error, "/api/stripe/checkout");
   }

--- a/apps/web/src/app/checkout/start/route.ts
+++ b/apps/web/src/app/checkout/start/route.ts
@@ -1,0 +1,42 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextRequest, NextResponse } from "next/server";
+import { resolvePriceId } from "@/lib/tiers";
+import { createSubscriptionCheckoutUrl } from "@/lib/stripe-checkout";
+
+/**
+ * GET /checkout/start?plan=<tier>&interval=<monthly|yearly>
+ *
+ * Resumes Stripe checkout after sign-up (WSM-000171). The sign-up page sets this
+ * as Clerk's post-signup redirect when a marketing pricing CTA carried a plan,
+ * so a coach who clicked "Upgrade to Plus" lands straight in checkout.
+ *
+ * - Not signed in → bounce back to /sign-up preserving the plan intent.
+ * - Missing/invalid plan → fall through to the billing page (no dead-end).
+ * - Otherwise → create a Checkout session and redirect to Stripe.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? origin;
+  const plan = searchParams.get("plan");
+  const interval = searchParams.get("interval");
+
+  const { userId } = await auth();
+  if (!userId) {
+    const q = plan
+      ? `?plan=${encodeURIComponent(plan)}&interval=${encodeURIComponent(interval ?? "monthly")}`
+      : "";
+    return NextResponse.redirect(`${appUrl}/sign-up${q}`);
+  }
+
+  const priceId = resolvePriceId(plan, interval);
+  if (!priceId) {
+    return NextResponse.redirect(`${appUrl}/dashboard/billing`);
+  }
+
+  try {
+    const url = await createSubscriptionCheckoutUrl(userId, priceId);
+    return NextResponse.redirect(url);
+  } catch {
+    return NextResponse.redirect(`${appUrl}/dashboard/billing?error=checkout`);
+  }
+}

--- a/apps/web/src/lib/__tests__/tiers.test.ts
+++ b/apps/web/src/lib/__tests__/tiers.test.ts
@@ -81,4 +81,27 @@ describe("tiers", () => {
     const { getTierLimits } = await import("../tiers");
     expect(getTierLimits("plus").maxTeams).toBe(-1);
   });
+
+  // resolvePriceId — the server-side tier+interval → price resolution that
+  // backs the upgrade CTAs and post-sign-up checkout (WSM-000169/171).
+  it("resolvePriceId resolves paid tier + interval to the configured price", async () => {
+    const { resolvePriceId } = await import("../tiers");
+    expect(resolvePriceId("plus", "monthly")).toBe("price_plus_monthly");
+    expect(resolvePriceId("plus", "yearly")).toBe("price_plus_yearly");
+    expect(resolvePriceId("club", "yearly")).toBe("price_club_yearly");
+  });
+
+  it("resolvePriceId defaults a missing/odd interval to monthly", async () => {
+    const { resolvePriceId } = await import("../tiers");
+    expect(resolvePriceId("league", undefined)).toBe("price_league_monthly");
+    expect(resolvePriceId("league", "bogus")).toBe("price_league_monthly");
+  });
+
+  it("resolvePriceId rejects free, unknown, and non-string tiers", async () => {
+    const { resolvePriceId } = await import("../tiers");
+    expect(resolvePriceId("free", "monthly")).toBeNull();
+    expect(resolvePriceId("enterprise", "monthly")).toBeNull();
+    expect(resolvePriceId(123, "monthly")).toBeNull();
+    expect(resolvePriceId(null, "monthly")).toBeNull();
+  });
 });

--- a/apps/web/src/lib/stripe-checkout.ts
+++ b/apps/web/src/lib/stripe-checkout.ts
@@ -1,0 +1,48 @@
+import { currentUser, clerkClient } from "@clerk/nextjs/server";
+import { getStripe } from "@/lib/stripe";
+import { getStripeCustomerId } from "@/lib/authorization";
+
+/**
+ * Create a Stripe subscription Checkout session for `userId` + `priceId` and
+ * return its hosted URL. Finds or lazily creates the user's Stripe customer
+ * (persisted to Clerk privateMetadata). Shared by `POST /api/stripe/checkout`
+ * (in-app upgrade) and `GET /checkout/start` (post-sign-up resume, WSM-000171).
+ */
+export async function createSubscriptionCheckoutUrl(
+  userId: string,
+  priceId: string,
+): Promise<string> {
+  const stripe = getStripe();
+  const user = await currentUser();
+  const email = user?.emailAddresses?.[0]?.emailAddress;
+
+  let customerId = await getStripeCustomerId();
+  if (!customerId) {
+    const customer = await stripe.customers.create({
+      email,
+      metadata: { clerkUserId: userId },
+    });
+    customerId = customer.id;
+    const client = await clerkClient();
+    await client.users.updateUserMetadata(userId, {
+      privateMetadata: { stripeCustomerId: customerId },
+    });
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    customer: customerId,
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${appUrl}/dashboard/billing?success=true&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${appUrl}/dashboard/billing?cancelled=true`,
+    client_reference_id: userId,
+    metadata: { clerkUserId: userId },
+    subscription_data: { metadata: { clerkUserId: userId } },
+  });
+
+  if (!session.url) {
+    throw new Error("Stripe did not return a checkout URL");
+  }
+  return session.url;
+}

--- a/apps/web/src/lib/tiers.ts
+++ b/apps/web/src/lib/tiers.ts
@@ -169,3 +169,19 @@ export function tierMeetsRequirement(userTier: Tier, requiredTier: Tier): boolea
 export function isPaidTier(tier: Tier): boolean {
   return tier !== "free";
 }
+
+/**
+ * Resolve a Stripe price id from a (paid) tier + interval. Price ids live in
+ * server-only env (`STRIPE_PRICE_*`), so callers pass the tier and we resolve
+ * here on the server (WSM-000169/171). Returns null for a free/unknown tier or
+ * a plan whose price isn't configured in this environment.
+ */
+export function resolvePriceId(tier: unknown, interval: unknown): string | null {
+  if (typeof tier !== "string" || !TIER_ORDER.includes(tier as Tier)) {
+    return null;
+  }
+  if (tier === "free") return null;
+  const billing: BillingInterval = interval === "yearly" ? "yearly" : "monthly";
+  const config = TIER_CONFIGS[tier as Tier];
+  return billing === "yearly" ? config.yearlyPriceId : config.monthlyPriceId;
+}


### PR DESCRIPTION
Closes #391 · completes the funnel from #389 (WSM-000169)

## What
A marketing **"Upgrade to <tier>"** click now carries through sign-up **into Stripe checkout**, instead of dropping the coach in the app to re-pick the plan.

Flow: pricing CTA → `/sign-up?plan=plus&interval=monthly` → sign up → Clerk `forceRedirectUrl` → `GET /checkout/start?plan=plus&interval=monthly` (now authed) → Stripe Checkout.

## Changes
- **`GET /checkout/start`** — authed route; resolves the price server-side and redirects to a Checkout session. Missing/invalid plan → `/dashboard/billing` (no dead-end). Unauth hits are caught by Clerk middleware (preserves the full intent via `redirect_url`); a defensive `/sign-up` fallback also exists in the handler.
- **Sign-up page** reads `plan`/`interval` and sets `<SignUp forceRedirectUrl=… fallbackRedirectUrl=… />`.
- **Extracted** `resolvePriceId` (`lib/tiers`) + `createSubscriptionCheckoutUrl` (`lib/stripe-checkout`); `POST /api/stripe/checkout` now shares both — one implementation, no drift.

## Tests / verification
- New `resolvePriceId` unit tests: rejects free/unknown/non-string tiers; resolves tier+interval; defaults odd interval to monthly. **637 pass**, tsc + eslint clean.
- Local: `/checkout/start?plan=plus` unauth → redirect preserving `plan`/`interval`; `/sign-up?plan=plus` renders 200. (Full signup→Stripe e2e needs live Clerk + Stripe.)

Web-only — no Convex deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)