### PR TITLE
feat(web): player hometown field + DOB/hometown on synthetic rosters (WSM-000174)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -104,6 +104,8 @@ export default defineSchema({
     // grade: 9–12; squad: "Varsity" | "JV" | "Freshman".
     grade: v.optional(v.union(v.number(), v.null())),
     squad: v.optional(v.union(v.string(), v.null())),
+    // Free-text player hometown, e.g. "Acworth, GA" (WSM-000174).
+    hometown: v.optional(v.union(v.string(), v.null())),
     // Org workspace (WSM-000114): a workspace player's link to the reference
     // player it was forked from — SPRT/Madden ratings resolve through it so
     // they stay live without duplicating the rating pipeline per org.

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -133,6 +133,7 @@ export const playerDtoValidator = v.object({
   experienceYears: v.union(v.number(), v.null()),
   grade: v.union(v.number(), v.null()),
   squad: v.union(v.string(), v.null()),
+  hometown: v.union(v.string(), v.null()),
 });
 
 function toPlayerDto(doc: {
@@ -148,6 +149,7 @@ function toPlayerDto(doc: {
   experienceYears?: number | null;
   grade?: number | null;
   squad?: string | null;
+  hometown?: string | null;
 }): Infer<typeof playerDtoValidator> {
   return {
     id: doc._id,
@@ -162,6 +164,7 @@ function toPlayerDto(doc: {
     experienceYears: doc.experienceYears ?? null,
     grade: doc.grade ?? null,
     squad: doc.squad ?? null,
+    hometown: doc.hometown ?? null,
   };
 }
 
@@ -1225,6 +1228,7 @@ export const upsertPlayer = internalMutationGeneric({
     experienceYears: v.optional(v.union(v.number(), v.null())),
     grade: v.optional(v.union(v.number(), v.null())),
     squad: v.optional(v.union(v.string(), v.null())),
+    hometown: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.object({
     dto: playerDtoValidator,
@@ -1250,6 +1254,7 @@ export const upsertPlayer = internalMutationGeneric({
         experienceYears: args.experienceYears ?? null,
         grade: args.grade ?? null,
         squad: args.squad ?? null,
+        hometown: args.hometown ?? existing.hometown ?? null,
       });
       return {
         dto: toPlayerDto({
@@ -1263,6 +1268,7 @@ export const upsertPlayer = internalMutationGeneric({
           experienceYears: args.experienceYears ?? null,
           grade: args.grade ?? null,
           squad: args.squad ?? null,
+          hometown: args.hometown ?? existing.hometown ?? null,
         }),
         created: false,
       };
@@ -1286,6 +1292,7 @@ export const upsertPlayer = internalMutationGeneric({
         experienceYears: args.experienceYears ?? null,
         grade: args.grade ?? null,
         squad: args.squad ?? null,
+        hometown: args.hometown ?? null,
       },
       created: true,
     };
@@ -1455,6 +1462,7 @@ export const createPlayer = internalMutationGeneric({
     status: v.string(),
     grade: v.optional(v.union(v.number(), v.null())),
     squad: v.optional(v.union(v.string(), v.null())),
+    hometown: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.object({
     id: v.string(),
@@ -1469,6 +1477,7 @@ export const createPlayer = internalMutationGeneric({
     experienceYears: v.optional(v.union(v.number(), v.null())),
     grade: v.union(v.number(), v.null()),
     squad: v.union(v.string(), v.null()),
+    hometown: v.union(v.string(), v.null()),
   }),
   handler: async (ctx, args) => {
     const team = await ctx.db.get(args.teamId);
@@ -1509,6 +1518,7 @@ export const createPlayer = internalMutationGeneric({
       experienceYears: null,
       grade: args.grade ?? null,
       squad: args.squad ?? null,
+      hometown: args.hometown ?? null,
     };
   },
 });
@@ -1528,6 +1538,7 @@ export const bulkCreatePlayers = internalMutationGeneric({
         grade: v.optional(v.union(v.number(), v.null())),
         squad: v.optional(v.union(v.string(), v.null())),
         dateOfBirth: v.optional(v.union(v.string(), v.null())),
+        hometown: v.optional(v.union(v.string(), v.null())),
       }),
     ),
   },
@@ -1552,6 +1563,7 @@ export const bulkCreatePlayers = internalMutationGeneric({
         experienceYears: null,
         grade: p.grade ?? null,
         squad: p.squad ?? null,
+        hometown: p.hometown ?? null,
         synthetic: true,
       });
       created += 1;
@@ -1592,6 +1604,7 @@ export const updatePlayer = internalMutationGeneric({
     status: v.optional(v.string()),
     grade: v.optional(v.union(v.number(), v.null())),
     squad: v.optional(v.union(v.string(), v.null())),
+    hometown: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.union(
     playerDtoValidator,
@@ -1642,6 +1655,7 @@ export const updatePlayer = internalMutationGeneric({
       ...(args.status !== undefined ? { status: args.status } : {}),
       ...(args.grade !== undefined ? { grade: args.grade } : {}),
       ...(args.squad !== undefined ? { squad: args.squad } : {}),
+      ...(args.hometown !== undefined ? { hometown: args.hometown } : {}),
       ...(args.teamId !== undefined ? { leagueId } : {}),
     };
 

--- a/apps/web/src/app/dashboard/_components/player-form.tsx
+++ b/apps/web/src/app/dashboard/_components/player-form.tsx
@@ -97,6 +97,7 @@ export default function PlayerForm({
   const [status, setStatus] = useState(player?.status ?? "Active");
   const [grade, setGrade] = useState(player?.grade?.toString() ?? "");
   const [squad, setSquad] = useState(player?.squad ?? "");
+  const [hometown, setHometown] = useState(player?.hometown ?? "");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -120,6 +121,7 @@ export default function PlayerForm({
         status,
         grade: grade ? Number(grade) : null,
         squad: squad || null,
+        hometown: hometown.trim() || null,
       };
 
       // When duplicates are allowed, a clash is a soft warning (saved anyway).
@@ -266,6 +268,17 @@ export default function PlayerForm({
               type="date"
               value={dateOfBirth}
               onChange={(e) => setDateOfBirth(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="player-hometown">Hometown</Label>
+            <Input
+              id="player-hometown"
+              type="text"
+              placeholder="Acworth, GA"
+              value={hometown}
+              onChange={(e) => setHometown(e.target.value)}
             />
           </div>
 

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -190,6 +190,12 @@ export default async function PlayerProfilePage({
                 </dd>
               </div>
             )}
+            {player.hometown && (
+              <div>
+                <dt className="font-medium text-muted-foreground">Hometown</dt>
+                <dd className="mt-1 text-foreground">{player.hometown}</dd>
+              </div>
+            )}
           </dl>
 
           {attributesEnabled && (

--- a/apps/web/src/lib/__tests__/synthetic-roster.test.ts
+++ b/apps/web/src/lib/__tests__/synthetic-roster.test.ts
@@ -54,6 +54,11 @@ describe("generateSyntheticRoster", () => {
       expect(p.grade).toBeLessThanOrEqual(12);
       expect(p.status).toBe("active");
       expect(["Varsity", "JV"]).toContain(p.squad);
+      expect(p.dateOfBirth).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      const year = Number(p.dateOfBirth.slice(0, 4));
+      expect(year).toBeGreaterThanOrEqual(2006);
+      expect(year).toBeLessThanOrEqual(2013);
+      expect(p.hometown).toMatch(/, [A-Z]{2}$/);
     }
   });
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -1139,6 +1139,7 @@ export interface BulkPlayerInput {
   grade?: number | null;
   squad?: string | null;
   dateOfBirth?: string | null;
+  hometown?: string | null;
 }
 
 export async function bulkCreatePlayers(

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -209,6 +209,7 @@ export class LocalWorkspaceProvider implements WorkspaceDataProvider {
       experienceYears: null,
       grade: input.grade ?? null,
       squad: input.squad ?? null,
+      hometown: input.hometown ?? null,
     };
     await this.db.players.add(player);
     return player;

--- a/apps/web/src/lib/synthetic-roster.ts
+++ b/apps/web/src/lib/synthetic-roster.ts
@@ -17,6 +17,24 @@ export interface SyntheticPlayer {
   grade: number; // 9–12 (US high school)
   squad: string; // "Varsity" | "JV"
   status: string; // "active"
+  dateOfBirth: string; // ISO date, age-appropriate for the grade
+  hometown: string; // "City, ST"
+}
+
+// Reference season year for deriving age-appropriate birth dates (a grade-9
+// player is ~14, grade-12 ~17). Constant so generation stays deterministic.
+const SEASON_YEAR = 2026;
+
+// GA-flavored hometowns (HS football); fake, just for believable demo data.
+const HOMETOWNS: readonly string[] = [
+  "Acworth, GA", "Marietta, GA", "Kennesaw, GA", "Smyrna, GA",
+  "Powder Springs, GA", "Austell, GA", "Mableton, GA", "Roswell, GA",
+  "Alpharetta, GA", "Woodstock, GA", "Canton, GA", "Dallas, GA",
+  "Douglasville, GA", "Sandy Springs, GA", "Decatur, GA", "Lawrenceville, GA",
+];
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
 }
 
 // A believable 48-man depth spread (concrete positions, not groups).
@@ -115,7 +133,25 @@ export function generateSyntheticRoster({
     // Upperclassmen lean varsity; underclassmen lean JV — just a believable mix.
     const squad = grade >= 11 ? "Varsity" : rand() < 0.5 ? "Varsity" : "JV";
 
-    players.push({ name, position, jerseyNumber: jersey, grade, squad, status: "active" });
+    // Age-appropriate DOB: ~14 at grade 9 → ~17 at grade 12 (+0/1 year jitter).
+    const age = 14 + (grade - 9) + Math.floor(rand() * 2);
+    const birthYear = SEASON_YEAR - age;
+    const birthMonth = 1 + Math.floor(rand() * 12);
+    const birthDay = 1 + Math.floor(rand() * 28);
+    const dateOfBirth = `${birthYear}-${pad2(birthMonth)}-${pad2(birthDay)}`;
+
+    const hometown = HOMETOWNS[Math.floor(rand() * HOMETOWNS.length)] ?? HOMETOWNS[0];
+
+    players.push({
+      name,
+      position,
+      jerseyNumber: jersey,
+      grade,
+      squad,
+      status: "active",
+      dateOfBirth,
+      hometown,
+    });
   }
 
   return players;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -73,6 +73,7 @@ export const PlayerDtoSchema = z.object({
   experienceYears: z.number().nullable(),
   grade: z.number().nullable(),
   squad: z.string().nullable(),
+  hometown: z.string().nullable(),
 }) satisfies z.ZodType<PlayerDto>;
 
 export const RosterAssignmentDtoSchema = z.object({
@@ -144,6 +145,7 @@ export const CreatePlayerInputSchema = z.object({
   status: z.string().min(1),
   grade: z.number().int().min(9).max(12).nullable().optional(),
   squad: z.enum(SQUADS).nullable().optional(),
+  hometown: z.string().max(120).nullable().optional(),
 }) satisfies z.ZodType<CreatePlayerInput>;
 
 export const UpdatePlayerInputSchema = z.object({
@@ -155,6 +157,7 @@ export const UpdatePlayerInputSchema = z.object({
   status: z.string().min(1).optional(),
   grade: z.number().int().min(9).max(12).nullable().optional(),
   squad: z.enum(SQUADS).nullable().optional(),
+  hometown: z.string().max(120).nullable().optional(),
 }) satisfies z.ZodType<UpdatePlayerInput>;
 
 const hexColor = z

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -69,6 +69,8 @@ export interface PlayerDto {
   grade: number | null;
   /** HS squad: "Varsity" | "JV" | "Freshman" (stored as string for forward-compat). */
   squad: string | null;
+  /** Player hometown, free-text (e.g. "Acworth, GA"). */
+  hometown: string | null;
 }
 
 export interface SeasonDto {
@@ -133,6 +135,7 @@ export interface CreatePlayerInput {
   status: string;
   grade?: number | null;
   squad?: Squad | null;
+  hometown?: string | null;
 }
 
 export interface UpdatePlayerInput {
@@ -144,6 +147,7 @@ export interface UpdatePlayerInput {
   status?: string;
   grade?: number | null;
   squad?: Squad | null;
+  hometown?: string | null;
 }
 
 export interface CreateLeagueInput {


### PR DESCRIPTION
Adds a **`hometown`** field to players end-to-end, and makes the synthetic-roster generator fill realistic **DOB** + **hometown** (they were blank before).

- **hometown** wired through: Convex schema, shared-types (`PlayerDto` + Create/Update inputs), api-contracts Zod, all four player mutations (create/upsert/update/bulkCreate) + `playerDtoValidator`/`toPlayerDto`, the local-workspace provider, the **player form** (text input), and the **player detail page** (display).
- **Generator**: age-appropriate `dateOfBirth` (≈14 at grade 9 → ≈17 at grade 12) + `hometown` ("City, ST"); deterministic/seeded, with tests.

Touches Convex (schema + mutations) → needs a Convex deploy on rollout. Next PR adds synthetic **attributes**.

Verified: tsc clean · eslint clean · **vitest 658** · build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)