### PR TITLE
feat(web): generate-rosters shortcut on league schedule page

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -8,6 +8,7 @@ import {
   statKeepingV1,
   liveScoringV1,
   playoffsV1,
+  syntheticRostersV1,
 } from "@/lib/flags";
 import {
   getLeague,
@@ -32,6 +33,7 @@ import {
   SimulateSeasonButton,
   SimulateChampionButton,
 } from "@/components/schedule/SimulateControls";
+import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 
@@ -72,6 +74,10 @@ export default async function LeagueSchedulePage({
   const liveEnabled = await liveScoringV1();
   // Playoffs (WSM-000164/165): bracket lives on its own page; link when enabled.
   const playoffsEnabled = await playoffsV1();
+  // Synthetic rosters (WSM-000173): discoverability shortcut — admins setting up
+  // a schedule often need rosters first. Same admin + flag gate as the league
+  // detail page; the server actions re-check flag + role.
+  const canGenerateRosters = canManageOrgSettings(role) && (await syntheticRostersV1());
 
   // Pick the active season — fall back to whichever exists if none flagged active.
   const allSeasons = await getSeasons([leagueId]);
@@ -174,6 +180,16 @@ export default async function LeagueSchedulePage({
               <SimulateChampionButton
                 leagueId={leagueId}
                 seasonId={activeSeason.id}
+              />
+            </>
+          ) : null}
+          {canGenerateRosters ? (
+            <>
+              <SyntheticRosterButton kind="league" id={leagueId} />
+              <SyntheticRosterButton
+                kind="league"
+                id={leagueId}
+                action="attributes"
               />
             </>
           ) : null}


### PR DESCRIPTION
## What

Adds the existing league-wide **Generate rosters** shortcut (and the **Generate ratings** variant) to the **league Schedule page** header, for discoverability. Today synthetic-roster generation only lives on the league *detail* page, but admins setting up a schedule often need rosters first.

## Changes

- `apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx`
  - Import `SyntheticRosterButton` and the `syntheticRostersV1` flag.
  - Compute `canGenerateRosters = canManageOrgSettings(role) && (await syntheticRostersV1())` — mirroring the detail page's `isAdmin && syntheticRostersV1()` gate. On the schedule page, `canManageOrgSettings(role)` is the true org-admin gate (the same one used for the live-streaming control), as opposed to the broader admin/coach `isAdmin`.
  - Render `SyntheticRosterButton kind="league"` (`generate`) and its `action="attributes"` (ratings) variants inside the existing admin control group in the header.

## Notes

- Reuses the existing component unchanged.
- The `clear` variant is intentionally left on the detail/management surface; the schedule shortcut is for setup (generate rosters + ratings).
- Server actions for generation are already flag + role gated, so this is purely a discoverability surface.
- No roster control existed on the schedule page previously (verified).

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @sports-management/shared-types --filter @sports-management/api-contracts run build`
- `pnpm exec eslint` on the changed file — clean
- `pnpm run build` (authoritative typecheck) — success
- No tests touch the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)