### PR TITLE
feat(web): flexible playoff brackets — byes + double-elim (WSM-flex-brackets)

### DIFF
--- a/apps/web/convex/__tests__/bracket.test.ts
+++ b/apps/web/convex/__tests__/bracket.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { seedOrder, buildBracket } from "../lib/bracket";
+import {
+  seedOrder,
+  buildBracket,
+  buildDoubleElimBracket,
+  nextPowerOfTwo,
+} from "../lib/bracket";
 
 describe("seedOrder (WSM-000164)", () => {
   it("rejects non-powers-of-two", () => {
@@ -23,20 +28,48 @@ describe("seedOrder (WSM-000164)", () => {
   });
 });
 
-describe("buildBracket (WSM-000164)", () => {
+describe("nextPowerOfTwo (WSM-flex-brackets)", () => {
+  it.each([
+    [2, 2],
+    [3, 4],
+    [4, 4],
+    [5, 8],
+    [6, 8],
+    [8, 8],
+    [10, 16],
+    [12, 16],
+    [16, 16],
+    [17, 32],
+  ])("nextPowerOfTwo(%i) === %i", (n, expected) => {
+    expect(nextPowerOfTwo(n)).toBe(expected);
+  });
+
+  it("rejects counts below 2", () => {
+    expect(() => nextPowerOfTwo(1)).toThrow("team_count_too_small");
+  });
+});
+
+describe("buildBracket — power-of-two counts (WSM-000164)", () => {
   it.each([
     [4, 2, 3],
     [8, 3, 7],
     [16, 4, 15],
-  ])("size %i → %i rounds and N-1 total matchups", (size, rounds, total) => {
-    const b = buildBracket(size);
+  ])("count %i → %i rounds and N-1 total matchups", (count, rounds, total) => {
+    const b = buildBracket(count);
+    expect(b.size).toBe(count);
     expect(b.rounds).toBe(rounds);
     expect(b.matchups).toHaveLength(total);
-    // Matchups per round halve each round.
     for (let r = 1; r <= rounds; r++) {
       expect(b.matchups.filter((m) => m.round === r)).toHaveLength(
-        size / 2 ** r,
+        count / 2 ** r,
       );
+    }
+  });
+
+  it("has no byes when count is a power of two", () => {
+    for (const count of [4, 8, 16]) {
+      const b = buildBracket(count);
+      expect(b.matchups.some((m) => m.isBye)).toBe(false);
     }
   });
 
@@ -56,7 +89,9 @@ describe("buildBracket (WSM-000164)", () => {
 
   it("keeps seeds 1 and 2 in opposite halves (meet only in the final)", () => {
     const b = buildBracket(8);
-    const r1 = b.matchups.filter((m) => m.round === 1).sort((a, z) => a.slot - z.slot);
+    const r1 = b.matchups
+      .filter((m) => m.round === 1)
+      .sort((a, z) => a.slot - z.slot);
     const half = r1.length / 2;
     const seed1Slot = r1.findIndex((m) => m.homeSeed === 1 || m.awaySeed === 1);
     const seed2Slot = r1.findIndex((m) => m.homeSeed === 2 || m.awaySeed === 2);
@@ -73,8 +108,194 @@ describe("buildBracket (WSM-000164)", () => {
       expect(m.parentSlot).toBe(Math.floor(m.slot / 2));
       expect(m.parentSide).toBe(m.slot % 2 === 0 ? "home" : "away");
     }
-    // Both round-1 slots 0 and 1 feed round-2 slot 0 (home + away).
-    const feeders = b.matchups.filter((m) => m.round === 1 && m.parentSlot === 0);
+    const feeders = b.matchups.filter(
+      (m) => m.round === 1 && m.parentSlot === 0,
+    );
     expect(feeders.map((m) => m.parentSide).sort()).toEqual(["away", "home"]);
+  });
+});
+
+describe("buildBracket — byes for non-power-of-two counts (WSM-flex-brackets)", () => {
+  it("rejects counts below 2", () => {
+    expect(() => buildBracket(1)).toThrow("team_count_too_small");
+  });
+
+  it.each([
+    [5, 8, 8 - 5],
+    [6, 8, 8 - 6],
+    [10, 16, 16 - 10],
+    [12, 16, 16 - 12],
+  ])(
+    "count %i → size %i with %i byes",
+    (count, size, expectedByes) => {
+      const b = buildBracket(count);
+      expect(b.size).toBe(size);
+      expect(b.rounds).toBe(Math.log2(size));
+      const byes = b.matchups.filter((m) => m.round === 1 && m.isBye);
+      expect(byes).toHaveLength(expectedByes);
+    },
+  );
+
+  it("byes go to the TOP seeds and carry the present team as homeSeed", () => {
+    const b = buildBracket(6); // size 8, 2 byes → seeds 1 and 2
+    const byes = b.matchups.filter((m) => m.isBye);
+    const byeSeeds = byes.map((m) => m.homeSeed).sort((a, z) => a! - z!);
+    expect(byeSeeds).toEqual([1, 2]);
+    for (const m of byes) {
+      expect(m.awaySeed).toBeNull(); // no opponent — auto-advance
+      expect(m.homeSeed).not.toBeNull();
+    }
+  });
+
+  it("every real seed 1..count appears exactly once in round 1", () => {
+    for (const count of [5, 6, 10, 12]) {
+      const b = buildBracket(count);
+      const seeds: number[] = [];
+      for (const m of b.matchups.filter((m) => m.round === 1)) {
+        if (m.homeSeed != null) seeds.push(m.homeSeed);
+        if (m.awaySeed != null) seeds.push(m.awaySeed);
+      }
+      // No phantom seed > count survives.
+      expect(Math.max(...seeds)).toBeLessThanOrEqual(count);
+      expect([...seeds].sort((a, z) => a - z)).toEqual(
+        Array.from({ length: count }, (_, i) => i + 1),
+      );
+    }
+  });
+
+  it("a bye matchup still wires into a round-2 parent slot", () => {
+    const b = buildBracket(6);
+    for (const m of b.matchups.filter((m) => m.isBye)) {
+      expect(m.parentSlot).not.toBeNull();
+      expect(m.parentSide).not.toBeNull();
+    }
+  });
+});
+
+describe("buildDoubleElimBracket (WSM-flex-brackets)", () => {
+  it("rejects counts below 2", () => {
+    expect(() => buildDoubleElimBracket(1)).toThrow("team_count_too_small");
+  });
+
+  it.each([4, 8, 16])(
+    "size %i: winners bracket matches single-elim + one grand final",
+    (count) => {
+      const single = buildBracket(count);
+      const de = buildDoubleElimBracket(count);
+      expect(de.format).toBe("double");
+      const wb = de.matchups.filter((m) => m.bracketType === "winners");
+      expect(wb).toHaveLength(single.matchups.length);
+      const gf = de.matchups.filter((m) => m.bracketType === "grandFinal");
+      expect(gf).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    // size, expected LB matchup count = size - 2 (a double-elim invariant)
+    [4, 2],
+    [8, 6],
+    [16, 14],
+  ])("size %i: losers bracket has size-2 matchups", (count, expected) => {
+    const de = buildDoubleElimBracket(count);
+    const lb = de.matchups.filter((m) => m.bracketType === "losers");
+    expect(lb).toHaveLength(expected);
+  });
+
+  it("LB has 2*(wbRounds-1) rounds with consistent slot counts", () => {
+    const de = buildDoubleElimBracket(8); // wbRounds 3 → lbRounds 4
+    const lbRoundNums = [
+      ...new Set(
+        de.matchups
+          .filter((m) => m.bracketType === "losers")
+          .map((m) => m.round),
+      ),
+    ].sort((a, z) => a - z);
+    expect(lbRoundNums).toEqual([1, 2, 3, 4]);
+    const counts = lbRoundNums.map(
+      (r) =>
+        de.matchups.filter((m) => m.bracketType === "losers" && m.round === r)
+          .length,
+    );
+    expect(counts).toEqual([2, 2, 1, 1]); // r1,r2 minor/feed; r3 major; r4 final
+  });
+
+  it("every WB matchup (except byes) routes its loser somewhere in the LB", () => {
+    const de = buildDoubleElimBracket(8);
+    const wb = de.matchups.filter((m) => m.bracketType === "winners");
+    for (const m of wb) {
+      if (m.isBye) {
+        expect(m.loserParentRound ?? null).toBeNull();
+        continue;
+      }
+      expect(m.loserParentRound).not.toBeNull();
+      expect(m.loserParentSlot).not.toBeNull();
+      expect(["home", "away"]).toContain(m.loserParentSide);
+    }
+  });
+
+  it("WB-round-1 losers fill both sides of LB round 1", () => {
+    const de = buildDoubleElimBracket(8);
+    const r1Losers = de.matchups.filter(
+      (m) => m.bracketType === "winners" && m.round === 1 && !m.isBye,
+    );
+    // 4 WB-r1 matchups → 4 losers → 2 LB-r1 matchups (home + away each).
+    const sides = r1Losers.map(
+      (m) => `${m.loserParentSlot}:${m.loserParentSide}`,
+    );
+    expect(new Set(sides).size).toBe(r1Losers.length); // no collisions
+    for (const m of r1Losers) {
+      expect(m.loserParentRound).toBe(1);
+    }
+  });
+
+  it("WB final loser drops into the final LB round (away side)", () => {
+    const de = buildDoubleElimBracket(8);
+    const wbFinal = de.matchups.find(
+      (m) => m.bracketType === "winners" && m.round === de.rounds,
+    )!;
+    expect(wbFinal.loserParentRound).toBe(4); // lbRounds for size 8
+    expect(wbFinal.loserParentSide).toBe("away");
+  });
+
+  it("LB loser-routing targets always reference an existing LB matchup", () => {
+    for (const count of [4, 8, 16]) {
+      const de = buildDoubleElimBracket(count);
+      const lbKeys = new Set(
+        de.matchups
+          .filter((m) => m.bracketType === "losers")
+          .map((m) => `${m.round}:${m.slot}`),
+      );
+      for (const m of de.matchups.filter(
+        (m) => m.bracketType === "winners" && !m.isBye,
+      )) {
+        expect(lbKeys.has(`${m.loserParentRound}:${m.loserParentSlot}`)).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("LB internal advancement targets always reference an existing LB matchup", () => {
+    for (const count of [4, 8, 16]) {
+      const de = buildDoubleElimBracket(count);
+      const lb = de.matchups.filter((m) => m.bracketType === "losers");
+      const lbKeys = new Set(lb.map((m) => `${m.round}:${m.slot}`));
+      for (const m of lb) {
+        if (m.parentSlot == null) continue; // LB final → grand final
+        expect(lbKeys.has(`${m.round + 1}:${m.parentSlot}`)).toBe(true);
+      }
+    }
+  });
+
+  it("supports double-elim with byes (non-power-of-two count)", () => {
+    const de = buildDoubleElimBracket(6); // size 8, 2 byes in WB
+    const byes = de.matchups.filter(
+      (m) => m.bracketType === "winners" && m.isBye,
+    );
+    expect(byes).toHaveLength(2);
+    // Byes carry no loser routing.
+    for (const m of byes) {
+      expect(m.loserParentRound ?? null).toBeNull();
+    }
   });
 });

--- a/apps/web/convex/__tests__/playoffBracket.test.ts
+++ b/apps/web/convex/__tests__/playoffBracket.test.ts
@@ -185,7 +185,7 @@ describe("playoff bracket (WSM-000164)", () => {
     await expect(
       t.mutation(internal.sports.generatePlayoffBracket, {
         seasonId,
-        size: 6,
+        size: 1, // < 2 is invalid (any count ≥ 2 is now supported)
         actorUserId: "user_1",
       }),
     ).rejects.toThrow("invalid_bracket_size");
@@ -193,7 +193,7 @@ describe("playoff bracket (WSM-000164)", () => {
     await expect(
       t.mutation(internal.sports.generatePlayoffBracket, {
         seasonId,
-        size: 8,
+        size: 8, // only 4 teams seeded
         actorUserId: "user_1",
       }),
     ).rejects.toThrow("not_enough_teams");
@@ -234,5 +234,203 @@ describe("playoff bracket (WSM-000164)", () => {
     }));
     expect(counts.results).toBe(0);
     expect(counts.fixtures).toBe(2);
+  });
+});
+
+describe("playoff bracket — byes (WSM-flex-brackets)", () => {
+  it("a 6-team bracket gives the top 2 seeds first-round byes (no fixture)", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 6);
+
+    const res = await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 6,
+      actorUserId: "user_1",
+    });
+    // Bracket rounds up to 8 → 3 rounds, 7 matchup nodes.
+    expect(res).toMatchObject({ size: 8, rounds: 3, matchups: 7 });
+
+    const r1 = await roundOneMatchups(t, seasonId);
+    const byes = r1.filter((m) => m.awayTeamId == null && m.homeTeamId != null);
+    const games = r1.filter((m) => m.awayTeamId != null);
+    expect(byes).toHaveLength(2); // seeds 1 and 2 get byes
+    expect(games).toHaveLength(2); // the other 4 teams play
+
+    // Bye matchups: winner pre-set, NO fixture spawned.
+    for (const b of byes) {
+      expect(b.winnerTeamId).toBe(b.homeTeamId);
+      expect(b.fixtureId).toBeNull();
+      expect(b.homeSeed).toBeLessThanOrEqual(2);
+    }
+    // Bye winners are already placed into their round-2 parent slots.
+    const all = await allMatchups(t, seasonId);
+    const r2WithBye = all.filter(
+      (m) => m.round === 2 && (m.homeTeamId != null || m.awayTeamId != null),
+    );
+    expect(r2WithBye.length).toBeGreaterThan(0);
+
+    // Only the two real round-1 games spawned fixtures.
+    const fixtures = await t.run(async (ctx) =>
+      (await ctx.db.query("fixtures").collect()).filter(
+        (f) => f.seasonId === seasonId,
+      ),
+    );
+    expect(fixtures).toHaveLength(2);
+  });
+
+  it("a bye team advances to play the winner of its sibling round-1 game", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 6);
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 6,
+      actorUserId: "user_1",
+    });
+
+    // Decide both real round-1 games (home wins).
+    const r1 = await roundOneMatchups(t, seasonId);
+    for (const m of r1.filter((x) => x.fixtureId)) {
+      await t.mutation(internal.sports.recordGameResult, {
+        fixtureId: m.fixtureId as Id<"fixtures">,
+        homeScore: 21,
+        awayScore: 7,
+        actorUserId: "user_1",
+      });
+    }
+
+    // Both round-2 (semifinal) matchups now have two teams + a fixture.
+    const r2 = (await allMatchups(t, seasonId)).filter((m) => m.round === 2);
+    expect(r2).toHaveLength(2);
+    for (const m of r2) {
+      expect(m.homeTeamId).not.toBeNull();
+      expect(m.awayTeamId).not.toBeNull();
+      expect(m.fixtureId).not.toBeNull();
+    }
+  });
+});
+
+describe("playoff bracket — double elimination (WSM-flex-brackets)", () => {
+  it("generates winners + losers brackets and a single grand final", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+
+    const res = await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+      format: "double",
+    });
+    // WB(3) + LB(2) + GF(1) = 6 matchups for size 4.
+    expect(res).toMatchObject({ size: 4, rounds: 2, matchups: 6 });
+
+    const all = await allMatchups(t, seasonId);
+    const wb = all.filter((m) => m.bracketType === "winners");
+    const lb = all.filter((m) => m.bracketType === "losers");
+    const gf = all.filter((m) => m.bracketType === "grandFinal");
+    expect(wb).toHaveLength(3);
+    expect(lb).toHaveLength(2);
+    expect(gf).toHaveLength(1);
+
+    // WB round-1 matchups carry loser-routing into the LB.
+    const wbR1 = wb.filter((m) => m.round === 1);
+    for (const m of wbR1) {
+      expect(m.loserNextMatchupId).not.toBeNull();
+      expect(["home", "away"]).toContain(m.loserNextSlot);
+    }
+    // The bracket is recorded as double-elim.
+    const bracket = await t.run(async (ctx) =>
+      (await ctx.db.query("playoffBrackets").collect()).find(
+        (b) => b.seasonId === seasonId,
+      ),
+    );
+    expect(bracket?.format).toBe("double");
+  });
+
+  it("WB losers drop into the losers bracket and the LB resolves to the grand final", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeague(t, 4);
+    await t.mutation(internal.sports.generatePlayoffBracket, {
+      seasonId,
+      size: 4,
+      actorUserId: "user_1",
+      format: "double",
+    });
+
+    // Play the two WB semifinals — home wins both, so two losers drop to LB r1.
+    const wbSemis = (await allMatchups(t, seasonId)).filter(
+      (m) => m.bracketType === "winners" && m.round === 1,
+    );
+    for (const m of wbSemis) {
+      await t.mutation(internal.sports.recordGameResult, {
+        fixtureId: m.fixtureId as Id<"fixtures">,
+        homeScore: 24,
+        awayScore: 10,
+        actorUserId: "user_1",
+      });
+    }
+
+    // LB round 1 now holds both WB losers and has a spawned fixture.
+    let all = await allMatchups(t, seasonId);
+    const lbR1 = all.filter((m) => m.bracketType === "losers" && m.round === 1);
+    expect(lbR1).toHaveLength(1);
+    expect(lbR1[0].homeTeamId).not.toBeNull();
+    expect(lbR1[0].awayTeamId).not.toBeNull();
+    expect(lbR1[0].fixtureId).not.toBeNull();
+    // WB losers are exactly the away teams of the two semifinals.
+    const wbLoserIds = new Set(wbSemis.map((m) => m.awayTeamId));
+    expect(wbLoserIds.has(lbR1[0].homeTeamId)).toBe(true);
+    expect(wbLoserIds.has(lbR1[0].awayTeamId)).toBe(true);
+
+    // Decide the WB final and the LB r1 game → both feed the LB final / GF.
+    const wbFinal = all.find(
+      (m) => m.bracketType === "winners" && m.round === 2,
+    )!;
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: wbFinal.fixtureId as Id<"fixtures">,
+      homeScore: 30,
+      awayScore: 13,
+      actorUserId: "user_1",
+    });
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: lbR1[0].fixtureId as Id<"fixtures">,
+      homeScore: 17,
+      awayScore: 14,
+      actorUserId: "user_1",
+    });
+
+    all = await allMatchups(t, seasonId);
+    const lbFinal = all.find((m) => m.bracketType === "losers" && m.round === 2)!;
+    // LB final = LB r1 winner (home) vs WB final loser (away).
+    expect(lbFinal.homeTeamId).toBe(lbR1[0].homeTeamId);
+    expect(lbFinal.awayTeamId).toBe(wbFinal.awayTeamId);
+    expect(lbFinal.fixtureId).not.toBeNull();
+
+    // Grand final has the WB champion in the home slot already.
+    const gf = all.find((m) => m.bracketType === "grandFinal")!;
+    expect(gf.homeTeamId).toBe(wbFinal.homeTeamId);
+
+    // Decide the LB final → its winner fills the grand-final away slot + a game.
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: lbFinal.fixtureId as Id<"fixtures">,
+      homeScore: 20,
+      awayScore: 19,
+      actorUserId: "user_1",
+    });
+    all = await allMatchups(t, seasonId);
+    const gf2 = all.find((m) => m.bracketType === "grandFinal")!;
+    expect(gf2.homeTeamId).toBe(wbFinal.homeTeamId);
+    expect(gf2.awayTeamId).toBe(lbFinal.homeTeamId);
+    expect(gf2.fixtureId).not.toBeNull();
+
+    // Decide the grand final → a champion (the WB champ here).
+    await t.mutation(internal.sports.recordGameResult, {
+      fixtureId: gf2.fixtureId as Id<"fixtures">,
+      homeScore: 31,
+      awayScore: 28,
+      actorUserId: "user_1",
+    });
+    all = await allMatchups(t, seasonId);
+    const champGf = all.find((m) => m.bracketType === "grandFinal")!;
+    expect(champGf.winnerTeamId).toBe(wbFinal.homeTeamId);
   });
 });

--- a/apps/web/convex/lib/bracket.ts
+++ b/apps/web/convex/lib/bracket.ts
@@ -1,16 +1,22 @@
 /*
  * WSM-000164 — Single-elimination bracket construction.
+ * WSM-flex-brackets — arbitrary team counts (byes) + double-elimination.
  *
  * Pure functions isolated from Convex `db` so they can be unit-tested directly.
- * `generatePlayoffBracket` in `sports.ts` calls `buildBracket(size)` to lay out
- * the matchup tree, then inserts rows + wires `nextMatchupId` pointers from the
- * (round, slot) structure here.
+ * `generatePlayoffBracket` in `sports.ts` calls `buildBracket(teamCount)` (or
+ * `buildDoubleElimBracket`) to lay out the matchup tree, then inserts rows +
+ * wires `nextMatchupId` / `loserNextMatchupId` pointers from the structure here.
  *
- * Sizes are powers of two ≥ 2 (the product restricts to 4/8/16). No byes.
+ * Bracket size is the next power of two ≥ teamCount. When size > teamCount the
+ * top `(size - teamCount)` seeds get first-round byes: the bye team auto-advances
+ * (no game / fixture) and is pre-placed into its round-2 parent slot.
  */
 
 /** Side of a parent matchup a winner advances into. */
 export type BracketSide = "home" | "away";
+
+/** Which sub-bracket a matchup belongs to (double-elim). Single-elim omits it. */
+export type BracketType = "winners" | "losers" | "grandFinal";
 
 export interface BracketMatchupPlan {
   round: number; // 1-based; round === rounds is the final
@@ -18,19 +24,45 @@ export interface BracketMatchupPlan {
   /** Round-1 seeds (1 = top seed). null for later rounds (TBD until played). */
   homeSeed: number | null;
   awaySeed: number | null;
-  /** The (round+1) slot this winner feeds, and which side. null for the final. */
+  /** The parent (round+1) slot this winner feeds, and which side. null = final. */
   parentSlot: number | null;
   parentSide: BracketSide | null;
+  /**
+   * True when this matchup is a first-round bye: a single present team that
+   * auto-advances. `homeSeed` carries that team; `awaySeed` is null. No fixture
+   * is spawned and the winner is set immediately at generation time.
+   */
+  isBye?: boolean;
+  /** Sub-bracket marker (double-elim only). Undefined for single-elim. */
+  bracketType?: BracketType;
+  /**
+   * Double-elim only: where the LOSER of this matchup drops to. Identifies the
+   * target matchup by (bracketType, round, slot) + which side. null when the
+   * loser is eliminated (losers-bracket games + the grand final).
+   */
+  loserParentRound?: number | null;
+  loserParentSlot?: number | null;
+  loserParentSide?: BracketSide | null;
 }
 
 export interface BracketPlan {
   size: number;
   rounds: number;
   matchups: BracketMatchupPlan[];
+  /** "single" | "double" — present for double-elim plans. */
+  format?: "single" | "double";
 }
 
 function isPowerOfTwo(n: number): boolean {
   return n >= 2 && (n & (n - 1)) === 0;
+}
+
+/** Smallest power of two ≥ n (n ≥ 2). */
+export function nextPowerOfTwo(n: number): number {
+  if (n < 2) throw new Error("team_count_too_small");
+  let size = 2;
+  while (size < n) size *= 2;
+  return size;
 }
 
 /**
@@ -53,12 +85,14 @@ export function seedOrder(size: number): number[] {
 }
 
 /**
- * Build the full bracket tree for `size` seeds. Round 1 carries the seeded
- * pairings (home = the higher/lower-numbered seed); later rounds are empty
- * placeholders whose teams resolve as games are played.
+ * Build the single-elimination bracket tree for `teamCount` teams (≥ 2). The
+ * bracket size is the next power of two ≥ teamCount; the top `(size-teamCount)`
+ * seeds get first-round byes (auto-advanced, no fixture). Round 1 carries the
+ * seeded pairings (higher seed hosts); later rounds resolve as games are played.
  */
-export function buildBracket(size: number): BracketPlan {
-  if (!isPowerOfTwo(size)) throw new Error("bracket_size_must_be_power_of_two");
+export function buildBracket(teamCount: number): BracketPlan {
+  if (teamCount < 2) throw new Error("team_count_too_small");
+  const size = nextPowerOfTwo(teamCount);
   const rounds = Math.log2(size);
   const order = seedOrder(size);
   const matchups: BracketMatchupPlan[] = [];
@@ -69,12 +103,22 @@ export function buildBracket(size: number): BracketPlan {
       const isFinal = round === rounds;
       let homeSeed: number | null = null;
       let awaySeed: number | null = null;
+      let isBye = false;
       if (round === 1) {
         const a = order[slot * 2];
         const b = order[slot * 2 + 1];
         // Higher seed (smaller number) hosts.
-        homeSeed = Math.min(a, b);
-        awaySeed = Math.max(a, b);
+        const high = Math.min(a, b);
+        const low = Math.max(a, b);
+        // A "seed" beyond teamCount is a phantom: the present team gets a bye.
+        if (low > teamCount) {
+          homeSeed = high; // the real, present team
+          awaySeed = null;
+          isBye = true;
+        } else {
+          homeSeed = high;
+          awaySeed = low;
+        }
       }
       matchups.push({
         round,
@@ -83,9 +127,131 @@ export function buildBracket(size: number): BracketPlan {
         awaySeed,
         parentSlot: isFinal ? null : Math.floor(slot / 2),
         parentSide: isFinal ? null : slot % 2 === 0 ? "home" : "away",
+        ...(isBye ? { isBye: true } : {}),
       });
     }
   }
 
   return { size, rounds, matchups };
+}
+
+/**
+ * Build a DOUBLE-elimination bracket for `teamCount` teams (≥ 2).
+ *
+ * Layout:
+ *   - Winners bracket (WB): identical to the single-elim tree (with byes).
+ *   - Losers bracket (LB): a team is eliminated only after a second loss. LB
+ *     rounds alternate "minor" (LB survivors meet WB drop-ins) and "major"
+ *     (LB survivors meet each other). Built generically for any size.
+ *   - Grand final (GF): WB champion vs LB champion — a SINGLE game (no bracket
+ *     reset / "if-necessary" second game). This is a deliberate simplification.
+ *
+ * Each matchup carries `bracketType`. WB matchups carry loser-routing pointers
+ * (`loserParent*`) into the LB. The convex layer drops a WB loser into the
+ * referenced LB slot. The GF home = WB champion, away = LB champion.
+ */
+export function buildDoubleElimBracket(teamCount: number): BracketPlan {
+  if (teamCount < 2) throw new Error("team_count_too_small");
+  const size = nextPowerOfTwo(teamCount);
+  const wbRounds = Math.log2(size); // winners-bracket rounds
+
+  // 1. Winners bracket — reuse the single-elim tree, tagged "winners".
+  const wb = buildBracket(teamCount).matchups.map((m) => ({
+    ...m,
+    bracketType: "winners" as const,
+  }));
+
+  // 2. Losers bracket. For a size-N WB with R = log2(N) rounds, the LB has
+  //    2*(R-1) rounds. The number of matchups in each LB round follows the
+  //    classic pattern of minor/major rounds, each holding N / 2^ceil((r+1)/2).
+  //    We build it generically and wire WB-loser drop-ins per round.
+  const lb: BracketMatchupPlan[] = [];
+  const lbRounds = wbRounds > 1 ? 2 * (wbRounds - 1) : 0;
+
+  // Slots per LB round: LB round r (1-based).
+  //   minor rounds (odd r): receive WB drop-ins, count = size / 2^((r+1)/2 + 1)
+  //   major rounds (even r): LB-only, count = size / 2^(r/2 + 1)
+  // Equivalently both reduce to size / 2^(floor(r/2) + 2) ... derive directly:
+  const lbCount = (r: number): number => {
+    // round 1 has size/4 matchups (losers of WB round 1, paired up),
+    // then the count halves every TWO rounds.
+    const pairExp = Math.floor((r + 1) / 2); // 1,1,2,2,3,3,...
+    return size / 2 ** (pairExp + 1);
+  };
+
+  for (let r = 1; r <= lbRounds; r++) {
+    const count = lbCount(r);
+    for (let slot = 0; slot < count; slot++) {
+      const isLast = r === lbRounds;
+      lb.push({
+        round: r,
+        slot,
+        homeSeed: null,
+        awaySeed: null,
+        bracketType: "losers",
+        // LB winner advances to the next LB round (same slot in major→minor
+        // collapse, slot/2 when the round halves). null on the last LB round
+        // (its winner goes to the grand final, handled by convex via GF).
+        parentSlot: isLast ? null : nextLbSlot(r, slot),
+        parentSide: isLast ? null : nextLbSide(r, slot),
+      });
+    }
+  }
+
+  // 3. Grand final — single game. WB champion (home) vs LB champion (away).
+  const gf: BracketMatchupPlan = {
+    round: 1,
+    slot: 0,
+    homeSeed: null,
+    awaySeed: null,
+    parentSlot: null,
+    parentSide: null,
+    bracketType: "grandFinal",
+  };
+
+  // 4. Wire WB loser routing into the LB.
+  //    WB round 1 losers feed LB round 1 (two losers per LB-r1 matchup).
+  //    WB round k (k≥2) losers feed LB minor round (2k-2), one per slot.
+  for (const m of wb) {
+    if (m.isBye) continue; // bye matchups have no loser
+    const k = m.round;
+    if (k === wbRounds) {
+      // WB final loser drops into the final LB round (the LB final's away slot).
+      m.loserParentRound = lbRounds;
+      m.loserParentSlot = 0;
+      m.loserParentSide = "away";
+      continue;
+    }
+    if (k === 1) {
+      // Two WB-r1 losers per LB-r1 matchup: slot s/2, alternating home/away.
+      m.loserParentRound = 1;
+      m.loserParentSlot = Math.floor(m.slot / 2);
+      m.loserParentSide = m.slot % 2 === 0 ? "home" : "away";
+    } else {
+      // WB round k loser → LB minor round (2k-2), one per slot, into the
+      // "away" slot (the LB survivor occupies "home" via LB advancement).
+      m.loserParentRound = 2 * k - 2;
+      m.loserParentSlot = m.slot;
+      m.loserParentSide = "away";
+    }
+  }
+
+  const matchups = [...wb, ...lb, gf];
+  return { size, rounds: wbRounds, matchups, format: "double" };
+}
+
+/** LB advancement: which slot in the next LB round a winner of (r, slot) goes to. */
+function nextLbSlot(r: number, slot: number): number {
+  // Minor rounds (odd) feed the major round at the SAME slot count → same slot.
+  // Major rounds (even) halve into the next minor round → slot/2.
+  return r % 2 === 1 ? slot : Math.floor(slot / 2);
+}
+
+/** LB advancement side: LB survivor always occupies "home"; drop-in fills "away". */
+function nextLbSide(r: number, slot: number): BracketSide {
+  // After a minor round, the survivor advances into the major round as "home".
+  // After a major round, two survivors collapse into the next minor round;
+  // even slot → home, odd slot → away.
+  if (r % 2 === 1) return "home";
+  return slot % 2 === 0 ? "home" : "away";
 }

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -372,10 +372,14 @@ export default defineSchema({
   playoffBrackets: defineTable({
     seasonId: v.id("seasons"),
     leagueId: v.id("leagues"),
-    size: v.number(), // 4 | 8 | 16
-    rounds: v.number(), // log2(size)
+    size: v.number(), // next power of two ≥ teamCount (byes fill the gap)
+    rounds: v.number(), // log2(size) — winners-bracket rounds for double-elim
     createdAt: v.string(),
     createdBy: v.string(),
+    // "single" | "double". Optional for back-compat (legacy rows = single-elim).
+    format: v.optional(v.string()),
+    // Number of qualifying teams (≤ size). Optional for legacy rows.
+    teamCount: v.optional(v.number()),
   })
     .index("by_seasonId", ["seasonId"])
     .index("by_leagueId", ["leagueId"]),
@@ -403,6 +407,13 @@ export default defineSchema({
     nextSlot: v.union(v.string(), v.null()), // "home" | "away" | null
     winnerTeamId: v.union(v.id("teams"), v.null()),
     fixtureId: v.union(v.id("fixtures"), v.null()),
+    // Double-elim (WSM-flex-brackets). Optional → legacy single-elim rows valid.
+    // "winners" | "losers" | "grandFinal"; undefined = single-elim.
+    bracketType: v.optional(v.string()),
+    // Where the LOSER of this matchup drops (double-elim WB → LB routing).
+    // Self-referential id stored as a string (same rationale as nextMatchupId).
+    loserNextMatchupId: v.optional(v.union(v.string(), v.null())),
+    loserNextSlot: v.optional(v.union(v.string(), v.null())), // "home" | "away"
   })
     .index("by_bracketId", ["bracketId"])
     .index("by_seasonId", ["seasonId"]),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -21,7 +21,11 @@ import {
   doubleRoundRobinSchedule,
   weekKickoff,
 } from "./lib/roundRobin";
-import { buildBracket } from "./lib/bracket";
+import {
+  buildBracket,
+  buildDoubleElimBracket,
+  nextPowerOfTwo,
+} from "./lib/bracket";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -5108,9 +5112,15 @@ async function spawnPlayoffFixture(
 }
 
 /**
- * Idempotent bracket recompute. In round order: spawn a fixture when both teams
- * are known, resolve a decisive game's winner, and propagate that winner into
- * its parent matchup's slot. A tie leaves the matchup unresolved (no advance).
+ * Idempotent bracket recompute. In (bracket, round, slot) order: spawn a
+ * fixture when both teams are known and the matchup is not a bye, resolve a
+ * decisive game's winner, propagate that winner into its parent slot, and — for
+ * double-elimination — drop the LOSER into its losers-bracket slot. First-round
+ * byes carry a pre-set winner (no fixture) and only need propagation. A tie
+ * leaves the matchup unresolved (playoff games are recorded decisive).
+ *
+ * The pass repeats until it reaches a fixed point so a chain of byes feeding
+ * one another (and bye-vs-bye round-2 matchups) all resolve in one call.
  */
 async function advanceBracketForSeason(
   ctx: MutationCtx,
@@ -5127,56 +5137,112 @@ async function advanceBracketForSeason(
     .withIndex("by_bracketId", (q) => q.eq("bracketId", bracket._id))
     .collect();
   const byId = new Map(matchups.map((m) => [m._id, m]));
+  const bracketRank = (t: string | undefined) =>
+    t === "losers" ? 1 : t === "grandFinal" ? 2 : 0; // winners first
   const ordered = [...matchups].sort(
-    (a, b) => a.round - b.round || a.slot - b.slot,
+    (a, b) =>
+      bracketRank(a.bracketType) - bracketRank(b.bracketType) ||
+      a.round - b.round ||
+      a.slot - b.slot,
   );
 
-  for (const m of ordered) {
-    // 1. Spawn this matchup's fixture once both teams are known.
-    if (m.homeTeamId && m.awayTeamId && !m.fixtureId) {
-      const fid = await spawnPlayoffFixture(ctx, m, "system");
-      await ctx.db.patch(m._id, { fixtureId: fid });
-      m.fixtureId = fid;
+  const setSide = async (
+    parentId: Id<"playoffMatchups">,
+    side: string,
+    teamId: Id<"teams">,
+  ) => {
+    const parent = byId.get(parentId);
+    if (!parent) return;
+    if (side === "home" && parent.homeTeamId !== teamId) {
+      await ctx.db.patch(parent._id, { homeTeamId: teamId });
+      parent.homeTeamId = teamId;
+    } else if (side === "away" && parent.awayTeamId !== teamId) {
+      await ctx.db.patch(parent._id, { awayTeamId: teamId });
+      parent.awayTeamId = teamId;
     }
-    // 2. Resolve a decisive winner from the played fixture.
-    if (m.fixtureId && !m.winnerTeamId) {
-      const fx = await ctx.db.get(m.fixtureId);
-      if (fx && fx.status === "final") {
-        const res = await ctx.db
-          .query("gameResults")
-          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
-          .first();
-        if (res && res.homeScore !== res.awayScore) {
-          const winner =
-            res.homeScore > res.awayScore ? fx.homeTeamId : fx.awayTeamId;
-          await ctx.db.patch(m._id, { winnerTeamId: winner });
-          m.winnerTeamId = winner;
+  };
+
+  // Iterate to a fixed point: bye winners can cascade into later matchups.
+  let changed = true;
+  let guard = 0;
+  while (changed && guard++ < matchups.length + 2) {
+    changed = false;
+    for (const m of ordered) {
+      // 1. Spawn this matchup's fixture once both teams are known (not a bye).
+      const isBye = !m.awayTeamId && m.homeSeed != null && m.awaySeed == null;
+      if (m.homeTeamId && m.awayTeamId && !m.fixtureId) {
+        const fid = await spawnPlayoffFixture(ctx, m, "system");
+        await ctx.db.patch(m._id, { fixtureId: fid });
+        m.fixtureId = fid;
+        changed = true;
+      }
+      // 2. Resolve a decisive winner from the played fixture.
+      if (m.fixtureId && !m.winnerTeamId) {
+        const fx = await ctx.db.get(m.fixtureId);
+        if (fx && fx.status === "final") {
+          const res = await ctx.db
+            .query("gameResults")
+            .withIndex("by_fixtureId", (q) => q.eq("fixtureId", m.fixtureId!))
+            .first();
+          if (res && res.homeScore !== res.awayScore) {
+            const winner =
+              res.homeScore > res.awayScore ? fx.homeTeamId : fx.awayTeamId;
+            await ctx.db.patch(m._id, { winnerTeamId: winner });
+            m.winnerTeamId = winner;
+            changed = true;
+          }
         }
       }
-    }
-    // 3. Propagate the winner into the parent slot.
-    if (m.winnerTeamId && m.nextMatchupId && m.nextSlot) {
-      const parent = byId.get(m.nextMatchupId as Id<"playoffMatchups">);
-      if (parent) {
-        if (m.nextSlot === "home" && parent.homeTeamId !== m.winnerTeamId) {
-          await ctx.db.patch(parent._id, { homeTeamId: m.winnerTeamId });
-          parent.homeTeamId = m.winnerTeamId;
-        } else if (
-          m.nextSlot === "away" &&
-          parent.awayTeamId !== m.winnerTeamId
-        ) {
-          await ctx.db.patch(parent._id, { awayTeamId: m.winnerTeamId });
-          parent.awayTeamId = m.winnerTeamId;
-        }
+      // The loser is the non-winning known side (null for byes / TBD games).
+      const loserTeamId: Id<"teams"> | null =
+        m.winnerTeamId && m.homeTeamId && m.awayTeamId
+          ? m.winnerTeamId === m.homeTeamId
+            ? m.awayTeamId
+            : m.homeTeamId
+          : null;
+      // 3. Propagate the winner into the parent slot.
+      if (m.winnerTeamId && m.nextMatchupId && m.nextSlot) {
+        const before = byId.get(m.nextMatchupId as Id<"playoffMatchups">);
+        const had =
+          m.nextSlot === "home"
+            ? before?.homeTeamId === m.winnerTeamId
+            : before?.awayTeamId === m.winnerTeamId;
+        await setSide(
+          m.nextMatchupId as Id<"playoffMatchups">,
+          m.nextSlot,
+          m.winnerTeamId,
+        );
+        if (!had) changed = true;
+      }
+      // 4. Double-elim: drop the loser of a decided game into the LB slot.
+      if (loserTeamId && !isBye && m.loserNextMatchupId && m.loserNextSlot) {
+        const target = byId.get(
+          m.loserNextMatchupId as Id<"playoffMatchups">,
+        );
+        const had =
+          m.loserNextSlot === "home"
+            ? target?.homeTeamId === loserTeamId
+            : target?.awayTeamId === loserTeamId;
+        await setSide(
+          m.loserNextMatchupId as Id<"playoffMatchups">,
+          m.loserNextSlot,
+          loserTeamId,
+        );
+        if (!had) changed = true;
       }
     }
   }
 }
 
 /**
- * Generate a single-elimination bracket from the season's standings. Sizes
- * 4/8/16. Re-running re-snapshots seeds, but refuses to wipe a bracket that has
- * a played/in-progress game unless `confirm` is set.
+ * Generate a playoff bracket from the season's standings (WSM-flex-brackets).
+ *
+ * `size` is the qualifying team count — any value ≥ 2 (e.g. 5, 6, 10, 12). The
+ * bracket size is rounded up to the next power of two and the top
+ * `(bracketSize - teamCount)` seeds get first-round byes (auto-advanced, no
+ * game). `format` selects single- or double-elimination (defaults to the
+ * season's `playoffFormat`). Re-running re-snapshots seeds, but refuses to wipe
+ * a bracket that has a played/in-progress game unless `confirm` is set.
  */
 export const generatePlayoffBracket = internalMutationGeneric({
   args: {
@@ -5185,6 +5251,7 @@ export const generatePlayoffBracket = internalMutationGeneric({
     actorUserId: v.string(),
     confirm: v.optional(v.boolean()),
     divisionWinnersQualify: v.optional(v.boolean()),
+    format: v.optional(v.string()), // "single" | "double"
   },
   returns: v.object({
     bracketId: v.string(),
@@ -5193,11 +5260,14 @@ export const generatePlayoffBracket = internalMutationGeneric({
     matchups: v.number(),
   }),
   handler: async (ctx, args) => {
-    if (![4, 8, 16].includes(args.size)) {
+    const teamCount = args.size;
+    if (!Number.isInteger(teamCount) || teamCount < 2 || teamCount > 64) {
       throw new Error("invalid_bracket_size");
     }
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
+    const format =
+      (args.format ?? season.playoffFormat) === "double" ? "double" : "single";
     // Honor the season's configured qualification rule (overridable per call).
     const divisionWinnersQualify =
       args.divisionWinnersQualify ?? season.divisionWinnersQualify ?? false;
@@ -5251,30 +5321,42 @@ export const generatePlayoffBracket = internalMutationGeneric({
       season,
       divisionWinnersQualify,
     );
-    if (seeds.length < args.size) throw new Error("not_enough_teams");
+    if (seeds.length < teamCount) throw new Error("not_enough_teams");
 
-    const plan = buildBracket(args.size);
+    const plan =
+      format === "double"
+        ? buildDoubleElimBracket(teamCount)
+        : buildBracket(teamCount);
+    const bracketSize = nextPowerOfTwo(teamCount);
     const createdAt = new Date().toISOString();
     const bracketId = await ctx.db.insert("playoffBrackets", {
       seasonId: args.seasonId,
       leagueId: season.leagueId,
-      size: args.size,
+      size: bracketSize,
       rounds: plan.rounds,
       createdAt,
       createdBy: args.actorUserId,
+      format,
+      teamCount,
     });
 
-    // Insert matchups, then wire parent pointers, then spawn round-1 fixtures.
+    // Keying must distinguish sub-brackets in double-elim (winners/losers each
+    // have their own round/slot space; grand final is its own bucket).
+    const keyOf = (
+      bracketType: string | undefined,
+      round: number,
+      slot: number,
+    ) => `${bracketType ?? "winners"}:${round}:${slot}`;
+
+    // Insert matchups, then wire parent + loser pointers, then spawn fixtures.
     const idByKey = new Map<string, Id<"playoffMatchups">>();
     for (const mp of plan.matchups) {
       const homeTeamId =
-        mp.homeSeed != null
-          ? (seeds[mp.homeSeed - 1] as Id<"teams">)
-          : null;
+        mp.homeSeed != null ? (seeds[mp.homeSeed - 1] as Id<"teams">) : null;
       const awayTeamId =
-        mp.awaySeed != null
-          ? (seeds[mp.awaySeed - 1] as Id<"teams">)
-          : null;
+        mp.awaySeed != null ? (seeds[mp.awaySeed - 1] as Id<"teams">) : null;
+      // A bye: the present (home) team auto-advances at generation time.
+      const isBye = mp.isBye === true && homeTeamId != null;
       const id = await ctx.db.insert("playoffMatchups", {
         bracketId,
         seasonId: args.seasonId,
@@ -5286,29 +5368,75 @@ export const generatePlayoffBracket = internalMutationGeneric({
         awayTeamId,
         nextMatchupId: null,
         nextSlot: null,
-        winnerTeamId: null,
+        winnerTeamId: isBye ? homeTeamId : null,
         fixtureId: null,
+        ...(mp.bracketType ? { bracketType: mp.bracketType } : {}),
+        loserNextMatchupId: null,
+        loserNextSlot: null,
       });
-      idByKey.set(`${mp.round}:${mp.slot}`, id);
+      idByKey.set(keyOf(mp.bracketType, mp.round, mp.slot), id);
     }
+
+    // Winner-advancement pointers (parent slot/side within the same bracket).
     for (const mp of plan.matchups) {
       if (mp.parentSlot == null || mp.parentSide == null) continue;
-      await ctx.db.patch(idByKey.get(`${mp.round}:${mp.slot}`)!, {
-        nextMatchupId: idByKey.get(`${mp.round + 1}:${mp.parentSlot}`)!,
-        nextSlot: mp.parentSide,
+      await ctx.db.patch(
+        idByKey.get(keyOf(mp.bracketType, mp.round, mp.slot))!,
+        {
+          nextMatchupId: idByKey.get(
+            keyOf(mp.bracketType, mp.round + 1, mp.parentSlot),
+          )!,
+          nextSlot: mp.parentSide,
+        },
+      );
+    }
+
+    // Double-elim: winners-bracket losers route into the losers bracket; the
+    // last LB matchup and the WB final's winner both feed the grand final.
+    if (format === "double") {
+      for (const mp of plan.matchups) {
+        if (
+          mp.loserParentRound == null ||
+          mp.loserParentSlot == null ||
+          mp.loserParentSide == null
+        ) {
+          continue;
+        }
+        await ctx.db.patch(
+          idByKey.get(keyOf(mp.bracketType, mp.round, mp.slot))!,
+          {
+            loserNextMatchupId: idByKey.get(
+              keyOf("losers", mp.loserParentRound, mp.loserParentSlot),
+            )!,
+            loserNextSlot: mp.loserParentSide,
+          },
+        );
+      }
+      // WB champion → grand final home; LB champion → grand final away.
+      const gfId = idByKey.get(keyOf("grandFinal", 1, 0))!;
+      const wbFinalKey = keyOf("winners", plan.rounds, 0);
+      await ctx.db.patch(idByKey.get(wbFinalKey)!, {
+        nextMatchupId: gfId,
+        nextSlot: "home",
       });
+      const lbRounds = plan.rounds > 1 ? 2 * (plan.rounds - 1) : 0;
+      const lbFinalKey = keyOf("losers", lbRounds, 0);
+      const lbFinalId = idByKey.get(lbFinalKey);
+      if (lbFinalId) {
+        await ctx.db.patch(lbFinalId, {
+          nextMatchupId: gfId,
+          nextSlot: "away",
+        });
+      }
     }
-    for (const mp of plan.matchups) {
-      if (mp.round !== 1) continue;
-      const id = idByKey.get(`1:${mp.slot}`)!;
-      const m = (await ctx.db.get(id))!;
-      const fid = await spawnPlayoffFixture(ctx as MutationCtx, m, args.actorUserId);
-      await ctx.db.patch(id, { fixtureId: fid });
-    }
+
+    // Resolve any first-round byes immediately (auto-advance, no fixture), then
+    // spawn fixtures for every matchup whose two teams are now known.
+    await advanceBracketForSeason(ctx as MutationCtx, args.seasonId);
 
     return {
       bracketId,
-      size: args.size,
+      size: bracketSize,
       rounds: plan.rounds,
       matchups: plan.matchups.length,
     };
@@ -5341,6 +5469,10 @@ const playoffMatchupDtoValidator = v.object({
   status: v.union(v.string(), v.null()),
   homeScore: v.union(v.number(), v.null()),
   awayScore: v.union(v.number(), v.null()),
+  // "winners" | "losers" | "grandFinal" — null for single-elim brackets.
+  bracketType: v.union(v.string(), v.null()),
+  // First-round bye marker (team auto-advanced, no game).
+  isBye: v.boolean(),
 });
 
 /** Bracket tree DTO for the UI (WSM-000165). Null when no bracket exists. */
@@ -5351,6 +5483,7 @@ export const getPlayoffBracket = queryGeneric({
       bracketId: v.string(),
       size: v.number(),
       rounds: v.number(),
+      format: v.string(), // "single" | "double"
       matchups: v.array(playoffMatchupDtoValidator),
     }),
     v.null(),
@@ -5390,6 +5523,9 @@ export const getPlayoffBracket = queryGeneric({
               awayScore = res?.awayScore ?? null;
             }
           }
+          // A first-round bye: a single present team with no opponent/game.
+          const isBye =
+            m.homeSeed != null && m.awaySeed == null && !m.awayTeamId;
           return {
             id: m._id,
             round: m.round,
@@ -5405,6 +5541,8 @@ export const getPlayoffBracket = queryGeneric({
             status,
             homeScore,
             awayScore,
+            bracketType: m.bracketType ?? null,
+            isBye,
           };
         }),
     );
@@ -5413,6 +5551,7 @@ export const getPlayoffBracket = queryGeneric({
       bracketId: bracket._id,
       size: bracket.size,
       rounds: bracket.rounds,
+      format: bracket.format ?? "single",
       matchups: dtos,
     };
   },

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
@@ -79,6 +79,7 @@ describe("generatePlayoffsAction (WSM-000164)", () => {
       size: 8,
       actorUserId: "user_1",
       confirm: undefined,
+      format: undefined,
     });
   });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -41,7 +41,7 @@ function friendlyError(code: string): string {
     return "Not enough teams in the standings for a bracket of this size.";
   }
   if (code.includes("invalid_bracket_size")) {
-    return "Bracket size must be 4, 8, or 16.";
+    return "Pick a playoff team count between 2 and 64.";
   }
   if (code.includes("season_not_found")) {
     return "This season no longer exists.";
@@ -50,15 +50,19 @@ function friendlyError(code: string): string {
 }
 
 /*
- * Seed a single-elimination bracket from the season's standings (WSM-000164).
- * The mutation refuses to overwrite a bracket that already has a played game;
- * that surfaces here as `needsConfirm` so the UI can re-call with confirm.
+ * Seed a playoff bracket from the season's standings (WSM-000164,
+ * WSM-flex-brackets). `size` is the qualifying team count (any value ≥ 2, with
+ * byes for non-powers-of-two); `format` selects single/double elimination
+ * (defaults to the season config). The mutation refuses to overwrite a bracket
+ * that already has a played game; that surfaces here as `needsConfirm` so the
+ * UI can re-call with confirm.
  */
 export async function generatePlayoffsAction(input: {
   leagueId: string;
   seasonId: string;
   size: number;
   confirm?: boolean;
+  format?: string;
 }): Promise<
   | { ok: true; bracketId: string; size: number; rounds: number; matchups: number }
   | { ok: false; needsConfirm: true }
@@ -76,6 +80,7 @@ export async function generatePlayoffsAction(input: {
       size: input.size,
       actorUserId: userId,
       confirm: input.confirm,
+      format: input.format,
     });
     revalidatePath(`/dashboard/leagues/${input.leagueId}/playoffs`);
     return { ok: true, ...res };

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -73,6 +73,8 @@ export default async function LeaguePlayoffsPage({
               seasonId={activeSeason.id}
               seasonName={activeSeason.name}
               hasBracket={bracket !== null}
+              defaultSize={activeSeason.playoffTeams}
+              defaultFormat={activeSeason.playoffFormat}
             />
           ) : null}
         </div>

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -36,6 +36,7 @@ export async function createSeasonAction(input: {
   startDate: string | null;
   endDate: string | null;
   playoffTeams?: number;
+  playoffFormat?: string;
   divisionWinnersQualify?: boolean;
 }): Promise<Result<{ id: string }>> {
   const name = input.name.trim();
@@ -57,7 +58,7 @@ export async function createSeasonAction(input: {
       endDate: input.endDate,
       status,
       playoffTeams: input.playoffTeams,
-      playoffFormat: "single",
+      playoffFormat: input.playoffFormat ?? "single",
       divisionWinnersQualify: input.divisionWinnersQualify,
     });
     revalidatePath("/dashboard/seasons");
@@ -76,6 +77,7 @@ export async function updateSeasonAction(input: {
   startDate: string | null;
   endDate: string | null;
   playoffTeams?: number;
+  playoffFormat?: string;
   divisionWinnersQualify?: boolean;
 }): Promise<Result> {
   const name = input.name.trim();
@@ -91,6 +93,7 @@ export async function updateSeasonAction(input: {
       startDate: input.startDate,
       endDate: input.endDate,
       playoffTeams: input.playoffTeams,
+      playoffFormat: input.playoffFormat,
       divisionWinnersQualify: input.divisionWinnersQualify,
     });
     revalidatePath("/dashboard/seasons");

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -22,16 +22,24 @@ function nullableDate(value: string): string | null {
   return value.trim() === "" ? null : value;
 }
 
-/** Playoff setup fields shared by the create + edit season forms (WSM-000184).
- *  Single-elimination only for now; double-elim is a future option. */
+/** Bye-friendly playoff team counts (any value ≥ 2 is supported; the bracket
+ *  rounds up to the next power of two and gives top seeds first-round byes). */
+const PLAYOFF_TEAM_OPTIONS = [2, 4, 6, 8, 10, 12, 16] as const;
+
+/** Playoff setup fields shared by the create + edit season forms (WSM-000184,
+ *  WSM-flex-brackets: bye-friendly counts + single/double elimination). */
 function PlayoffConfigFields({
   playoffTeams,
   setPlayoffTeams,
+  playoffFormat,
+  setPlayoffFormat,
   divisionWinnersQualify,
   setDivisionWinnersQualify,
 }: {
   playoffTeams: number;
   setPlayoffTeams: (n: number) => void;
+  playoffFormat: string;
+  setPlayoffFormat: (f: string) => void;
   divisionWinnersQualify: boolean;
   setDivisionWinnersQualify: (b: boolean) => void;
 }) {
@@ -46,9 +54,24 @@ function PlayoffConfigFields({
           aria-label="Number of playoff teams"
         >
           <option value={0}>None</option>
-          <option value={4}>4 teams (single-elim)</option>
-          <option value={8}>8 teams (single-elim)</option>
-          <option value={16}>16 teams (single-elim)</option>
+          {PLAYOFF_TEAM_OPTIONS.map((n) => (
+            <option key={n} value={n}>
+              {n} teams
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-1 text-xs text-muted-foreground">
+        Format
+        <select
+          className={inputClass}
+          value={playoffFormat}
+          onChange={(e) => setPlayoffFormat(e.target.value)}
+          aria-label="Playoff format"
+          disabled={playoffTeams === 0}
+        >
+          <option value="single">Single elimination</option>
+          <option value="double">Double elimination</option>
         </select>
       </label>
       <label className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -70,6 +93,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [playoffTeams, setPlayoffTeams] = useState(8);
+  const [playoffFormat, setPlayoffFormat] = useState("single");
   const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -78,6 +102,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
     setStartDate("");
     setEndDate("");
     setPlayoffTeams(8);
+    setPlayoffFormat("single");
     setDivisionWinnersQualify(false);
     setOpen(false);
   }
@@ -92,6 +117,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
       startDate: nullableDate(startDate),
       endDate: nullableDate(endDate),
       playoffTeams,
+      playoffFormat,
       divisionWinnersQualify,
     });
     setBusy(false);
@@ -147,6 +173,8 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
       <PlayoffConfigFields
         playoffTeams={playoffTeams}
         setPlayoffTeams={setPlayoffTeams}
+        playoffFormat={playoffFormat}
+        setPlayoffFormat={setPlayoffFormat}
         divisionWinnersQualify={divisionWinnersQualify}
         setDivisionWinnersQualify={setDivisionWinnersQualify}
       />
@@ -223,6 +251,9 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
   const [startDate, setStartDate] = useState(season.startDate ?? "");
   const [endDate, setEndDate] = useState(season.endDate ?? "");
   const [playoffTeams, setPlayoffTeams] = useState(season.playoffTeams ?? 8);
+  const [playoffFormat, setPlayoffFormat] = useState(
+    season.playoffFormat ?? "single",
+  );
   const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(
     season.divisionWinnersQualify ?? false,
   );
@@ -252,6 +283,7 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
       startDate: nullableDate(startDate),
       endDate: nullableDate(endDate),
       playoffTeams,
+      playoffFormat,
       divisionWinnersQualify,
     });
     setBusy(false);
@@ -313,6 +345,8 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
         <PlayoffConfigFields
           playoffTeams={playoffTeams}
           setPlayoffTeams={setPlayoffTeams}
+          playoffFormat={playoffFormat}
+          setPlayoffFormat={setPlayoffFormat}
           divisionWinnersQualify={divisionWinnersQualify}
           setDivisionWinnersQualify={setDivisionWinnersQualify}
         />

--- a/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
@@ -13,19 +13,37 @@ export interface GeneratePlayoffsButtonProps {
   seasonName: string;
   /** Whether a bracket already exists (changes the button label + confirm copy). */
   hasBracket: boolean;
+  /** Season's configured playoff team count — the default dropdown selection. */
+  defaultSize?: number | null;
+  /** Season's configured playoff format ("single" | "double"). */
+  defaultFormat?: string | null;
 }
 
-const SIZES = [4, 8, 16] as const;
+// Bye-friendly counts (any value ≥ 2 is valid server-side; bracket rounds up to
+// the next power of two and gives top seeds first-round byes).
+const SIZES = [2, 4, 6, 8, 10, 12, 16] as const;
 
 export default function GeneratePlayoffsButton({
   leagueId,
   seasonId,
   seasonName,
   hasBracket,
+  defaultSize,
+  defaultFormat,
 }: GeneratePlayoffsButtonProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
-  const [size, setSize] = useState<number>(8);
+  // Default to the season's configured team count (fall back to 8). If the
+  // configured count is not one of the offered options, it is still added below.
+  const initialSize = defaultSize && defaultSize >= 2 ? defaultSize : 8;
+  const [size, setSize] = useState<number>(initialSize);
+  const [format, setFormat] = useState<string>(
+    defaultFormat === "double" ? "double" : "single",
+  );
+
+  const sizeOptions = SIZES.includes(initialSize as (typeof SIZES)[number])
+    ? [...SIZES]
+    : [...SIZES, initialSize].sort((a, b) => a - b);
 
   function run(confirm: boolean) {
     startTransition(async () => {
@@ -33,11 +51,16 @@ export default function GeneratePlayoffsButton({
         leagueId,
         seasonId,
         size,
+        format,
         confirm,
       });
 
       if (res.ok) {
-        toast.success(`Generated a ${res.size}-team bracket (${res.rounds} rounds).`);
+        toast.success(
+          `Generated a ${size}-team ${
+            format === "double" ? "double" : "single"
+          }-elim bracket (${res.rounds} rounds).`,
+        );
         router.refresh();
         return;
       }
@@ -78,11 +101,24 @@ export default function GeneratePlayoffsButton({
         onChange={(e) => setSize(Number(e.target.value))}
         className="h-9 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {SIZES.map((s) => (
+        {sizeOptions.map((s) => (
           <option key={s} value={s}>
             {s} teams
           </option>
         ))}
+      </select>
+      <label className="sr-only" htmlFor="bracket-format">
+        Bracket format
+      </label>
+      <select
+        id="bracket-format"
+        value={format}
+        disabled={pending}
+        onChange={(e) => setFormat(e.target.value)}
+        className="h-9 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <option value="single">Single elim</option>
+        <option value="double">Double elim</option>
       </select>
       <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
         <Trophy className="mr-1.5 h-4 w-4" />

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { PlayoffBracketDto, PlayoffMatchupDto } from "@/lib/data-api";
-import { groupMatchupsByRound, winnerSide } from "@/lib/playoffs";
+import { bracketSections, winnerSide } from "@/lib/playoffs";
 
 function Side({
   seed,
@@ -41,6 +41,24 @@ function Side({
 function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
   const side = winnerSide(m);
   const decided = side !== null;
+  // A first-round bye: a single present team auto-advances with no opponent.
+  if (m.isBye) {
+    return (
+      <div className="overflow-hidden rounded-md border border-dashed border-border bg-card">
+        <Side
+          seed={m.homeSeed}
+          name={m.homeTeamName}
+          score={null}
+          won={true}
+          dim={false}
+        />
+        <div className="border-t border-border" />
+        <div className="px-2 py-1 text-xs italic text-muted-foreground">
+          Bye — advances
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="overflow-hidden rounded-md border border-border bg-card">
       <Side
@@ -63,32 +81,52 @@ function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
 }
 
 /**
- * Read-only single-elimination bracket (WSM-000165). Renders one column per
- * round left→right; columns scroll horizontally on small screens. Winners are
- * bolded, the loser dimmed, and unresolved slots show "TBD".
+ * Read-only playoff bracket (WSM-000165, WSM-flex-brackets). Single-elim renders
+ * one column per round; double-elim renders three stacked regions (winners
+ * bracket, losers bracket, grand final), each as columns. Columns scroll
+ * horizontally on small screens. Winners are bolded, losers dimmed, unresolved
+ * slots show "TBD", and first-round byes are marked.
  */
 export default function PlayoffBracket({
   bracket,
 }: {
   bracket: PlayoffBracketDto;
 }) {
-  const rounds = groupMatchupsByRound(bracket.matchups, bracket.rounds);
+  const sections = bracketSections(
+    bracket.matchups,
+    bracket.rounds,
+    bracket.format,
+  );
   return (
-    <div className="overflow-x-auto">
-      <div className="flex min-w-max gap-6 pb-2">
-        {rounds.map((r) => (
-          <div key={r.round} className="flex w-56 shrink-0 flex-col">
-            <h3 className="mb-3 font-mono text-xs uppercase tracking-wide text-muted-foreground">
-              {r.label}
+    <div className="flex flex-col gap-8">
+      {sections.map((section) => (
+        <section key={section.type}>
+          {section.title ? (
+            <h3 className="mb-3 text-sm font-semibold text-foreground">
+              {section.title}
             </h3>
-            <div className="flex flex-1 flex-col justify-around gap-4">
-              {r.matchups.map((m) => (
-                <MatchupCard key={m.id} m={m} />
+          ) : null}
+          <div className="overflow-x-auto">
+            <div className="flex min-w-max gap-6 pb-2">
+              {section.rounds.map((r) => (
+                <div
+                  key={`${section.type}-${r.round}`}
+                  className="flex w-56 shrink-0 flex-col"
+                >
+                  <h4 className="mb-3 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+                    {r.label}
+                  </h4>
+                  <div className="flex flex-1 flex-col justify-around gap-4">
+                    {r.matchups.map((m) => (
+                      <MatchupCard key={m.id} m={m} />
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           </div>
-        ))}
-      </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/playoffs.test.ts
+++ b/apps/web/src/lib/__tests__/playoffs.test.ts
@@ -3,6 +3,7 @@ import {
   roundLabel,
   groupMatchupsByRound,
   winnerSide,
+  bracketSections,
 } from "../playoffs";
 import type { PlayoffMatchupDto } from "@/lib/data-api";
 
@@ -22,6 +23,8 @@ function m(partial: Partial<PlayoffMatchupDto>): PlayoffMatchupDto {
     status: null,
     homeScore: null,
     awayScore: null,
+    bracketType: null,
+    isBye: false,
     ...partial,
   };
 }
@@ -65,5 +68,52 @@ describe("winnerSide", () => {
     expect(
       winnerSide(m({ winnerTeamId: "t2", homeTeamId: "t1", awayTeamId: "t2" })),
     ).toBe("away");
+  });
+});
+
+describe("bracketSections (WSM-flex-brackets)", () => {
+  it("single-elim → one untitled winners section using named rounds", () => {
+    const matchups = [
+      m({ id: "s0", round: 1, slot: 0 }),
+      m({ id: "s1", round: 1, slot: 1 }),
+      m({ id: "f", round: 2, slot: 0 }),
+    ];
+    const sections = bracketSections(matchups, 2, "single");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].type).toBe("winners");
+    expect(sections[0].title).toBe("");
+    expect(sections[0].rounds.map((r) => r.label)).toEqual([
+      "Semifinals",
+      "Final",
+    ]);
+  });
+
+  it("double-elim → winners, losers, and grand-final sections", () => {
+    const matchups = [
+      m({ id: "w0", round: 1, slot: 0, bracketType: "winners" }),
+      m({ id: "w1", round: 1, slot: 1, bracketType: "winners" }),
+      m({ id: "wf", round: 2, slot: 0, bracketType: "winners" }),
+      m({ id: "l1", round: 1, slot: 0, bracketType: "losers" }),
+      m({ id: "l2", round: 2, slot: 0, bracketType: "losers" }),
+      m({ id: "gf", round: 1, slot: 0, bracketType: "grandFinal" }),
+    ];
+    const sections = bracketSections(matchups, 2, "double");
+    expect(sections.map((s) => s.type)).toEqual([
+      "winners",
+      "losers",
+      "grandFinal",
+    ]);
+    expect(sections[0].title).toBe("Winners Bracket");
+    expect(sections[1].title).toBe("Losers Bracket");
+    // Losers final is the last LB round.
+    const lbLabels = sections[1].rounds.map((r) => r.label);
+    expect(lbLabels[lbLabels.length - 1]).toBe("Losers Final");
+    expect(sections[2].rounds[0].matchups.map((x) => x.id)).toEqual(["gf"]);
+  });
+
+  it("omits losers/grand-final sections when those matchups are absent", () => {
+    const matchups = [m({ id: "w0", round: 1, slot: 0, bracketType: "winners" })];
+    const sections = bracketSections(matchups, 1, "double");
+    expect(sections.map((s) => s.type)).toEqual(["winners"]);
   });
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -83,12 +83,18 @@ export interface PlayoffMatchupDto {
   status: string | null;
   homeScore: number | null;
   awayScore: number | null;
+  /** "winners" | "losers" | "grandFinal" — null for single-elim brackets. */
+  bracketType: string | null;
+  /** First-round bye: the present team auto-advanced with no game. */
+  isBye: boolean;
 }
 
 export interface PlayoffBracketDto {
   bracketId: string;
   size: number;
   rounds: number;
+  /** "single" | "double". */
+  format: string;
   matchups: PlayoffMatchupDto[];
 }
 
@@ -545,6 +551,7 @@ const refs = {
       actorUserId: string;
       confirm?: boolean;
       divisionWinnersQualify?: boolean;
+      format?: string;
     },
     { bracketId: string; size: number; rounds: number; matchups: number }
   >("sports:generatePlayoffBracket"),
@@ -1742,6 +1749,7 @@ export async function generatePlayoffBracket(input: {
   actorUserId: string;
   confirm?: boolean;
   divisionWinnersQualify?: boolean;
+  format?: string;
 }): Promise<{
   bracketId: string;
   size: number;

--- a/apps/web/src/lib/playoffs.ts
+++ b/apps/web/src/lib/playoffs.ts
@@ -54,3 +54,80 @@ export function winnerSide(
   if (m.winnerTeamId === m.awayTeamId) return "away";
   return null;
 }
+
+/*
+ * Double-elimination presentation helpers (WSM-flex-brackets). A double-elim
+ * bracket carries `bracketType` per matchup; the UI renders three regions:
+ * the winners bracket (single-elim layout), the losers bracket, and a single
+ * grand final.
+ */
+
+export interface BracketSection {
+  /** "winners" | "losers" | "grandFinal" */
+  type: string;
+  title: string;
+  rounds: BracketRound[];
+}
+
+/** Generic round label for the losers bracket (no fixed "Final/Semis" names). */
+function loserRoundLabel(round: number, totalRounds: number): string {
+  return round === totalRounds ? "Losers Final" : `Losers R${round}`;
+}
+
+/**
+ * Split a (single- or double-elim) bracket into ordered display sections.
+ * Single-elim → one untitled "winners" section using the standard round names.
+ * Double-elim → winners bracket, losers bracket, and the grand final.
+ */
+export function bracketSections(
+  matchups: PlayoffMatchupDto[],
+  wbRounds: number,
+  format: string,
+): BracketSection[] {
+  if (format !== "double") {
+    return [
+      {
+        type: "winners",
+        title: "",
+        rounds: groupMatchupsByRound(matchups, wbRounds),
+      },
+    ];
+  }
+
+  const wb = matchups.filter((m) => (m.bracketType ?? "winners") === "winners");
+  const lb = matchups.filter((m) => m.bracketType === "losers");
+  const gf = matchups.filter((m) => m.bracketType === "grandFinal");
+
+  const sections: BracketSection[] = [
+    {
+      type: "winners",
+      title: "Winners Bracket",
+      rounds: groupMatchupsByRound(wb, wbRounds),
+    },
+  ];
+
+  if (lb.length > 0) {
+    const lbRounds = Math.max(...lb.map((m) => m.round));
+    const rounds: BracketRound[] = [];
+    for (let round = 1; round <= lbRounds; round++) {
+      rounds.push({
+        round,
+        label: loserRoundLabel(round, lbRounds),
+        matchups: lb
+          .filter((m) => m.round === round)
+          .sort((a, b) => a.slot - b.slot),
+      });
+    }
+    sections.push({ type: "losers", title: "Losers Bracket", rounds });
+  }
+
+  if (gf.length > 0) {
+    sections.push({
+      type: "grandFinal",
+      title: "Grand Final",
+      rounds: [{ round: 1, label: "Grand Final", matchups: gf }],
+    });
+  }
+
+  return sections;
+}


### PR DESCRIPTION
## Summary

Extends the playoff bracket subsystem (`apps/web`) with three capabilities, in one branch:

1. **Arbitrary playoff team counts with byes.** Previously only 4/8/16 were allowed (power-of-two, no byes). Any count ≥ 2 is now accepted (e.g. 5, 6, 10, 12). Bracket size = next power of two ≥ teamCount; the top `(size − teamCount)` seeds get **first-round byes** — the bye team auto-advances at generation time (winner set immediately, **no game / fixture**), and its round-2 fixture spawns once its opponent is decided.
2. **Double-elimination format.** A losers bracket routes each winners-bracket loser so a team is eliminated only after a **second loss**. Selected via the season's `playoffFormat` (`"single" | "double"`), overridable per generate call.
3. **Generate-playoffs UI default.** The bracket-size control now defaults to the season's configured `playoffTeams` (was hardcoded 8) and gains a format select. The season form adds a **Single / Double elimination** select and bye-friendly counts (2,4,6,8,10,12,16).

### ⚠️ Deliberate simplification — single grand final
The double-elim **grand final is a single game** (winners-bracket champion vs losers-bracket champion). There is **no bracket reset / "if-necessary" second game** — i.e. the losers-bracket champion does *not* get the extra game it would in a strict double-elimination format. This keeps advancement deterministic and the engine simple; a future change could add the reset game.

## Key changes

- **`convex/lib/bracket.ts`** (pure, thoroughly unit-tested): `nextPowerOfTwo`, bye-aware `buildBracket(teamCount)` (was power-of-two-only), and new `buildDoubleElimBracket(teamCount)` (winners bracket + generic losers bracket + single grand final, with WB→LB loser-routing pointers).
- **`convex/sports.ts`**: `generatePlayoffBracket` relaxed to accept any count 2–64, takes a `format` arg (default from `season.playoffFormat`), inserts byes pre-resolved, wires `loserNextMatchupId`/`loserNextSlot` + grand-final pointers. `advanceBracketForSeason` rewritten to iterate to a fixed point — auto-advancing byes, propagating winners, and dropping losers into the LB. `getPlayoffBracket` DTO now exposes `bracketType` + `isBye` + bracket `format`.
- **`convex/schema.ts`**: optional, back-compat fields — `playoffBrackets.format`/`teamCount`; `playoffMatchups.bracketType`/`loserNextMatchupId`/`loserNextSlot`. Legacy single-elim rows remain valid (optional = legacy works).
- **`src/lib/data-api.ts`**: `PlayoffMatchupDto` gains `bracketType`/`isBye`, `PlayoffBracketDto` gains `format`; `generatePlayoffBracket` ref+wrapper gain `format`.
- **`src/lib/playoffs.ts` + `src/components/playoffs/PlayoffBracket.tsx`**: new `bracketSections` helper; the view renders winners/losers/grand-final regions and marks byes.
- **`src/components/playoffs/GeneratePlayoffsButton.tsx`** + playoffs `page.tsx`/`actions.ts`: default size from season config, format select, expanded sizes.
- **`src/app/dashboard/seasons/season-actions.tsx` + `actions.ts`**: Format select wired through create/update season.

Convex strict-validator note: every new DTO/validator field is optional in the schema but consistently emitted from `getPlayoffBracket`. No playoff DTOs exist in `shared-types`/`api-contracts`, so no drift there.

## Verification (from `apps/web`)
- `pnpm exec vitest run` — **730 passed** (96 files). New coverage: 45 pure-lib tests (byes, double-elim layout, seed order, loser-routing target validity) + Convex integration tests driving a full **6-team bye bracket** and a complete **double-elim run through to a champion**.
- `pnpm exec eslint <changed files>` — clean.
- `pnpm run build` — succeeds (authoritative typecheck).

No Salesforce (`sportsmgmt/**`) files touched. Not merged, not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)