### PR TITLE
fix(web): toasts follow the app theme (light/dark) (WSM-000172)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Toaster } from "sonner";
+import { AppToaster } from "@/components/app-toaster";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
@@ -86,7 +86,7 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             {children}
-            <Toaster position="bottom-right" richColors closeButton />
+            <AppToaster />
           </ThemeProvider>
           <Analytics />
           <SpeedInsights />

--- a/apps/web/src/components/app-toaster.tsx
+++ b/apps/web/src/components/app-toaster.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Toaster } from "sonner";
+import { useTheme } from "next-themes";
+
+/**
+ * Toaster wired to the app theme (WSM-000172).
+ *
+ * sonner's bare `<Toaster>` defaults to the light theme, so toasts rendered
+ * light even in dark mode once the app moved to a system-default theme (design
+ * system, WSM-000166). Pass next-themes' `resolvedTheme` so toasts track
+ * light/dark — including the manual top-bar toggle. Must render inside
+ * `ThemeProvider` (it reads the theme via `useTheme`).
+ */
+export function AppToaster() {
+  const { resolvedTheme } = useTheme();
+  return (
+    <Toaster
+      theme={resolvedTheme === "dark" ? "dark" : "light"}
+      position="bottom-right"
+      richColors
+      closeButton
+    />
+  );
+}


### PR DESCRIPTION
The design-system cutover (#381) moved the app to a **system-default theme**, but the bare sonner `<Toaster>` had no theme wired — so it defaulted to light and **toasts rendered light even in dark mode**.

Adds `AppToaster` (client) that passes `next-themes`' `resolvedTheme` to `<Toaster theme>`, so toasts track light/dark — including the manual top-bar toggle. Rendered inside `ThemeProvider`.

Completes the substance of the deferred design 'feedback' polish.

Verified: tsc clean · eslint clean · vitest **637 passed** · build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)