### PR TITLE
feat(web): simulate a season through to a champion (WSM-000185)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -10,11 +10,15 @@ import {
   getLeague,
   getLeagueOrgId,
   getFixture,
+  getSeason,
   listFixturesBySeason,
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
+  generatePlayoffBracket,
+  getPlayoffBracket,
   recordGameResult,
 } from "@/lib/data-api";
+import type { PlayoffMatchupDto } from "@/lib/data-api";
 import type { OrgContext } from "@/lib/org-context";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
@@ -307,6 +311,42 @@ export async function simulateGameAction(input: {
   }
 }
 
+/** Sim every unplayed regular-season fixture; returns how many were played.
+ *  Shared by simulateSeasonAction and the through-to-champion flow. */
+async function simulateUnplayedRegularSeason(
+  seasonId: string,
+  userId: string,
+  orgContext: OrgContext,
+  cache: Map<string, number>,
+): Promise<number> {
+  const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
+  // Regular-season, unplayed games only — never overwrite real results, and
+  // leave playoff games to the bracket flow.
+  const unplayed = fixtures.filter(
+    (f) => f.status === "scheduled" && f.stage !== "playoff",
+  );
+  let simulated = 0;
+  for (const fixture of unplayed) {
+    const [homeStrength, awayStrength] = await Promise.all([
+      teamStrength(fixture.homeTeamId, orgContext, cache),
+      teamStrength(fixture.awayTeamId, orgContext, cache),
+    ]);
+    const { homeScore, awayScore } = simulateScore({
+      homeStrength,
+      awayStrength,
+      seed: seedFromString(fixture.id),
+    });
+    await recordGameResult({
+      fixtureId: fixture.id,
+      homeScore,
+      awayScore,
+      actorUserId: userId,
+    });
+    simulated += 1;
+  }
+  return simulated;
+}
+
 export async function simulateSeasonAction(input: {
   leagueId: string;
   seasonId: string;
@@ -318,38 +358,128 @@ export async function simulateSeasonAction(input: {
   if (!userId) return { ok: false, error: "unauthorized" };
 
   const orgContext = await resolveOrgContext(userId);
-  const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
-  // Regular-season, unplayed games only — never overwrite real results, and
-  // leave playoff games to the bracket flow.
-  const unplayed = fixtures.filter(
-    (f) => f.status === "scheduled" && f.stage !== "playoff",
-  );
-
-  const cache = new Map<string, number>();
-  let simulated = 0;
   try {
-    for (const fixture of unplayed) {
-      const [homeStrength, awayStrength] = await Promise.all([
-        teamStrength(fixture.homeTeamId, orgContext, cache),
-        teamStrength(fixture.awayTeamId, orgContext, cache),
-      ]);
-      const { homeScore, awayScore } = simulateScore({
-        homeStrength,
-        awayStrength,
-        seed: seedFromString(fixture.id),
-      });
-      await recordGameResult({
-        fixtureId: fixture.id,
-        homeScore,
-        awayScore,
-        actorUserId: userId,
-      });
-      simulated += 1;
-    }
+    const simulated = await simulateUnplayedRegularSeason(
+      input.seasonId,
+      userId,
+      orgContext,
+      new Map(),
+    );
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
     revalidatePath(`/leagues/${input.leagueId}/standings`);
     return { ok: true, simulated };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/*
+ * Simulate a whole season through to a champion (WSM-000185): sim every unplayed
+ * regular-season game, then — if the season is configured for playoffs —
+ * (re)generate the bracket from its config and sim each playoff round until a
+ * winner emerges. Playoff games are simulated `decisive` so a bracket never
+ * stalls on a tie. Bounded loop (≤ 8 rounds) as a safety net.
+ */
+export async function simulateSeasonThroughChampionAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<
+  | {
+      ok: true;
+      regularSimulated: number;
+      playoffGames: number;
+      champion: string | null;
+    }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const cache = new Map<string, number>();
+  try {
+    const regularSimulated = await simulateUnplayedRegularSeason(
+      input.seasonId,
+      userId,
+      orgContext,
+      cache,
+    );
+
+    const season = await getSeason(input.seasonId, orgContext).catch(() => null);
+    const size = season?.playoffTeams ?? 0;
+    if (!season || !size) {
+      // No playoffs configured — regular season is the whole story.
+      revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+      revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+      revalidatePath(`/leagues/${input.leagueId}/standings`);
+      return { ok: true, regularSimulated, playoffGames: 0, champion: null };
+    }
+
+    // Fresh bracket from the configured size + qualification rule.
+    await generatePlayoffBracket({
+      seasonId: input.seasonId,
+      size,
+      actorUserId: userId,
+      confirm: true,
+      divisionWinnersQualify: season.divisionWinnersQualify,
+    });
+
+    // Sim round by round — each result advances the bracket and spawns the next
+    // round's fixtures once both feeders are decided.
+    let playoffGames = 0;
+    for (let round = 0; round < 8; round++) {
+      const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
+      const pending = fixtures.filter(
+        (f) => f.stage === "playoff" && f.status === "scheduled",
+      );
+      if (pending.length === 0) break;
+      for (const fixture of pending) {
+        const [homeStrength, awayStrength] = await Promise.all([
+          teamStrength(fixture.homeTeamId, orgContext, cache),
+          teamStrength(fixture.awayTeamId, orgContext, cache),
+        ]);
+        const { homeScore, awayScore } = simulateScore({
+          homeStrength,
+          awayStrength,
+          seed: seedFromString(fixture.id),
+          decisive: true,
+        });
+        await recordGameResult({
+          fixtureId: fixture.id,
+          homeScore,
+          awayScore,
+          actorUserId: userId,
+        });
+        playoffGames += 1;
+      }
+    }
+
+    // Champion = the final (highest-round) matchup's winner.
+    const bracket = await getPlayoffBracket(input.seasonId).catch(() => null);
+    let champion: string | null = null;
+    if (bracket) {
+      const final = bracket.matchups.reduce<PlayoffMatchupDto | null>(
+        (best, m) => (m.round > (best?.round ?? -1) ? m : best),
+        null,
+      );
+      if (final?.winnerTeamId) {
+        champion =
+          final.winnerTeamId === final.homeTeamId
+            ? final.homeTeamName
+            : final.awayTeamName;
+      }
+    }
+
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    revalidatePath(`/leagues/${input.leagueId}/standings`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/playoffs`);
+    return { ok: true, regularSimulated, playoffGames, champion };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -30,6 +30,7 @@ import GoLiveControl from "@/components/schedule/GoLiveControl";
 import {
   SimulateGameButton,
   SimulateSeasonButton,
+  SimulateChampionButton,
 } from "@/components/schedule/SimulateControls";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
@@ -165,10 +166,16 @@ export default async function LeagueSchedulePage({
             />
           ) : null}
           {isAdmin && activeSeason && fixtures.length > 0 ? (
-            <SimulateSeasonButton
-              leagueId={leagueId}
-              seasonId={activeSeason.id}
-            />
+            <>
+              <SimulateSeasonButton
+                leagueId={leagueId}
+                seasonId={activeSeason.id}
+              />
+              <SimulateChampionButton
+                leagueId={leagueId}
+                seasonId={activeSeason.id}
+              />
+            </>
           ) : null}
         </div>
       </header>

--- a/apps/web/src/components/schedule/SimulateControls.tsx
+++ b/apps/web/src/components/schedule/SimulateControls.tsx
@@ -3,11 +3,12 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Dices, Wand2 } from "lucide-react";
+import { Dices, Wand2, Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   simulateGameAction,
   simulateSeasonAction,
+  simulateSeasonThroughChampionAction,
 } from "@/app/dashboard/leagues/[id]/schedule/actions";
 
 /*
@@ -110,6 +111,64 @@ export function SimulateSeasonButton({
   );
 }
 
+export function SimulateChampionButton({
+  leagueId,
+  seasonId,
+}: {
+  leagueId: string;
+  seasonId: string;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run() {
+    if (
+      !window.confirm(
+        "Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept.",
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulateSeasonThroughChampionAction({ leagueId, seasonId });
+      if (res.ok) {
+        const parts = [
+          res.regularSimulated > 0
+            ? `${res.regularSimulated} regular-season game${res.regularSimulated === 1 ? "" : "s"}`
+            : null,
+          res.playoffGames > 0
+            ? `${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
+            : null,
+        ].filter(Boolean);
+        toast.success(
+          res.champion
+            ? `🏆 ${res.champion} wins! Simulated ${parts.join(" + ")}.`
+            : parts.length > 0
+              ? `Simulated ${parts.join(" + ")}.`
+              : "Nothing left to simulate.",
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={run}
+      title="Simulate the rest of the season and the playoffs to crown a champion"
+    >
+      <Trophy className="mr-1 h-4 w-4" />
+      {pending ? "Simulating…" : "Sim to champion"}
+    </Button>
+  );
+}
+
 function simError(error: string): string {
   switch (error) {
     case "flag_disabled":
@@ -125,6 +184,12 @@ function simError(error: string): string {
     case "fixture_not_found":
       return "Game not found.";
     default:
+      if (error.includes("not_enough_teams")) {
+        return "Not enough teams for the configured playoff bracket. Lower the playoff team count in season settings.";
+      }
+      if (error.includes("invalid_bracket_size")) {
+        return "Playoff team count must be 4, 8, or 16 (set it in season settings).";
+      }
       return error;
   }
 }

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -539,7 +539,13 @@ const refs = {
     }
   >("sports:copySeasonRosters"),
   generatePlayoffBracket: mutationRef<
-    { seasonId: string; size: number; actorUserId: string; confirm?: boolean },
+    {
+      seasonId: string;
+      size: number;
+      actorUserId: string;
+      confirm?: boolean;
+      divisionWinnersQualify?: boolean;
+    },
     { bracketId: string; size: number; rounds: number; matchups: number }
   >("sports:generatePlayoffBracket"),
   getPlayoffBracket: queryRef<{ seasonId: string }, PlayoffBracketDto | null>(
@@ -1735,6 +1741,7 @@ export async function generatePlayoffBracket(input: {
   size: number;
   actorUserId: string;
   confirm?: boolean;
+  divisionWinnersQualify?: boolean;
 }): Promise<{
   bracketId: string;
   size: number;


### PR DESCRIPTION
## What & why
Part 3 — ties the sim engine (#407) and playoff config (#408) together. One action runs a whole season: sim every unplayed regular-season game, then (when the season is configured for playoffs) regenerate the bracket from its config and sim each playoff round to crown a champion.

## Changes
- **`simulateSeasonThroughChampionAction`**: sim regular season → `generatePlayoffBracket` (size + `divisionWinnersQualify` from the season config, `confirm`-wipes any prior bracket) → loop round-by-round simming playoff fixtures **`decisive`** (no ties stall the bracket; each recorded result auto-advances the bracket and spawns the next round's fixtures) → resolve the champion from the final (highest-round) matchup. Bounded loop (≤8 rounds) as a safety net.
- Refactored the regular-season sim into a shared `simulateUnplayedRegularSeason` helper (used by both season-sim actions).
- `generatePlayoffBracket` data-api wrapper gains `divisionWinnersQualify`.
- **UI**: a **Sim to champion** button on the schedule header; the toast announces the winner (🏆) and how many games were simulated. Friendly errors for "not enough teams" / bad bracket size.

## Feature complete
With #407 + #408 + this: simulate one game, simulate the regular season, configure playoffs at season setup (teams + division-winner qualification, single-elim), and simulate the whole thing to a champion — all ratings-weighted.

## Verification
- `pnpm exec vitest run` (sim/schedule/convex) — 198/198.
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Deploy note
Includes the PR2 Convex schema (already needs deploy) + the bracket-arg change — ship **web + Convex together**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)