### PR TITLE
fix(web): clean error when Mux live streaming is on the free plan (WSM-000179)

### DIFF
--- a/apps/web/src/components/schedule/GoLiveControl.tsx
+++ b/apps/web/src/components/schedule/GoLiveControl.tsx
@@ -185,6 +185,10 @@ function errorLabel(error: string): string {
       return "Game not found.";
     case "stream_not_found":
       return "No live stream to stop.";
+    case "mux_plan_required":
+      return "Live streaming needs a paid Mux plan — the account is on the free plan. Upgrade at dashboard.mux.com, then try again.";
+    case "mux_live_stream_incomplete":
+      return "Mux didn't return complete stream details. Please try again.";
     default:
       return error;
   }

--- a/apps/web/src/lib/__tests__/mux-create-stream.test.ts
+++ b/apps/web/src/lib/__tests__/mux-create-stream.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// mux.ts is `import "server-only"`; neutralize that guard for the test runner.
+vi.mock("server-only", () => ({}));
+
+// Mock the Mux SDK so we can drive liveStreams.create's outcome without a
+// real account. The mock's create() reads from `createImpl`, set per test.
+let createImpl: () => Promise<unknown>;
+vi.mock("@mux/mux-node", () => {
+  return {
+    default: class MockMux {
+      video = {
+        liveStreams: {
+          create: () => createImpl(),
+        },
+      };
+    },
+  };
+});
+
+describe("createMuxLiveStream", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("MUX_TOKEN_ID", "test-id");
+    vi.stubEnv("MUX_TOKEN_SECRET", "test-secret");
+  });
+
+  it("maps Mux's free-plan rejection to a clean mux_plan_required error", async () => {
+    createImpl = () =>
+      Promise.reject(
+        new Error(
+          '400 {"error":{"type":"invalid_parameters","messages":["Live streams are unavailable on the free plan"]}}',
+        ),
+      );
+    const { createMuxLiveStream } = await import("../mux");
+    await expect(createMuxLiveStream(180)).rejects.toThrow("mux_plan_required");
+  });
+
+  it("rethrows unrelated Mux errors unchanged", async () => {
+    createImpl = () => Promise.reject(new Error("503 service unavailable"));
+    const { createMuxLiveStream } = await import("../mux");
+    await expect(createMuxLiveStream(180)).rejects.toThrow(
+      "503 service unavailable",
+    );
+  });
+
+  it("returns stream details on success", async () => {
+    createImpl = () =>
+      Promise.resolve({
+        id: "ls_123",
+        stream_key: "sk_abc",
+        playback_ids: [{ id: "pb_xyz" }],
+      });
+    const { createMuxLiveStream } = await import("../mux");
+    const result = await createMuxLiveStream(180);
+    expect(result).toEqual({
+      liveStreamId: "ls_123",
+      streamKey: "sk_abc",
+      playbackId: "pb_xyz",
+      rtmpUrl: "rtmps://global-live.mux.com:443/app",
+    });
+  });
+});

--- a/apps/web/src/lib/mux.ts
+++ b/apps/web/src/lib/mux.ts
@@ -52,12 +52,23 @@ export async function createMuxLiveStream(
   maxDurationMinutes: number,
 ): Promise<CreatedMuxLiveStream> {
   const mux = getMux();
-  const liveStream = await mux.video.liveStreams.create({
-    playback_policy: ["public"],
-    new_asset_settings: { playback_policy: ["public"] },
-    // Mux expects seconds; this is the guardrail auto-stop.
-    max_continuous_duration: maxDurationMinutes * 60,
-  });
+  let liveStream;
+  try {
+    liveStream = await mux.video.liveStreams.create({
+      playback_policy: ["public"],
+      new_asset_settings: { playback_policy: ["public"] },
+      // Mux expects seconds; this is the guardrail auto-stop.
+      max_continuous_duration: maxDurationMinutes * 60,
+    });
+  } catch (err) {
+    // Mux rejects live-stream creation on the free plan with a 400. Surface a
+    // clean, actionable code instead of leaking the raw Mux JSON to a toast.
+    const raw = err instanceof Error ? err.message : String(err);
+    if (/free plan|live streams are unavailable/i.test(raw)) {
+      throw new Error("mux_plan_required");
+    }
+    throw err;
+  }
 
   const playbackId = liveStream.playback_ids?.[0]?.id;
   if (!liveStream.id || !liveStream.stream_key || !playbackId) {


### PR DESCRIPTION
## Bug
Tapping **Go live** showed a raw Mux API error in the toast:
> `400 {"error":{"type":"invalid_parameters","messages":["Live streams are unavailable on the free plan"]}}`

## Root cause
The Mux account is on the **free plan**, which can't create live streams. `createMuxLiveStream` let the raw Mux SDK error bubble through `GoLiveControl`'s `errorLabel` default case, dumping JSON to the user. (The flag is on and credentials are valid — this is an account/plan limitation, not a code defect.)

## Fix (error UX only)
- `createMuxLiveStream`: catch Mux's plan rejection and throw a clean `mux_plan_required` code; unrelated Mux errors rethrow unchanged.
- `GoLiveControl`: map `mux_plan_required` → *"Live streaming needs a paid Mux plan … Upgrade at dashboard.mux.com, then try again."* (also added a friendly `mux_live_stream_incomplete` message).
- Regression test mocking the Mux SDK: free-plan → `mux_plan_required`, unrelated errors rethrown, success path returns full stream details.

## ⚠️ The real blocker (account action, not code)
Live streaming requires a **paid Mux plan**. Upgrade the Mux account (add billing at dashboard.mux.com → Settings → Billing). No code change enables live streams on the free plan.

## Verification
- `pnpm exec vitest run` — new mux suite 3/3.
- `pnpm exec eslint` — clean. `pnpm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)