### PR TITLE
fix(web): dialogs no longer pop the mobile keyboard on open (WSM-000181)

### DIFF
--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -51,15 +51,30 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
 }) {
+  // By default Radix focuses the first focusable element when a dialog opens,
+  // which on mobile pops the on-screen keyboard the instant any dialog with a
+  // text field appears (e.g. "Record game result"). Instead, move focus to the
+  // dialog container itself — focus stays trapped inside the dialog for
+  // keyboard/screen-reader users, but no input is focused, so the keyboard
+  // stays closed. Callers that genuinely want a field focused can pass their
+  // own onOpenAutoFocus.
+  const handleOpenAutoFocus =
+    onOpenAutoFocus ??
+    ((event: Event) => {
+      event.preventDefault()
+      ;(event.currentTarget as HTMLElement | null)?.focus()
+    })
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        onOpenAutoFocus={handleOpenAutoFocus}
         className={cn(
           // max-h + overflow safety net: a dialog taller than the viewport
           // (long forms on mobile) scrolls instead of pushing its footer


### PR DESCRIPTION
## Bug
On mobile, opening a dialog with a text field — e.g. **Record game result** — instantly popped the on-screen keyboard, forcing the user to dismiss it before they could even read the dialog. (Reported with screenshot.)

## Root cause
Radix's `Dialog` default `onOpenAutoFocus` focuses the first focusable element on open. For any dialog whose first element is an input, that means the mobile keyboard fires immediately.

## Fix (global — all dialogs)
`DialogContent` now defaults `onOpenAutoFocus` to move focus to the **dialog container** instead of the first input:
- Focus still enters and is trapped inside the dialog → Esc, focus-trap, and screen-reader context all preserved (a11y intact).
- No text input is focused → the mobile keyboard stays closed until the user taps a field.
- Callers that genuinely want a field focused can still pass their own `onOpenAutoFocus`.

This fixes **every** dialog at once (record result, add player, player form, camera settings, etc.), per the request to prevent it "for all similar scenarios."

## Notes
- Explicit `autoFocus` on inline tap-to-edit fields (Rename league, New division, New season) is left as-is — those are single-purpose edit affordances the user taps specifically to type into, not modal ambushes. Happy to remove those too if wanted.

## Verification
- `pnpm exec eslint` — clean. `pnpm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)