### PR TITLE
feat(web): add Standings + Schedule links to the leagues screen (WSM-000178)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -3,10 +3,11 @@ import { redirect } from "next/navigation";
 import { getDivisions, getTeams, getLeagueOrgId } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
 import { getUserRoleInOrg } from "@/lib/org-context";
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
-import { Trophy } from "lucide-react";
+import { Trophy, BarChart3, CalendarDays } from "lucide-react";
 import { LeagueSwitcher } from "../_components/league-switcher";
 import {
   CreateLeagueButton,
@@ -104,6 +105,22 @@ export default async function LeaguesPage() {
           </div>
         </CardHeader>
         <CardContent>
+          <div className="mb-4 flex flex-wrap gap-x-4 gap-y-2 border-b border-border pb-4">
+            <Link
+              href={`/dashboard/leagues/${activeLeague.id}/standings`}
+              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              <BarChart3 className="h-4 w-4" />
+              Standings
+            </Link>
+            <Link
+              href={`/dashboard/leagues/${activeLeague.id}/schedule`}
+              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              <CalendarDays className="h-4 w-4" />
+              Schedule
+            </Link>
+          </div>
           <LeaguesAccordion
             leagueId={activeLeague.id}
             isAdmin={isAdmin}


### PR DESCRIPTION
## What & why
On `/dashboard/leagues` the league card listed divisions but offered no way to reach the league's **standings** or **schedule** — those links only lived on the separate league detail page, which isn't obviously reachable from this screen. Reported from the leagues screen.

## Change
Adds a quick-nav row (Standings + Schedule, with icons) to the active-league card, just above the divisions accordion. Visible to all roles; links to the existing `/dashboard/leagues/[id]/standings` and `/schedule` routes.

## Verification
- `pnpm exec eslint` — clean.
- `pnpm run build` — green.
- Target routes confirmed to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)