### PR TITLE
feat(web): generate synthetic rosters (per team / league-wide) (WSM-000173)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1513,6 +1513,52 @@ export const createPlayer = internalMutationGeneric({
   },
 });
 
+// Bulk-insert synthetic players for a team (WSM-000173). Thin insert loop —
+// the realistic data is generated in the web layer (lib/synthetic-roster) and
+// passed in; this just persists. Mirrors createPlayer's insert shape.
+export const bulkCreatePlayers = internalMutationGeneric({
+  args: {
+    teamId: v.id("teams"),
+    players: v.array(
+      v.object({
+        name: v.string(),
+        position: v.string(),
+        jerseyNumber: v.union(v.number(), v.null()),
+        status: v.string(),
+        grade: v.optional(v.union(v.number(), v.null())),
+        squad: v.optional(v.union(v.string(), v.null())),
+        dateOfBirth: v.optional(v.union(v.string(), v.null())),
+      }),
+    ),
+  },
+  returns: v.object({ created: v.number() }),
+  handler: async (ctx, args) => {
+    const team = await ctx.db.get(args.teamId);
+    if (!team) {
+      throw new Error("Team not found");
+    }
+    let created = 0;
+    for (const p of args.players) {
+      await ctx.db.insert("players", {
+        name: p.name,
+        leagueId: team.leagueId,
+        teamId: args.teamId,
+        position: p.position,
+        positionGroup: null,
+        jerseyNumber: p.jerseyNumber,
+        dateOfBirth: p.dateOfBirth ?? null,
+        status: p.status,
+        headshotUrl: null,
+        experienceYears: null,
+        grade: p.grade ?? null,
+        squad: p.squad ?? null,
+      });
+      created += 1;
+    }
+    return { created };
+  },
+});
+
 export const updatePlayer = internalMutationGeneric({
   args: {
     playerId: v.id("players"),

--- a/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockFlag,
+  mockAuth,
+  mockCanManageTeam,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockGetPlayersByTeam,
+  mockGetTeamsByLeague,
+  mockGetLeagueOrgId,
+  mockBulkCreatePlayers,
+} = vi.hoisted(() => ({
+  mockFlag: vi.fn(),
+  mockAuth: vi.fn(),
+  mockCanManageTeam: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetPlayersByTeam: vi.fn(),
+  mockGetTeamsByLeague: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockBulkCreatePlayers: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ syntheticRostersV1: mockFlag }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getPlayersByTeam: mockGetPlayersByTeam,
+  getTeamsByLeague: mockGetTeamsByLeague,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  bulkCreatePlayers: mockBulkCreatePlayers,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+// @/lib/permissions (canManageOrgSettings) and @/lib/synthetic-roster are real.
+
+import {
+  generateTeamRosterAction,
+  generateLeagueRostersAction,
+} from "../synthetic-rosters";
+
+const TEAM = "team_1";
+const LEAGUE = "league_1";
+const ORG = "org_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFlag.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE], orgIds: [ORG] });
+});
+
+describe("generateTeamRosterAction", () => {
+  beforeEach(() => {
+    mockCanManageTeam.mockResolvedValue(true);
+    mockGetPlayersByTeam.mockResolvedValue([]); // empty team
+    mockBulkCreatePlayers.mockResolvedValue({ created: 48 });
+  });
+
+  it("blocks when the flag is off", async () => {
+    mockFlag.mockResolvedValue(false);
+    expect(await generateTeamRosterAction({ teamId: TEAM })).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("blocks an unauthenticated caller", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    expect(await generateTeamRosterAction({ teamId: TEAM })).toEqual({ ok: false, error: "unauthorized" });
+  });
+
+  it("rejects a caller who can't manage the team", async () => {
+    mockCanManageTeam.mockResolvedValue(false);
+    expect(await generateTeamRosterAction({ teamId: TEAM })).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("generates a full roster onto an empty team", async () => {
+    const res = await generateTeamRosterAction({ teamId: TEAM });
+    expect(res).toEqual({ ok: true, created: 48 });
+    // bulkCreatePlayers called with teamId + 48 generated players.
+    const [teamId, players] = mockBulkCreatePlayers.mock.calls[0];
+    expect(teamId).toBe(TEAM);
+    expect(players).toHaveLength(48);
+    expect(players[0]).toHaveProperty("position");
+    expect(players[0]).toHaveProperty("jerseyNumber");
+  });
+
+  it("fills to count (creates nothing when already full)", async () => {
+    mockGetPlayersByTeam.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => ({ jerseyNumber: i })),
+    );
+    const res = await generateTeamRosterAction({ teamId: TEAM, count: 48 });
+    expect(res).toEqual({ ok: true, created: 0 });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateLeagueRostersAction", () => {
+  beforeEach(() => {
+    mockGetLeagueOrgId.mockResolvedValue(ORG);
+    mockResolveOrgRole.mockResolvedValue("admin");
+    mockGetTeamsByLeague.mockResolvedValue([{ id: "t1" }, { id: "t2" }]);
+    mockGetPlayersByTeam.mockResolvedValue([]);
+    mockBulkCreatePlayers.mockResolvedValue({ created: 48 });
+  });
+
+  it("is admin-only (coach rejected)", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    expect(await generateLeagueRostersAction({ leagueId: LEAGUE })).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the flag is off", async () => {
+    mockFlag.mockResolvedValue(false);
+    expect(await generateLeagueRostersAction({ leagueId: LEAGUE })).toEqual({ ok: false, error: "flag_disabled" });
+  });
+
+  it("fills every team and aggregates the counts", async () => {
+    const res = await generateLeagueRostersAction({ leagueId: LEAGUE });
+    expect(res).toEqual({ ok: true, teams: 2, created: 96 });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { syntheticRostersV1 } from "@/lib/flags";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  getPlayersByTeam,
+  getTeamsByLeague,
+  getLeagueOrgId,
+  bulkCreatePlayers,
+} from "@/lib/data-api";
+import {
+  generateSyntheticRoster,
+  seedFromString,
+} from "@/lib/synthetic-roster";
+
+/*
+ * Synthetic-roster generation (WSM-000173) — fills demo/test rosters with fake
+ * players. Per team (coach/admin) or league-wide (admin only). "Fill to count":
+ * generates only `count - existing` players, so re-running tops up rather than
+ * piling on. Gated by the syntheticRostersV1 flag. Players are clearly fake
+ * (the generator never uses real data).
+ */
+
+const DEFAULT_ROSTER_SIZE = 48;
+const MAX_ROSTER_SIZE = 60;
+
+type TeamResult = { ok: true; created: number } | { ok: false; error: string };
+type LeagueResult =
+  | { ok: true; teams: number; created: number }
+  | { ok: false; error: string };
+
+function existingJerseys(players: { jerseyNumber: number | null }[]): number[] {
+  return players.map((p) => p.jerseyNumber).filter((n): n is number => n != null);
+}
+
+export async function generateTeamRosterAction(input: {
+  teamId: string;
+  count?: number;
+}): Promise<TeamResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  const target = Math.max(1, Math.min(input.count ?? DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE));
+  const orgContext = await resolveOrgContext(userId);
+  const existing = await getPlayersByTeam(input.teamId, orgContext).catch(() => []);
+  const toCreate = Math.max(0, target - existing.length);
+  if (toCreate === 0) return { ok: true, created: 0 };
+
+  const players = generateSyntheticRoster({
+    count: toCreate,
+    excludeJerseys: existingJerseys(existing),
+    seed: seedFromString(input.teamId) + existing.length,
+  });
+  try {
+    const { created } = await bulkCreatePlayers(input.teamId, players);
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    return { ok: true, created };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function generateLeagueRostersAction(input: {
+  leagueId: string;
+  perTeam?: number;
+}): Promise<LeagueResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  // League-wide generation is an admin-only operation.
+  const orgId = await getLeagueOrgId(input.leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
+
+  const target = Math.max(1, Math.min(input.perTeam ?? DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE));
+  const orgContext = await resolveOrgContext(userId);
+  const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+
+  let created = 0;
+  let touched = 0;
+  try {
+    for (const team of teams) {
+      const existing = await getPlayersByTeam(team.id, orgContext).catch(() => []);
+      const toCreate = Math.max(0, target - existing.length);
+      if (toCreate === 0) continue;
+      const players = generateSyntheticRoster({
+        count: toCreate,
+        excludeJerseys: existingJerseys(existing),
+        seed: seedFromString(team.id),
+      });
+      const res = await bulkCreatePlayers(team.id, players);
+      created += res.created;
+      touched += 1;
+    }
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    return { ok: true, teams: touched, created };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -16,6 +16,8 @@ import InviteLinkSection from "./invite-link-section";
 import LeaguePublicToggle from "./league-public-toggle";
 import LeagueClaimableToggle from "./league-claimable-toggle";
 import { RenameLeagueForm, DeleteLeagueButton } from "../leagues-actions";
+import { syntheticRostersV1 } from "@/lib/flags";
+import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 
 export default async function LeagueDetailPage({
   params,
@@ -41,6 +43,9 @@ export default async function LeagueDetailPage({
       // Not admin — read-only view
     }
   }
+
+  // WSM-000173: league-wide synthetic-roster generation — admins only, flagged.
+  const canGenerateRosters = isAdmin && (await syntheticRostersV1());
 
   return (
     <div>
@@ -90,6 +95,18 @@ export default async function LeagueDetailPage({
                 initialClaimable={claimable}
                 isPublic={visibility?.isPublic ?? false}
               />
+              {canGenerateRosters && (
+                <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
+                  <div className="min-w-0">
+                    <p className="text-label-14 text-foreground">Synthetic rosters</p>
+                    <p className="text-caption-12 text-text-muted">
+                      Fill every team in this league with fake test players (~48
+                      each) for demos. Not real people.
+                    </p>
+                  </div>
+                  <SyntheticRosterButton kind="league" id={id} />
+                </div>
+              )}
               <div className="flex flex-wrap gap-x-4 gap-y-2">
                 <Link
                   href={`/dashboard/leagues/${id}/members`}

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam, canAdministerTeam } from "@/lib/authorization";
-import { playerAttributesV1 } from "@/lib/flags";
+import { playerAttributesV1, syntheticRostersV1 } from "@/lib/flags";
 import type { PlayerSnapshot } from "@/lib/attributes/headline-columns";
 import TeamManagement from "./team-management";
 import { ClaimTeamButton } from "./claim-team-button";
@@ -55,6 +55,9 @@ export default async function TeamDetailPage({
   if (!canManage) {
     offerFork = await getLeagueClaimable(team.leagueId).catch(() => false);
   }
+
+  // WSM-000173: synthetic-roster generation — managers only, behind the flag.
+  const canGenerateRoster = canManage && (await syntheticRostersV1());
 
   // WSM-000090: attribute snapshots feed the SPRT stat columns. Phase 2-gated;
   // the season is resolved server-side — including workspace forks, which read
@@ -101,6 +104,7 @@ export default async function TeamDetailPage({
         players={players}
         canManage={canManage}
         canDelete={canDelete}
+        canGenerateRoster={canGenerateRoster}
         attributeSnapshots={Object.fromEntries(snapshots)}
         maddenOveralls={Object.fromEntries(maddenOveralls)}
       />

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -9,6 +9,7 @@ import DeleteConfirm from "../../_components/delete-confirm";
 import { DataTable, type Column } from "@/components/data-table";
 import { PositionGroupTabs } from "@/components/roster/PositionGroupTabs";
 import { RosterStatusIndicator } from "@/components/roster/RosterStatusIndicator";
+import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { orderByDepth } from "@/lib/roster/depth-order";
 import { abbreviateName } from "@/lib/position-group";
 import {
@@ -29,6 +30,8 @@ interface TeamManagementProps {
   canManage: boolean;
   /** Admin only: remove the whole team (WSM-000121). */
   canDelete?: boolean;
+  /** WSM-000173: show the "Generate roster" (synthetic players) action. */
+  canGenerateRoster?: boolean;
   /** WSM-000090: playerId → attribute snapshot; empty when Phase 2 is
       dark or the season has no ingested attributes. */
   attributeSnapshots?: Record<string, PlayerSnapshot>;
@@ -49,6 +52,7 @@ export default function TeamManagement({
   players,
   canManage,
   canDelete = false,
+  canGenerateRoster = false,
   attributeSnapshots = {},
   maddenOveralls = {},
 }: TeamManagementProps) {
@@ -336,9 +340,14 @@ export default function TeamManagement({
           Player Roster ({players.length})
         </h3>
         {canManage && (
-          <Button onClick={() => setModal({ type: "addPlayer" })}>
-            Add Player
-          </Button>
+          <div className="flex items-center gap-2">
+            {canGenerateRoster && (
+              <SyntheticRosterButton kind="team" id={team.id} />
+            )}
+            <Button onClick={() => setModal({ type: "addPlayer" })}>
+              Add Player
+            </Button>
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  generateTeamRosterAction,
+  generateLeagueRostersAction,
+} from "@/app/dashboard/_actions/synthetic-rosters";
+
+/*
+ * Generate synthetic (fake) players to populate a roster for testing/demos
+ * (WSM-000173). `team` fills one team; `league` fills every team in the league
+ * (admin-only). Clearly labels the data as synthetic so it's never mistaken for
+ * real entries. Gated upstream by the syntheticRostersV1 flag (the parent only
+ * renders this when the flag is on and the role allows it).
+ */
+interface SyntheticRosterButtonProps {
+  kind: "team" | "league";
+  id: string;
+}
+
+export function SyntheticRosterButton({ kind, id }: SyntheticRosterButtonProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run() {
+    const confirmMsg =
+      kind === "team"
+        ? "Generate a synthetic (fake) roster for this team? These are test players, not real people."
+        : "Generate synthetic (fake) rosters for ALL teams in this league? These are test players, not real people.";
+    if (!window.confirm(confirmMsg)) return;
+
+    start(async () => {
+      if (kind === "team") {
+        const res = await generateTeamRosterAction({ teamId: id });
+        if (res.ok) {
+          toast.success(
+            res.created === 0
+              ? "Roster already full — nothing to add."
+              : `Added ${res.created} synthetic player${res.created === 1 ? "" : "s"}.`,
+          );
+          router.refresh();
+        } else {
+          toast.error(errorLabel(res.error));
+        }
+      } else {
+        const res = await generateLeagueRostersAction({ leagueId: id });
+        if (res.ok) {
+          toast.success(
+            res.created === 0
+              ? "All rosters already full — nothing to add."
+              : `Added ${res.created} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+          );
+          router.refresh();
+        } else {
+          toast.error(errorLabel(res.error));
+        }
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={run}
+      title="Generate fake players to populate this roster for testing/demos"
+    >
+      <Sparkles className="mr-1 h-4 w-4" />
+      {pending
+        ? "Generating…"
+        : kind === "team"
+          ? "Generate roster"
+          : "Generate rosters"}
+    </Button>
+  );
+}
+
+function errorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Synthetic rosters aren't enabled.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "You don't have permission to do that.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/lib/__tests__/synthetic-roster.test.ts
+++ b/apps/web/src/lib/__tests__/synthetic-roster.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateSyntheticRoster,
+  seedFromString,
+} from "../synthetic-roster";
+
+describe("generateSyntheticRoster", () => {
+  it("generates exactly `count` players", () => {
+    expect(generateSyntheticRoster({ count: 48, seed: 1 })).toHaveLength(48);
+    expect(generateSyntheticRoster({ count: 12, seed: 1 })).toHaveLength(12);
+    expect(generateSyntheticRoster({ count: 0, seed: 1 })).toHaveLength(0);
+  });
+
+  it("is deterministic for a given seed", () => {
+    const a = generateSyntheticRoster({ count: 24, seed: 42 });
+    const b = generateSyntheticRoster({ count: 24, seed: 42 });
+    expect(a).toEqual(b);
+  });
+
+  it("varies with the seed", () => {
+    const a = generateSyntheticRoster({ count: 24, seed: 1 });
+    const b = generateSyntheticRoster({ count: 24, seed: 2 });
+    expect(a).not.toEqual(b);
+  });
+
+  it("assigns unique jersey numbers and avoids excluded ones", () => {
+    const exclude = [1, 2, 3, 7, 12];
+    const roster = generateSyntheticRoster({ count: 40, excludeJerseys: exclude, seed: 9 });
+    const jerseys = roster.map((p) => p.jerseyNumber);
+    expect(new Set(jerseys).size).toBe(jerseys.length); // all unique
+    for (const e of exclude) expect(jerseys).not.toContain(e); // none excluded
+    for (const j of jerseys) expect(j).toBeGreaterThanOrEqual(0);
+    for (const j of jerseys) expect(j).toBeLessThanOrEqual(99);
+  });
+
+  it("produces unique names within a batch", () => {
+    const roster = generateSyntheticRoster({ count: 48, seed: 5 });
+    const names = roster.map((p) => p.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("gives a believable position spread (not all one position)", () => {
+    const roster = generateSyntheticRoster({ count: 48, seed: 3 });
+    const positions = new Set(roster.map((p) => p.position));
+    expect(positions.size).toBeGreaterThan(8); // many distinct positions
+    expect(roster.some((p) => p.position === "QB")).toBe(true);
+    expect(roster.some((p) => p.position === "K")).toBe(true);
+  });
+
+  it("uses HS grades 9–12 and active status", () => {
+    const roster = generateSyntheticRoster({ count: 30, seed: 7 });
+    for (const p of roster) {
+      expect(p.grade).toBeGreaterThanOrEqual(9);
+      expect(p.grade).toBeLessThanOrEqual(12);
+      expect(p.status).toBe("active");
+      expect(["Varsity", "JV"]).toContain(p.squad);
+    }
+  });
+});
+
+describe("seedFromString", () => {
+  it("is stable and varies by input", () => {
+    expect(seedFromString("team_abc")).toBe(seedFromString("team_abc"));
+    expect(seedFromString("team_abc")).not.toBe(seedFromString("team_xyz"));
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -316,6 +316,10 @@ const refs = {
     TeamDto | null
   >("sports:updateTeam"),
   createPlayer: mutationRef<CreatePlayerInput, PlayerDto>("sports:createPlayer"),
+  bulkCreatePlayers: mutationRef<
+    { teamId: string; players: BulkPlayerInput[] },
+    { created: number }
+  >("sports:bulkCreatePlayers"),
   updatePlayer: mutationRef<
     { playerId: string } & UpdatePlayerInput,
     PlayerDto | null
@@ -1120,6 +1124,24 @@ export async function getSeason(
 
 export async function createPlayer(input: CreatePlayerInput): Promise<PlayerDto> {
   return mutateConvex(refs.createPlayer, input);
+}
+
+/** A synthetic player row for bulk insert (WSM-000173). */
+export interface BulkPlayerInput {
+  name: string;
+  position: string;
+  jerseyNumber: number | null;
+  status: string;
+  grade?: number | null;
+  squad?: string | null;
+  dateOfBirth?: string | null;
+}
+
+export async function bulkCreatePlayers(
+  teamId: string,
+  players: BulkPlayerInput[],
+): Promise<{ created: number }> {
+  return mutateConvex(refs.bulkCreatePlayers, { teamId, players });
 }
 
 export async function updatePlayer(

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -137,6 +137,22 @@ export const liveScoringV1 = flag<boolean>({
   },
 });
 
+export const syntheticRostersV1 = flag<boolean>({
+  key: "synthetic_rosters_v1",
+  description:
+    "Generate synthetic (fake) players to populate demo/test rosters — per team or league-wide (WSM-000173). Enabled in prod for demo leagues.",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_SYNTHETIC_ROSTERS_V1");
+    void trackFlagExposure("synthetic_rosters_v1", enabled);
+    return enabled;
+  },
+});
+
 export const playoffsV1 = flag<boolean>({
   key: "playoffs_v1",
   description:

--- a/apps/web/src/lib/synthetic-roster.ts
+++ b/apps/web/src/lib/synthetic-roster.ts
@@ -1,0 +1,122 @@
+/*
+ * Synthetic roster generator (WSM-000173).
+ *
+ * Produces realistic-but-fake football players to populate demo/test rosters —
+ * never real player data (HS players are minors; the product fills rosters from
+ * coaches, not scraping). Pure + deterministic given a seed, so it's
+ * unit-testable and re-running a team yields stable output.
+ *
+ * A full ~48-man roster follows a believable position spread (QB→K/P). Jersey
+ * numbers are unique within the batch and avoid any the team already uses.
+ */
+
+export interface SyntheticPlayer {
+  name: string;
+  position: string;
+  jerseyNumber: number;
+  grade: number; // 9–12 (US high school)
+  squad: string; // "Varsity" | "JV"
+  status: string; // "active"
+}
+
+// A believable 48-man depth spread (concrete positions, not groups).
+const ROSTER_TEMPLATE: readonly string[] = [
+  "QB", "QB", "QB",
+  "RB", "RB", "RB", "FB",
+  "WR", "WR", "WR", "WR", "WR", "WR",
+  "TE", "TE", "TE",
+  "LT", "LG", "C", "RG", "RT", "OL", "OL", "OL",
+  "DE", "DE", "DT", "DT", "NT", "DL", "DL",
+  "OLB", "OLB", "MLB", "ILB", "LB", "LB",
+  "CB", "CB", "S", "FS", "SS", "DB", "DB",
+  "K", "P", "LS", "ATH",
+];
+
+const FIRST_NAMES: readonly string[] = [
+  "Jalen", "Marcus", "Devin", "Tyler", "Cameron", "Isaiah", "Mason", "Elijah",
+  "Xavier", "Caleb", "Jordan", "Brayden", "Damari", "Zion", "Carter", "Trey",
+  "Malik", "Gavin", "Bryce", "Kaden", "Jaxon", "Amari", "Dominic", "Hunter",
+  "Micah", "Tristan", "Khalil", "Owen", "Cole", "Darius", "Landon", "Jamarcus",
+  "Reece", "Aiden", "Quentin", "Silas", "Roman", "Davion", "Beckham", "Tate",
+];
+
+const LAST_NAMES: readonly string[] = [
+  "Carter", "Brooks", "Hayes", "Coleman", "Reed", "Bennett", "Foster", "Bryant",
+  "Greer", "Mathis", "Dawson", "Pierce", "Ellison", "Holland", "Ferguson", "Sutton",
+  "Vance", "Whitfield", "Barlow", "Crawford", "Sterling", "Maddox", "Calloway", "Rhodes",
+  "Yates", "Beckett", "Lowery", "Tatum", "Goodwin", "Hampton", "Fields", "Mercer",
+  "Underwood", "Padgett", "Larkin", "Easton", "Boone", "Cross", "Maxwell", "Vaughn",
+];
+
+/** mulberry32 — tiny deterministic PRNG so generation is seedable + testable. */
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Stable 32-bit hash of a string — used to seed generation from a team id. */
+export function seedFromString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export interface GenerateOptions {
+  count: number;
+  /** Jersey numbers already used on the team — never reused. */
+  excludeJerseys?: number[];
+  /** Seed for deterministic output (e.g. seedFromString(teamId)). */
+  seed?: number;
+}
+
+export function generateSyntheticRoster({
+  count,
+  excludeJerseys = [],
+  seed = 1,
+}: GenerateOptions): SyntheticPlayer[] {
+  const n = Math.max(0, Math.min(count, 99)); // cap at a sane jersey-bound size
+  const rand = rng(seed);
+  const used = new Set<number>(excludeJerseys);
+  const usedNames = new Set<string>();
+  const players: SyntheticPlayer[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const position =
+      ROSTER_TEMPLATE[i % ROSTER_TEMPLATE.length] ?? "ATH";
+
+    // Unique jersey 0–99 not already taken.
+    let jersey = Math.floor(rand() * 100);
+    let guard = 0;
+    while (used.has(jersey) && guard < 200) {
+      jersey = (jersey + 1) % 100;
+      guard++;
+    }
+    used.add(jersey);
+
+    // Unique name within the batch.
+    let name = `${FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)]} ${LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)]}`;
+    let nameGuard = 0;
+    while (usedNames.has(name) && nameGuard < 200) {
+      name = `${FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)]} ${LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)]}`;
+      nameGuard++;
+    }
+    usedNames.add(name);
+
+    const grade = 9 + Math.floor(rand() * 4); // 9–12
+    // Upperclassmen lean varsity; underclassmen lean JV — just a believable mix.
+    const squad = grade >= 11 ? "Varsity" : rand() < 0.5 ? "Varsity" : "JV";
+
+    players.push({ name, position, jerseyNumber: jersey, grade, squad, status: "active" });
+  }
+
+  return players;
+}


### PR DESCRIPTION
Lets managers **populate demo/test rosters with realistic fake players** — never real data (HS players are minors; real rosters come from coaches). Requested to be available in **prod** for demo leagues.

### What you get
- **Per-team** "Generate roster" button (team page, coach/admin) → fills that team.
- **League-wide** "Generate rosters" button (league page, **admin only**) → fills every team.
- **Fill-to-count**: generates `count − existing` (~48 target), so re-running tops up rather than duplicating. Re-running a full roster adds nothing.
- Players are **clearly labeled synthetic** in the UI + confirm dialog ("test players, not real people").

### How it's built
- `lib/synthetic-roster.ts` — pure, **seeded** generator: believable 48-man position spread (QB→K/P), unique jerseys (avoids existing), unique names, HS grades 9–12, Varsity/JV. Deterministic → unit-tested.
- `convex/sports.ts` `bulkCreatePlayers` (internalMutationGeneric, admin-keyed) — thin bulk insert mirroring `createPlayer`.
- `_actions/synthetic-rosters.ts` — `generateTeamRosterAction` (`canManageTeam`) + `generateLeagueRostersAction` (admin-only), behind the `syntheticRostersV1` flag.
- `SyntheticRosterButton` wired into team-management + league page.

### Flag / prod
`syntheticRostersV1` defaults on outside prod; I'll set `FLAG_SYNTHETIC_ROSTERS_V1=on` in prod on deploy so it's live there too (with a kill-switch).

### Verification
tsc clean · eslint clean · **vitest 653 passed** (generator + action authz tests, internal-write backstop) · build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)