### PR TITLE
feat(web): generate synthetic player attributes (ratings) (WSM-000175)

### DIFF
--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -9,14 +9,18 @@ import { canManageOrgSettings } from "@/lib/permissions";
 import {
   getPlayersByTeam,
   getTeamsByLeague,
+  getTeamLeagueId,
   getLeagueOrgId,
+  getSeasons,
   bulkCreatePlayers,
   clearSyntheticPlayers,
+  ingestPlayerAttributesBatch,
 } from "@/lib/data-api";
 import {
   generateSyntheticRoster,
   seedFromString,
 } from "@/lib/synthetic-roster";
+import { generateSyntheticAttributes } from "@/lib/synthetic-attributes";
 
 /*
  * Synthetic-roster generation (WSM-000173) — fills demo/test rosters with fake
@@ -33,9 +37,48 @@ type TeamResult = { ok: true; created: number } | { ok: false; error: string };
 type LeagueResult =
   | { ok: true; teams: number; created: number }
   | { ok: false; error: string };
+type AttributeResult =
+  | { ok: true; rated: number }
+  | { ok: false; error: string };
+type LeagueAttributeResult =
+  | { ok: true; teams: number; rated: number }
+  | { ok: false; error: string };
 
 function existingJerseys(players: { jerseyNumber: number | null }[]): number[] {
   return players.map((p) => p.jerseyNumber).filter((n): n is number => n != null);
+}
+
+/** Active season for a league (the season attributes attach to), or null if
+ *  the league has no seasons. Prefers the explicitly-active one. */
+async function resolveActiveSeasonId(leagueId: string): Promise<string | null> {
+  const seasons = await getSeasons([leagueId]).catch(() => []);
+  if (seasons.length === 0) return null;
+  const active = seasons.find((s) => s.status === "active") ?? seasons[0];
+  return active.id;
+}
+
+/** Build attribute-snapshot rows for a team's players (seeded per player so
+ *  re-running yields stable ratings). */
+function buildAttributeRows(
+  players: { id: string; position: string }[],
+): {
+  playerId: string;
+  positionGroup: string;
+  attributesJson: string;
+  weightedOverall: number | null;
+}[] {
+  return players.map((p) => {
+    const snapshot = generateSyntheticAttributes({
+      position: p.position,
+      seed: seedFromString(p.id),
+    });
+    return {
+      playerId: p.id,
+      positionGroup: snapshot.positionGroup,
+      attributesJson: JSON.stringify(snapshot.attributes),
+      weightedOverall: snapshot.weightedOverall,
+    };
+  });
 }
 
 export async function generateTeamRosterAction(input: {
@@ -152,6 +195,74 @@ export async function clearLeagueSyntheticAction(input: {
     }
     revalidatePath(`/dashboard/leagues/${input.leagueId}`);
     return { ok: true, teams: touched, deleted };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// --- Generate synthetic attributes (ratings) for existing players ---
+// Separate from roster generation so it works on any roster (generated or
+// real test data): gives players Madden-style ratings for the SPRT/Madden
+// rating, development, and ranking surfaces. Attached to the league's active
+// season. Idempotent — re-running overwrites the same per-player snapshot.
+
+export async function generateTeamAttributesAction(input: {
+  teamId: string;
+}): Promise<AttributeResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  const leagueId = await getTeamLeagueId(input.teamId);
+  const seasonId = await resolveActiveSeasonId(leagueId);
+  if (!seasonId) return { ok: false, error: "no_season" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const players = await getPlayersByTeam(input.teamId, orgContext).catch(() => []);
+  if (players.length === 0) return { ok: true, rated: 0 };
+
+  try {
+    const rows = buildAttributeRows(players);
+    const { created, updated } = await ingestPlayerAttributesBatch(seasonId, rows);
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    return { ok: true, rated: created + updated };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function generateLeagueAttributesAction(input: {
+  leagueId: string;
+}): Promise<LeagueAttributeResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  const orgId = await getLeagueOrgId(input.leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
+
+  const seasonId = await resolveActiveSeasonId(input.leagueId);
+  if (!seasonId) return { ok: false, error: "no_season" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+
+  let rated = 0;
+  let touched = 0;
+  try {
+    for (const team of teams) {
+      const players = await getPlayersByTeam(team.id, orgContext).catch(() => []);
+      if (players.length === 0) continue;
+      const rows = buildAttributeRows(players);
+      const { created, updated } = await ingestPlayerAttributesBatch(seasonId, rows);
+      rated += created + updated;
+      touched += 1;
+    }
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    return { ok: true, teams: touched, rated };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -106,6 +106,7 @@ export default async function LeagueDetailPage({
                   </div>
                   <div className="flex items-center gap-2">
                     <SyntheticRosterButton kind="league" id={id} />
+                    <SyntheticRosterButton kind="league" id={id} action="attributes" />
                     <SyntheticRosterButton kind="league" id={id} action="clear" />
                   </div>
                 </div>

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -344,6 +344,7 @@ export default function TeamManagement({
             {canGenerateRoster && (
               <>
                 <SyntheticRosterButton kind="team" id={team.id} />
+                <SyntheticRosterButton kind="team" id={team.id} action="attributes" />
                 <SyntheticRosterButton kind="team" id={team.id} action="clear" />
               </>
             )}

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -3,13 +3,15 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Sparkles, Trash2 } from "lucide-react";
+import { Sparkles, Trash2, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   generateTeamRosterAction,
   generateLeagueRostersAction,
   clearTeamSyntheticAction,
   clearLeagueSyntheticAction,
+  generateTeamAttributesAction,
+  generateLeagueAttributesAction,
 } from "@/app/dashboard/_actions/synthetic-rosters";
 
 /*
@@ -22,7 +24,7 @@ import {
 interface SyntheticRosterButtonProps {
   kind: "team" | "league";
   id: string;
-  action?: "generate" | "clear";
+  action?: "generate" | "clear" | "attributes";
 }
 
 export function SyntheticRosterButton({
@@ -37,7 +39,29 @@ export function SyntheticRosterButton({
     if (!window.confirm(CONFIRM[action][kind])) return;
 
     start(async () => {
-      if (action === "generate" && kind === "team") {
+      if (action === "attributes" && kind === "team") {
+        const res = await generateTeamAttributesAction({ teamId: id });
+        if (!res.ok) {
+          toast.error(errorLabel(res.error));
+          return;
+        }
+        toast.success(
+          res.rated === 0
+            ? "No players to rate yet — generate a roster first."
+            : `Generated ratings for ${res.rated} player${res.rated === 1 ? "" : "s"}.`,
+        );
+      } else if (action === "attributes") {
+        const res = await generateLeagueAttributesAction({ leagueId: id });
+        if (!res.ok) {
+          toast.error(errorLabel(res.error));
+          return;
+        }
+        toast.success(
+          res.rated === 0
+            ? "No players to rate yet — generate rosters first."
+            : `Generated ratings for ${res.rated} player${res.rated === 1 ? "" : "s"} across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        );
+      } else if (action === "generate" && kind === "team") {
         const res = await generateTeamRosterAction({ teamId: id });
         if (!res.ok) {
           toast.error(errorLabel(res.error));
@@ -87,16 +111,21 @@ export function SyntheticRosterButton({
   }
 
   const isClear = action === "clear";
-  const Icon = isClear ? Trash2 : Sparkles;
+  const isAttributes = action === "attributes";
+  const Icon = isClear ? Trash2 : isAttributes ? Gauge : Sparkles;
   const label = isClear
     ? pending
       ? "Clearing…"
       : "Clear synthetic"
-    : pending
-      ? "Generating…"
-      : kind === "team"
-        ? "Generate roster"
-        : "Generate rosters";
+    : isAttributes
+      ? pending
+        ? "Rating…"
+        : "Generate ratings"
+      : pending
+        ? "Generating…"
+        : kind === "team"
+          ? "Generate roster"
+          : "Generate rosters";
 
   return (
     <Button
@@ -109,7 +138,9 @@ export function SyntheticRosterButton({
       title={
         isClear
           ? "Delete generated test players (keeps real players)"
-          : "Generate fake players to populate this roster for testing/demos"
+          : isAttributes
+            ? "Generate Madden-style ratings for this roster's players (test data)"
+            : "Generate fake players to populate this roster for testing/demos"
       }
     >
       <Icon className="mr-1 h-4 w-4" />
@@ -118,7 +149,10 @@ export function SyntheticRosterButton({
   );
 }
 
-const CONFIRM: Record<"generate" | "clear", Record<"team" | "league", string>> = {
+const CONFIRM: Record<
+  "generate" | "clear" | "attributes",
+  Record<"team" | "league", string>
+> = {
   generate: {
     team: "Generate a synthetic (fake) roster for this team? These are test players, not real people.",
     league:
@@ -128,6 +162,11 @@ const CONFIRM: Record<"generate" | "clear", Record<"team" | "league", string>> =
     team: "Delete all synthetic (generated) players from this team? Real players are kept.",
     league:
       "Delete all synthetic (generated) players from EVERY team in this league? Real players are kept.",
+  },
+  attributes: {
+    team: "Generate Madden-style ratings for this team's players? Test data — overwrites any existing synthetic ratings for the active season.",
+    league:
+      "Generate Madden-style ratings for EVERY team's players in this league? Test data — overwrites existing synthetic ratings for the active season.",
   },
 };
 
@@ -139,6 +178,8 @@ function errorLabel(error: string): string {
       return "Please sign in.";
     case "not_authorized":
       return "You don't have permission to do that.";
+    case "no_season":
+      return "This league has no season yet — create one first.";
     default:
       return error;
   }

--- a/apps/web/src/lib/__tests__/synthetic-attributes.test.ts
+++ b/apps/web/src/lib/__tests__/synthetic-attributes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateSyntheticAttributes,
+  attributeGroupForPosition,
+  seedFromString,
+} from "../synthetic-attributes";
+
+describe("attributeGroupForPosition", () => {
+  it("maps concrete positions to attribute groups", () => {
+    expect(attributeGroupForPosition("QB")).toBe("QB");
+    expect(attributeGroupForPosition("RB")).toBe("RB");
+    expect(attributeGroupForPosition("LT")).toBe("OL");
+    expect(attributeGroupForPosition("CB")).toBe("DB");
+    expect(attributeGroupForPosition("MLB")).toBe("LB");
+  });
+
+  it("splits the roster K/P group into K and P", () => {
+    expect(attributeGroupForPosition("K")).toBe("K");
+    expect(attributeGroupForPosition("P")).toBe("P");
+    expect(attributeGroupForPosition("LS")).toBe("K"); // long snapper → special teams
+  });
+
+  it("falls back to WR for unmappable positions", () => {
+    expect(attributeGroupForPosition("ATH")).toBe("WR");
+    expect(attributeGroupForPosition("???")).toBe("WR");
+  });
+});
+
+describe("generateSyntheticAttributes", () => {
+  it("is deterministic for a given position + seed", () => {
+    const a = generateSyntheticAttributes({ position: "QB", seed: 42 });
+    const b = generateSyntheticAttributes({ position: "QB", seed: 42 });
+    expect(a).toEqual(b);
+  });
+
+  it("varies with the seed", () => {
+    const a = generateSyntheticAttributes({ position: "QB", seed: 1 });
+    const b = generateSyntheticAttributes({ position: "QB", seed: 2 });
+    expect(a.attributes).not.toEqual(b.attributes);
+  });
+
+  it("produces position-appropriate keys", () => {
+    const qb = generateSyntheticAttributes({ position: "QB", seed: 7 });
+    expect(qb.positionGroup).toBe("QB");
+    // Common athletic keys + QB-specific throwing keys.
+    expect(qb.attributes).toHaveProperty("SPD");
+    expect(qb.attributes).toHaveProperty("THP");
+    expect(qb.attributes).toHaveProperty("DAC");
+
+    const ol = generateSyntheticAttributes({ position: "C", seed: 7 });
+    expect(ol.positionGroup).toBe("OL");
+    expect(ol.attributes).toHaveProperty("PBK");
+    expect(ol.attributes).not.toHaveProperty("THP");
+  });
+
+  it("keeps every attribute and the overall in the 40–99 band", () => {
+    for (const pos of ["QB", "RB", "WR", "TE", "LT", "DE", "MLB", "CB", "K", "P"]) {
+      const snap = generateSyntheticAttributes({ position: pos, seed: 13 });
+      for (const value of Object.values(snap.attributes)) {
+        expect(value).toBeGreaterThanOrEqual(40);
+        expect(value).toBeLessThanOrEqual(99);
+        expect(Number.isInteger(value)).toBe(true);
+      }
+      expect(snap.weightedOverall).toBeGreaterThanOrEqual(40);
+      expect(snap.weightedOverall).toBeLessThanOrEqual(99);
+      expect(Number.isInteger(snap.weightedOverall)).toBe(true);
+    }
+  });
+
+  it("the overall is the rounded mean of the attribute map", () => {
+    const snap = generateSyntheticAttributes({ position: "WR", seed: 99 });
+    const values = Object.values(snap.attributes);
+    const mean = Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+    expect(snap.weightedOverall).toBe(mean);
+  });
+
+  it("re-exports seedFromString for per-player seeding", () => {
+    expect(typeof seedFromString("player_abc")).toBe("number");
+    expect(seedFromString("player_abc")).toBe(seedFromString("player_abc"));
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -1155,6 +1155,22 @@ export async function clearSyntheticPlayers(
   return mutateConvex(refs.clearSyntheticPlayers, { teamId });
 }
 
+/** A precomputed attribute snapshot for bulk ingest (WSM-000175). */
+export interface AttributeBatchRow {
+  playerId: string;
+  positionGroup: string;
+  attributesJson: string;
+  weightedOverall: number | null;
+}
+
+/** Upsert many players' season attribute snapshots in one call (WSM-000175). */
+export async function ingestPlayerAttributesBatch(
+  seasonId: string,
+  rows: AttributeBatchRow[],
+): Promise<{ created: number; updated: number }> {
+  return mutateConvex(refs.ingestPlayerAttributesBatch, { seasonId, rows });
+}
+
 export async function updatePlayer(
   id: string,
   input: UpdatePlayerInput,

--- a/apps/web/src/lib/synthetic-attributes.ts
+++ b/apps/web/src/lib/synthetic-attributes.ts
@@ -1,0 +1,127 @@
+/*
+ * Synthetic player-attribute generator (WSM-000175).
+ *
+ * Companion to `synthetic-roster.ts`: where that fills a roster with fake
+ * players, this gives those players believable Madden-style ratings so the
+ * SPRT rating / development / ranking surfaces have data to show in demos and
+ * tests. Never real player data.
+ *
+ * Pure + deterministic given a seed (e.g. seedFromString(playerId)), so
+ * re-running a team yields stable ratings and the lib is unit-testable. The
+ * output shape matches what `ingestPlayerAttributesBatch` expects: a
+ * position-group code, a 0–99 attribute map, and a weighted overall.
+ */
+import { derivePositionGroup } from "@/lib/position-group";
+import { seedFromString } from "@/lib/synthetic-roster";
+
+/** Attribute-domain position groups (kicker/punter split, unlike the roster
+ *  K/P group). Mirrors `lib/attributes/position-groups.ts`. */
+export type AttributeGroup =
+  | "QB"
+  | "RB"
+  | "WR"
+  | "TE"
+  | "OL"
+  | "DL"
+  | "LB"
+  | "DB"
+  | "K"
+  | "P";
+
+/** Universal athletic attributes every group carries. */
+const COMMON_KEYS: readonly string[] = ["SPD", "STR", "AGI", "ACC", "AWR", "STA"];
+
+/** Madden-style position-specific attribute codes per group. */
+const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
+  QB: ["THP", "SAC", "MAC", "DAC", "TUP", "PAC"],
+  RB: ["CAR", "BCV", "TRK", "ELU", "JKM", "BTK"],
+  WR: ["CTH", "SRR", "MRR", "DRR", "CIT", "RLS"],
+  TE: ["CTH", "RBK", "CIT", "SRR", "PBK"],
+  OL: ["RBK", "PBK", "RBP", "PBP", "IBL"],
+  DL: ["PMV", "FMV", "BSH", "TAK", "PUR"],
+  LB: ["TAK", "PUR", "PRC", "ZCV", "MCV", "POW"],
+  DB: ["MCV", "ZCV", "PRS", "CTH", "PUR"],
+  K: ["KPW", "KAC"],
+  P: ["KPW", "KAC"],
+};
+
+/**
+ * Map a concrete roster position to an attribute-domain group. The roster
+ * util collapses kickers + punters into "K/P"; here we split them by the
+ * concrete position. Unmappable positions (e.g. "ATH") fall back to "WR" — a
+ * generic athletic skill profile — so every synthetic player gets ratings.
+ */
+export function attributeGroupForPosition(position: string): AttributeGroup {
+  const group = derivePositionGroup(position);
+  if (group === "K/P") {
+    return position.trim().toUpperCase() === "P" ? "P" : "K";
+  }
+  if (group === null) return "WR";
+  return group;
+}
+
+/** mulberry32 — tiny deterministic PRNG (same family as synthetic-roster). */
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+export interface SyntheticAttributes {
+  /** Attribute-domain position group (e.g. "QB", "DB"). */
+  positionGroup: AttributeGroup;
+  /** Madden-style attribute map, integer values 0–99. */
+  attributes: Record<string, number>;
+  /** Rounded overall (40–99), the mean of the player's attributes. */
+  weightedOverall: number;
+}
+
+export interface GenerateAttributesOptions {
+  position: string;
+  /** Seed for deterministic output (e.g. seedFromString(playerId)). */
+  seed: number;
+}
+
+/**
+ * Generate a believable attribute snapshot for one player. Each player gets a
+ * base skill level (≈58–90) from the seed, then every attribute jitters around
+ * it (±12), clamped to 40–99. The overall is the rounded mean of the map.
+ */
+export function generateSyntheticAttributes({
+  position,
+  seed,
+}: GenerateAttributesOptions): SyntheticAttributes {
+  const positionGroup = attributeGroupForPosition(position);
+  const rand = rng(seed);
+
+  // Per-player base skill: most players land mid-pack, a few are studs.
+  const base = 58 + Math.floor(rand() * 33); // 58–90
+
+  const keys = [...COMMON_KEYS, ...GROUP_KEYS[positionGroup]];
+  const attributes: Record<string, number> = {};
+  let sum = 0;
+  for (const key of keys) {
+    // Skip duplicate keys (a group could repeat a common one) — first wins.
+    if (key in attributes) continue;
+    const jitter = Math.floor(rand() * 25) - 12; // -12..+12
+    const value = clamp(base + jitter, 40, 99);
+    attributes[key] = value;
+    sum += value;
+  }
+
+  const count = Object.keys(attributes).length;
+  const weightedOverall = count > 0 ? clamp(Math.round(sum / count), 40, 99) : base;
+
+  return { positionGroup, attributes, weightedOverall };
+}
+
+export { seedFromString };


### PR DESCRIPTION
## What & why
Companion to synthetic rosters (#395/#396/#398). Generated/test players had no ratings, so the SPRT rating, player development, and ranking surfaces showed nothing for them. This adds a **"Generate ratings"** action that gives every player on a roster a believable Madden-style attribute snapshot, attached to the league's active season.

## Changes
- **`apps/web/src/lib/synthetic-attributes.ts`** (new, pure + seeded): per-position-group attribute keys (Madden codes like `THP`/`CTH`/`PBK` + universal `SPD`/`STR`/`AGI`/`AWR`/…), integer 0–99 values, and a weighted overall (rounded mean). Deterministic per `seedFromString(playerId)` so re-running is stable. Splits the roster `K/P` group into `K`/`P` and falls back to `WR` for unmappable positions (`ATH`). + unit test (9 cases).
- **`data-api.ts`**: `ingestPlayerAttributesBatch(seasonId, rows)` wrapper over the existing Convex batch mutation.
- **`_actions/synthetic-rosters.ts`**: `generateTeamAttributesAction` / `generateLeagueAttributesAction` — resolve the league's active season, rate every roster player, upsert via the batch mutation. Idempotent (re-run overwrites the same per-player/season snapshot). Same flag (`syntheticRostersV1`) + role gating as roster generation (team = coach/admin, league = admin).
- **`SyntheticRosterButton.tsx`**: new `action="attributes"` variant (gauge icon, "Generate ratings"), rendered on team-management and league detail next to the existing generate/clear buttons.

It works on **any** roster (generated or hand-entered test data), separate from roster generation, so ratings can be (re)generated independently.

## Verification
- `pnpm exec vitest run` — new `synthetic-attributes` suite 9/9; synthetic roster + actions suites green (30 total).
- `pnpm exec eslint` on all changed files — clean.
- `pnpm run build` (web) — green.
- Pre-existing `tsc` noise from raw `@sports-management/api-contracts` resolution + `espn-nfl` test `any`s is unrelated (none of these files); the Next build resolves the workspace package correctly.

## Deploy note
Touches a Convex mutation call path only via the existing `ingestPlayerAttributesBatch` (no schema change in this PR). Deploy with web + Convex from the same merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)