### PR TITLE
chore(launch): Clerk prod-cutover runbook + launch-readiness gate (WSM-000168)

### DIFF
--- a/docs/launch/clerk-prod-cutover.md
+++ b/docs/launch/clerk-prod-cutover.md
@@ -1,0 +1,93 @@
+# Clerk production-instance cutover (WSM-000168 / #386)
+
+**Status: launch blocker.** Production currently initializes Clerk with a
+**development** instance (`pk_test_…` / `sk_test_…`, frontend API
+`present-mouse-98.clerk.accounts.dev`). Clerk dev instances have strict rate
+limits and are not for production — under real signup/login traffic, auth (the
+top of the funnel) will throttle or fail. Preview and Production share this one
+dev instance today.
+
+This cutover moves **Production** to a Clerk **production** instance. It's an
+ops task (Clerk dashboard + DNS + Vercel env) — most steps require a human in
+the Clerk dashboard. Verify each with the preflight at the end.
+
+## Prerequisites
+- Owner access to the Clerk dashboard and the DNS for `andrewsolomon.dev`.
+- Vercel CLI logged in (`vercel whoami`), linked to the `sprtsmng` project.
+- Google OAuth console access (the app offers Google sign-in).
+
+## Steps
+
+### 1. Create the Clerk production instance
+Clerk dashboard → the app → top-left instance switcher → **Production**. Clerk
+provisions a separate prod instance with its own `pk_live_…` / `sk_live_…` keys
+and **its own user pool** (dev users do NOT carry over).
+
+### 2. Add the domain + DNS
+In the prod instance → **Domains**, add `sprtsmng.andrewsolomon.dev`. Clerk lists
+**CNAME records** (typically `clerk`, `accounts`, plus `clkmail`/`clk._domainkey`
+mail records). Add them at the DNS provider for `andrewsolomon.dev` and wait for
+Clerk to show **Verified** (can take minutes to hours).
+
+### 3. Configure Google OAuth for prod
+In the prod instance → **SSO connections → Google**, supply production Google
+OAuth client credentials and add Clerk's prod redirect URL to the Google console
+(the dev OAuth client won't work against the prod instance).
+
+### 4. Confirm sign-in methods
+Prod instance → **User & Authentication → Email/Password** — ensure password
+(and/or email-code) is enabled, matching the dev instance, so existing flows and
+the seeded test users work.
+
+### 5. Swap the Vercel Production env vars
+Copy the prod **publishable** + **secret** keys, then overwrite the Production
+env (they currently hold `pk_test_`/`sk_test_`):
+
+```bash
+cd apps/web   # repo root works too; project is linked
+vercel env rm NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY production --yes
+printf 'pk_live_XXXX' | vercel env add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY production
+vercel env rm CLERK_SECRET_KEY production --yes
+printf 'sk_live_XXXX' | vercel env add CLERK_SECRET_KEY production
+```
+
+Leave **Preview** on the dev instance (preview/local keep using `pk_test_`).
+
+### 6. Redeploy production
+Deploy web from the repo root (the prod domain auto-assigns to the latest):
+
+```bash
+vercel --prod --yes
+```
+
+### 7. Re-seed the test users onto the prod instance (optional)
+The prod instance has an empty user pool. To recreate the role test users there,
+run the seed against the **live** secret key:
+
+```bash
+CLERK_SECRET_KEY=sk_live_XXXX \
+NEXT_PUBLIC_CONVEX_URL=https://terrific-aardvark-395.convex.cloud \
+CONVEX_ADMIN_KEY=<prod deploy key> \
+npx tsx apps/web/scripts/seed-test-users.mts --write
+```
+
+(Org + league names are tagged `(live)` so they don't collide with the existing
+`(dev)` ones in the shared Convex.)
+
+## Verify
+1. **Preflight gate** — must pass:
+   ```bash
+   pnpm run check:launch
+   ```
+   It pulls the Production env and asserts both Clerk keys are `pk_live_`/`sk_live_`
+   (exits non-zero with this runbook's pointer if not).
+2. **No dev-keys console warning** — load `https://sprtsmng.andrewsolomon.dev`,
+   open the console; the "Clerk has been loaded with development keys" warning
+   must be **gone**.
+3. **Sign in** as a test user (or a real account) against the live instance.
+
+Once `check:launch` passes and the console warning is gone, #386 is resolved.
+
+## Rollback
+If sign-in breaks, restore the dev keys in Vercel Production (re-add the
+`pk_test_`/`sk_test_` values) and redeploy — the dev instance is unchanged.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "create-scratch-org": "node scripts/create-scratch-org.js",
     "seed-data": "node scripts/seed-data.js",
     "check:css": "node scripts/check-css-comments.mjs",
+    "check:env": "node scripts/check-web-env-parity.js",
+    "check:launch": "node scripts/check-web-env-parity.js --launch",
     "tui": "pnpm --filter @sports-management/tui dev",
     "test": "pnpm run test:unit",
     "test:unit": "sf force lightning lwc test run",

--- a/scripts/check-web-env-parity.js
+++ b/scripts/check-web-env-parity.js
@@ -14,6 +14,11 @@ const tempEnvPath = path.join(
   `sprtsmng-vercel-prod-${Date.now()}.env`,
 );
 
+// `--launch` turns the prod Clerk-key identity marker into a hard launch gate:
+// production must be on pk_live_/sk_live_ (WSM-000168 / #386). Off by default so
+// normal parity runs are unaffected pre-launch.
+const LAUNCH = process.argv.includes("--launch");
+
 const KEYS_TO_COMPARE = [
   "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
   "CLERK_SECRET_KEY",
@@ -184,8 +189,28 @@ function main() {
       return localValue !== productionValue;
     });
 
+    let launchFailed = false;
+    if (LAUNCH) {
+      const prodClerk = clerkKeyType(
+        normalizeValue(productionEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY),
+      );
+      const prodSecret = clerkKeyType(normalizeValue(productionEnv.CLERK_SECRET_KEY));
+      if (prodClerk === "live" && prodSecret === "live") {
+        console.log("\nLaunch readiness: production Clerk is LIVE ✓");
+      } else {
+        launchFailed = true;
+        console.error(
+          `\nLaunch readiness FAILED — production is on Clerk ${prodClerk}/${prodSecret} keys (need pk_live_ / sk_live_).\n` +
+            "Clerk development instances rate-limit and are not for production (WSM-000168 / #386).\n" +
+            "Cut over per docs/launch/clerk-prod-cutover.md, then re-run: pnpm run check:launch",
+        );
+      }
+    }
+
     if (hasDrift) {
-      console.error("\nEnv parity check failed.");
+      console.error("\nEnv parity check failed (drift).");
+    }
+    if (hasDrift || launchFailed) {
       process.exit(1);
     }
 


### PR DESCRIPTION
Advances the **#386 P0** (production runs Clerk *development* keys) as far as possible without the Clerk dashboard.

- **Runbook** `docs/launch/clerk-prod-cutover.md` — exact ops steps (create prod instance, DNS CNAMEs, Google OAuth, swap Vercel env with copy-paste commands, redeploy, re-seed test users against the live key) + verification + rollback.
- **Launch gate** — `--launch` mode on `check-web-env-parity.js` turns the existing prod-Clerk identity marker into a hard gate: **fails (exit 1) when prod isn't on `pk_live_`/`sk_live_`**, pointing at the runbook. Wired as `pnpm run check:launch` (+ `check:env`). Default parity behavior unchanged.

I first-hand confirmed prod is on the dev instance (`present-mouse-98…`, `pk_test_/sk_test_`) during the test-user work. The gate correctly **fails today** and will pass once the cutover lands. The cutover clicks themselves still need you (Clerk dashboard + DNS).

Docs/script/package.json only — no app or Convex change, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)