### PR TITLE
feat(web): free YouTube Live streaming (paste-a-link) (WSM-000180)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -293,16 +293,19 @@ export default defineSchema({
   }).index("by_fixtureId", ["fixtureId"]),
 
   /*
-   * One live stream per fixture (WSM-000144, streaming epic #225). The Mux
-   * stream KEY is never stored — Mux holds it; we keep only the live-stream id
-   * (server-side) and the public HLS playback id. Public reads project to
-   * status/playbackId/vodAssetId only; the key + live-stream id never transit a
-   * public query (see getStreamByFixture).
+   * One live stream per fixture (WSM-000144, streaming epic #225). Two
+   * providers (WSM-000180): "mux" (RTMP ingest, paid) keeps the server-side
+   * live-stream id + public HLS playback id; "youtube" (free, paste-a-link)
+   * keeps only the public YouTube video id. The Mux stream KEY is never stored.
+   * Public reads project to status / playback ids / vodAssetId only; the Mux
+   * live-stream id never transits a public query (see getStreamByFixture).
    */
   gameStreams: defineTable({
     fixtureId: v.id("fixtures"),
-    muxLiveStreamId: v.string(), // server-side; never returned by a public read
-    muxPlaybackId: v.string(), // public HLS id
+    provider: v.optional(v.string()), // "mux" | "youtube" (legacy rows = mux)
+    muxLiveStreamId: v.optional(v.string()), // mux: server-side; never public
+    muxPlaybackId: v.optional(v.string()), // mux: public HLS id
+    youtubeVideoId: v.optional(v.union(v.string(), v.null())), // youtube: public
     status: v.string(), // "idle" | "active" | "ended"
     vodAssetId: v.union(v.string(), v.null()),
     startedBy: v.string(),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4312,10 +4312,14 @@ export const computeStandingsPublic = query({
  */
 
 // Public projection — what an unauthenticated viewer is allowed to see.
+// Provider-agnostic (WSM-000180): a viewer gets the public playback id for
+// whichever provider backs the stream, never the Mux live-stream id.
 const publicStreamDtoValidator = v.union(
   v.object({
     status: v.string(),
-    muxPlaybackId: v.string(),
+    provider: v.string(), // "mux" | "youtube"
+    muxPlaybackId: v.union(v.string(), v.null()),
+    youtubeVideoId: v.union(v.string(), v.null()),
     vodAssetId: v.union(v.string(), v.null()),
   }),
   v.null(),
@@ -4324,8 +4328,10 @@ const publicStreamDtoValidator = v.union(
 export const createGameStream = internalMutationGeneric({
   args: {
     fixtureId: v.id("fixtures"),
-    muxLiveStreamId: v.string(),
-    muxPlaybackId: v.string(),
+    provider: v.optional(v.string()), // "mux" (default) | "youtube"
+    muxLiveStreamId: v.optional(v.string()),
+    muxPlaybackId: v.optional(v.string()),
+    youtubeVideoId: v.optional(v.union(v.string(), v.null())),
     startedBy: v.string(),
     maxDurationMinutes: v.number(),
   },
@@ -4333,17 +4339,21 @@ export const createGameStream = internalMutationGeneric({
     id: v.string(),
     fixtureId: v.string(),
     status: v.string(),
-    muxPlaybackId: v.string(),
   }),
   handler: async (ctx, args) => {
     const fixture = await ctx.db.get(args.fixtureId);
     if (!fixture) throw new Error("fixture_not_found");
 
+    const provider = args.provider ?? "mux";
     const payload = {
       fixtureId: args.fixtureId,
+      provider,
       muxLiveStreamId: args.muxLiveStreamId,
       muxPlaybackId: args.muxPlaybackId,
-      status: "idle",
+      youtubeVideoId: args.youtubeVideoId ?? null,
+      // A pasted YouTube link is already live, so it starts "active"; Mux waits
+      // for its webhook (video.live_stream.active) to confirm before flipping.
+      status: provider === "youtube" ? "active" : "idle",
       vodAssetId: null,
       startedBy: args.startedBy,
       startedAt: new Date().toISOString(),
@@ -4370,8 +4380,25 @@ export const createGameStream = internalMutationGeneric({
       id,
       fixtureId: args.fixtureId,
       status: payload.status,
-      muxPlaybackId: args.muxPlaybackId,
     };
+  },
+});
+
+/*
+ * Manual end-by-fixture (WSM-000180) — used to stop a YouTube stream, which has
+ * no Mux webhook to flip it. Provider-agnostic and idempotent.
+ */
+export const endGameStreamByFixture = internalMutationGeneric({
+  args: { fixtureId: v.id("fixtures"), endedAt: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameStreams")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    if (!row) return false;
+    await ctx.db.patch(row._id, { status: "ended", endedAt: args.endedAt });
+    return true;
   },
 });
 
@@ -4422,7 +4449,9 @@ export const getStreamByFixture = queryGeneric({
     // PUBLIC PROJECTION ONLY — never return muxLiveStreamId (server-side) here.
     return {
       status: row.status,
-      muxPlaybackId: row.muxPlaybackId,
+      provider: row.provider ?? "mux",
+      muxPlaybackId: row.muxPlaybackId ?? null,
+      youtubeVideoId: row.youtubeVideoId ?? null,
       vodAssetId: row.vodAssetId,
     };
   },
@@ -4438,7 +4467,11 @@ export const getStreamByFixture = queryGeneric({
 export const getStreamAdminByFixture = internalQueryGeneric({
   args: { fixtureId: v.id("fixtures") },
   returns: v.union(
-    v.object({ muxLiveStreamId: v.string(), status: v.string() }),
+    v.object({
+      provider: v.string(),
+      muxLiveStreamId: v.union(v.string(), v.null()),
+      status: v.string(),
+    }),
     v.null(),
   ),
   handler: async (ctx, args) => {
@@ -4447,7 +4480,11 @@ export const getStreamAdminByFixture = internalQueryGeneric({
       .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
       .first();
     if (!row) return null;
-    return { muxLiveStreamId: row.muxLiveStreamId, status: row.status };
+    return {
+      provider: row.provider ?? "mux",
+      muxLiveStreamId: row.muxLiveStreamId ?? null,
+      status: row.status,
+    };
   },
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -7,6 +7,7 @@ const {
   mockGetPublicSeason,
   mockCreateGameStream,
   mockUpdateGameStreamStatus,
+  mockEndGameStreamByFixture,
   mockGetActiveStreamCountForLeague,
   mockGetStreamAdminByFixture,
   mockCanAdministerTeam,
@@ -19,6 +20,7 @@ const {
   mockGetPublicSeason: vi.fn(),
   mockCreateGameStream: vi.fn(),
   mockUpdateGameStreamStatus: vi.fn(),
+  mockEndGameStreamByFixture: vi.fn(),
   mockGetActiveStreamCountForLeague: vi.fn(),
   mockGetStreamAdminByFixture: vi.fn(),
   mockCanAdministerTeam: vi.fn(),
@@ -33,6 +35,7 @@ vi.mock("@/lib/data-api", () => ({
   getPublicSeason: mockGetPublicSeason,
   createGameStream: mockCreateGameStream,
   updateGameStreamStatus: mockUpdateGameStreamStatus,
+  endGameStreamByFixture: mockEndGameStreamByFixture,
   getActiveStreamCountForLeague: mockGetActiveStreamCountForLeague,
   getStreamAdminByFixture: mockGetStreamAdminByFixture,
 }));
@@ -45,7 +48,11 @@ vi.mock("@/lib/mux", () => ({
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-import { startGameStream, stopGameStream } from "../stream-actions";
+import {
+  startGameStream,
+  startYoutubeStream,
+  stopGameStream,
+} from "../stream-actions";
 
 const LEAGUE = "league_1";
 const FIXTURE = "fixture_1";
@@ -146,6 +153,62 @@ describe("startGameStream", () => {
   });
 });
 
+describe("startYoutubeStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+    mockCanAdministerTeam.mockResolvedValue(true);
+    mockGetActiveStreamCountForLeague.mockResolvedValue(0);
+    mockCreateGameStream.mockResolvedValue({
+      id: "gs_1",
+      fixtureId: FIXTURE,
+      status: "active",
+    });
+  });
+
+  it("persists a youtube stream from a pasted watch URL", async () => {
+    const res = await startYoutubeStream(
+      LEAGUE,
+      FIXTURE,
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    );
+    expect(res).toEqual({ ok: true });
+    expect(mockCreateGameStream).toHaveBeenCalledWith({
+      fixtureId: FIXTURE,
+      provider: "youtube",
+      youtubeVideoId: "dQw4w9WgXcQ",
+      startedBy: "user_1",
+      maxDurationMinutes: 180,
+    });
+  });
+
+  it("rejects a non-YouTube link without persisting", async () => {
+    expect(
+      await startYoutubeStream(LEAGUE, FIXTURE, "https://vimeo.com/123"),
+    ).toEqual({ ok: false, error: "invalid_youtube_url" });
+    expect(mockCreateGameStream).not.toHaveBeenCalled();
+  });
+
+  it("enforces the per-league concurrent cap", async () => {
+    mockGetActiveStreamCountForLeague.mockResolvedValue(3);
+    expect(
+      await startYoutubeStream(
+        LEAGUE,
+        FIXTURE,
+        "https://youtu.be/dQw4w9WgXcQ",
+      ),
+    ).toEqual({ ok: false, error: "stream_cap_reached" });
+    expect(mockCreateGameStream).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the dark flag is off", async () => {
+    mockLiveStreamingV1.mockResolvedValue(false);
+    expect(
+      await startYoutubeStream(LEAGUE, FIXTURE, "https://youtu.be/dQw4w9WgXcQ"),
+    ).toEqual({ ok: false, error: "flag_disabled" });
+  });
+});
+
 describe("stopGameStream", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -155,6 +218,7 @@ describe("stopGameStream", () => {
 
   it("disables the Mux stream and marks it ended", async () => {
     mockGetStreamAdminByFixture.mockResolvedValue({
+      provider: "mux",
       muxLiveStreamId: "ls_1",
       status: "active",
     });
@@ -164,6 +228,21 @@ describe("stopGameStream", () => {
     expect(mockUpdateGameStreamStatus).toHaveBeenCalledWith(
       expect.objectContaining({ muxLiveStreamId: "ls_1", status: "ended" }),
     );
+  });
+
+  it("ends a youtube stream without touching Mux", async () => {
+    mockGetStreamAdminByFixture.mockResolvedValue({
+      provider: "youtube",
+      muxLiveStreamId: null,
+      status: "active",
+    });
+    const res = await stopGameStream(LEAGUE, FIXTURE);
+    expect(res).toEqual({ ok: true });
+    expect(mockEndGameStreamByFixture).toHaveBeenCalledWith(
+      FIXTURE,
+      expect.any(String),
+    );
+    expect(mockDisableMuxLiveStream).not.toHaveBeenCalled();
   });
 
   it("returns stream_not_found when there is no stream", async () => {

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -8,11 +8,13 @@ import {
   getPublicSeason,
   createGameStream,
   updateGameStreamStatus,
+  endGameStreamByFixture,
   getActiveStreamCountForLeague,
   getStreamAdminByFixture,
 } from "@/lib/data-api";
 import { canAdministerTeam } from "@/lib/authorization";
 import { createMuxLiveStream, disableMuxLiveStream } from "@/lib/mux";
+import { parseYoutubeVideoId } from "@/lib/youtube";
 
 /*
  * Live-stream start/stop server actions (WSM-000144, dark behind
@@ -112,6 +114,46 @@ export async function startGameStream(
   }
 }
 
+/**
+ * Free streaming path (WSM-000180): a coach goes live on their own (unlisted)
+ * YouTube broadcast and pastes the watch/live URL. We store only the public
+ * video id and embed the player — YouTube handles ingest, delivery, and the
+ * recording (the same link becomes the replay). No RTMP key transits our app.
+ */
+export async function startYoutubeStream(
+  leagueId: string,
+  fixtureId: string,
+  youtubeUrl: string,
+): Promise<StopResult> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  const videoId = parseYoutubeVideoId(youtubeUrl);
+  if (!videoId) return { ok: false, error: "invalid_youtube_url" };
+
+  // Same concurrent cap as Mux — bounds how many live games a league juggles.
+  const activeCount = await getActiveStreamCountForLeague(leagueId);
+  if (activeCount >= PER_LEAGUE_CONCURRENT_CAP) {
+    return { ok: false, error: "stream_cap_reached" };
+  }
+
+  try {
+    await createGameStream({
+      fixtureId,
+      provider: "youtube",
+      youtubeVideoId: videoId,
+      startedBy: guard.userId,
+      maxDurationMinutes: MAX_STREAM_DURATION_MINUTES,
+    });
+    revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+    revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
 export async function stopGameStream(
   leagueId: string,
   fixtureId: string,
@@ -123,13 +165,21 @@ export async function stopGameStream(
     const stream = await getStreamAdminByFixture(fixtureId);
     if (!stream) return { ok: false, error: "stream_not_found" };
 
-    await disableMuxLiveStream(stream.muxLiveStreamId);
-    // Reflect the stop immediately; the webhook also flips this idempotently.
-    await updateGameStreamStatus({
-      muxLiveStreamId: stream.muxLiveStreamId,
-      status: "ended",
-      endedAt: new Date().toISOString(),
-    });
+    if (stream.provider === "youtube") {
+      // No Mux resource to tear down — the broadcast lives on YouTube. Just mark
+      // it ended; the same video id then serves as the replay on the game page.
+      await endGameStreamByFixture(fixtureId, new Date().toISOString());
+    } else {
+      if (stream.muxLiveStreamId) {
+        await disableMuxLiveStream(stream.muxLiveStreamId);
+        // Reflect the stop immediately; the webhook also flips this idempotently.
+        await updateGameStreamStatus({
+          muxLiveStreamId: stream.muxLiveStreamId,
+          status: "ended",
+          endedAt: new Date().toISOString(),
+        });
+      }
+    }
 
     revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
     revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -128,9 +128,12 @@ export default async function PublicGamePage({
       ? await getLiveGameState(gameId).catch(() => null)
       : null;
   const liveActive = stream?.status === "active";
-  const hasReplay = stream?.status === "ended" && stream.vodAssetId !== null;
-  const streamEndedNoReplay =
-    stream?.status === "ended" && stream.vodAssetId === null;
+  // A replay exists when Mux has attached a VOD asset, or — for YouTube — the
+  // same broadcast video id keeps serving the recording after it ends.
+  const hasReplay =
+    stream?.status === "ended" &&
+    (stream.vodAssetId !== null || stream.youtubeVideoId !== null);
+  const streamEndedNoReplay = stream?.status === "ended" && !hasReplay;
 
   const { fixture, result, seasonName } = view;
   const isFinal = fixture.status === "final" && result !== null;
@@ -187,7 +190,9 @@ export default async function PublicGamePage({
           <CardContent>
             <div className="relative">
               <GameStreamPlayer
-                playbackId={stream!.muxPlaybackId}
+                provider={stream!.provider}
+                muxPlaybackId={stream!.muxPlaybackId}
+                youtubeVideoId={stream!.youtubeVideoId}
                 live={liveActive}
                 title={`${fixture.homeTeamName} vs ${fixture.awayTeamName}`}
               />

--- a/apps/web/src/components/games/GameStreamPlayer.tsx
+++ b/apps/web/src/components/games/GameStreamPlayer.tsx
@@ -1,28 +1,51 @@
 "use client";
 
 import MuxPlayer from "@mux/mux-player-react";
+import { youtubeEmbedUrl } from "@/lib/youtube";
 
 /*
- * Public HLS player for a game's live stream / replay (WSM-000144). Takes only
- * the public Mux playback id — no key, no live-stream id ever reaches here.
- * While live, the live-stream playback id streams the live edge; once ended it
- * serves the recorded replay (streamType "on-demand").
+ * Public player for a game's live stream / replay (WSM-000144, WSM-000180).
+ * Provider-agnostic: "mux" plays the public HLS playback id (live edge while
+ * live, recorded replay once ended); "youtube" embeds the public video id (the
+ * same broadcast serves as the replay after it ends). No key or server-side id
+ * ever reaches here.
  */
 export interface GameStreamPlayerProps {
-  playbackId: string;
+  provider: string; // "mux" | "youtube"
+  muxPlaybackId: string | null;
+  youtubeVideoId: string | null;
   live: boolean;
   title: string;
 }
 
 export default function GameStreamPlayer({
-  playbackId,
+  provider,
+  muxPlaybackId,
+  youtubeVideoId,
   live,
   title,
 }: GameStreamPlayerProps) {
+  if (provider === "youtube") {
+    if (!youtubeVideoId) return null;
+    const src = `${youtubeEmbedUrl(youtubeVideoId)}?rel=0&playsinline=1${
+      live ? "&autoplay=1" : ""
+    }`;
+    return (
+      <iframe
+        src={src}
+        title={title}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        className="aspect-video w-full overflow-hidden rounded-md border-0"
+      />
+    );
+  }
+
+  if (!muxPlaybackId) return null;
   return (
     <MuxPlayer
       streamType={live ? "live" : "on-demand"}
-      playbackId={playbackId}
+      playbackId={muxPlaybackId}
       metadata={{ video_title: title }}
       accentColor="#dc2626"
       className="aspect-video w-full overflow-hidden rounded-md"

--- a/apps/web/src/components/schedule/GoLiveControl.tsx
+++ b/apps/web/src/components/schedule/GoLiveControl.tsx
@@ -3,21 +3,31 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Radio, Square, Copy } from "lucide-react";
+import { Radio, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  startGameStream,
+  startYoutubeStream,
   stopGameStream,
 } from "@/app/dashboard/leagues/[id]/schedule/stream-actions";
 
+/*
+ * Go-live control (WSM-000180) — free YouTube path. The coach starts a (best:
+ * unlisted) live broadcast on their own YouTube via YouTube Studio / OBS, then
+ * pastes the watch/live link here. We embed it on the public game page;
+ * YouTube does the ingest, delivery, and recording. No RTMP key touches our
+ * app. (The paid Mux RTMP path remains in stream-actions for a future upgrade.)
+ */
 export interface GoLiveControlProps {
   leagueId: string;
   fixtureId: string;
@@ -25,11 +35,6 @@ export interface GoLiveControlProps {
   awayTeamName: string;
   /** Current stream status from getStreamByFixture, or null if none exists. */
   status: "idle" | "active" | "ended" | null;
-}
-
-interface Credentials {
-  rtmpUrl: string;
-  streamKey: string;
 }
 
 export default function GoLiveControl({
@@ -41,18 +46,23 @@ export default function GoLiveControl({
 }: GoLiveControlProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
-  // The stream key is returned ONCE by startGameStream and never re-readable —
-  // hold it in local state to show the coach; it's gone on refresh.
-  const [creds, setCreds] = useState<Credentials | null>(null);
+  const [open, setOpen] = useState(false);
+  const [url, setUrl] = useState("");
 
   const isLive = status === "active";
 
-  function goLive() {
+  function start() {
+    const value = url.trim();
+    if (!value) {
+      toast.error("Paste your YouTube live link first.");
+      return;
+    }
     startTransition(async () => {
-      const res = await startGameStream(leagueId, fixtureId);
+      const res = await startYoutubeStream(leagueId, fixtureId, value);
       if (res.ok) {
-        setCreds({ rtmpUrl: res.rtmpUrl, streamKey: res.streamKey });
-        toast.success("Live stream ready — paste the camera settings below.");
+        toast.success("Live — your YouTube stream is now on the game page.");
+        setUrl("");
+        setOpen(false);
         router.refresh();
       } else {
         toast.error(errorLabel(res.error));
@@ -61,27 +71,20 @@ export default function GoLiveControl({
   }
 
   function stop() {
-    if (!window.confirm(`Stop the live stream for ${homeTeamName} vs ${awayTeamName}?`)) {
+    if (
+      !window.confirm(`Stop the live stream for ${homeTeamName} vs ${awayTeamName}?`)
+    ) {
       return;
     }
     startTransition(async () => {
       const res = await stopGameStream(leagueId, fixtureId);
       if (res.ok) {
-        toast.success("Live stream stopped.");
+        toast.success("Live stream stopped — the recording stays on the game page.");
         router.refresh();
       } else {
         toast.error(errorLabel(res.error));
       }
     });
-  }
-
-  async function copy(value: string, label: string) {
-    try {
-      await navigator.clipboard.writeText(value);
-      toast.success(`${label} copied.`);
-    } catch {
-      toast.error("Copy failed — select and copy manually.");
-    }
   }
 
   return (
@@ -106,67 +109,56 @@ export default function GoLiveControl({
           size="sm"
           variant="ghost"
           disabled={pending}
-          onClick={goLive}
+          onClick={() => setOpen(true)}
           aria-label={`Go live for ${homeTeamName} vs ${awayTeamName}`}
         >
           <Radio className="mr-1 h-4 w-4" /> Go live
         </Button>
       )}
 
-      <Dialog open={creds !== null} onOpenChange={(open) => !open && setCreds(null)}>
+      <Dialog open={open} onOpenChange={(o) => !pending && setOpen(o)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Camera settings</DialogTitle>
+            <DialogTitle>Go live with YouTube</DialogTitle>
             <DialogDescription>
-              Paste these into your camera or encoder&apos;s &ldquo;Custom
-              RTMP&rdquo; settings (Mevo, OBS, etc.). The stream key is shown
-              once — copy it now.
+              Start your live broadcast on YouTube (we recommend{" "}
+              <strong>Unlisted</strong> for student athletes), then paste its
+              link below. It&apos;ll play right here on the game page, and the
+              recording stays available afterward.
             </DialogDescription>
           </DialogHeader>
-          {creds ? (
-            <div className="space-y-3">
-              <CredentialRow
-                label="RTMP URL"
-                value={creds.rtmpUrl}
-                onCopy={() => copy(creds.rtmpUrl, "RTMP URL")}
-              />
-              <CredentialRow
-                label="Stream key"
-                value={creds.streamKey}
-                secret
-                onCopy={() => copy(creds.streamKey, "Stream key")}
-              />
-            </div>
-          ) : null}
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="yt-url">YouTube live link</Label>
+            <Input
+              id="yt-url"
+              inputMode="url"
+              placeholder="https://www.youtube.com/watch?v=…"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") start();
+              }}
+            />
+            <p className="text-caption-12 text-text-muted">
+              Paste a watch, youtu.be, or /live link — we&apos;ll detect the
+              video automatically.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={start} disabled={pending || !url.trim()}>
+              {pending ? "Starting…" : "Start stream"}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>
-  );
-}
-
-function CredentialRow({
-  label,
-  value,
-  secret,
-  onCopy,
-}: {
-  label: string;
-  value: string;
-  secret?: boolean;
-  onCopy: () => void;
-}) {
-  return (
-    <div>
-      <p className="mb-1 text-xs font-medium text-muted-foreground">{label}</p>
-      <div className="flex items-center gap-2">
-        <code className="flex-1 overflow-x-auto rounded border border-border bg-muted px-2 py-1 font-mono text-xs">
-          {secret ? "•".repeat(Math.min(value.length, 32)) : value}
-        </code>
-        <Button size="sm" variant="outline" onClick={onCopy} aria-label={`Copy ${label}`}>
-          <Copy className="h-4 w-4" />
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -180,15 +172,13 @@ function errorLabel(error: string): string {
       return "Only an admin of one of the two teams can start a stream.";
     case "stream_cap_reached":
       return "This league already has the maximum number of live streams running.";
+    case "invalid_youtube_url":
+      return "That doesn't look like a YouTube link — paste the watch, youtu.be, or /live URL.";
     case "fixture_not_found":
     case "fixture_not_in_league":
       return "Game not found.";
     case "stream_not_found":
       return "No live stream to stop.";
-    case "mux_plan_required":
-      return "Live streaming needs a paid Mux plan — the account is on the free plan. Upgrade at dashboard.mux.com, then try again.";
-    case "mux_live_stream_incomplete":
-      return "Mux didn't return complete stream details. Please try again.";
     default:
       return error;
   }

--- a/apps/web/src/lib/__tests__/youtube.test.ts
+++ b/apps/web/src/lib/__tests__/youtube.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parseYoutubeVideoId, youtubeEmbedUrl } from "../youtube";
+
+describe("parseYoutubeVideoId", () => {
+  const ID = "dQw4w9WgXcQ"; // 11 chars
+
+  it("parses the common URL shapes", () => {
+    expect(parseYoutubeVideoId(`https://www.youtube.com/watch?v=${ID}`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://youtube.com/watch?v=${ID}&t=10s`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://youtu.be/${ID}`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://www.youtube.com/live/${ID}`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://www.youtube.com/embed/${ID}`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://www.youtube.com/shorts/${ID}`)).toBe(ID);
+    expect(parseYoutubeVideoId(`https://m.youtube.com/watch?v=${ID}`)).toBe(ID);
+  });
+
+  it("accepts a bare 11-char id", () => {
+    expect(parseYoutubeVideoId(ID)).toBe(ID);
+    expect(parseYoutubeVideoId(`  ${ID}  `)).toBe(ID);
+  });
+
+  it("rejects non-YouTube and malformed input", () => {
+    expect(parseYoutubeVideoId("")).toBeNull();
+    expect(parseYoutubeVideoId("not a url")).toBeNull();
+    expect(parseYoutubeVideoId("https://vimeo.com/12345")).toBeNull();
+    expect(parseYoutubeVideoId("https://www.youtube.com/watch?v=short")).toBeNull();
+    expect(parseYoutubeVideoId("https://www.youtube.com/")).toBeNull();
+    expect(parseYoutubeVideoId("https://evil.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+  });
+
+  it("builds a no-cookie embed URL", () => {
+    expect(youtubeEmbedUrl(ID)).toBe(
+      `https://www.youtube-nocookie.com/embed/${ID}`,
+    );
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -571,13 +571,19 @@ const refs = {
   createGameStream: mutationRef<
     {
       fixtureId: string;
-      muxLiveStreamId: string;
-      muxPlaybackId: string;
+      provider?: string;
+      muxLiveStreamId?: string;
+      muxPlaybackId?: string;
+      youtubeVideoId?: string | null;
       startedBy: string;
       maxDurationMinutes: number;
     },
-    { id: string; fixtureId: string; status: string; muxPlaybackId: string }
+    { id: string; fixtureId: string; status: string }
   >("sports:createGameStream"),
+  endGameStreamByFixture: mutationRef<
+    { fixtureId: string; endedAt: string },
+    boolean
+  >("sports:endGameStreamByFixture"),
   updateGameStreamStatus: mutationRef<
     {
       muxLiveStreamId: string;
@@ -597,7 +603,7 @@ const refs = {
   // Internal query (not on public api) — admin-keyed server code only.
   getStreamAdminByFixture: queryRef<
     { fixtureId: string },
-    { muxLiveStreamId: string; status: string } | null
+    { provider: string; muxLiveStreamId: string | null; status: string } | null
   >("sports:getStreamAdminByFixture"),
   // Stat-keeping keystone (WSM-000112)
   upsertPlayerGameStats: mutationRef<
@@ -1768,17 +1774,22 @@ export async function getResultByFixture(
 // --- Phase 1 live streaming wrappers (WSM-000144) ---
 
 /** Public projection of a game stream — what an unauthenticated viewer sees.
- *  Never carries the Mux live-stream id or stream key. */
+ *  Never carries the Mux live-stream id or stream key. Provider-agnostic:
+ *  `provider` selects which public playback id is populated. */
 export interface PublicGameStream {
   status: string; // "idle" | "active" | "ended"
-  muxPlaybackId: string;
+  provider: string; // "mux" | "youtube"
+  muxPlaybackId: string | null;
+  youtubeVideoId: string | null;
   vodAssetId: string | null;
 }
 
 export interface CreateGameStreamInput {
   fixtureId: string;
-  muxLiveStreamId: string;
-  muxPlaybackId: string;
+  provider?: string; // "mux" (default) | "youtube"
+  muxLiveStreamId?: string;
+  muxPlaybackId?: string;
+  youtubeVideoId?: string | null;
   startedBy: string;
   maxDurationMinutes: number;
 }
@@ -1789,9 +1800,16 @@ export async function createGameStream(
   id: string;
   fixtureId: string;
   status: string;
-  muxPlaybackId: string;
 }> {
   return mutateConvex(refs.createGameStream, input);
+}
+
+/** Mark a fixture's stream ended (YouTube stop — no Mux webhook to flip it). */
+export async function endGameStreamByFixture(
+  fixtureId: string,
+  endedAt: string,
+): Promise<boolean> {
+  return mutateConvex(refs.endGameStreamByFixture, { fixtureId, endedAt });
 }
 
 export async function updateGameStreamStatus(input: {
@@ -1820,7 +1838,11 @@ export async function getActiveStreamCountForLeague(
  *  action can disable/transition it. Admin-keyed; not a public projection. */
 export async function getStreamAdminByFixture(
   fixtureId: string,
-): Promise<{ muxLiveStreamId: string; status: string } | null> {
+): Promise<{
+  provider: string;
+  muxLiveStreamId: string | null;
+  status: string;
+} | null> {
   return queryConvex(refs.getStreamAdminByFixture, { fixtureId });
 }
 

--- a/apps/web/src/lib/youtube.ts
+++ b/apps/web/src/lib/youtube.ts
@@ -1,0 +1,69 @@
+/*
+ * YouTube Live helpers (WSM-000180) — the free "paste a link" streaming path.
+ *
+ * A coach goes live on their own (unlisted) YouTube broadcast via YouTube
+ * Studio / OBS, then pastes the watch/live URL into the game. We extract the
+ * 11-character video id and embed the player; YouTube does the ingest,
+ * transcode, delivery, and recording (the same URL becomes the replay). Pure +
+ * dependency-free so it's unit-testable.
+ */
+
+// YouTube video ids are exactly 11 chars from this alphabet.
+const VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
+
+/**
+ * Extract a YouTube video id from a pasted URL or a raw id. Handles the common
+ * shapes: watch?v=, youtu.be/, /live/, /embed/, /shorts/, and a bare id.
+ * Returns null if no valid id is found.
+ */
+export function parseYoutubeVideoId(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Bare id pasted directly.
+  if (VIDEO_ID_RE.test(trimmed)) return trimmed;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const host = url.hostname.replace(/^www\./, "").toLowerCase();
+  const isYouTube =
+    host === "youtube.com" ||
+    host === "m.youtube.com" ||
+    host === "youtu.be" ||
+    host === "youtube-nocookie.com";
+  if (!isYouTube) return null;
+
+  // youtu.be/<id>
+  if (host === "youtu.be") {
+    const id = url.pathname.slice(1).split("/")[0];
+    return VIDEO_ID_RE.test(id) ? id : null;
+  }
+
+  // youtube.com/watch?v=<id>
+  const vParam = url.searchParams.get("v");
+  if (vParam && VIDEO_ID_RE.test(vParam)) return vParam;
+
+  // youtube.com/{live,embed,shorts,v}/<id>
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length >= 2) {
+    const [kind, id] = segments;
+    if (
+      (kind === "live" || kind === "embed" || kind === "shorts" || kind === "v") &&
+      VIDEO_ID_RE.test(id)
+    ) {
+      return id;
+    }
+  }
+
+  return null;
+}
+
+/** Privacy-friendly embed URL for a video id (uses the no-cookie host). */
+export function youtubeEmbedUrl(videoId: string): string {
+  return `https://www.youtube-nocookie.com/embed/${videoId}`;
+}


### PR DESCRIPTION
## What & why
Mux live streaming needs a paid plan (#403). This adds a **free** streaming path: a coach goes live on their own **(unlisted)** YouTube broadcast (YouTube Studio / OBS), pastes the link into the game's **Go live** control, and the broadcast embeds on the public game page. YouTube does ingest, transcode, delivery, and recording — the same link becomes the replay. No RTMP key touches our app, no recurring cost, no API quota.

Chosen over OAuth automation for speed/simplicity; the Mux RTMP path stays intact for a future upgrade (only the UI entry point switched).

## Changes
- **schema** (`gameStreams`): `provider` ("mux"|"youtube") + `youtubeVideoId`; Mux id fields relaxed to optional (legacy rows default to `mux`).
- **convex** (`sports.ts`): `createGameStream` provider-aware (YouTube starts `active` — no webhook to confirm it); public stream DTO is provider-agnostic; `getStreamAdminByFixture` returns `provider`; new `endGameStreamByFixture` for the YouTube stop (no Mux teardown).
- **`lib/youtube.ts`**: pure `parseYoutubeVideoId` (watch / youtu.be / live / embed / shorts / bare id) + privacy-friendly no-cookie embed URL. Unit-tested.
- **actions**: `startYoutubeStream` (validates URL → stores video id; same team-admin auth + per-league concurrent cap as Mux); `stopGameStream` branches by provider.
- **UI**: `GoLiveControl` → "paste your YouTube link" dialog (recommends Unlisted for student athletes); `GameStreamPlayer` branches to a YouTube `<iframe>` vs `MuxPlayer`; public game page treats a YouTube ended stream as having a replay.

Reuses the existing `live_streaming_v1` flag (already on in prod).

## Verification
- `pnpm exec vitest run` — youtube (4) + stream-actions (incl. new startYoutubeStream + youtube-stop) + mux webhook suites green (26).
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Deploy note
Touches the Convex `gameStreams` schema → ship **web + Convex together from merged main** (per the skew lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)