### PR TITLE
fix(web): synthetic players show neutral status badge, not green Active (WSM-000176)

### DIFF
--- a/apps/web/src/components/__tests__/status-badge.test.ts
+++ b/apps/web/src/components/__tests__/status-badge.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { resolveStatusBadge } from "../status-badge";
+
+describe("resolveStatusBadge", () => {
+  it("maps a canonical status to its variant + label", () => {
+    expect(resolveStatusBadge("Active")).toEqual({
+      variant: "success",
+      label: "Active",
+    });
+    expect(resolveStatusBadge("Injured")).toEqual({
+      variant: "warning",
+      label: "Injured",
+    });
+  });
+
+  it("normalizes non-canonical casing to the canonical variant + label", () => {
+    // Synthetic rosters historically wrote lowercase "active"; it should still
+    // resolve to the green Active badge.
+    expect(resolveStatusBadge("active")).toEqual({
+      variant: "success",
+      label: "Active",
+    });
+    expect(resolveStatusBadge("INACTIVE")).toEqual({
+      variant: "secondary",
+      label: "Inactive",
+    });
+  });
+
+  it("passes an unknown status through with a neutral variant", () => {
+    expect(resolveStatusBadge("Suspended")).toEqual({
+      variant: "secondary",
+      label: "Suspended",
+    });
+  });
+});

--- a/apps/web/src/components/status-badge.tsx
+++ b/apps/web/src/components/status-badge.tsx
@@ -10,16 +10,36 @@ const statusVariantMap: Record<string, BadgeProps["variant"]> = {
   Cancelled: "destructive",
 };
 
+/**
+ * Resolve a status string to its badge variant + display label. Matching is
+ * case-insensitive so non-canonical casing (e.g. a synthetic roster's
+ * lowercase "active") still maps to the right variant and renders the
+ * canonical label ("Active"). Unknown statuses pass through unchanged with a
+ * neutral variant.
+ */
+export function resolveStatusBadge(status: string): {
+  variant: BadgeProps["variant"];
+  label: string;
+} {
+  const canonicalKey = Object.keys(statusVariantMap).find(
+    (key) => key.toLowerCase() === status.toLowerCase(),
+  );
+  return {
+    variant: canonicalKey ? statusVariantMap[canonicalKey] : "secondary",
+    label: canonicalKey ?? status,
+  };
+}
+
 interface StatusBadgeProps {
   status: string;
   className?: string;
 }
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {
-  const variant = statusVariantMap[status] ?? "secondary";
+  const { variant, label } = resolveStatusBadge(status);
   return (
     <Badge variant={variant} className={className}>
-      {status}
+      {label}
     </Badge>
   );
 }

--- a/apps/web/src/lib/__tests__/synthetic-roster.test.ts
+++ b/apps/web/src/lib/__tests__/synthetic-roster.test.ts
@@ -47,12 +47,12 @@ describe("generateSyntheticRoster", () => {
     expect(roster.some((p) => p.position === "K")).toBe(true);
   });
 
-  it("uses HS grades 9–12 and active status", () => {
+  it("uses HS grades 9–12 and canonical Active status", () => {
     const roster = generateSyntheticRoster({ count: 30, seed: 7 });
     for (const p of roster) {
       expect(p.grade).toBeGreaterThanOrEqual(9);
       expect(p.grade).toBeLessThanOrEqual(12);
-      expect(p.status).toBe("active");
+      expect(p.status).toBe("Active");
       expect(["Varsity", "JV"]).toContain(p.squad);
       expect(p.dateOfBirth).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       const year = Number(p.dateOfBirth.slice(0, 4));

--- a/apps/web/src/lib/synthetic-roster.ts
+++ b/apps/web/src/lib/synthetic-roster.ts
@@ -16,7 +16,7 @@ export interface SyntheticPlayer {
   jerseyNumber: number;
   grade: number; // 9–12 (US high school)
   squad: string; // "Varsity" | "JV"
-  status: string; // "active"
+  status: string; // "Active" (canonical — matches the status badge map)
   dateOfBirth: string; // ISO date, age-appropriate for the grade
   hometown: string; // "City, ST"
 }
@@ -148,7 +148,7 @@ export function generateSyntheticRoster({
       jerseyNumber: jersey,
       grade,
       squad,
-      status: "active",
+      status: "Active",
       dateOfBirth,
       hometown,
     });


### PR DESCRIPTION
## Bug
On the Players list, real players show a green **Active** badge but synthetic/generated players show a neutral gray **active** badge (see report screenshot).

## Root cause
`status-badge.tsx`'s `statusVariantMap` is keyed on canonical capitalized statuses (`Active` → `success`/green). The synthetic roster generator wrote lowercase `"active"`, which missed the map and fell through to the neutral `secondary` default — rendering the raw lowercase text too.

## Fix
- **`StatusBadge`**: match the variant map **case-insensitively** and render the canonical label. This also fixes **already-generated** players (lowercase `"active"` in the DB) without re-generating them. Extracted a pure `resolveStatusBadge(status)` helper and unit-tested it.
- **`synthetic-roster.ts`**: write the canonical `"Active"` going forward.

## Verification
- `pnpm exec vitest run` — new `resolveStatusBadge` suite 3/3; synthetic roster suite updated + green.
- `pnpm exec eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)