### PR TITLE
feat(web): game-status badges + block live-streaming an ended game (WSM-000182)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -67,6 +67,7 @@ function happyFixture() {
     awayTeamId: "team_away",
     homeTeamName: "Home",
     awayTeamName: "Away",
+    status: "scheduled",
   });
   mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
 }
@@ -131,6 +132,23 @@ describe("startGameStream", () => {
     expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
       ok: false,
       error: "stream_cap_reached",
+    });
+    expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
+  });
+
+  it("refuses to start a stream for a finished game", async () => {
+    mockGetFixture.mockResolvedValue({
+      id: FIXTURE,
+      seasonId: "season_1",
+      homeTeamId: "team_home",
+      awayTeamId: "team_away",
+      homeTeamName: "Home",
+      awayTeamName: "Away",
+      status: "final",
+    });
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "game_over",
     });
     expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -27,6 +27,7 @@ import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
+import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 
 type StreamStatus = "idle" | "active" | "ended";
@@ -235,8 +236,8 @@ export default async function LeagueSchedulePage({
                               ? `${result.homeScore} – ${result.awayScore}`
                               : "—"}
                           </td>
-                          <td className="px-4 py-2 font-mono text-xs uppercase text-muted-foreground">
-                            {fixture.status}
+                          <td className="px-4 py-2">
+                            <StatusBadge status={fixture.status} />
                           </td>
                           {isAdmin ? (
                             <td className="px-4 py-2">
@@ -263,6 +264,7 @@ export default async function LeagueSchedulePage({
                                     homeTeamName={fixture.homeTeamName}
                                     awayTeamName={fixture.awayTeamName}
                                     status={streamStatuses.get(fixture.id) ?? null}
+                                    gameStatus={fixture.status}
                                   />
                                 ) : null}
                                 {statsEnabled ? (

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -48,7 +48,7 @@ async function authorizeStreamAction(
   leagueId: string,
   fixtureId: string,
 ): Promise<
-  { ok: true; userId: string } | { ok: false; error: string }
+  { ok: true; userId: string; fixtureStatus: string } | { ok: false; error: string }
 > {
   const enabled = await liveStreamingV1();
   if (!enabled) return { ok: false, error: "flag_disabled" };
@@ -71,7 +71,7 @@ async function authorizeStreamAction(
   ]);
   if (!canHome && !canAway) return { ok: false, error: "not_authorized" };
 
-  return { ok: true, userId };
+  return { ok: true, userId, fixtureStatus: fixture.status };
 }
 
 export async function startGameStream(
@@ -80,6 +80,10 @@ export async function startGameStream(
 ): Promise<StartResult> {
   const guard = await authorizeStreamAction(leagueId, fixtureId);
   if (!guard.ok) return guard;
+  // A finished/cancelled game can't go live.
+  if (guard.fixtureStatus === "final" || guard.fixtureStatus === "cancelled") {
+    return { ok: false, error: "game_over" };
+  }
 
   // Concurrent-stream cap — bounds the absorbed cost for a pilot league.
   // TODO(streaming paid tier): replace/augment with an entitlement check here.
@@ -127,6 +131,10 @@ export async function startYoutubeStream(
 ): Promise<StopResult> {
   const guard = await authorizeStreamAction(leagueId, fixtureId);
   if (!guard.ok) return guard;
+  // A finished/cancelled game can't go live.
+  if (guard.fixtureStatus === "final" || guard.fixtureStatus === "cancelled") {
+    return { ok: false, error: "game_over" };
+  }
 
   const videoId = parseYoutubeVideoId(youtubeUrl);
   if (!videoId) return { ok: false, error: "invalid_youtube_url" };

--- a/apps/web/src/components/schedule/GoLiveControl.tsx
+++ b/apps/web/src/components/schedule/GoLiveControl.tsx
@@ -35,6 +35,8 @@ export interface GoLiveControlProps {
   awayTeamName: string;
   /** Current stream status from getStreamByFixture, or null if none exists. */
   status: "idle" | "active" | "ended" | null;
+  /** Fixture status — a finished/cancelled game can't start a new stream. */
+  gameStatus?: string;
 }
 
 export default function GoLiveControl({
@@ -43,6 +45,7 @@ export default function GoLiveControl({
   homeTeamName,
   awayTeamName,
   status,
+  gameStatus,
 }: GoLiveControlProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -50,6 +53,9 @@ export default function GoLiveControl({
   const [url, setUrl] = useState("");
 
   const isLive = status === "active";
+  // A game that's over (or cancelled) can't go live. We still show the LIVE +
+  // Stop control if a stream is somehow active, so it can always be stopped.
+  const gameOver = gameStatus === "final" || gameStatus === "cancelled";
 
   function start() {
     const value = url.trim();
@@ -104,7 +110,7 @@ export default function GoLiveControl({
             <Square className="h-4 w-4 text-destructive" />
           </Button>
         </div>
-      ) : (
+      ) : gameOver ? null : (
         <Button
           size="sm"
           variant="ghost"
@@ -179,6 +185,8 @@ function errorLabel(error: string): string {
       return "Game not found.";
     case "stream_not_found":
       return "No live stream to stop.";
+    case "game_over":
+      return "This game has ended — you can't start a live stream for it.";
     default:
       return error;
   }

--- a/apps/web/src/components/status-badge.tsx
+++ b/apps/web/src/components/status-badge.tsx
@@ -1,13 +1,18 @@
 import { Badge, type BadgeProps } from "@/components/ui/badge";
 
 const statusVariantMap: Record<string, BadgeProps["variant"]> = {
+  // Player statuses
   Active: "success",
   Injured: "warning",
   Inactive: "secondary",
+  // Season / generic statuses
   Planned: "outline",
   "In Progress": "default",
   Completed: "success",
   Cancelled: "destructive",
+  // Game (fixture) statuses
+  Scheduled: "outline",
+  Final: "secondary",
 };
 
 /**


### PR DESCRIPTION
## Two fixes from one report
Reported from the league schedule screen.

### 1. Game statuses now use badges
Status was plain uppercase gray text (`SCHEDULED`, `FINAL`). Now rendered with `StatusBadge`:
- **Scheduled** → outline, **Final** → muted/secondary, **Cancelled** → danger.
- Adds `Scheduled`/`Final` keys to the shared status→variant map (matched case-insensitively, so casing from the DB doesn't matter).

### 2. Can't live-stream a game that has ended
A `final` game still showed a **Go live** button. Now:
- The Go-live button is hidden for `final`/`cancelled` fixtures (the **LIVE + Stop** control still renders if a stream is somehow active, so an in-progress stream can always be stopped).
- Server-side, `startGameStream` and `startYoutubeStream` reject a finished/cancelled fixture with a `game_over` error (defense-in-depth, not just UI).

## Verification
- `pnpm exec vitest run` — stream-actions suite 14/14 (incl. new "refuses to start a stream for a finished game").
- `pnpm exec eslint` — clean. `pnpm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)