### PR TITLE
feat(web): simulate games (ratings-weighted) — engine + regular season (WSM-000183)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -3586,6 +3586,7 @@ const fixtureDtoValidator = v.object({
   week: v.union(v.number(), v.null()),
   venue: v.union(v.string(), v.null()),
   status: v.string(),
+  stage: v.string(), // "regular" | "playoff" (legacy rows = regular)
   createdAt: v.string(),
   createdBy: v.string(),
 });
@@ -3643,6 +3644,7 @@ export const createFixture = internalMutationGeneric({
       week: args.week,
       venue: args.venue,
       status: "scheduled",
+      stage: "regular",
       createdAt,
       createdBy: args.actorUserId,
     };
@@ -3685,6 +3687,7 @@ export const updateFixture = internalMutationGeneric({
       week: merged.week,
       venue: merged.venue,
       status: merged.status,
+      stage: merged.stage ?? "regular",
       createdAt: merged.createdAt,
       createdBy: merged.createdBy,
     };
@@ -3737,6 +3740,7 @@ export const listFixturesBySeason = queryGeneric({
           week: row.week,
           venue: row.venue,
           status: row.status,
+          stage: row.stage ?? "regular",
           createdAt: row.createdAt,
           createdBy: row.createdBy,
         };
@@ -3983,6 +3987,7 @@ export const getFixture = queryGeneric({
       week: row.week,
       venue: row.venue,
       status: row.status,
+      stage: row.stage ?? "regular",
       createdAt: row.createdAt,
       createdBy: row.createdBy,
     };

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -9,10 +9,16 @@ import {
   generateSeasonSchedule,
   getLeague,
   getLeagueOrgId,
+  getFixture,
+  listFixturesBySeason,
+  getTeamAttributeSnapshots,
+  getTeamMaddenOveralls,
   recordGameResult,
 } from "@/lib/data-api";
+import type { OrgContext } from "@/lib/org-context";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
+import { simulateScore, seedFromString } from "@/lib/simulate-game";
 import {
   trackFixtureCreated,
   trackResultRecorded,
@@ -200,6 +206,150 @@ export async function deleteFixtureAction(
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
     return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/*
+ * Game simulation (WSM-000183) — fill plausible, ratings-weighted scores for
+ * unplayed games. A team's strength is the mean of its roster's SPRT/Madden
+ * `weightedOverall` (50 = unrated/neutral). Sims are deterministic per fixture
+ * and recorded as normal results (never overwrite a real/final game), so
+ * standings + playoff advancement flow exactly as hand-entered results do.
+ */
+
+const NEUTRAL_STRENGTH = 50;
+
+function mean(values: number[]): number {
+  if (values.length === 0) return NEUTRAL_STRENGTH;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Aggregate team strength for a season, cached per team across a batch sim. */
+async function teamStrength(
+  teamId: string,
+  orgContext: OrgContext,
+  cache: Map<string, number>,
+): Promise<number> {
+  const cached = cache.get(teamId);
+  if (cached !== undefined) return cached;
+
+  let strength = NEUTRAL_STRENGTH;
+  const snaps = await getTeamAttributeSnapshots(teamId, orgContext).catch(
+    () => null,
+  );
+  const sprt = snaps
+    ? [...snaps.values()]
+        .map((s) => s.weightedOverall)
+        .filter((n): n is number => n != null)
+    : [];
+  if (sprt.length > 0) {
+    strength = mean(sprt);
+  } else {
+    // Fall back to Madden overalls when no SPRT snapshot exists this season.
+    const madden = await getTeamMaddenOveralls(teamId, orgContext).catch(
+      () => null,
+    );
+    if (madden && madden.size > 0) strength = mean([...madden.values()]);
+  }
+
+  cache.set(teamId, strength);
+  return strength;
+}
+
+export async function simulateGameAction(input: {
+  leagueId: string;
+  fixtureId: string;
+}): Promise<
+  { ok: true; homeScore: number; awayScore: number } | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const fixture = await getFixture(input.fixtureId);
+  if (!fixture) return { ok: false, error: "fixture_not_found" };
+  if (fixture.status === "final") return { ok: false, error: "already_final" };
+  if (fixture.status === "cancelled") return { ok: false, error: "cancelled" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const cache = new Map<string, number>();
+  const [homeStrength, awayStrength] = await Promise.all([
+    teamStrength(fixture.homeTeamId, orgContext, cache),
+    teamStrength(fixture.awayTeamId, orgContext, cache),
+  ]);
+
+  const { homeScore, awayScore } = simulateScore({
+    homeStrength,
+    awayStrength,
+    seed: seedFromString(input.fixtureId),
+    decisive: fixture.stage === "playoff",
+  });
+
+  try {
+    await recordGameResult({
+      fixtureId: input.fixtureId,
+      homeScore,
+      awayScore,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    revalidatePath(`/leagues/${input.leagueId}/standings`);
+    return { ok: true, homeScore, awayScore };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export async function simulateSeasonAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<{ ok: true; simulated: number } | { ok: false; error: string }> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
+  // Regular-season, unplayed games only — never overwrite real results, and
+  // leave playoff games to the bracket flow.
+  const unplayed = fixtures.filter(
+    (f) => f.status === "scheduled" && f.stage !== "playoff",
+  );
+
+  const cache = new Map<string, number>();
+  let simulated = 0;
+  try {
+    for (const fixture of unplayed) {
+      const [homeStrength, awayStrength] = await Promise.all([
+        teamStrength(fixture.homeTeamId, orgContext, cache),
+        teamStrength(fixture.awayTeamId, orgContext, cache),
+      ]);
+      const { homeScore, awayScore } = simulateScore({
+        homeStrength,
+        awayStrength,
+        seed: seedFromString(fixture.id),
+      });
+      await recordGameResult({
+        fixtureId: fixture.id,
+        homeScore,
+        awayScore,
+        actorUserId: userId,
+      });
+      simulated += 1;
+    }
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    revalidatePath(`/leagues/${input.leagueId}/standings`);
+    return { ok: true, simulated };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -27,6 +27,10 @@ import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
+import {
+  SimulateGameButton,
+  SimulateSeasonButton,
+} from "@/components/schedule/SimulateControls";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 
@@ -160,6 +164,12 @@ export default async function LeagueSchedulePage({
               teams={teams.map((t) => ({ id: t.id, name: t.name }))}
             />
           ) : null}
+          {isAdmin && activeSeason && fixtures.length > 0 ? (
+            <SimulateSeasonButton
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+            />
+          ) : null}
         </div>
       </header>
 
@@ -251,6 +261,14 @@ export default async function LeagueSchedulePage({
                                   initialAwayScore={result?.awayScore ?? null}
                                   triggerLabel={result ? "Edit result" : "Record result"}
                                 />
+                                {fixture.status === "scheduled" ? (
+                                  <SimulateGameButton
+                                    leagueId={leagueId}
+                                    fixtureId={fixture.id}
+                                    homeTeamName={fixture.homeTeamName}
+                                    awayTeamName={fixture.awayTeamName}
+                                  />
+                                ) : null}
                                 <DeleteFixtureButton
                                   leagueId={leagueId}
                                   fixtureId={fixture.id}

--- a/apps/web/src/components/schedule/SimulateControls.tsx
+++ b/apps/web/src/components/schedule/SimulateControls.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Dices, Wand2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  simulateGameAction,
+  simulateSeasonAction,
+} from "@/app/dashboard/leagues/[id]/schedule/actions";
+
+/*
+ * Simulation controls (WSM-000183) — fill plausible, ratings-weighted scores.
+ * Per-game "Sim" sits next to Record result; "Simulate season" fills every
+ * unplayed regular-season game at once. Both record normal results, so
+ * standings update exactly as hand-entered scores do. Manager/admin only
+ * (parent gates rendering).
+ */
+
+export function SimulateGameButton({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+}: {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run() {
+    start(async () => {
+      const res = await simulateGameAction({ leagueId, fixtureId });
+      if (res.ok) {
+        toast.success(
+          `Simulated: ${homeTeamName} ${res.homeScore}–${res.awayScore} ${awayTeamName}.`,
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      disabled={pending}
+      onClick={run}
+      title="Simulate a score for this game (weighted by team ratings)"
+      aria-label={`Simulate ${homeTeamName} vs ${awayTeamName}`}
+    >
+      <Dices className="mr-1 h-4 w-4" />
+      {pending ? "Simulating…" : "Sim"}
+    </Button>
+  );
+}
+
+export function SimulateSeasonButton({
+  leagueId,
+  seasonId,
+}: {
+  leagueId: string;
+  seasonId: string;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run() {
+    if (
+      !window.confirm(
+        "Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched.",
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulateSeasonAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.simulated === 0
+            ? "No unplayed games to simulate."
+            : `Simulated ${res.simulated} game${res.simulated === 1 ? "" : "s"}.`,
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={run}
+      title="Fill every unplayed regular-season game with a ratings-weighted score"
+    >
+      <Wand2 className="mr-1 h-4 w-4" />
+      {pending ? "Simulating…" : "Simulate season"}
+    </Button>
+  );
+}
+
+function simError(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Schedules feature is disabled.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "Only league admins/coaches can simulate games.";
+    case "already_final":
+      return "That game already has a result.";
+    case "cancelled":
+      return "That game is cancelled.";
+    case "fixture_not_found":
+      return "Game not found.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/lib/__tests__/simulate-game.test.ts
+++ b/apps/web/src/lib/__tests__/simulate-game.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { simulateScore, seedFromString } from "../simulate-game";
+
+describe("simulateScore", () => {
+  it("is deterministic for a given seed", () => {
+    const a = simulateScore({ homeStrength: 70, awayStrength: 60, seed: 42 });
+    const b = simulateScore({ homeStrength: 70, awayStrength: 60, seed: 42 });
+    expect(a).toEqual(b);
+  });
+
+  it("returns non-negative integer scores", () => {
+    for (let s = 0; s < 50; s++) {
+      const { homeScore, awayScore } = simulateScore({
+        homeStrength: 50,
+        awayStrength: 50,
+        seed: s,
+      });
+      for (const v of [homeScore, awayScore]) {
+        expect(Number.isInteger(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("lets the stronger team win the clear majority — but upsets still happen", () => {
+    let strongWins = 0;
+    const N = 400;
+    for (let s = 0; s < N; s++) {
+      // Home is clearly stronger (72 vs 52) — favored, not a lock.
+      const { homeScore, awayScore } = simulateScore({
+        homeStrength: 72,
+        awayStrength: 52,
+        seed: s * 7919 + 1,
+      });
+      if (homeScore > awayScore) strongWins++;
+    }
+    // Favored team wins a clear majority, but the underdog steals some.
+    expect(strongWins / N).toBeGreaterThan(0.65);
+    expect(strongWins).toBeLessThan(N);
+  });
+
+  it("evenly-matched teams are roughly a coin flip over many seeds", () => {
+    let homeWins = 0;
+    const N = 400;
+    for (let s = 0; s < N; s++) {
+      const { homeScore, awayScore } = simulateScore({
+        homeStrength: 55,
+        awayStrength: 55,
+        seed: s * 104729 + 3,
+      });
+      if (homeScore > awayScore) homeWins++;
+    }
+    // Home-field nudges it slightly above 50% but it stays competitive.
+    expect(homeWins / N).toBeGreaterThan(0.45);
+    expect(homeWins / N).toBeLessThan(0.7);
+  });
+
+  it("never ties when decisive is set", () => {
+    for (let s = 0; s < 200; s++) {
+      const { homeScore, awayScore } = simulateScore({
+        homeStrength: 50,
+        awayStrength: 50,
+        seed: s,
+        decisive: true,
+      });
+      expect(homeScore).not.toBe(awayScore);
+    }
+  });
+
+  it("re-exports seedFromString for per-fixture seeding", () => {
+    expect(seedFromString("fixture_1")).toBe(seedFromString("fixture_1"));
+    expect(seedFromString("fixture_1")).not.toBe(seedFromString("fixture_2"));
+  });
+});

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -343,6 +343,7 @@ export class LocalWorkspaceProvider implements WorkspaceDataProvider {
       week: input.week ?? null,
       venue: input.venue ?? null,
       status: "scheduled",
+      stage: "regular",
       createdAt: nowIso(),
       createdBy: "local",
     };

--- a/apps/web/src/lib/simulate-game.ts
+++ b/apps/web/src/lib/simulate-game.ts
@@ -1,0 +1,88 @@
+/*
+ * Game-score simulator (WSM-000183) — produces believable football scores for
+ * an unplayed fixture, weighted by relative team strength so stronger rosters
+ * win more often (but upsets still happen). Pure + deterministic given a seed,
+ * so a fixture always sims the same way and the lib is unit-testable.
+ *
+ * Team "strength" is a 0–99 aggregate (mean of the roster's SPRT/Madden
+ * `weightedOverall`); 50 is a neutral/unrated team. The score model: each side's
+ * expected points start at a league-average baseline, shift with the strength
+ * differential, get a small home-field bump, then add seeded variance — enough
+ * that a clearly stronger team usually (not always) wins.
+ */
+import { seedFromString } from "@/lib/synthetic-roster";
+
+/** Average points an average matchup yields per team. */
+const BASELINE_POINTS = 21;
+/** Points swing per point of strength differential (full 99-gap ≈ ±25). */
+const STRENGTH_WEIGHT = 0.26;
+/** Home-field edge, in points. */
+const HOME_FIELD = 2.5;
+/** Peak ± seeded swing applied to each team's expected points. */
+const VARIANCE = 13;
+
+/** mulberry32 — small deterministic PRNG (same family as synthetic-roster). */
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface SimulateScoreInput {
+  /** Home team strength, ~0–99 (50 = neutral). */
+  homeStrength: number;
+  /** Away team strength, ~0–99. */
+  awayStrength: number;
+  /** Deterministic seed (e.g. seedFromString(fixtureId)). */
+  seed: number;
+  /** When true, never returns a tie — re-rolls to a clean winner (playoffs). */
+  decisive?: boolean;
+}
+
+export interface SimulatedScore {
+  homeScore: number;
+  awayScore: number;
+}
+
+function pointsFor(
+  strength: number,
+  oppStrength: number,
+  homeEdge: number,
+  rand: () => number,
+): number {
+  const base =
+    BASELINE_POINTS + (strength - oppStrength) * STRENGTH_WEIGHT + homeEdge;
+  const swing = (rand() - 0.5) * 2 * VARIANCE;
+  return Math.max(0, Math.round(base + swing));
+}
+
+/**
+ * Simulate a final score. Deterministic for a given seed. When `decisive` is
+ * set (playoff games), a tie is broken by nudging the stronger team (or home on
+ * an exact strength tie) ahead, so the bracket always advances.
+ */
+export function simulateScore({
+  homeStrength,
+  awayStrength,
+  seed,
+  decisive = false,
+}: SimulateScoreInput): SimulatedScore {
+  const rand = rng(seed);
+  let homeScore = pointsFor(homeStrength, awayStrength, HOME_FIELD, rand);
+  let awayScore = pointsFor(awayStrength, homeStrength, 0, rand);
+
+  if (decisive && homeScore === awayScore) {
+    // Overtime field goal for the favorite (home wins an exact-strength tie).
+    if (awayStrength > homeStrength) awayScore += 3;
+    else homeScore += 3;
+  }
+
+  return { homeScore, awayScore };
+}
+
+export { seedFromString };

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -252,6 +252,7 @@ export interface FixtureDto {
   week: number | null;
   venue: string | null;
   status: FixtureStatus;
+  stage: string; // "regular" | "playoff"
   createdAt: string;
   createdBy: string;
 }


### PR DESCRIPTION
## What & why
Part 1 of the game/season simulation feature. Fills plausible final scores for **unplayed** games, **weighted by team strength** (the SPRT/Madden `weightedOverall` from the ratings feature) so stronger rosters win more often — but upsets still happen. Simulated games are recorded as normal results, so standings and playoff advancement behave exactly as hand-entered scores do.

## Changes
- **`lib/simulate-game.ts`** (new, pure + seeded): score model = league-average baseline + strength differential + small home-field edge + seeded variance, with an optional `decisive` flag that breaks ties (for playoff games). Deterministic per fixture. Unit-tested: favorite wins the clear majority but not always; evenly-matched ≈ coin-flip; `decisive` never ties.
- **actions** (`schedule/actions.ts`): `simulateGameAction` (one game) and `simulateSeasonAction` (every unplayed **regular-season** game). Team strength = mean of the roster's SPRT `weightedOverall`, falling back to Madden overalls, else 50 (neutral/unrated). Never overwrites a `final`/`cancelled` game. Reuses the existing manager-auth guard (`schedulesStandingsV1` + `canManageRoster`).
- **`FixtureDto.stage`** ("regular" | "playoff"): added to the Convex DTO validator + all 4 construction sites, shared-types, and the local provider — so the sim can exclude playoff fixtures (PR3 needs this too).
- **UI**: per-row **Sim** button (scheduled games) + header **Simulate season** button on the league schedule page.

## Follow-ups (next PRs)
- Playoff config on the season (division winners, # teams, single-elim with byes).
- "Simulate through to a champion" (regular season → bracket → playoffs).

## Verification
- `pnpm exec vitest run` — simulate-game 6/6; local/schedule suites green (37).
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Deploy note
Convex DTO/validator change (no table migration — `stage` already existed on the fixtures table). Ship **web + Convex together**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)