### PR TITLE
feat(web): clear synthetic players (per team / league-wide) (WSM-000173)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -108,6 +108,10 @@ export default defineSchema({
     // player it was forked from — SPRT/Madden ratings resolve through it so
     // they stay live without duplicating the rating pipeline per org.
     sourcePlayerId: v.optional(v.id("players")),
+    // WSM-000173: marks players created by the synthetic-roster generator, so
+    // the "clear synthetic" action only ever deletes generated test players,
+    // never real entries. Absent/false on all real players.
+    synthetic: v.optional(v.boolean()),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_teamId", ["teamId"])

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1552,10 +1552,32 @@ export const bulkCreatePlayers = internalMutationGeneric({
         experienceYears: null,
         grade: p.grade ?? null,
         squad: p.squad ?? null,
+        synthetic: true,
       });
       created += 1;
     }
     return { created };
+  },
+});
+
+// Delete the synthetic (generator-created) players on a team (WSM-000173).
+// Only rows flagged `synthetic` are removed — real players are never touched.
+export const clearSyntheticPlayers = internalMutationGeneric({
+  args: { teamId: v.id("teams") },
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx, args) => {
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    let deleted = 0;
+    for (const p of players) {
+      if (p.synthetic === true) {
+        await ctx.db.delete(p._id);
+        deleted += 1;
+      }
+    }
+    return { deleted };
   },
 });
 

--- a/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetTeamsByLeague,
   mockGetLeagueOrgId,
   mockBulkCreatePlayers,
+  mockClearSyntheticPlayers,
 } = vi.hoisted(() => ({
   mockFlag: vi.fn(),
   mockAuth: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockGetTeamsByLeague: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
   mockBulkCreatePlayers: vi.fn(),
+  mockClearSyntheticPlayers: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({ syntheticRostersV1: mockFlag }));
@@ -34,6 +36,7 @@ vi.mock("@/lib/data-api", () => ({
   getTeamsByLeague: mockGetTeamsByLeague,
   getLeagueOrgId: mockGetLeagueOrgId,
   bulkCreatePlayers: mockBulkCreatePlayers,
+  clearSyntheticPlayers: mockClearSyntheticPlayers,
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 // @/lib/permissions (canManageOrgSettings) and @/lib/synthetic-roster are real.
@@ -41,6 +44,8 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 import {
   generateTeamRosterAction,
   generateLeagueRostersAction,
+  clearTeamSyntheticAction,
+  clearLeagueSyntheticAction,
 } from "../synthetic-rosters";
 
 const TEAM = "team_1";
@@ -123,5 +128,51 @@ describe("generateLeagueRostersAction", () => {
     const res = await generateLeagueRostersAction({ leagueId: LEAGUE });
     expect(res).toEqual({ ok: true, teams: 2, created: 96 });
     expect(mockBulkCreatePlayers).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clearTeamSyntheticAction", () => {
+  beforeEach(() => {
+    mockCanManageTeam.mockResolvedValue(true);
+    mockClearSyntheticPlayers.mockResolvedValue({ deleted: 48 });
+  });
+
+  it("blocks when the flag is off", async () => {
+    mockFlag.mockResolvedValue(false);
+    expect(await clearTeamSyntheticAction({ teamId: TEAM })).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockClearSyntheticPlayers).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller who can't manage the team", async () => {
+    mockCanManageTeam.mockResolvedValue(false);
+    expect(await clearTeamSyntheticAction({ teamId: TEAM })).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockClearSyntheticPlayers).not.toHaveBeenCalled();
+  });
+
+  it("deletes synthetic players on the team", async () => {
+    const res = await clearTeamSyntheticAction({ teamId: TEAM });
+    expect(res).toEqual({ ok: true, deleted: 48 });
+    expect(mockClearSyntheticPlayers).toHaveBeenCalledWith(TEAM);
+  });
+});
+
+describe("clearLeagueSyntheticAction", () => {
+  beforeEach(() => {
+    mockGetLeagueOrgId.mockResolvedValue(ORG);
+    mockResolveOrgRole.mockResolvedValue("admin");
+    mockGetTeamsByLeague.mockResolvedValue([{ id: "t1" }, { id: "t2" }]);
+    mockClearSyntheticPlayers.mockResolvedValue({ deleted: 10 });
+  });
+
+  it("is admin-only (coach rejected)", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    expect(await clearLeagueSyntheticAction({ leagueId: LEAGUE })).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockClearSyntheticPlayers).not.toHaveBeenCalled();
+  });
+
+  it("clears every team and aggregates the deletions", async () => {
+    const res = await clearLeagueSyntheticAction({ leagueId: LEAGUE });
+    expect(res).toEqual({ ok: true, teams: 2, deleted: 20 });
+    expect(mockClearSyntheticPlayers).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -11,6 +11,7 @@ import {
   getTeamsByLeague,
   getLeagueOrgId,
   bulkCreatePlayers,
+  clearSyntheticPlayers,
 } from "@/lib/data-api";
 import {
   generateSyntheticRoster,
@@ -102,6 +103,55 @@ export async function generateLeagueRostersAction(input: {
     }
     revalidatePath(`/dashboard/leagues/${input.leagueId}`);
     return { ok: true, teams: touched, created };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// --- Clear synthetic players (delete generator-created test players only) ---
+
+export async function clearTeamSyntheticAction(input: {
+  teamId: string;
+}): Promise<{ ok: true; deleted: number } | { ok: false; error: string }> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+  try {
+    const { deleted } = await clearSyntheticPlayers(input.teamId);
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    return { ok: true, deleted };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function clearLeagueSyntheticAction(input: {
+  leagueId: string;
+}): Promise<
+  { ok: true; teams: number; deleted: number } | { ok: false; error: string }
+> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  const orgId = await getLeagueOrgId(input.leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+  let deleted = 0;
+  let touched = 0;
+  try {
+    for (const team of teams) {
+      const res = await clearSyntheticPlayers(team.id);
+      deleted += res.deleted;
+      if (res.deleted > 0) touched += 1;
+    }
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    return { ok: true, teams: touched, deleted };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -104,7 +104,10 @@ export default async function LeagueDetailPage({
                       each) for demos. Not real people.
                     </p>
                   </div>
-                  <SyntheticRosterButton kind="league" id={id} />
+                  <div className="flex items-center gap-2">
+                    <SyntheticRosterButton kind="league" id={id} />
+                    <SyntheticRosterButton kind="league" id={id} action="clear" />
+                  </div>
                 </div>
               )}
               <div className="flex flex-wrap gap-x-4 gap-y-2">

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -342,7 +342,10 @@ export default function TeamManagement({
         {canManage && (
           <div className="flex items-center gap-2">
             {canGenerateRoster && (
-              <SyntheticRosterButton kind="team" id={team.id} />
+              <>
+                <SyntheticRosterButton kind="team" id={team.id} />
+                <SyntheticRosterButton kind="team" id={team.id} action="clear" />
+              </>
             )}
             <Button onClick={() => setModal({ type: "addPlayer" })}>
               Add Player

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -3,83 +3,133 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   generateTeamRosterAction,
   generateLeagueRostersAction,
+  clearTeamSyntheticAction,
+  clearLeagueSyntheticAction,
 } from "@/app/dashboard/_actions/synthetic-rosters";
 
 /*
- * Generate synthetic (fake) players to populate a roster for testing/demos
- * (WSM-000173). `team` fills one team; `league` fills every team in the league
- * (admin-only). Clearly labels the data as synthetic so it's never mistaken for
- * real entries. Gated upstream by the syntheticRostersV1 flag (the parent only
- * renders this when the flag is on and the role allows it).
+ * Generate or clear synthetic (fake) players for testing/demos (WSM-000173).
+ * `team` acts on one team; `league` acts on every team (admin-only). Clear only
+ * ever deletes generator-created players (flagged `synthetic`), never real
+ * entries. Gated upstream by the syntheticRostersV1 flag + role (the parent
+ * only renders this when allowed).
  */
 interface SyntheticRosterButtonProps {
   kind: "team" | "league";
   id: string;
+  action?: "generate" | "clear";
 }
 
-export function SyntheticRosterButton({ kind, id }: SyntheticRosterButtonProps) {
+export function SyntheticRosterButton({
+  kind,
+  id,
+  action = "generate",
+}: SyntheticRosterButtonProps) {
   const router = useRouter();
   const [pending, start] = useTransition();
 
   function run() {
-    const confirmMsg =
-      kind === "team"
-        ? "Generate a synthetic (fake) roster for this team? These are test players, not real people."
-        : "Generate synthetic (fake) rosters for ALL teams in this league? These are test players, not real people.";
-    if (!window.confirm(confirmMsg)) return;
+    if (!window.confirm(CONFIRM[action][kind])) return;
 
     start(async () => {
-      if (kind === "team") {
+      if (action === "generate" && kind === "team") {
         const res = await generateTeamRosterAction({ teamId: id });
-        if (res.ok) {
-          toast.success(
-            res.created === 0
-              ? "Roster already full — nothing to add."
-              : `Added ${res.created} synthetic player${res.created === 1 ? "" : "s"}.`,
-          );
-          router.refresh();
-        } else {
+        if (!res.ok) {
           toast.error(errorLabel(res.error));
+          return;
         }
-      } else {
+        toast.success(
+          res.created === 0
+            ? "Roster already full — nothing to add."
+            : `Added ${res.created} synthetic player${res.created === 1 ? "" : "s"}.`,
+        );
+      } else if (action === "generate") {
         const res = await generateLeagueRostersAction({ leagueId: id });
-        if (res.ok) {
-          toast.success(
-            res.created === 0
-              ? "All rosters already full — nothing to add."
-              : `Added ${res.created} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
-          );
-          router.refresh();
-        } else {
+        if (!res.ok) {
           toast.error(errorLabel(res.error));
+          return;
         }
+        toast.success(
+          res.created === 0
+            ? "All rosters already full — nothing to add."
+            : `Added ${res.created} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        );
+      } else if (kind === "team") {
+        const res = await clearTeamSyntheticAction({ teamId: id });
+        if (!res.ok) {
+          toast.error(errorLabel(res.error));
+          return;
+        }
+        toast.success(
+          res.deleted === 0
+            ? "No synthetic players to remove."
+            : `Removed ${res.deleted} synthetic player${res.deleted === 1 ? "" : "s"}.`,
+        );
+      } else {
+        const res = await clearLeagueSyntheticAction({ leagueId: id });
+        if (!res.ok) {
+          toast.error(errorLabel(res.error));
+          return;
+        }
+        toast.success(
+          res.deleted === 0
+            ? "No synthetic players to remove."
+            : `Removed ${res.deleted} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        );
       }
+      router.refresh();
     });
   }
+
+  const isClear = action === "clear";
+  const Icon = isClear ? Trash2 : Sparkles;
+  const label = isClear
+    ? pending
+      ? "Clearing…"
+      : "Clear synthetic"
+    : pending
+      ? "Generating…"
+      : kind === "team"
+        ? "Generate roster"
+        : "Generate rosters";
 
   return (
     <Button
       type="button"
-      variant="outline"
+      variant={isClear ? "ghost" : "outline"}
       size="sm"
       disabled={pending}
       onClick={run}
-      title="Generate fake players to populate this roster for testing/demos"
+      className={isClear ? "text-destructive hover:text-destructive" : undefined}
+      title={
+        isClear
+          ? "Delete generated test players (keeps real players)"
+          : "Generate fake players to populate this roster for testing/demos"
+      }
     >
-      <Sparkles className="mr-1 h-4 w-4" />
-      {pending
-        ? "Generating…"
-        : kind === "team"
-          ? "Generate roster"
-          : "Generate rosters"}
+      <Icon className="mr-1 h-4 w-4" />
+      {label}
     </Button>
   );
 }
+
+const CONFIRM: Record<"generate" | "clear", Record<"team" | "league", string>> = {
+  generate: {
+    team: "Generate a synthetic (fake) roster for this team? These are test players, not real people.",
+    league:
+      "Generate synthetic (fake) rosters for ALL teams in this league? These are test players, not real people.",
+  },
+  clear: {
+    team: "Delete all synthetic (generated) players from this team? Real players are kept.",
+    league:
+      "Delete all synthetic (generated) players from EVERY team in this league? Real players are kept.",
+  },
+};
 
 function errorLabel(error: string): string {
   switch (error) {

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -320,6 +320,10 @@ const refs = {
     { teamId: string; players: BulkPlayerInput[] },
     { created: number }
   >("sports:bulkCreatePlayers"),
+  clearSyntheticPlayers: mutationRef<
+    { teamId: string },
+    { deleted: number }
+  >("sports:clearSyntheticPlayers"),
   updatePlayer: mutationRef<
     { playerId: string } & UpdatePlayerInput,
     PlayerDto | null
@@ -1142,6 +1146,12 @@ export async function bulkCreatePlayers(
   players: BulkPlayerInput[],
 ): Promise<{ created: number }> {
   return mutateConvex(refs.bulkCreatePlayers, { teamId, players });
+}
+
+export async function clearSyntheticPlayers(
+  teamId: string,
+): Promise<{ deleted: number }> {
+  return mutateConvex(refs.clearSyntheticPlayers, { teamId });
 }
 
 export async function updatePlayer(


### PR DESCRIPTION
Companion cleanup for synthetic rosters: deletes **only generator-created test players**, never real ones.

- **`players.synthetic`** flag (optional) marks generated players; `bulkCreatePlayers` sets it. Real players have it absent → never deleted.
- **`clearSyntheticPlayers`** Convex mutation (admin-keyed) deletes a team's synthetic players.
- Actions: **clearTeamSyntheticAction** (coach/admin) + **clearLeagueSyntheticAction** (admin-only), behind `syntheticRostersV1`.
- **"Clear synthetic"** button (trash icon, "real players are kept" confirm) beside the generate button on the team + league pages.

Forward-only (no synthetic players exist yet → no backfill). Touches Convex (schema + mutation) → needs a Convex deploy.

Verified: tsc clean · eslint clean · **vitest 658 passed** · build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)