### PR TITLE
feat(web): playoff configuration on the season + division-winner seeding (WSM-000184)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -126,6 +126,11 @@ export default defineSchema({
     endDate: v.union(v.string(), v.null()),
     status: v.string(),
     rosterLocked: v.boolean(),
+    // Playoff configuration set at season setup (WSM-000184). Optional so legacy
+    // seasons default sensibly (8 teams, single-elim, no division auto-qualify).
+    playoffTeams: v.optional(v.number()), // 0 = no playoffs; else 4 | 8 | 16
+    playoffFormat: v.optional(v.string()), // "single" (double = future)
+    divisionWinnersQualify: v.optional(v.boolean()),
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_leagueId_name", ["leagueId", "name"]),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -176,6 +176,9 @@ function toSeasonDto(doc: {
   endDate: string | null;
   status: string;
   rosterLocked?: boolean;
+  playoffTeams?: number;
+  playoffFormat?: string;
+  divisionWinnersQualify?: boolean;
 }) {
   return {
     id: doc._id,
@@ -185,6 +188,9 @@ function toSeasonDto(doc: {
     endDate: doc.endDate ?? null,
     status: doc.status,
     rosterLocked: doc.rosterLocked ?? false,
+    playoffTeams: doc.playoffTeams ?? null,
+    playoffFormat: doc.playoffFormat ?? null,
+    divisionWinnersQualify: doc.divisionWinnersQualify ?? false,
   };
 }
 
@@ -708,6 +714,9 @@ export const listSeasons = queryGeneric({
       endDate: v.union(v.string(), v.null()),
       status: v.string(),
       rosterLocked: v.boolean(),
+      playoffTeams: v.optional(v.union(v.number(), v.null())),
+      playoffFormat: v.optional(v.union(v.string(), v.null())),
+      divisionWinnersQualify: v.optional(v.boolean()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -734,6 +743,9 @@ export const getSeason = queryGeneric({
       endDate: v.union(v.string(), v.null()),
       status: v.string(),
       rosterLocked: v.boolean(),
+      playoffTeams: v.optional(v.union(v.number(), v.null())),
+      playoffFormat: v.optional(v.union(v.string(), v.null())),
+      divisionWinnersQualify: v.optional(v.boolean()),
     }),
     v.null(),
   ),
@@ -1772,6 +1784,9 @@ export const upsertSeason = internalMutationGeneric({
     startDate: v.union(v.string(), v.null()),
     endDate: v.union(v.string(), v.null()),
     status: v.string(),
+    playoffTeams: v.optional(v.number()),
+    playoffFormat: v.optional(v.string()),
+    divisionWinnersQualify: v.optional(v.boolean()),
   },
   returns: v.object({
     dto: v.object({
@@ -1782,6 +1797,9 @@ export const upsertSeason = internalMutationGeneric({
       endDate: v.union(v.string(), v.null()),
       status: v.string(),
       rosterLocked: v.boolean(),
+      playoffTeams: v.optional(v.union(v.number(), v.null())),
+      playoffFormat: v.optional(v.union(v.string(), v.null())),
+      divisionWinnersQualify: v.optional(v.boolean()),
     }),
     created: v.boolean(),
   }),
@@ -1795,17 +1813,29 @@ export const upsertSeason = internalMutationGeneric({
       ).find((season) => season.name === args.name) ?? null;
 
     if (existing) {
-      await ctx.db.patch(existing._id, {
+      // Only overwrite playoff config when the caller actually supplied it, so
+      // non-config callers (e.g. bulk import) don't wipe a season's settings.
+      const patch: Record<string, unknown> = {
         startDate: args.startDate,
         endDate: args.endDate,
         status: args.status,
-      });
+      };
+      if (args.playoffTeams !== undefined) patch.playoffTeams = args.playoffTeams;
+      if (args.playoffFormat !== undefined) patch.playoffFormat = args.playoffFormat;
+      if (args.divisionWinnersQualify !== undefined) {
+        patch.divisionWinnersQualify = args.divisionWinnersQualify;
+      }
+      await ctx.db.patch(existing._id, patch);
       return {
         dto: toSeasonDto({
           ...existing,
           startDate: args.startDate,
           endDate: args.endDate,
           status: args.status,
+          playoffTeams: args.playoffTeams ?? existing.playoffTeams,
+          playoffFormat: args.playoffFormat ?? existing.playoffFormat,
+          divisionWinnersQualify:
+            args.divisionWinnersQualify ?? existing.divisionWinnersQualify,
         }),
         created: false,
       };
@@ -1816,15 +1846,18 @@ export const upsertSeason = internalMutationGeneric({
       rosterLocked: false,
     });
     return {
-      dto: {
-        id: seasonId,
+      dto: toSeasonDto({
+        _id: seasonId,
         name: args.name,
         leagueId: args.leagueId,
         startDate: args.startDate,
         endDate: args.endDate,
         status: args.status,
         rosterLocked: false,
-      },
+        playoffTeams: args.playoffTeams,
+        playoffFormat: args.playoffFormat,
+        divisionWinnersQualify: args.divisionWinnersQualify,
+      }),
       created: true,
     };
   },
@@ -1840,6 +1873,9 @@ export const updateSeason = internalMutationGeneric({
     name: v.string(),
     startDate: v.union(v.string(), v.null()),
     endDate: v.union(v.string(), v.null()),
+    playoffTeams: v.optional(v.number()),
+    playoffFormat: v.optional(v.string()),
+    divisionWinnersQualify: v.optional(v.boolean()),
   },
   returns: v.union(
     v.object({
@@ -1850,22 +1886,35 @@ export const updateSeason = internalMutationGeneric({
       endDate: v.union(v.string(), v.null()),
       status: v.string(),
       rosterLocked: v.boolean(),
+      playoffTeams: v.optional(v.union(v.number(), v.null())),
+      playoffFormat: v.optional(v.union(v.string(), v.null())),
+      divisionWinnersQualify: v.optional(v.boolean()),
     }),
     v.null(),
   ),
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.seasonId);
     if (!existing) return null;
-    await ctx.db.patch(args.seasonId, {
+    const patch: Record<string, unknown> = {
       name: args.name,
       startDate: args.startDate,
       endDate: args.endDate,
-    });
+    };
+    if (args.playoffTeams !== undefined) patch.playoffTeams = args.playoffTeams;
+    if (args.playoffFormat !== undefined) patch.playoffFormat = args.playoffFormat;
+    if (args.divisionWinnersQualify !== undefined) {
+      patch.divisionWinnersQualify = args.divisionWinnersQualify;
+    }
+    await ctx.db.patch(args.seasonId, patch);
     return toSeasonDto({
       ...existing,
       name: args.name,
       startDate: args.startDate,
       endDate: args.endDate,
+      playoffTeams: args.playoffTeams ?? existing.playoffTeams,
+      playoffFormat: args.playoffFormat ?? existing.playoffFormat,
+      divisionWinnersQualify:
+        args.divisionWinnersQualify ?? existing.divisionWinnersQualify,
     });
   },
 });
@@ -4996,6 +5045,43 @@ async function seasonStandingTeamIds(
   }).map((r) => r.teamId);
 }
 
+/**
+ * Playoff seed order (WSM-000184). Default = league standings order. When
+ * `divisionWinnersQualify` is on, each division's best team (its first
+ * appearance in standings order) is seeded ahead of all non-winners, with both
+ * groups keeping their standings order — so division champs always make the
+ * field and get the top seeds. Teams without a division are never "winners".
+ */
+async function seasonPlayoffSeeds(
+  ctx: MutationCtx,
+  season: { _id: Id<"seasons">; leagueId: Id<"leagues"> },
+  divisionWinnersQualify: boolean,
+): Promise<string[]> {
+  const ordered = await seasonStandingTeamIds(ctx, season);
+  if (!divisionWinnersQualify) return ordered;
+
+  const teamRows = await ctx.db
+    .query("teams")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+    .collect();
+  const divisionByTeam = new Map<string, string | null>(
+    teamRows.map((t) => [t._id as string, (t.divisionId as string | null) ?? null]),
+  );
+
+  const winners: string[] = [];
+  const seenDivisions = new Set<string>();
+  for (const teamId of ordered) {
+    const division = divisionByTeam.get(teamId) ?? null;
+    if (division && !seenDivisions.has(division)) {
+      seenDivisions.add(division);
+      winners.push(teamId);
+    }
+  }
+  const winnerSet = new Set(winners);
+  const rest = ordered.filter((t) => !winnerSet.has(t));
+  return [...winners, ...rest];
+}
+
 /** Insert a playoff fixture for a matchup whose two teams are known. */
 async function spawnPlayoffFixture(
   ctx: MutationCtx,
@@ -5098,6 +5184,7 @@ export const generatePlayoffBracket = internalMutationGeneric({
     size: v.number(),
     actorUserId: v.string(),
     confirm: v.optional(v.boolean()),
+    divisionWinnersQualify: v.optional(v.boolean()),
   },
   returns: v.object({
     bracketId: v.string(),
@@ -5111,6 +5198,9 @@ export const generatePlayoffBracket = internalMutationGeneric({
     }
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
+    // Honor the season's configured qualification rule (overridable per call).
+    const divisionWinnersQualify =
+      args.divisionWinnersQualify ?? season.divisionWinnersQualify ?? false;
 
     // Existing bracket: results-guard, then clean wipe.
     const existing = await ctx.db
@@ -5156,7 +5246,11 @@ export const generatePlayoffBracket = internalMutationGeneric({
       await ctx.db.delete(existing._id);
     }
 
-    const seeds = await seasonStandingTeamIds(ctx as MutationCtx, season);
+    const seeds = await seasonPlayoffSeeds(
+      ctx as MutationCtx,
+      season,
+      divisionWinnersQualify,
+    );
     if (seeds.length < args.size) throw new Error("not_enough_teams");
 
     const plan = buildBracket(args.size);

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -35,6 +35,8 @@ export async function createSeasonAction(input: {
   name: string;
   startDate: string | null;
   endDate: string | null;
+  playoffTeams?: number;
+  divisionWinnersQualify?: boolean;
 }): Promise<Result<{ id: string }>> {
   const name = input.name.trim();
   if (!name) return { ok: false, error: "Season name is required." };
@@ -54,6 +56,9 @@ export async function createSeasonAction(input: {
       startDate: input.startDate,
       endDate: input.endDate,
       status,
+      playoffTeams: input.playoffTeams,
+      playoffFormat: "single",
+      divisionWinnersQualify: input.divisionWinnersQualify,
     });
     revalidatePath("/dashboard/seasons");
     return { ok: true, id: dto.id };
@@ -70,6 +75,8 @@ export async function updateSeasonAction(input: {
   name: string;
   startDate: string | null;
   endDate: string | null;
+  playoffTeams?: number;
+  divisionWinnersQualify?: boolean;
 }): Promise<Result> {
   const name = input.name.trim();
   if (!name) return { ok: false, error: "Season name is required." };
@@ -83,6 +90,8 @@ export async function updateSeasonAction(input: {
       name,
       startDate: input.startDate,
       endDate: input.endDate,
+      playoffTeams: input.playoffTeams,
+      divisionWinnersQualify: input.divisionWinnersQualify,
     });
     revalidatePath("/dashboard/seasons");
     return { ok: true };

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -22,18 +22,63 @@ function nullableDate(value: string): string | null {
   return value.trim() === "" ? null : value;
 }
 
+/** Playoff setup fields shared by the create + edit season forms (WSM-000184).
+ *  Single-elimination only for now; double-elim is a future option. */
+function PlayoffConfigFields({
+  playoffTeams,
+  setPlayoffTeams,
+  divisionWinnersQualify,
+  setDivisionWinnersQualify,
+}: {
+  playoffTeams: number;
+  setPlayoffTeams: (n: number) => void;
+  divisionWinnersQualify: boolean;
+  setDivisionWinnersQualify: (b: boolean) => void;
+}) {
+  return (
+    <>
+      <label className="flex items-center gap-1 text-xs text-muted-foreground">
+        Playoffs
+        <select
+          className={inputClass}
+          value={playoffTeams}
+          onChange={(e) => setPlayoffTeams(Number(e.target.value))}
+          aria-label="Number of playoff teams"
+        >
+          <option value={0}>None</option>
+          <option value={4}>4 teams (single-elim)</option>
+          <option value={8}>8 teams (single-elim)</option>
+          <option value={16}>16 teams (single-elim)</option>
+        </select>
+      </label>
+      <label className="flex items-center gap-1 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={divisionWinnersQualify}
+          onChange={(e) => setDivisionWinnersQualify(e.target.checked)}
+        />
+        Division winners qualify
+      </label>
+    </>
+  );
+}
+
 export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+  const [playoffTeams, setPlayoffTeams] = useState(8);
+  const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(false);
   const [busy, setBusy] = useState(false);
 
   function reset() {
     setName("");
     setStartDate("");
     setEndDate("");
+    setPlayoffTeams(8);
+    setDivisionWinnersQualify(false);
     setOpen(false);
   }
 
@@ -46,6 +91,8 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
       name: trimmed,
       startDate: nullableDate(startDate),
       endDate: nullableDate(endDate),
+      playoffTeams,
+      divisionWinnersQualify,
     });
     setBusy(false);
     if (res.ok) {
@@ -97,6 +144,12 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
           className={inputClass}
         />
       </label>
+      <PlayoffConfigFields
+        playoffTeams={playoffTeams}
+        setPlayoffTeams={setPlayoffTeams}
+        divisionWinnersQualify={divisionWinnersQualify}
+        setDivisionWinnersQualify={setDivisionWinnersQualify}
+      />
       <Button size="sm" disabled={busy} onClick={submit}>
         {busy ? "…" : "Create"}
       </Button>
@@ -169,6 +222,10 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
   const [name, setName] = useState(season.name);
   const [startDate, setStartDate] = useState(season.startDate ?? "");
   const [endDate, setEndDate] = useState(season.endDate ?? "");
+  const [playoffTeams, setPlayoffTeams] = useState(season.playoffTeams ?? 8);
+  const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(
+    season.divisionWinnersQualify ?? false,
+  );
   const [busy, setBusy] = useState(false);
 
   const isActive = season.status === "active";
@@ -194,6 +251,8 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
       name: trimmed,
       startDate: nullableDate(startDate),
       endDate: nullableDate(endDate),
+      playoffTeams,
+      divisionWinnersQualify,
     });
     setBusy(false);
     if (res.ok) {
@@ -250,6 +309,12 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
           onChange={(e) => setEndDate(e.target.value)}
           className={inputClass}
           aria-label="End date"
+        />
+        <PlayoffConfigFields
+          playoffTeams={playoffTeams}
+          setPlayoffTeams={setPlayoffTeams}
+          divisionWinnersQualify={divisionWinnersQualify}
+          setDivisionWinnersQualify={setDivisionWinnersQualify}
         />
         <Button size="sm" disabled={busy} onClick={save}>
           {busy ? "…" : "Save"}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -290,6 +290,9 @@ const refs = {
       startDate: string | null;
       endDate: string | null;
       status: string;
+      playoffTeams?: number;
+      playoffFormat?: string;
+      divisionWinnersQualify?: boolean;
     },
     { dto: SeasonDto; created: boolean }
   >("sports:upsertSeason"),
@@ -299,6 +302,9 @@ const refs = {
       name: string;
       startDate: string | null;
       endDate: string | null;
+      playoffTeams?: number;
+      playoffFormat?: string;
+      divisionWinnersQualify?: boolean;
     },
     SeasonDto | null
   >("sports:updateSeason"),
@@ -1219,6 +1225,9 @@ export async function upsertSeason(input: {
   startDate: string | null;
   endDate: string | null;
   status: string;
+  playoffTeams?: number;
+  playoffFormat?: string;
+  divisionWinnersQualify?: boolean;
 }): Promise<{ dto: SeasonDto; created: boolean }> {
   return mutateConvex(refs.upsertSeason, input);
 }
@@ -1228,6 +1237,9 @@ export async function updateSeason(input: {
   name: string;
   startDate: string | null;
   endDate: string | null;
+  playoffTeams?: number;
+  playoffFormat?: string;
+  divisionWinnersQualify?: boolean;
 }): Promise<SeasonDto> {
   const dto = await mutateConvex(refs.updateSeason, input);
   if (!dto) throw new Error("Season not found");

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -275,6 +275,9 @@ export class LocalWorkspaceProvider implements WorkspaceDataProvider {
       endDate: input.endDate ?? null,
       status: "active",
       rosterLocked: false,
+      playoffTeams: null,
+      playoffFormat: null,
+      divisionWinnersQualify: false,
     };
     await this.db.seasons.add(season);
     return season;

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -116,6 +116,9 @@ export const SeasonDtoSchema = z.object({
   endDate: z.string().nullable(),
   status: z.string(),
   rosterLocked: z.boolean(),
+  playoffTeams: z.number().nullable(),
+  playoffFormat: z.string().nullable(),
+  divisionWinnersQualify: z.boolean(),
 }) satisfies z.ZodType<SeasonDto>;
 
 // --- Mutation input schemas ---

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -81,6 +81,10 @@ export interface SeasonDto {
   endDate: string | null;
   status: string;
   rosterLocked: boolean;
+  /** Playoff configuration (WSM-000184). */
+  playoffTeams: number | null; // 0/null = no playoffs; else 4 | 8 | 16
+  playoffFormat: string | null; // "single"
+  divisionWinnersQualify: boolean;
 }
 
 export interface DepthChartEntryDto {


### PR DESCRIPTION
## What & why
Part 2 of the simulation feature. You can now decide playoff structure **at season setup**, and **division winners actually affect seeding**.

## Changes
- **schema** (`seasons`): optional `playoffTeams` (0/4/8/16), `playoffFormat` ("single"), `divisionWinnersQualify`. `SeasonDto` + Zod `SeasonDtoSchema` + the four Convex season-DTO validators + `toSeasonDto` updated together — new fields are **optional in the validators** but always emitted by `toSeasonDto`, so there's no validator drift (the WSM-000166 failure mode).
- **`upsertSeason`/`updateSeason`**: accept + persist the config, and only overwrite playoff fields when actually supplied (so bulk-import / non-config callers don't wipe a season's settings).
- **`generatePlayoffBracket`**: honors the season's `divisionWinnersQualify`. New `seasonPlayoffSeeds()` seeds each division's **best team ahead of all non-winners** (both groups keep standings order), so division champs always make the field and earn the top seeds. Bracket sizes stay 4/8/16 (arbitrary counts with byes = future).
- **season form** (create + edit): a **Playoffs** team-count select + **Division winners qualify** toggle, wired through the season actions.

## Scope
Single-elimination only for now (double-elim is a future option). **"Simulate through to a champion"** is the next PR (ties PR1 sim + this config together).

## Verification
- `pnpm exec vitest run` (seasons/local/convex) — 209/209.
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Deploy note
Convex **schema change** (additive, optional columns; no index drops). Ship **web + Convex together**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)