### PR TITLE
feat(web): add teams to an existing league from the league screen (WSM-000177)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -15,7 +15,11 @@ import InvitationList from "./invitation-list";
 import InviteLinkSection from "./invite-link-section";
 import LeaguePublicToggle from "./league-public-toggle";
 import LeagueClaimableToggle from "./league-claimable-toggle";
-import { RenameLeagueForm, DeleteLeagueButton } from "../leagues-actions";
+import {
+  RenameLeagueForm,
+  DeleteLeagueButton,
+  AddTeamForm,
+} from "../leagues-actions";
 import { syntheticRostersV1 } from "@/lib/flags";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 
@@ -95,6 +99,15 @@ export default async function LeagueDetailPage({
                 initialClaimable={claimable}
                 isPublic={visibility?.isPublic ?? false}
               />
+              <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
+                <div className="min-w-0">
+                  <p className="text-label-14 text-foreground">Teams</p>
+                  <p className="text-caption-12 text-text-muted">
+                    Add a team to this league.
+                  </p>
+                </div>
+                <AddTeamForm leagueId={id} />
+              </div>
               {canGenerateRosters && (
                 <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
                   <div className="min-w-0">

--- a/apps/web/src/app/dashboard/leagues/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/actions.ts
@@ -6,6 +6,7 @@ import {
   createLeague as createLeagueMutation,
   renameLeague as renameLeagueMutation,
   deleteLeague as deleteLeagueMutation,
+  createTeam as createTeamMutation,
   getLeagueOrgId,
 } from "@/lib/data-api";
 import { getUserRoleInOrg } from "@/lib/org-context";
@@ -89,4 +90,34 @@ export async function deleteLeagueAction(leagueId: string): Promise<Result> {
   await deleteLeagueMutation(leagueId);
   revalidatePath("/dashboard/leagues");
   return { ok: true };
+}
+
+/** Add a team to an existing league (org-admin only). City/stadium optional. */
+export async function createTeamInLeagueAction(input: {
+  leagueId: string;
+  name: string;
+  city?: string;
+  stadium?: string;
+}): Promise<Result<{ id: string; name: string }>> {
+  const name = input.name.trim();
+  if (!name) return { ok: false, error: "Team name is required." };
+  const gate = await requireLeagueAdmin(input.leagueId);
+  if (!gate.ok) return gate;
+
+  try {
+    const team = await createTeamMutation({
+      name,
+      leagueId: input.leagueId,
+      city: input.city?.trim() ?? "",
+      stadium: input.stadium?.trim() ?? "",
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    revalidatePath("/dashboard/teams");
+    return { ok: true, id: team.id, name: team.name };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Could not create team.",
+    };
+  }
 }

--- a/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
@@ -7,9 +7,21 @@ import { toast } from "sonner";
 import { Plus, Trash2, Pencil } from "lucide-react";
 import {
   createLeagueAction,
+  createTeamInLeagueAction,
   deleteLeagueAction,
   renameLeagueAction,
 } from "./actions";
+
+function friendlyError(error: string): string {
+  switch (error) {
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_admin":
+      return "Only league admins can do that.";
+    default:
+      return error;
+  }
+}
 
 const inputClass =
   "rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground";
@@ -175,6 +187,93 @@ export function RenameLeagueForm({
         {busy ? "…" : "Save"}
       </Button>
       <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+/** Add a team to a league from the league screen (org-admin only). */
+export function AddTeamForm({ leagueId }: { leagueId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [city, setCity] = useState("");
+  const [stadium, setStadium] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setName("");
+    setCity("");
+    setStadium("");
+    setOpen(false);
+  }
+
+  async function submit() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    const res = await createTeamInLeagueAction({
+      leagueId,
+      name: trimmed,
+      city,
+      stadium,
+    });
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`Added ${res.name}.`);
+      reset();
+      router.refresh();
+    } else {
+      toast.error(friendlyError(res.error));
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Plus className="mr-1 h-4 w-4" />
+        Add team
+      </Button>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") reset();
+        }}
+        placeholder="Team name"
+        className={inputClass}
+      />
+      <input
+        value={city}
+        onChange={(e) => setCity(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") reset();
+        }}
+        placeholder="City (optional)"
+        className={inputClass}
+      />
+      <input
+        value={stadium}
+        onChange={(e) => setStadium(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+          if (e.key === "Escape") reset();
+        }}
+        placeholder="Stadium (optional)"
+        className={inputClass}
+      />
+      <Button size="sm" disabled={busy || !name.trim()} onClick={submit}>
+        {busy ? "…" : "Add"}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={reset}>
         Cancel
       </Button>
     </div>


### PR DESCRIPTION
## What & why
There was no dashboard UI to create a team — teams only ever came from the CLI API, bulk import, or the local workspace. This adds an **"Add team"** form directly on the league detail page so an admin can grow an existing league in place.

## Changes
- **`createTeamInLeagueAction`** (`leagues/actions.ts`): reuses the existing `requireLeagueAdmin` org-admin gate, calls the `createTeam` data-api wrapper. Team **name required**; **city/stadium optional**. Revalidates the league detail + teams pages.
- **`AddTeamForm`** (`leagues-actions.tsx`): inline name / city / stadium form (Enter to submit, Esc to cancel), mirroring the existing `CreateLeagueButton`, with a friendly error mapping (`not_admin` / `unauthorized`).
- **League detail page**: renders `AddTeamForm` in a new "Teams" section within the admin-only block.

## Notes
- Admin-gated (org admin of the league's org), consistent with rename/delete league.
- New teams get `divisionId: null` and the default roster limit (53), same as every other create path; division assignment stays in team management.

## Verification
- `pnpm exec eslint` on changed files — clean.
- `pnpm run build` (web) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)