### PR TITLE
feat(design-system): add Sports League design system package

### DIFF
--- a/packages/design-system/.gitignore
+++ b/packages/design-system/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build output
+dist/
+build/
+*.tsbuildinfo
+
+# Generated design-system bundle (rebuilt by the compiler)
+_ds_bundle.js
+_ds_manifest.json
+_adherence.oxlintrc.json
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.log
+
+# Local working artifacts (not part of the system)
+*.standalone-src.html
+*-print-*.html
+uploads/

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,0 +1,133 @@
+# Sports League — Design System
+
+A token-driven design system for **Sports League**, a league-management
+platform where operators import leagues, build rosters and divisions, run
+seasons, and sync live data. The product is a dense, keyboard-friendly
+dashboard with a high-contrast aesthetic and a single live-data accent.
+
+This system was derived from the product's dashboard UI (Discover, Teams,
+Seasons, Import flows). It ships tokens, a React component library, foundation
+specimens, and a Dashboard UI kit. There is no external Figma or repo bound to
+this system — it is self-contained in this project.
+
+---
+
+## Content fundamentals
+
+How the product writes copy:
+
+- **Voice: direct and operational.** Labels are imperative verbs —
+  "New Season", "Add all (32)", "Start Import", "Make active". Buttons say what
+  they do.
+- **Second person, implied.** UI speaks to the operator ("Browse leagues and
+  add teams to your dashboard"). Rarely "we".
+- **Sentence case everywhere** except small uppercase mono labels (stat labels,
+  table headers, eyebrows). Never Title Case On Buttons.
+- **Numbers are first-class.** Counts ride alongside nouns — "413 Teams",
+  "AFC East (4)", "0 / 2929 Players". Use the mono font and tabular figures.
+- **Terse system feedback.** "Last sync complete · 2,929 players updated",
+  "Sync failed", "Build failed. Bundle exceeds 50 MB." A status, then an
+  optional muted clause.
+- **No emoji, no exclamation.** Tone is a calm operator console, not a
+  consumer app. Iconography carries warmth, not punctuation.
+
+---
+
+## Visual foundations
+
+- **Two themes, one token set.** Dark is primary (near-black `#0a0a0b`
+  canvas, `#161618` cards). Light is a clean off-white (`#fbfbfc` / `#fff`).
+  Components never hard-code color — they read semantic CSS variables, and the
+  active theme is chosen by a `data-theme` attribute on a `.sl-root` wrapper.
+- **High-contrast primary action.** The primary button/active-nav fill is the
+  *opposite* of the canvas: near-white on dark, near-black on light
+  (`--primary` / `--primary-fg`). This is the signature move — it reads as
+  crisp and editorial rather than colorful.
+- **One accent, for life/data.** A single green (`--accent`) marks success,
+  "added", "active", and live totals — never decoration. It has a soft
+  translucent companion (`--accent-soft`) for badge/banner backgrounds. The
+  accent is an independent axis (`data-accent`: green default, blue, violet,
+  orange).
+- **Hierarchy from tone + border first, shadow last.** Surfaces step
+  `bg → surface → surface-2 → surface-3`; hairline borders (`--border`,
+  `--border-strong`) separate. Shadows are reserved for true overlays
+  (menus, dialogs, toasts) via `--shadow`.
+- **Text in three ranks:** `--text` (primary), `--text-muted` (secondary),
+  `--text-subtle` (hint/placeholder/disabled). Don't introduce more.
+- **Type:** Hanken Grotesk for everything UI + prose (400–800), JetBrains Mono
+  for data, keys, paths, and stat/table numerals. Headings are tight-tracked
+  (`-0.7px` to `-1px`); body is 14–15px with generous line-height.
+- **Shape:** a 4px spacing grid (`--space-1…10`) and a two-step radius —
+  `--r` for controls (10px), `--r-lg` for cards (14px) — plus full pills for
+  badges. Radius is its own axis (`data-round`: sharp / default / soft).
+- **Borders over fills.** Inputs, secondary buttons, chips, and cards are
+  defined by 1px borders on subtle surfaces, not heavy fills.
+- **Focus:** a 3px soft ring (`--ring`) on focus-visible; inputs also darken
+  their border to `--text`.
+- **Motion:** restrained. 120–150ms ease on background/border/transform for
+  hovers and the switch knob. No bounce, no large entrance animations.
+- **Hover/press:** secondary surfaces lighten one step (`surface-2 →
+  surface-3`); primary shifts to `--primary-hover`; ghost items gain a
+  `surface-2` wash. Danger brightens slightly.
+- **Cards:** `--surface` background, 1px `--border`, `--r-lg` radius, little or
+  no shadow. Dashed `--border-strong` for empty/drop states.
+
+---
+
+## Iconography
+
+- **Lucide-style line icons** on a 24px grid, ~1.9 stroke, round caps/joins,
+  drawn with `currentColor` so they inherit text color. Implemented as the
+  `Icon` component (`components/icon/`) with a named set — no icon font, no PNG
+  sprites.
+- Icons are **monochrome and functional**: nav glyphs, status checks, chevrons,
+  search, theme toggle, row actions (pencil/trash). The accent color is applied
+  to check/added states only.
+- The brand glyph is a **trophy** on a `--primary` tile (radius 9). Wordmark is
+  "Sports League" in Hanken Grotesk 700, `-0.5px` tracking.
+- **No emoji or unicode-as-icon.** If you need a glyph the set lacks, add it to
+  `Icon` rather than reaching for an emoji.
+- *Substitution note:* icons are hand-paths in the Lucide visual style (not the
+  Lucide package). If you adopt the npm Lucide set later, the look matches.
+
+---
+
+## Index / manifest
+
+```
+styles.css                  global entry — link this one file
+tokens/
+  fonts.css                 webfont import (Hanken Grotesk, JetBrains Mono)
+  colors.css                theme + accent tokens
+  typography.css            font + type-ramp tokens
+  spacing.css               4px grid + radius tokens
+  components.css            component classes (.sl-*)
+components/
+  icon/        Icon
+  forms/       Button, IconButton, Input, Select, Search, Switch, Checkbox, Radio
+  data/        Badge, Card, Stat, Avatar, Table
+  navigation/  NavItem, Tabs, Segmented, Breadcrumb, PageHeader
+  feedback/    Banner
+guidelines/                 foundation specimen cards (Colors, Type, Spacing, Brand)
+ui_kits/dashboard/          Discover screen — index.html (interactive) + DiscoverScreen.jsx
+react/                      stand-alone npm-style package mirror (tokens.css + src/)
+SKILL.md                    Agent-Skill manifest
+```
+
+**Components** (19): Icon · Button · IconButton · Input · Select · Search ·
+Switch · Checkbox · Radio · Badge · Card · Stat · Avatar · Table · NavItem ·
+Tabs · Segmented · Breadcrumb · PageHeader · Banner.
+
+**UI kits** (1): Dashboard — the Discover view.
+
+### Consuming the system
+
+Link the stylesheet once, then wrap your app in a `.sl-root` with theme
+attributes (or use the `ThemeProvider` in `react/src/theme.tsx`):
+
+```html
+<link rel="stylesheet" href="styles.css">
+<div class="sl-root" data-theme="dark" data-accent="green" data-round="default">
+  <!-- components here -->
+</div>
+```

--- a/packages/design-system/SKILL.md
+++ b/packages/design-system/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: sports-league-design
+description: Use this skill to generate well-branded interfaces and assets for Sports League, a league-management dashboard platform, for production code or throwaway prototypes/mocks. Contains the full token system (light + dark), typography, components, voice, and a UI kit for prototyping.
+user-invocable: true
+version: 1.0
+system-name: Sports League
+themes: dark (default), light
+fonts:
+  sans: Hanken Grotesk
+  mono: JetBrains Mono
+colors-dark:
+  bg: "#0a0a0b"
+  surface: "#161618"
+  surface-2: "#1d1d20"
+  surface-3: "#26262a"
+  border: "#2a2a2e"
+  border-strong: "#3a3a40"
+  text: "#fafafa"
+  text-muted: "#9b9ba3"
+  text-subtle: "#67676f"
+  primary: "#fafafa"
+  primary-fg: "#0c0c0d"
+  primary-hover: "#e6e6e8"
+  danger: "#f2555c"
+  danger-strong: "#ff6166"
+  ring: "rgba(250,250,250,0.20)"
+  shadow: "0 16px 40px rgba(0,0,0,0.60)"
+  accent: "#46c964"
+  accent-soft: "rgba(70,201,100,0.16)"
+colors-light:
+  bg: "#fbfbfc"
+  surface: "#ffffff"
+  surface-2: "#f4f4f5"
+  surface-3: "#eaeaec"
+  border: "#e6e6e9"
+  border-strong: "#d6d6da"
+  text: "#0c0c0d"
+  text-muted: "#5b5b61"
+  text-subtle: "#9a9aa1"
+  primary: "#0c0c0d"
+  primary-fg: "#ffffff"
+  primary-hover: "#2a2a2e"
+  danger: "#dc2626"
+  danger-strong: "#e5484d"
+  ring: "rgba(12,12,13,0.15)"
+  shadow: "0 12px 30px rgba(0,0,0,0.13)"
+  accent: "#18a558"
+  accent-soft: "rgba(24,165,88,0.10)"
+colors-accent:
+  # accent axis — [data-accent]; first value dark, second light
+  green: ["#46c964", "#18a558"]
+  blue: ["#5b8dff", "#2563eb"]
+  violet: ["#a17bff", "#7c3aed"]
+  orange: ["#ff9e4a", "#d9730a"]
+typography:
+  display-32: { fontFamily: Hanken Grotesk, fontSize: 32px, fontWeight: 700, lineHeight: 38px, letterSpacing: -1px }
+  stat-30:    { fontFamily: Hanken Grotesk, fontSize: 30px, fontWeight: 700, lineHeight: 32px, letterSpacing: -0.6px }
+  title-22:   { fontFamily: Hanken Grotesk, fontSize: 22px, fontWeight: 700, lineHeight: 28px, letterSpacing: -0.4px }
+  heading-18: { fontFamily: Hanken Grotesk, fontSize: 18px, fontWeight: 600, lineHeight: 24px }
+  body-15:    { fontFamily: Hanken Grotesk, fontSize: 15px, fontWeight: 400, lineHeight: 23px }
+  label-14:   { fontFamily: Hanken Grotesk, fontSize: 14px, fontWeight: 500, lineHeight: 20px }
+  caption-12: { fontFamily: Hanken Grotesk, fontSize: 12px, fontWeight: 500, lineHeight: 16px }
+  mono-13:    { fontFamily: JetBrains Mono, fontSize: 13px, fontWeight: 500, lineHeight: 18px }
+spacing:
+  1: 4px
+  2: 8px
+  3: 12px
+  4: 16px
+  5: 20px
+  6: 24px
+  8: 32px
+  10: 40px
+  base: 4px
+rounded:
+  # [data-round]: default / sharp / soft
+  control: { default: 10px, sharp: 6px, soft: 14px }   # --r
+  card:    { default: 14px, sharp: 9px, soft: 20px }   # --r-lg
+  pill: 9999px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.primary-fg}"
+    typography: "{typography.label-14}"
+    rounded: "{rounded.control}"
+    padding: "0 14px"
+    height: 38px
+    hover: "{colors.primary-hover}"
+  button-secondary:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.text}"
+    border: "1px solid {colors.border-strong}"
+    rounded: "{rounded.control}"
+    padding: "0 14px"
+    height: 38px
+    hover: "{colors.surface-3}"
+  button-ghost:
+    backgroundColor: transparent
+    textColor: "{colors.text-muted}"
+    rounded: "{rounded.control}"
+    padding: "0 14px"
+    height: 38px
+    hover: "{colors.surface-2}"
+  button-danger:
+    backgroundColor: "{colors.danger-strong}"
+    textColor: "#ffffff"
+    rounded: "{rounded.control}"
+    padding: "0 14px"
+    height: 38px
+  button-sm: { height: 32px, padding: "0 11px", typography: "{typography.caption-12}" }
+  button-lg: { height: 44px, padding: "0 18px" }
+  input:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    border: "1px solid {colors.border}"
+    rounded: "{rounded.control}"
+    padding: "0 12px"
+    height: 38px
+    focus: "border {colors.text}; box-shadow 0 0 0 3px {colors.ring}"
+  badge:
+    rounded: "{rounded.pill}"
+    height: 24px
+    padding: "0 10px"
+    typography: "{typography.caption-12}"
+  card:
+    backgroundColor: "{colors.surface}"
+    border: "1px solid {colors.border}"
+    rounded: "{rounded.card}"
+    padding: "18px"
+---
+
+# Sports League
+
+## Overview
+
+Sports League is a league-management platform — operators import leagues, build rosters and divisions, run seasons, and sync live data. The aesthetic is a dense, keyboard-friendly **operator console**: near-neutral surfaces, a high-contrast primary action, and a single accent reserved for live data. It is **dual-theme** — dark is the default, light is a clean off-white — and both themes share one set of semantic token names. Prioritize readability, scannable numbers, and accessibility; use color to signal state and one important action, never decoration.
+
+The runtime picks a theme with attributes on a `.sl-root` wrapper: `data-theme` (`dark` | `light`), `data-accent` (`green` | `blue` | `violet` | `orange`), `data-round` (`sharp` | `default` | `soft`). Every component reads CSS variables off that wrapper. Link `styles.css` once; it pulls in `tokens/` (fonts, colors, typography, spacing, component classes).
+
+## Colors
+
+Tokens are **semantic, not literal** — components reference the name (`--surface`, `--text-muted`, `--accent`), never the hex, so the same markup re-themes by swapping `data-theme`. Both theme tables are in the frontmatter (`colors-dark`, `colors-light`).
+
+Roles:
+
+- **Surfaces** step in four tones: `--bg` (app canvas) → `--surface` (cards) → `--surface-2` (inset / secondary fill, hover) → `--surface-3` (pressed / stronger fill). Don't introduce surfaces between these.
+- **Borders**: `--border` is the hairline that separates surfaces; `--border-strong` is the control/interactive border.
+- **Text in three ranks**: `--text` (primary), `--text-muted` (secondary, captions, labels), `--text-subtle` (hint, placeholder, disabled). Never add a fourth rank.
+- **Primary action**: `--primary` / `--primary-fg` is the signature high-contrast pair — near-white on dark, near-black on light. It is the *inverse* of the canvas, which reads crisp and editorial. `--primary-hover` is its hover.
+- **Accent** (`--accent`, `--accent-soft`): one color, reserved for **live data, success, "added", "active", and key totals** — never decoration. `--accent-soft` is its translucent companion for badge/banner fills. The accent is an independent axis (`data-accent`), so green can become blue/violet/orange without touching any other token.
+- **Danger** (`--danger`, `--danger-strong`): destructive actions and error states only.
+
+## Typography
+
+Hanken Grotesk sets all UI and prose; JetBrains Mono sets data, keyboard keys, paths, and tabular numerals. The `typography` tokens carry concrete `fontFamily`, `fontSize`, `fontWeight`, `lineHeight` (and tracking on the big sizes):
+
+- `display-32` / `stat-30` — page heroes and big KPI numbers; tight tracking.
+- `title-22` / `heading-18` — card titles and section heads.
+- `body-15` — default multi-line prose (`--text-muted` for supporting copy).
+- `label-14` — controls, nav, form labels, single-line UI text.
+- `caption-12` — metadata, small uppercase labels (`letter-spacing:.5px; text-transform:uppercase` for stat labels and table headers).
+- `mono-13` — paths, keys, and any figures that must align. Prefer tabular figures for stats and tables.
+
+Apply the tokens (or the `--font-sans` / `--font-mono` + ramp variables) rather than setting size/weight/tracking by hand. Headings use 700–800; never run more than two weights in one view.
+
+## Layout
+
+Spacing is a **4px grid**: 4, 8, 12, 16, 20, 24, 32, 40px (`--space-1…10`). Keep a three-step rhythm — 8px inside a group, 16px between groups, 24–40px between sections. Cards use 18px padding (compact) up to 24px. Center primary content in a ~1180px column with 24–32px side padding. The app shell is a fixed ~200px sidebar + a 54–56px top bar over a scrolling content area. Every layout should hold up from mobile to desktop.
+
+## Elevation & Depth
+
+Hierarchy comes from **tonal surfaces and borders first**, so shadows stay reserved for true overlays. Use `--shadow` (dark: `0 16px 40px rgba(0,0,0,.60)`, light: `0 12px 30px rgba(0,0,0,.13)`) on menus, dialogs, and toasts. Cards take little or no shadow — a 1px `--border` and `--surface` fill do the separating. Empty/drop states use a dashed `--border-strong`. Pair every elevated surface with the card radius (`--r-lg`).
+
+## Motion
+
+Restrained and physical. Most state changes are 120–150ms ease on `background`, `border-color`, and `transform` (button hovers, the switch knob, accordion chevrons). Overlays fade/scale in ~200ms. No bounce, no looping or attention-grabbing animation, no large entrance effects. Honor `prefers-reduced-motion` by dropping nonessential motion.
+
+## Shapes
+
+Two control radii plus a pill, exposed as an axis (`data-round`): `--r` for controls (default 10px) and `--r-lg` for cards (default 14px); `sharp` tightens them to 6/9px, `soft` opens them to 14/20px. Reserve `9999px` for badges, avatars, and circular controls. Keep one radius family per view — don't mix rounded and sharp.
+
+## Components
+
+19 primitives ship as React (`components/<group>/<Name>.jsx` + `.d.ts` + `.prompt.md`) and as CSS classes (`.sl-*` in `tokens/components.css`). The `components` frontmatter gives ready values per element.
+
+- **Button** — `primary` (high-contrast, the single most important action per view), `secondary` (bordered surface-2), `ghost` (text), `danger` (solid danger). Sizes `sm` 32 / `md` 38 / `lg` 44px. Optional leading icon.
+- **IconButton** — 34px square, bordered ghost; always give an `aria-label`.
+- **Input / Select / Search** — `--surface` fill, 1px `--border`; focus darkens the border to `--text` and adds a 3px `--ring`. Search carries a leading magnifier and a `⌘K` chip.
+- **Switch / Checkbox / Radio** — Switch track turns `--accent` when on; Checkbox fills `--primary`; Radio ring fills `--accent`.
+- **Badge** — pill; variants `outline` / `neutral` / `solid` / `success` (accent-soft) / `danger`; optional dot or icon.
+- **Card / Stat / Avatar / Table** — Stat is a big number over an uppercase caption (`accent` for live totals); Avatar falls back to initials on accent-soft; Table uses mono uppercase headers.
+- **NavItem / Tabs / Segmented / Breadcrumb / PageHeader** — NavItem active state is the `--primary` fill; exactly one active. Segmented is the inline pill toggle; Tabs is the underline bar.
+- **Banner** — inline feedback; `success` (accent-soft) or `danger` (danger border), each with a leading status icon.
+
+States: secondary surfaces lighten one step on hover (`surface-2 → surface-3`); primary shifts to `--primary-hover`; ghost gains a `surface-2` wash; danger brightens. Disabled uses a `surface-2` fill, `text-subtle` text, and a not-allowed cursor. Focus shows the 3px `--ring` at `:focus-visible`.
+
+## Iconography
+
+**Lucide-style line icons** on a 24px grid, ~1.9 stroke, round caps/joins, drawn with `currentColor` so they inherit text color. Implemented as the `Icon` component (`components/icon/`) with a named set — no icon font, no PNG sprites. Icons are monochrome and functional (nav glyphs, status checks, chevrons, search, theme toggle, row pencil/trash); the accent color is applied only to check/added states. The brand glyph is a **trophy** on a `--primary` tile (radius 9); the wordmark is "Sports League" in Hanken Grotesk 700, `-0.5px` tracking. No emoji, no unicode-as-icon — extend the `Icon` set instead.
+
+## Voice & Content
+
+Copy is part of the design; keep it precise and operational.
+
+- **Sentence case** for everything except small uppercase mono labels (stat labels, table headers, eyebrows). Never Title Case On Buttons.
+- **Name actions with a verb (+ noun):** `New Season`, `Add all (32)`, `Start Import`, `Make active` — never `Confirm`, `OK`, or a bare label.
+- **Second person, implied.** UI speaks to the operator: "Browse leagues and add teams to your dashboard." Rarely "we".
+- **Numbers are first-class** and ride with the noun — `413 Teams`, `AFC East (4)`, `0 / 2929 Players` — set in the mono font with tabular figures.
+- **Errors = what happened + what to do:** `Build failed. Bundle exceeds 50 MB. Reduce it or raise the limit.`
+- **Status feedback is terse**, no trailing period, never "successfully": `Last sync complete · 2,929 players updated`, `Sync failed`.
+- **Empty states point to the first action:** `No players yet. Add players to build the roster.`
+- **In-progress** uses the present participle + ellipsis: `Syncing…`, `Importing…`. No emoji, no exclamation, no marketing superlatives.
+
+## Do's and Don'ts
+
+- Rank information with the three text tokens: `--text` primary, `--text-muted` secondary, `--text-subtle` hint/disabled.
+- Keep the accent for live data, success, and the one most important action on a view.
+- Build hierarchy with surface tone + 1px borders before reaching for shadow.
+- Hold WCAG AA contrast (4.5:1 for body text); pair any state color with an icon or text label — never color alone.
+- Show the `--ring` focus on every interactive element at `:focus-visible`; never remove an outline without a visible replacement.
+- Apply the typography tokens instead of setting font size, weight, or tracking by hand.
+- Don't add a fourth text rank or a surface tone between the four defined ones.
+- Don't use the accent decoratively, and don't introduce a second accent in one view.
+- Don't mix rounded and sharp radii, or more than two font weights, in one view.
+- Don't hard-code hex — reference the semantic token so both themes resolve.
+
+## Using this system
+
+- **Files:** `styles.css` (link this one) → `tokens/` (fonts, colors, typography, spacing, components). `components/` (React: icon, forms, data, navigation, feedback). `guidelines/` (foundation specimen cards). `ui_kits/dashboard/` (the interactive Discover screen + `DiscoverScreen.jsx`). `readme.md` (full design guide).
+- **HTML artifacts** (slides, mocks, prototypes): copy assets out, link `styles.css`, and wrap content in `<div class="sl-root" data-theme="dark" data-accent="green">…</div>` so tokens resolve. Use the `.sl-*` classes or copy the components.
+- **Production React:** copy `components/` (or the mirror in `react/`), import `styles.css`, and wrap the app in the `ThemeProvider` (`react/src/theme.tsx`) or a `.sl-root` with the data attributes.
+- If invoked with no other guidance, ask what the user wants to build, ask a few questions, and act as an expert designer who outputs HTML artifacts **or** production code as needed.

--- a/packages/design-system/components/data/Avatar.d.ts
+++ b/packages/design-system/components/data/Avatar.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface AvatarProps {
+  /** Initials shown when no `src`. */
+  initials?: string;
+  /** Image URL. */
+  src?: string;
+  alt?: string;
+  /** Diameter in px. Default 32. */
+  size?: number;
+}
+
+/** User/team avatar. Falls back to initials on accent-soft. Overlap several with negative margins for a stack. */
+export declare function Avatar(props: AvatarProps): JSX.Element;

--- a/packages/design-system/components/data/Avatar.jsx
+++ b/packages/design-system/components/data/Avatar.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+/** Round avatar showing an image or initials (accent-soft fallback). */
+export function Avatar({ initials, src, alt = '', size = 32 }) {
+  return (
+    <span className="sl-avatar" style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}>
+      {src ? <img src={src} alt={alt} /> : initials}
+    </span>
+  );
+}

--- a/packages/design-system/components/data/Badge.d.ts
+++ b/packages/design-system/components/data/Badge.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import type { IconName } from '../icon/Icon';
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Color treatment. Default 'neutral'. */
+  variant?: 'outline' | 'neutral' | 'solid' | 'success' | 'danger';
+  /** Show a leading accent dot (e.g. "active"). */
+  dot?: boolean;
+  /** Optional leading icon. */
+  icon?: IconName;
+}
+
+/** Status / metadata pill. Use `success` for live/added states, `danger` for failures. */
+export declare function Badge(props: BadgeProps): JSX.Element;

--- a/packages/design-system/components/data/Badge.jsx
+++ b/packages/design-system/components/data/Badge.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Pill label for status/metadata. Variants outline/neutral/solid/success/danger; optional dot or icon. */
+export function Badge({ variant = 'neutral', dot, icon, className, children, ...rest }) {
+  return (
+    <span className={cx('sl-badge', `sl-badge--${variant}`, className)} {...rest}>
+      {dot && <span className="sl-badge__dot" />}
+      {icon && <Icon name={icon} size={12} strokeWidth={2.6} />}
+      {children}
+    </span>
+  );
+}

--- a/packages/design-system/components/data/Badge.prompt.md
+++ b/packages/design-system/components/data/Badge.prompt.md
@@ -1,0 +1,10 @@
+Status/metadata pill. Variants `outline`/`neutral`/`solid`/`success`/`danger`; optional `dot` or `icon`.
+
+```jsx
+<Badge variant="outline">Public</Badge>
+<Badge variant="solid" dot>active</Badge>
+<Badge variant="success" icon="check">All added</Badge>
+<Badge variant="danger">Sync failed</Badge>
+```
+
+Use `success` for live/added states (accent), `danger` for failures.

--- a/packages/design-system/components/data/Card.d.ts
+++ b/packages/design-system/components/data/Card.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Surfaces" subtitle="Bordered content surface" viewport="700x150"
+ */
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+/** Primary content surface (`--surface` bg, hairline border, `--r-lg` radius). Forwards div props. */
+export declare function Card(props: CardProps): JSX.Element;

--- a/packages/design-system/components/data/Card.jsx
+++ b/packages/design-system/components/data/Card.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Bordered surface container at card radius. Compose anything inside. */
+export function Card({ className, ...rest }) {
+  return <div className={cx('sl-card', className)} {...rest} />;
+}

--- a/packages/design-system/components/data/Stat.d.ts
+++ b/packages/design-system/components/data/Stat.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface StatProps {
+  value: React.ReactNode;
+  label: React.ReactNode;
+  /** Color the value with --accent (e.g. live totals). */
+  accent?: boolean;
+}
+
+/** KPI display: large value over a small uppercase label. Lay several out in a flex row. */
+export declare function Stat(props: StatProps): JSX.Element;

--- a/packages/design-system/components/data/Stat.jsx
+++ b/packages/design-system/components/data/Stat.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/** Big-number metric with an uppercase label. Set `accent` to color the number. */
+export function Stat({ value, label, accent }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <span className="sl-stat__value" style={accent ? { color: 'var(--accent)' } : undefined}>{value}</span>
+      <span className="sl-stat__label">{label}</span>
+    </div>
+  );
+}

--- a/packages/design-system/components/data/Table.d.ts
+++ b/packages/design-system/components/data/Table.d.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export interface Column<T> {
+  key: keyof T & string;
+  header: string;
+}
+
+export interface TableProps<T> {
+  columns: Column<T>[];
+  rows: T[];
+  /** Stable key per row. */
+  rowKey: (row: T) => string;
+  /** Optional trailing actions cell renderer. */
+  actions?: (row: T) => React.ReactNode;
+}
+
+/** Lightweight table with mono uppercase headers. For dense roster/division lists. */
+export declare function Table<T>(props: TableProps<T>): JSX.Element;

--- a/packages/design-system/components/data/Table.jsx
+++ b/packages/design-system/components/data/Table.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/** Simple data table. Columns map keys→headers; optional per-row actions cell. */
+export function Table({ columns, rows, rowKey, actions }) {
+  return (
+    <table className="sl-table">
+      <thead>
+        <tr>
+          {columns.map((c) => <th key={c.key}>{c.header}</th>)}
+          {actions && <th style={{ textAlign: 'right' }}>Actions</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={rowKey(row)}>
+            {columns.map((c) => <td key={c.key}>{String(row[c.key])}</td>)}
+            {actions && <td style={{ textAlign: 'right' }}>{actions(row)}</td>}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/design-system/components/data/data.card.html
+++ b/packages/design-system/components/data/data.card.html
@@ -1,0 +1,30 @@
+<!-- @dsCard group="Components" viewport="700x230" name="Data display" subtitle="Badges, stats, avatars, card, table" -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg)}.row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-bottom:16px}.row:last-child{margin-bottom:0}</style>
+</head>
+<body>
+<div class="sl-root" data-theme="dark" data-accent="green">
+  <div class="row">
+    <span class="sl-badge sl-badge--outline">Public</span>
+    <span class="sl-badge sl-badge--neutral">2 seasons</span>
+    <span class="sl-badge sl-badge--solid"><span class="sl-badge__dot"></span>active</span>
+    <span class="sl-badge sl-badge--success"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>All added</span>
+    <span class="sl-badge sl-badge--danger">Sync failed</span>
+    <span style="display:inline-flex;margin-left:8px">
+      <span class="sl-avatar" style="border:2px solid var(--bg)">AS</span>
+      <span class="sl-avatar" style="background:var(--surface-3);color:var(--text);border:2px solid var(--bg);margin-left:-10px">MK</span>
+      <span class="sl-avatar" style="background:var(--surface-2);color:var(--text-muted);border:2px solid var(--bg);margin-left:-10px;font-size:11px">+9</span>
+    </span>
+  </div>
+  <div class="sl-card" style="display:flex;gap:30px">
+    <span style="display:flex;flex-direction:column;gap:3px"><span class="sl-stat__value">56</span><span class="sl-stat__label">Divisions</span></span>
+    <span style="display:flex;flex-direction:column;gap:3px"><span class="sl-stat__value">413</span><span class="sl-stat__label">Teams</span></span>
+    <span style="display:flex;flex-direction:column;gap:3px"><span class="sl-stat__value" style="color:var(--accent)">2,929</span><span class="sl-stat__label">Players</span></span>
+  </div>
+</div>
+</body>
+</html>

--- a/packages/design-system/components/feedback/Banner.d.ts
+++ b/packages/design-system/components/feedback/Banner.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface BannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Tone. Default 'success'. */
+  variant?: 'success' | 'danger';
+}
+
+/** Inline feedback banner with a leading status icon. `success` for sync/confirmation, `danger` for errors. */
+export declare function Banner(props: BannerProps): JSX.Element;

--- a/packages/design-system/components/feedback/Banner.jsx
+++ b/packages/design-system/components/feedback/Banner.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+/** Inline status banner. `success` (accent-soft) or `danger` (bordered). */
+export function Banner({ variant = 'success', className, children, ...rest }) {
+  const cls = ['sl-banner', `sl-banner--${variant}`, className].filter(Boolean).join(' ');
+  return (
+    <div className={cls} {...rest}>
+      <span className="sl-banner__icon">
+        <Icon name={variant === 'success' ? 'check-circle' : 'alert'} size={17} strokeWidth={2.1} />
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/packages/design-system/components/feedback/Banner.prompt.md
+++ b/packages/design-system/components/feedback/Banner.prompt.md
@@ -1,0 +1,8 @@
+Inline status banner with a leading icon.
+
+```jsx
+<Banner variant="success">Last sync complete · 2,929 players updated</Banner>
+<Banner variant="danger">Build failed. Bundle exceeds 50 MB.</Banner>
+```
+
+`success` uses accent-soft; `danger` uses a danger border. For prose feedback, not toasts.

--- a/packages/design-system/components/feedback/feedback.card.html
+++ b/packages/design-system/components/feedback/feedback.card.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Components" viewport="700x180" name="Feedback" subtitle="Status banners — success & danger" -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;flex-direction:column;gap:12px}</style>
+</head>
+<body>
+<div class="sl-root" data-theme="dark" data-accent="green">
+  <div class="sl-banner sl-banner--success"><span class="sl-banner__icon"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="m8.5 12 2.3 2.3 4.7-4.6"/></svg></span><span>Last sync complete · 2,929 players updated</span></div>
+  <div class="sl-banner sl-banner--danger"><span class="sl-banner__icon"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 2 20h20Z"/><path d="M12 10v4M12 17.5v.5"/></svg></span><span>Build failed. Bundle exceeds 50&nbsp;MB. <span style="color:var(--text-muted)">Reduce it or raise the limit.</span></span></div>
+</div>
+</body>
+</html>

--- a/packages/design-system/components/forms/Button.d.ts
+++ b/packages/design-system/components/forms/Button.d.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import type { IconName } from '../icon/Icon';
+
+/**
+ * @startingPoint section="Forms" subtitle="Themeable action button — 4 variants, 3 sizes" viewport="700x150"
+ */
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual weight. Default 'secondary'. */
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  /** Control height. Default 'md'. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Optional leading icon name. */
+  icon?: IconName;
+}
+
+/** High-contrast themeable button. Use `primary` for the main action per view; `danger` for destructive. */
+export declare function Button(props: ButtonProps): JSX.Element;

--- a/packages/design-system/components/forms/Button.jsx
+++ b/packages/design-system/components/forms/Button.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/**
+ * Primary action element. Variants: primary (high-contrast), secondary
+ * (bordered), ghost (text), danger. Sizes sm/md/lg. Optional leading icon.
+ */
+export function Button({ variant = 'secondary', size = 'md', icon, className, children, ...rest }) {
+  return (
+    <button
+      className={cx('sl-btn', `sl-btn--${variant}`, size !== 'md' && `sl-btn--${size}`, className)}
+      {...rest}
+    >
+      {icon && <Icon name={icon} size={size === 'lg' ? 16 : 14} strokeWidth={2.2} />}
+      {children}
+    </button>
+  );
+}

--- a/packages/design-system/components/forms/Button.prompt.md
+++ b/packages/design-system/components/forms/Button.prompt.md
@@ -1,0 +1,10 @@
+A leading-icon button for the primary action in a view. Variants `primary`/`secondary`/`ghost`/`danger`; sizes `sm`/`md`/`lg`.
+
+```jsx
+<Button variant="primary" icon="plus">New Season</Button>
+<Button>Add all (32)</Button>
+<Button variant="danger" icon="trash">Delete</Button>
+<Button variant="ghost">Cancel</Button>
+```
+
+One `primary` per view. `secondary` is the default. Forwards `onClick`, `disabled`, etc.

--- a/packages/design-system/components/forms/Checkbox.d.ts
+++ b/packages/design-system/components/forms/Checkbox.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface CheckboxProps {
+  checked: boolean;
+  onChange?: (next: boolean) => void;
+  label?: React.ReactNode;
+}
+
+/** Labeled checkbox for multi-select options. Controlled. */
+export declare function Checkbox(props: CheckboxProps): JSX.Element;

--- a/packages/design-system/components/forms/Checkbox.jsx
+++ b/packages/design-system/components/forms/Checkbox.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Controlled checkbox with an optional label. Filled with --primary when on. */
+export function Checkbox({ checked, onChange, label }) {
+  return (
+    <label className={cx('sl-control', !checked && 'sl-control--muted')} onClick={() => onChange && onChange(!checked)}>
+      <span className={cx('sl-check', checked && 'is-on')}>
+        <Icon name="check" size={12} strokeWidth={3} />
+      </span>
+      {label}
+    </label>
+  );
+}

--- a/packages/design-system/components/forms/IconButton.d.ts
+++ b/packages/design-system/components/forms/IconButton.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import type { IconName } from '../icon/Icon';
+
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Glyph to show. */
+  icon: IconName;
+}
+
+/** Compact icon-only button for toolbars (theme toggle, close, overflow). Always pass an aria-label. */
+export declare function IconButton(props: IconButtonProps): JSX.Element;

--- a/packages/design-system/components/forms/IconButton.jsx
+++ b/packages/design-system/components/forms/IconButton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Square icon-only button (34px) with a bordered, ghost-style surface. */
+export function IconButton({ icon, className, ...rest }) {
+  return (
+    <button className={cx('sl-iconbtn', className)} {...rest}>
+      <Icon name={icon} size={17} />
+    </button>
+  );
+}

--- a/packages/design-system/components/forms/Input.d.ts
+++ b/packages/design-system/components/forms/Input.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Control height. Default 'md'. */
+  inputSize?: 'sm' | 'md' | 'lg';
+}
+
+/** Single-line text field. Forwards all native input props (placeholder, value, onChange, disabled…). */
+export declare function Input(props: InputProps): JSX.Element;

--- a/packages/design-system/components/forms/Input.jsx
+++ b/packages/design-system/components/forms/Input.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Text input with token-driven focus ring. Sizes sm/md/lg via inputSize. */
+export function Input({ inputSize = 'md', className, ...rest }) {
+  return <input className={cx('sl-input', inputSize !== 'md' && `sl-input--${inputSize}`, className)} {...rest} />;
+}

--- a/packages/design-system/components/forms/Radio.d.ts
+++ b/packages/design-system/components/forms/Radio.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface RadioProps {
+  checked: boolean;
+  onChange?: () => void;
+  label?: React.ReactNode;
+}
+
+/** Single radio option; group several and own the selected value in the parent. */
+export declare function Radio(props: RadioProps): JSX.Element;

--- a/packages/design-system/components/forms/Radio.jsx
+++ b/packages/design-system/components/forms/Radio.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Controlled radio with an optional label. Ring fills with --accent when selected. */
+export function Radio({ checked, onChange, label }) {
+  return (
+    <label className={cx('sl-control', !checked && 'sl-control--muted')} onClick={onChange}>
+      <span className={cx('sl-radio', checked && 'is-on')} />
+      {label}
+    </label>
+  );
+}

--- a/packages/design-system/components/forms/Search.d.ts
+++ b/packages/design-system/components/forms/Search.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface SearchProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Trailing shortcut hint. Default '⌘K'. Pass '' to hide. */
+  shortcut?: string;
+}
+
+/** Search input with leading icon and a keyboard-shortcut chip. Forwards native input props. */
+export declare function Search(props: SearchProps): JSX.Element;

--- a/packages/design-system/components/forms/Search.jsx
+++ b/packages/design-system/components/forms/Search.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Search field with a leading magnifier and a trailing keyboard shortcut hint. */
+export function Search({ shortcut = '⌘K', placeholder = 'Search…', className, ...rest }) {
+  return (
+    <label className={cx('sl-search', className)}>
+      <Icon name="search" size={14} strokeWidth={2} />
+      <input placeholder={placeholder} {...rest} />
+      {shortcut && <span className="sl-kbd">{shortcut}</span>}
+    </label>
+  );
+}

--- a/packages/design-system/components/forms/Select.d.ts
+++ b/packages/design-system/components/forms/Select.d.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+/** Styled native `<select>`. Pass `<option>` children; forwards value/onChange/disabled. */
+export declare function Select(props: SelectProps): JSX.Element;

--- a/packages/design-system/components/forms/Select.jsx
+++ b/packages/design-system/components/forms/Select.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Native select styled to match inputs, with a token-colored chevron. */
+export function Select({ className, children, ...rest }) {
+  return (
+    <span className="sl-select-wrap">
+      <select className={cx('sl-select', className)} {...rest}>{children}</select>
+      <span className="sl-select-wrap__chevron"><Icon name="chevron-down" size={15} strokeWidth={2} /></span>
+    </span>
+  );
+}

--- a/packages/design-system/components/forms/Switch.d.ts
+++ b/packages/design-system/components/forms/Switch.d.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export interface SwitchProps {
+  /** Current state (controlled). */
+  checked: boolean;
+  /** Called with the next state on toggle. */
+  onChange?: (next: boolean) => void;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+
+/** Binary toggle for settings (e.g. live-data sync). Controlled — own the `checked` state. */
+export declare function Switch(props: SwitchProps): JSX.Element;

--- a/packages/design-system/components/forms/Switch.jsx
+++ b/packages/design-system/components/forms/Switch.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Controlled on/off toggle. Track turns accent when on. */
+export function Switch({ checked, onChange, disabled, ...aria }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      className={cx('sl-switch', checked && 'is-on')}
+      onClick={() => onChange && onChange(!checked)}
+      {...aria}
+    >
+      <span className="sl-switch__knob" />
+    </button>
+  );
+}

--- a/packages/design-system/components/forms/forms.card.html
+++ b/packages/design-system/components/forms/forms.card.html
@@ -1,0 +1,34 @@
+<!-- @dsCard group="Components" viewport="700x250" name="Forms" subtitle="Buttons, inputs, select, search, toggles" -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg)}.row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-bottom:14px}.row:last-child{margin-bottom:0}</style>
+</head>
+<body>
+<div class="sl-root" data-theme="dark" data-accent="green">
+  <div class="row">
+    <button class="sl-btn sl-btn--primary"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>New Season</button>
+    <button class="sl-btn sl-btn--secondary">Add all (32)</button>
+    <button class="sl-btn sl-btn--ghost">Cancel</button>
+    <button class="sl-btn sl-btn--danger"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg>Delete</button>
+    <button class="sl-btn sl-btn--primary sl-btn--sm">Small</button>
+    <button class="sl-btn sl-btn--primary sl-btn--lg">Large</button>
+    <button class="sl-btn sl-btn--primary" disabled>Disabled</button>
+  </div>
+  <div class="row">
+    <input class="sl-input" style="width:200px" placeholder="Season name (2026)">
+    <span class="sl-select-wrap" style="width:170px"><select class="sl-select"><option>Quarterback</option></select><span class="sl-select-wrap__chevron"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></span>
+    <label class="sl-search" style="width:210px"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-3.6-3.6"/></svg><input placeholder="Search…"><span class="sl-kbd">⌘K</span></label>
+  </div>
+  <div class="row">
+    <button class="sl-switch is-on"><span class="sl-switch__knob"></span></button>
+    <button class="sl-switch"><span class="sl-switch__knob"></span></button>
+    <label class="sl-control"><span class="sl-check is-on"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></span>Public viewer</label>
+    <label class="sl-control sl-control--muted"><span class="sl-radio is-on" style="border-color:var(--accent)"></span>Single elim</label>
+    <label class="sl-control sl-control--muted"><span class="sl-radio"></span>Round robin</label>
+  </div>
+</div>
+</body>
+</html>

--- a/packages/design-system/components/icon/Icon.d.ts
+++ b/packages/design-system/components/icon/Icon.d.ts
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+export type IconName =
+  | 'trophy' | 'grid' | 'compass' | 'users' | 'target' | 'calendar'
+  | 'layers' | 'upload' | 'card' | 'search' | 'plus' | 'x' | 'check'
+  | 'check-circle' | 'chevron-down' | 'chevron-up' | 'chevron-right'
+  | 'chevron-vertical' | 'sun' | 'moon' | 'alert' | 'user' | 'logout'
+  | 'pencil' | 'trash' | 'bell';
+
+export interface IconProps extends React.SVGProps<SVGSVGElement> {
+  /** Which glyph to render. */
+  name: IconName;
+  /** Square size in px. Default 16. */
+  size?: number;
+  /** Stroke width on the 24px grid. Default 1.9. */
+  strokeWidth?: number;
+}
+
+/** Lucide-style inline icon; inherits color via currentColor. */
+export declare function Icon(props: IconProps): JSX.Element;

--- a/packages/design-system/components/icon/Icon.jsx
+++ b/packages/design-system/components/icon/Icon.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+/**
+ * Inline icon set (Lucide-style, 24px grid, 1.9 stroke). Stroke uses
+ * currentColor so icons inherit text color. See Icon.d.ts for names.
+ */
+const PATHS = {
+  trophy: <><path d="M6 9a6 6 0 0 0 12 0V4H6Z" /><path d="M9 20h6M12 14v6" /></>,
+  grid: <><rect x="3" y="3" width="7" height="7" rx="1.2" /><rect x="14" y="3" width="7" height="7" rx="1.2" /><rect x="3" y="14" width="7" height="7" rx="1.2" /><rect x="14" y="14" width="7" height="7" rx="1.2" /></>,
+  compass: <><circle cx="12" cy="12" r="9" /><path d="m15 9-2 5-4 1 2-5z" /></>,
+  users: <><circle cx="9" cy="8" r="3.2" /><path d="M3.5 20a5.5 5.5 0 0 1 11 0" /><path d="M16 6.2a3 3 0 0 1 0 5.6" /><path d="M20.5 20a5 5 0 0 0-4-4.9" /></>,
+  target: <><circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="2.4" /></>,
+  calendar: <><rect x="3" y="4.5" width="18" height="16" rx="2" /><path d="M3 9h18M8 2.5v4M16 2.5v4" /></>,
+  layers: <><path d="m12 3 9 5-9 5-9-5Z" /><path d="m3 13 9 5 9-5" /></>,
+  upload: <><path d="M12 15V3M8 7l4-4 4 4" /><path d="M4 17v2a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-2" /></>,
+  card: <><rect x="2.5" y="5" width="19" height="14" rx="2.5" /><path d="M2.5 10h19" /></>,
+  search: <><circle cx="11" cy="11" r="7" /><path d="m21 21-3.6-3.6" /></>,
+  plus: <path d="M12 5v14M5 12h14" />,
+  x: <path d="M18 6 6 18M6 6l12 12" />,
+  check: <path d="M20 6 9 17l-5-5" />,
+  'check-circle': <><circle cx="12" cy="12" r="9" /><path d="m9 12 2 2 4-4" /></>,
+  'chevron-down': <path d="m6 9 6 6 6-6" />,
+  'chevron-up': <path d="m18 15-6-6-6 6" />,
+  'chevron-right': <path d="m9 6 6 6-6 6" />,
+  'chevron-vertical': <path d="m8 9 4-4 4 4M8 15l4 4 4-4" />,
+  sun: <><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.4 1.4M17.6 17.6 19 19M19 5l-1.4 1.4M6.4 17.6 5 19" /></>,
+  moon: <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />,
+  alert: <><path d="M12 3 2 20h20Z" /><path d="M12 10v4M12 17.5v.5" /></>,
+  user: <><circle cx="12" cy="8" r="4" /><path d="M5 21a7 7 0 0 1 14 0" /></>,
+  logout: <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />,
+  pencil: <path d="M12 20h9M16.5 3.5a2.05 2.05 0 0 1 3 3L7 19l-4 1 1-4Z" />,
+  trash: <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />,
+  bell: <><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6Z" /><path d="M10 20a2 2 0 0 0 4 0" /></>,
+};
+
+export function Icon({ name, size = 16, strokeWidth = 1.9, ...rest }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      {PATHS[name] || null}
+    </svg>
+  );
+}

--- a/packages/design-system/components/icon/Icon.prompt.md
+++ b/packages/design-system/components/icon/Icon.prompt.md
@@ -1,0 +1,8 @@
+Inline, single-color icon (Lucide-style, 24px grid) that inherits the current text color — use it inside buttons, badges, nav items, and anywhere a glyph is needed.
+
+```jsx
+<Icon name="trophy" size={18} />
+<Icon name="check-circle" size={14} strokeWidth={2.4} style={{ color: 'var(--accent)' }} />
+```
+
+Names: trophy, grid, compass, users, target, calendar, layers, upload, card, search, plus, x, check, check-circle, chevron-down/up/right/vertical, sun, moon, alert, user, logout, pencil, trash, bell. Color it by setting `color` on the icon or its parent; size and strokeWidth are numeric props.

--- a/packages/design-system/components/icon/icon.card.html
+++ b/packages/design-system/components/icon/icon.card.html
@@ -1,0 +1,29 @@
+<!-- @dsCard group="Components" viewport="700x150" name="Icons" subtitle="Lucide-style, 24px grid, currentColor" -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg)}.grid{display:flex;flex-wrap:wrap;gap:18px;color:var(--text)}.grid svg{display:block}</style>
+</head>
+<body>
+<div class="sl-root" data-theme="dark" data-accent="green">
+  <div class="grid">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 0 0 12 0V4H6Z"/><path d="M9 20h6M12 14v6"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.2"/><rect x="14" y="3" width="7" height="7" rx="1.2"/><rect x="3" y="14" width="7" height="7" rx="1.2"/><rect x="14" y="14" width="7" height="7" rx="1.2"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="m15 9-2 5-4 1 2-5z"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 20a5.5 5.5 0 0 1 11 0"/><path d="M16 6.2a3 3 0 0 1 0 5.6"/><path d="M20.5 20a5 5 0 0 0-4-4.9"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2.4"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4.5" width="18" height="16" rx="2"/><path d="M3 9h18M8 2.5v4M16 2.5v4"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3 9 5-9 5-9-5Z"/><path d="m3 13 9 5 9-5"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3M8 7l4-4 4 4"/><path d="M4 17v2a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-2"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="m9 12 2 2 4-4"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-3.6-3.6"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.4 1.4M17.6 17.6 19 19M19 5l-1.4 1.4M6.4 17.6 5 19"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.05 2.05 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg>
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6Z"/><path d="M10 20a2 2 0 0 0 4 0"/></svg>
+  </div>
+</div>
+</body>
+</html>

--- a/packages/design-system/components/navigation/Breadcrumb.d.ts
+++ b/packages/design-system/components/navigation/Breadcrumb.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface BreadcrumbProps {
+  /** Ordered trail; the last is the current page. */
+  items: string[];
+}
+
+/** Path trail above a page title. Chevron-separated; final crumb emphasized. */
+export declare function Breadcrumb(props: BreadcrumbProps): JSX.Element;

--- a/packages/design-system/components/navigation/Breadcrumb.jsx
+++ b/packages/design-system/components/navigation/Breadcrumb.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+/** Breadcrumb trail; last item is emphasized. */
+export function Breadcrumb({ items }) {
+  return (
+    <nav style={{ display: 'flex', alignItems: 'center', gap: 8, font: '500 13px/1 var(--font-sans)', color: 'var(--text-muted)' }}>
+      {items.map((item, i) => (
+        <React.Fragment key={item}>
+          {i > 0 && <Icon name="chevron-right" size={13} strokeWidth={2} />}
+          <span style={i === items.length - 1 ? { color: 'var(--text)' } : undefined}>{item}</span>
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+}

--- a/packages/design-system/components/navigation/NavItem.d.ts
+++ b/packages/design-system/components/navigation/NavItem.d.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import type { IconName } from '../icon/Icon';
+
+export interface NavItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Leading icon. */
+  icon?: IconName;
+  /** Selected state — primary fill. */
+  active?: boolean;
+}
+
+/** One row in the app sidebar. Exactly one should be `active`. */
+export declare function NavItem(props: NavItemProps): JSX.Element;

--- a/packages/design-system/components/navigation/NavItem.jsx
+++ b/packages/design-system/components/navigation/NavItem.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Icon } from '../icon/Icon.jsx';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Sidebar navigation row. `active` paints the high-contrast primary fill. */
+export function NavItem({ icon, active, className, children, ...rest }) {
+  return (
+    <button className={cx('sl-nav', active && 'is-active', className)} {...rest}>
+      {icon && <Icon name={icon} size={18} />}
+      {children}
+    </button>
+  );
+}

--- a/packages/design-system/components/navigation/NavItem.prompt.md
+++ b/packages/design-system/components/navigation/NavItem.prompt.md
@@ -1,0 +1,8 @@
+Sidebar nav row with an icon and active state.
+
+```jsx
+<NavItem icon="grid">Overview</NavItem>
+<NavItem icon="compass" active>Discover</NavItem>
+```
+
+Exactly one item active. Pairs with Tabs/Segmented for in-page switching.

--- a/packages/design-system/components/navigation/PageHeader.d.ts
+++ b/packages/design-system/components/navigation/PageHeader.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface PageHeaderProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Right-aligned actions (e.g. a primary Button). */
+  actions?: React.ReactNode;
+}
+
+/** Standard page header: title + supporting copy, with an actions slot. Pair with Breadcrumb above. */
+export declare function PageHeader(props: PageHeaderProps): JSX.Element;

--- a/packages/design-system/components/navigation/PageHeader.jsx
+++ b/packages/design-system/components/navigation/PageHeader.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/** Page title + optional description on the left, actions slot on the right. */
+export function PageHeader({ title, description, actions }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 16 }}>
+      <div>
+        <h1 style={{ margin: 0, font: '700 25px/1 var(--font-sans)', letterSpacing: '-0.7px', color: 'var(--text)' }}>{title}</h1>
+        {description && <p style={{ margin: '8px 0 0', font: '400 14px/1.5 var(--font-sans)', color: 'var(--text-muted)', maxWidth: 600 }}>{description}</p>}
+      </div>
+      {actions}
+    </div>
+  );
+}

--- a/packages/design-system/components/navigation/Segmented.d.ts
+++ b/packages/design-system/components/navigation/Segmented.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface SegmentedProps {
+  options: string[];
+  value: string;
+  onChange?: (option: string) => void;
+}
+
+/** Inline segmented toggle (Active/Completed/Upcoming, accent picker, …). Controlled. Keep labels short. */
+export declare function Segmented(props: SegmentedProps): JSX.Element;

--- a/packages/design-system/components/navigation/Segmented.jsx
+++ b/packages/design-system/components/navigation/Segmented.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Segmented control — pill group for 2–4 mutually exclusive options. */
+export function Segmented({ options, value, onChange }) {
+  return (
+    <div className="sl-segmented" role="tablist">
+      {options.map((o) => (
+        <button key={o} role="tab" aria-selected={o === value} className={cx('sl-segmented__item', o === value && 'is-active')} onClick={() => onChange && onChange(o)}>
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/design-system/components/navigation/Tabs.d.ts
+++ b/packages/design-system/components/navigation/Tabs.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface TabsProps {
+  tabs: string[];
+  value: string;
+  onChange?: (tab: string) => void;
+}
+
+/** Underlined tab bar for switching views within a page. Controlled. */
+export declare function Tabs(props: TabsProps): JSX.Element;

--- a/packages/design-system/components/navigation/Tabs.jsx
+++ b/packages/design-system/components/navigation/Tabs.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const cx = (...p) => p.filter(Boolean).join(' ');
+
+/** Underline tab bar. Controlled via `value`/`onChange` over a list of labels. */
+export function Tabs({ tabs, value, onChange }) {
+  return (
+    <div className="sl-tabs" role="tablist">
+      {tabs.map((t) => (
+        <button key={t} role="tab" aria-selected={t === value} className={cx('sl-tab', t === value && 'is-active')} onClick={() => onChange && onChange(t)}>
+          {t}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/design-system/components/navigation/navigation.card.html
+++ b/packages/design-system/components/navigation/navigation.card.html
@@ -1,0 +1,31 @@
+<!-- @dsCard group="Components" viewport="700x250" name="Navigation" subtitle="Nav, tabs, segmented, breadcrumb" -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:grid;grid-template-columns:200px 1fr;gap:24px}.stack{display:flex;flex-direction:column;gap:14px;min-width:0}</style>
+</head>
+<body>
+<div class="sl-root" data-theme="dark" data-accent="green">
+  <div style="display:flex;flex-direction:column;gap:3px">
+    <button class="sl-nav"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.2"/><rect x="14" y="3" width="7" height="7" rx="1.2"/><rect x="3" y="14" width="7" height="7" rx="1.2"/><rect x="14" y="14" width="7" height="7" rx="1.2"/></svg>Overview</button>
+    <button class="sl-nav is-active"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="m15 9-2 5-4 1 2-5z"/></svg>Discover</button>
+    <button class="sl-nav"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 20a5.5 5.5 0 0 1 11 0"/><path d="M16 6.2a3 3 0 0 1 0 5.6"/><path d="M20.5 20a5 5 0 0 0-4-4.9"/></svg>Teams</button>
+  </div>
+  <div class="stack">
+    <nav style="display:flex;align-items:center;gap:8px;font:500 13px/1 var(--font-sans);color:var(--text-muted)"><span>Dashboard</span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg><span style="color:var(--text)">Discover</span></nav>
+    <div class="sl-tabs">
+      <button class="sl-tab is-active">Roster</button>
+      <button class="sl-tab">Schedule</button>
+      <button class="sl-tab">Depth Chart</button>
+    </div>
+    <div class="sl-segmented" style="align-self:flex-start">
+      <button class="sl-segmented__item is-active">Active</button>
+      <button class="sl-segmented__item">Completed</button>
+      <button class="sl-segmented__item">Upcoming</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/packages/design-system/guidelines/brand-logo.card.html
+++ b/packages/design-system/guidelines/brand-logo.card.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Brand" viewport="700x180" name="Logo & lockup" subtitle="Wordmark, glyph, monochrome rule" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;gap:36px;align-items:center}.lock{display:flex;align-items:center;gap:11px}.glyph{display:flex;align-items:center;justify-content:center;border-radius:9px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="lock">
+    <span class="glyph" style="width:34px;height:34px;background:var(--primary)"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--primary-fg)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 0 0 12 0V4H6Z"/><path d="M9 20h6M12 14v6"/></svg></span>
+    <span style="font:700 22px/1 var(--font-sans);color:var(--text);letter-spacing:-0.5px">Sports League</span>
+  </div>
+  <span class="glyph" style="width:52px;height:52px;background:var(--accent-soft)"><svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 0 0 12 0V4H6Z"/><path d="M9 20h6M12 14v6"/></svg></span>
+  <div style="display:flex;flex-direction:column;gap:6px;font:var(--text-caption);color:var(--text-muted)">
+    <span>Glyph: trophy on --primary tile, radius 9</span>
+    <span>Wordmark: Hanken Grotesk 700, -0.5 tracking</span>
+    <span>Monochrome only — never gradient-fill the mark</span>
+  </div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/colors-accent.card.html
+++ b/packages/design-system/guidelines/colors-accent.card.html
@@ -1,0 +1,20 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Accent & semantic" subtitle="Accent axis (green/blue/violet/orange) + danger" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:20px;background:var(--bg);display:flex;gap:26px;align-items:flex-start}.col{display:flex;gap:10px}.sw{text-align:center}.chip{width:54px;height:46px;border-radius:10px}.soft{width:54px;height:46px;border-radius:10px}.lbl{font:500 11px/1.4 var(--font-mono);color:var(--text-muted);margin-top:6px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="col">
+    <div class="sw" data-accent="green"><div class="chip" style="background:var(--accent)"></div><div class="lbl">green</div></div>
+    <div class="sw" data-accent="blue"><div class="chip" style="background:var(--accent)"></div><div class="lbl">blue</div></div>
+    <div class="sw" data-accent="violet"><div class="chip" style="background:var(--accent)"></div><div class="lbl">violet</div></div>
+    <div class="sw" data-accent="orange"><div class="chip" style="background:var(--accent)"></div><div class="lbl">orange</div></div>
+  </div>
+  <div class="col">
+    <div class="sw"><div class="soft" style="background:var(--accent-soft)"></div><div class="lbl">accent-soft</div></div>
+    <div class="sw"><div class="chip" style="background:var(--danger-strong)"></div><div class="lbl">danger</div></div>
+    <div class="sw"><div class="chip" style="background:var(--primary)"></div><div class="lbl">primary</div></div>
+  </div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/colors-dark.card.html
+++ b/packages/design-system/guidelines/colors-dark.card.html
@@ -1,0 +1,20 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Surfaces & text (dark)" subtitle="Default theme — surface ramp and text ranks" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:20px;background:var(--bg);display:flex;gap:20px;align-items:flex-start}.col{display:flex;gap:8px}.sw{width:60px}.chip{height:46px;border-radius:10px;border:1px solid var(--border-strong)}.lbl{font:500 11px/1.4 var(--font-mono);color:var(--text-muted);margin-top:6px}.txt{display:flex;flex-direction:column;gap:7px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="col">
+    <div class="sw"><div class="chip" style="background:var(--bg)"></div><div class="lbl">bg</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface)"></div><div class="lbl">surface</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface-2)"></div><div class="lbl">surf-2</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface-3)"></div><div class="lbl">surf-3</div></div>
+  </div>
+  <div class="txt">
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text)">text — primary</span>
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text-muted)">text-muted — secondary</span>
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text-subtle)">text-subtle — hint</span>
+  </div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/colors-light.card.html
+++ b/packages/design-system/guidelines/colors-light.card.html
@@ -1,0 +1,20 @@
+<!-- @dsCard group="Colors" viewport="700x150" name="Surfaces & text (light)" subtitle="Light theme — surface ramp and text ranks" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:20px;background:var(--bg);display:flex;gap:20px;align-items:flex-start}.col{display:flex;gap:8px}.sw{width:60px}.chip{height:46px;border-radius:10px;border:1px solid var(--border-strong)}.lbl{font:500 11px/1.4 var(--font-mono);color:var(--text-muted);margin-top:6px}.txt{display:flex;flex-direction:column;gap:7px}</style></head>
+<body>
+<div class="sl-root" data-theme="light">
+  <div class="col">
+    <div class="sw"><div class="chip" style="background:var(--bg)"></div><div class="lbl">bg</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface)"></div><div class="lbl">surface</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface-2)"></div><div class="lbl">surf-2</div></div>
+    <div class="sw"><div class="chip" style="background:var(--surface-3)"></div><div class="lbl">surf-3</div></div>
+  </div>
+  <div class="txt">
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text)">text — primary</span>
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text-muted)">text-muted — secondary</span>
+    <span style="font:600 16px/1 var(--font-sans);color:var(--text-subtle)">text-subtle — hint</span>
+  </div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/radius-elevation.card.html
+++ b/packages/design-system/guidelines/radius-elevation.card.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Spacing" viewport="700x150" name="Radius & elevation" subtitle="Control vs card radius; shadow token" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;gap:24px;align-items:center}.s{text-align:center}.box{width:64px;height:64px;background:var(--surface);border:1px solid var(--border-strong)}.lbl{font:500 11px/1.4 var(--font-mono);color:var(--text-muted);margin-top:8px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="s"><div class="box" style="border-radius:var(--r)"></div><div class="lbl">--r · control</div></div>
+  <div class="s"><div class="box" style="border-radius:var(--r-lg)"></div><div class="lbl">--r-lg · card</div></div>
+  <div class="s"><div class="box" style="border-radius:999px"></div><div class="lbl">pill</div></div>
+  <div class="s" data-round="sharp"><div class="box" style="border-radius:var(--r-lg)"></div><div class="lbl">round=sharp</div></div>
+  <div class="s" data-round="soft"><div class="box" style="border-radius:var(--r-lg)"></div><div class="lbl">round=soft</div></div>
+  <div class="s"><div class="box" style="border-radius:var(--r-lg);box-shadow:var(--shadow);border-color:var(--border)"></div><div class="lbl">--shadow</div></div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/spacing-scale.card.html
+++ b/packages/design-system/guidelines/spacing-scale.card.html
@@ -1,0 +1,17 @@
+<!-- @dsCard group="Spacing" viewport="700x150" name="Spacing scale" subtitle="4px base grid — space-1 to space-10" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;gap:16px;align-items:flex-end}.s{text-align:center}.bar{background:var(--accent);border-radius:3px;height:46px}.lbl{font:500 11px/1.5 var(--font-mono);color:var(--text-muted);margin-top:7px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="s"><div class="bar" style="width:var(--space-1)"></div><div class="lbl">1 · 4</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-2)"></div><div class="lbl">2 · 8</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-3)"></div><div class="lbl">3 · 12</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-4)"></div><div class="lbl">4 · 16</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-5)"></div><div class="lbl">5 · 20</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-6)"></div><div class="lbl">6 · 24</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-8)"></div><div class="lbl">8 · 32</div></div>
+  <div class="s"><div class="bar" style="width:var(--space-10)"></div><div class="lbl">10 · 40</div></div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/type-mono.card.html
+++ b/packages/design-system/guidelines/type-mono.card.html
@@ -1,0 +1,17 @@
+<!-- @dsCard group="Type" viewport="700x150" name="Mono & numerals" subtitle="JetBrains Mono — data, keys, stats" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;flex-direction:column;gap:14px}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div style="display:flex;align-items:baseline;gap:30px">
+    <span style="font:700 34px/1 var(--font-sans);color:var(--text);letter-spacing:-1px">413</span>
+    <span style="font:700 34px/1 var(--font-sans);color:var(--accent);letter-spacing:-1px">2,929</span>
+    <span style="font:var(--text-mono);color:var(--text-muted)">sprtsmng.dev</span>
+    <span class="sl-kbd">⌘K</span>
+    <span style="font:var(--text-mono);color:var(--text-muted)">deploy --prod</span>
+  </div>
+  <div style="font:var(--text-mono);color:var(--text-subtle)">--font-mono · 0123456789 · tabular figures for stats &amp; tables</div>
+</div>
+</body></html>

--- a/packages/design-system/guidelines/type-ramp.card.html
+++ b/packages/design-system/guidelines/type-ramp.card.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" viewport="700x200" name="Type ramp" subtitle="Hanken Grotesk — display to caption" -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css">
+<style>body{margin:0}.sl-root{padding:22px;background:var(--bg);display:flex;flex-direction:column;gap:12px}.r{display:flex;align-items:baseline;gap:14px}.t{font:500 11px/1 var(--font-mono);color:var(--text-subtle);width:96px;flex:none}</style></head>
+<body>
+<div class="sl-root" data-theme="dark">
+  <div class="r"><span class="t">display 32</span><span style="font:var(--text-display);color:var(--text);letter-spacing:-1px">Discover Leagues</span></div>
+  <div class="r"><span class="t">title 22</span><span style="font:var(--text-title);color:var(--text)">Cobb County Football</span></div>
+  <div class="r"><span class="t">heading 18</span><span style="font:var(--text-heading);color:var(--text)">Player Roster</span></div>
+  <div class="r"><span class="t">body 15</span><span style="font:var(--text-body);color:var(--text-muted)">Browse leagues and add teams to your dashboard.</span></div>
+  <div class="r"><span class="t">label 14</span><span style="font:var(--text-label);color:var(--text)">Add Player</span></div>
+  <div class="r"><span class="t">caption 12</span><span style="font:var(--text-caption);color:var(--text-subtle)">City · Acworth</span></div>
+</div>
+</body></html>

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@sports-management/design-system",
+  "version": "1.0.0",
+  "description": "Sports League — a token-driven, dual-theme design system (CSS variables + React components) for league-management dashboards.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "main": "react/src/index.ts",
+  "exports": {
+    ".": "./react/src/index.ts",
+    "./styles.css": "./styles.css",
+    "./tokens/*": "./tokens/*"
+  },
+  "files": [
+    "styles.css",
+    "tokens",
+    "components",
+    "react",
+    "guidelines",
+    "ui_kits",
+    "README.md",
+    "SKILL.md"
+  ],
+  "keywords": [
+    "design-system",
+    "design-tokens",
+    "react",
+    "css-variables",
+    "dark-mode",
+    "sports-league"
+  ],
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    }
+  }
+}

--- a/packages/design-system/react/README.md
+++ b/packages/design-system/react/README.md
@@ -1,0 +1,102 @@
+# Sports League — Design System (React)
+
+Production React + TypeScript implementation of the Sports League design
+system. Zero runtime dependencies beyond React. Theming (light/dark, accent,
+radius) is driven entirely by CSS variables — no CSS-in-JS, no build step
+beyond your bundler.
+
+## Install
+
+Copy the `react/` folder into your project. Import the stylesheet once at your
+entry point:
+
+```tsx
+import '@/sportsleague/tokens.css';
+```
+
+## Usage
+
+```tsx
+import { ThemeProvider, useTheme, Button, Badge, Card, Stat } from '@/sportsleague/src';
+
+function App() {
+  return (
+    <ThemeProvider defaultTheme="dark" defaultAccent="green">
+      <Dashboard />
+    </ThemeProvider>
+  );
+}
+
+function Dashboard() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <Card>
+      <Stat value="413" label="Teams" />
+      <Button variant="primary" icon="plus">New Season</Button>
+      <Badge variant="success" icon="check">All added</Badge>
+      <button onClick={toggleTheme}>Theme: {theme}</button>
+    </Card>
+  );
+}
+```
+
+## Theming
+
+`<ThemeProvider>` writes three data attributes onto a `.sl-root` wrapper, and
+every component reads CSS variables from there:
+
+| Attribute      | Values                                   | Default   |
+| -------------- | ---------------------------------------- | --------- |
+| `data-theme`   | `light` · `dark`                         | `dark`    |
+| `data-accent`  | `green` · `blue` · `violet` · `orange`   | `green`   |
+| `data-round`   | `sharp` · `default` · `soft`             | `default` |
+
+Change them at runtime via `useTheme()` (`setTheme`, `toggleTheme`, `setAccent`,
+`setRound`). Because it's all CSS variables, nested subtrees can override the
+theme by rendering another `.sl-root` with different attributes.
+
+### Tokens
+
+Semantic, not literal — components reference the name, never the hex.
+
+```
+--bg --surface --surface-2 --surface-3            surfaces
+--border --border-strong                          lines
+--text --text-muted --text-subtle                 text ranks
+--primary --primary-fg --primary-hover            high-contrast action
+--accent --accent-soft                            success / live data
+--danger --danger-strong                          destructive
+--r --r-lg                                         radius
+--space-1 … --space-10                             4px spacing grid
+```
+
+## Components
+
+`Button` · `IconButton` · `Badge` · `Input` · `Select` · `Search` · `Switch` ·
+`Checkbox` · `Radio` · `Card` · `Stat` · `NavItem` · `Tabs` · `Segmented` ·
+`Banner` · `Avatar` · `Table` · `Breadcrumb` · `PageHeader` · `Icon`
+
+All are typed; props extend the matching native element where it makes sense
+(`ButtonProps extends React.ButtonHTMLAttributes<…>`), so `onClick`, `disabled`,
+`aria-*`, etc. pass straight through.
+
+## Files
+
+```
+react/
+  tokens.css              all CSS variables + component classes
+  src/
+    theme.tsx             ThemeProvider + useTheme()
+    icons.tsx             Icon component + icon set
+    components.tsx        every component
+    index.ts              barrel export
+  examples/
+    DiscoverScreen.tsx    full screen composed from components
+    App.tsx               mounts the provider + theme/accent controls
+```
+
+## Example screen
+
+`examples/DiscoverScreen.tsx` rebuilds the Discover view (sidebar, topbar,
+league cards, division accordions, team chips) from the components above — a
+reference for composition and a smoke test that the tokens hold up in context.

--- a/packages/design-system/react/examples/App.tsx
+++ b/packages/design-system/react/examples/App.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ThemeProvider, useTheme, IconButton, Segmented } from '../src';
+import { DiscoverScreen } from './DiscoverScreen';
+import '../tokens.css';
+
+/**
+ * Mount point. Wrap the whole app in <ThemeProvider>; everything inside
+ * reads the CSS variables and re-themes instantly.
+ */
+export default function App() {
+  return (
+    <ThemeProvider defaultTheme="dark" defaultAccent="green" style={{ minHeight: '100vh' }}>
+      <Demo />
+    </ThemeProvider>
+  );
+}
+
+function Demo() {
+  const { theme, toggleTheme, accent, setAccent } = useTheme();
+  return (
+    <div style={{ maxWidth: 1120, margin: '0 auto', padding: '24px' }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
+        <strong style={{ font: '700 16px/1 inherit', letterSpacing: '-0.2px' }}>Sports League · React</strong>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <Segmented
+            options={['green', 'blue', 'violet', 'orange']}
+            value={accent}
+            onChange={(a) => setAccent(a as typeof accent)}
+          />
+          <IconButton icon={theme === 'dark' ? 'sun' : 'moon'} aria-label="Toggle theme" onClick={toggleTheme} />
+        </div>
+      </header>
+      <DiscoverScreen />
+    </div>
+  );
+}

--- a/packages/design-system/react/examples/DiscoverScreen.tsx
+++ b/packages/design-system/react/examples/DiscoverScreen.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import {
+  NavItem, Search, IconButton, Avatar, Breadcrumb, PageHeader,
+  Card, Badge, Button, Icon,
+} from '../src';
+
+/**
+ * The Discover view, assembled entirely from design-system components.
+ * Drop it inside a <ThemeProvider> (see App.tsx) — it fills its container
+ * and re-themes automatically with the active theme/accent/round.
+ */
+export function DiscoverScreen() {
+  const [open, setOpen] = useState<string | null>('Class 4A');
+
+  return (
+    <div style={{ display: 'flex', height: '100%', minHeight: 560, border: '1px solid var(--border)', borderRadius: 16, overflow: 'hidden', background: 'var(--bg)' }}>
+      {/* Sidebar */}
+      <aside style={{ width: 198, flex: 'none', borderRight: '1px solid var(--border)', padding: '18px 12px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '4px 8px 16px' }}>
+          <span style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--primary)', color: 'var(--primary-fg)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Icon name="trophy" size={13} strokeWidth={2.4} />
+          </span>
+          <span style={{ font: '700 15px/1 inherit', letterSpacing: '-0.2px' }}>Sports League</span>
+        </div>
+        <NavItem icon="grid">Overview</NavItem>
+        <NavItem icon="compass" active>Discover</NavItem>
+        <NavItem icon="users">Teams</NavItem>
+        <NavItem icon="target">Players</NavItem>
+        <NavItem icon="calendar">Seasons</NavItem>
+        <NavItem icon="layers">Divisions</NavItem>
+        <NavItem icon="upload">Import</NavItem>
+        <NavItem icon="card">Billing</NavItem>
+      </aside>
+
+      {/* Main */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        {/* Topbar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, height: 54, flex: 'none', padding: '0 20px', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, height: 36, padding: '0 12px', borderRadius: 9, border: '1px solid var(--border)', background: 'var(--surface)', font: '600 13px/1 inherit' }}>
+            <Icon name="trophy" size={14} />Cobb County Football<Icon name="chevron-vertical" size={14} strokeWidth={2} />
+          </div>
+          <div style={{ flex: 1, maxWidth: 340 }}><Search /></div>
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 10 }}>
+            <IconButton icon="sun" aria-label="Toggle theme" />
+            <Avatar initials="AS" />
+          </div>
+        </div>
+
+        {/* Content */}
+        <div style={{ flex: 1, overflow: 'auto', padding: '22px 24px' }}>
+          <div style={{ marginBottom: 12 }}>
+            <Breadcrumb items={['Dashboard', 'Discover']} />
+          </div>
+          <PageHeader
+            title="Discover Leagues"
+            description="Browse leagues and add teams to your dashboard. Each team you add becomes your own private copy to manage."
+          />
+
+          <Card style={{ margin: '22px 0 16px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+              <Icon name="trophy" size={18} />
+              <span style={{ font: '700 18px/1 inherit' }}>Cobb County Football</span>
+              <Badge variant="outline">Public</Badge>
+            </div>
+
+            <DivisionRow name="Class 4A" count={2} allAdded open={open === 'Class 4A'} onToggle={() => setOpen(open === 'Class 4A' ? null : 'Class 4A')} />
+            {open === 'Class 4A' && (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, margin: '6px 0' }}>
+                <TeamChip name="Allatoona" />
+                <TeamChip name="Kell" />
+              </div>
+            )}
+            <DivisionRow name="Class 5A" count={3} allAdded bordered open={false} onToggle={() => {}} />
+            <DivisionRow name="Class 6A" count={11} allAdded bordered open={false} onToggle={() => {}} />
+          </Card>
+
+          <Card>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <Icon name="trophy" size={18} />
+                <span style={{ font: '700 18px/1 inherit' }}>NFL</span>
+                <Badge variant="outline">Public</Badge>
+              </div>
+              <Button size="sm">Add all (32)</Button>
+            </div>
+            <DivisionRow name="AFC East" count={4} bordered open={false} onToggle={() => {}} />
+            <DivisionRow name="AFC North" count={4} bordered open={false} onToggle={() => {}} />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DivisionRow({ name, count, allAdded, bordered, open, onToggle }: {
+  name: string; count: number; allAdded?: boolean; bordered?: boolean; open: boolean; onToggle: () => void;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%',
+        padding: '12px 0', background: 'none', border: 'none', cursor: 'pointer',
+        borderTop: bordered ? '1px solid var(--border)' : 'none', color: 'var(--text)', font: 'inherit',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <span style={{ font: '700 15px/1 inherit' }}>{name}</span>
+        <span style={{ font: '500 13px/1 inherit', color: 'var(--text-subtle)' }}>({count})</span>
+        {allAdded && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--accent)', font: '600 12px/1 inherit' }}>
+            <Icon name="check-circle" size={13} strokeWidth={2.4} />All added
+          </span>
+        )}
+      </span>
+      <Icon name={open ? 'chevron-up' : 'chevron-down'} size={16} strokeWidth={2} style={{ color: 'var(--text-muted)' }} />
+    </button>
+  );
+}
+
+function TeamChip({ name }: { name: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 14px', borderRadius: 'var(--r)', border: '1px solid var(--border)', background: 'var(--bg)' }}>
+      <span style={{ font: '600 14px/1 inherit' }}>{name}</span>
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--accent)', font: '600 12px/1 inherit' }}>
+          <Icon name="check-circle" size={13} strokeWidth={2.4} />Added
+        </span>
+        <span style={{ color: 'var(--text-subtle)', display: 'inline-flex', cursor: 'pointer' }}><Icon name="x" size={13} strokeWidth={2} /></span>
+      </span>
+    </div>
+  );
+}

--- a/packages/design-system/react/src/components.tsx
+++ b/packages/design-system/react/src/components.tsx
@@ -1,0 +1,299 @@
+import React from 'react';
+import { Icon, IconName } from './icons';
+
+const cx = (...parts: Array<string | false | undefined>) => parts.filter(Boolean).join(' ');
+
+/* ============================================================ Button */
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  size?: 'sm' | 'md' | 'lg';
+  icon?: IconName;
+}
+export function Button({ variant = 'secondary', size = 'md', icon, className, children, ...rest }: ButtonProps) {
+  return (
+    <button
+      className={cx('sl-btn', `sl-btn--${variant}`, size !== 'md' && `sl-btn--${size}`, className)}
+      {...rest}
+    >
+      {icon && <Icon name={icon} size={size === 'lg' ? 16 : 14} strokeWidth={2.2} />}
+      {children}
+    </button>
+  );
+}
+
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: IconName;
+}
+export function IconButton({ icon, className, ...rest }: IconButtonProps) {
+  return (
+    <button className={cx('sl-iconbtn', className)} {...rest}>
+      <Icon name={icon} size={17} />
+    </button>
+  );
+}
+
+/* ============================================================ Badge */
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: 'outline' | 'neutral' | 'solid' | 'success' | 'danger';
+  dot?: boolean;
+  icon?: IconName;
+}
+export function Badge({ variant = 'neutral', dot, icon, className, children, ...rest }: BadgeProps) {
+  return (
+    <span className={cx('sl-badge', `sl-badge--${variant}`, className)} {...rest}>
+      {dot && <span className="sl-badge__dot" />}
+      {icon && <Icon name={icon} size={12} strokeWidth={2.6} />}
+      {children}
+    </span>
+  );
+}
+
+/* ============================================================ Inputs */
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  inputSize?: 'sm' | 'md' | 'lg';
+}
+export function Input({ inputSize = 'md', className, ...rest }: InputProps) {
+  return <input className={cx('sl-input', inputSize !== 'md' && `sl-input--${inputSize}`, className)} {...rest} />;
+}
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+export function Select({ className, children, ...rest }: SelectProps) {
+  return (
+    <span className="sl-select-wrap">
+      <select className={cx('sl-select', className)} {...rest}>{children}</select>
+      <span className="sl-select-wrap__chevron"><Icon name="chevron-down" size={15} strokeWidth={2} /></span>
+    </span>
+  );
+}
+
+export interface SearchProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  shortcut?: string;
+}
+export function Search({ shortcut = '⌘K', placeholder = 'Search…', className, ...rest }: SearchProps) {
+  return (
+    <label className={cx('sl-search', className)}>
+      <Icon name="search" size={14} strokeWidth={2} />
+      <input placeholder={placeholder} {...rest} />
+      {shortcut && <span className="sl-kbd">{shortcut}</span>}
+    </label>
+  );
+}
+
+export interface SwitchProps {
+  checked: boolean;
+  onChange?: (next: boolean) => void;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+export function Switch({ checked, onChange, disabled, ...aria }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      className={cx('sl-switch', checked && 'is-on')}
+      onClick={() => onChange?.(!checked)}
+      {...aria}
+    >
+      <span className="sl-switch__knob" />
+    </button>
+  );
+}
+
+export interface CheckboxProps {
+  checked: boolean;
+  onChange?: (next: boolean) => void;
+  label?: React.ReactNode;
+}
+export function Checkbox({ checked, onChange, label }: CheckboxProps) {
+  return (
+    <label className={cx('sl-control', !checked && 'sl-control--muted')} onClick={() => onChange?.(!checked)}>
+      <span className={cx('sl-check', checked && 'is-on')}>
+        <Icon name="check" size={12} strokeWidth={3} />
+      </span>
+      {label}
+    </label>
+  );
+}
+
+export interface RadioProps {
+  checked: boolean;
+  onChange?: () => void;
+  label?: React.ReactNode;
+}
+export function Radio({ checked, onChange, label }: RadioProps) {
+  return (
+    <label className={cx('sl-control', !checked && 'sl-control--muted')} onClick={onChange}>
+      <span className={cx('sl-radio', checked && 'is-on')} />
+      {label}
+    </label>
+  );
+}
+
+/* ============================================================ Surfaces */
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function Card({ className, ...rest }: CardProps) {
+  return <div className={cx('sl-card', className)} {...rest} />;
+}
+
+export interface StatProps {
+  value: React.ReactNode;
+  label: React.ReactNode;
+  accent?: boolean;
+}
+export function Stat({ value, label, accent }: StatProps) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <span className="sl-stat__value" style={accent ? { color: 'var(--accent)' } : undefined}>{value}</span>
+      <span className="sl-stat__label">{label}</span>
+    </div>
+  );
+}
+
+export interface NavItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: IconName;
+  active?: boolean;
+}
+export function NavItem({ icon, active, className, children, ...rest }: NavItemProps) {
+  return (
+    <button className={cx('sl-nav', active && 'is-active', className)} {...rest}>
+      {icon && <Icon name={icon} size={18} />}
+      {children}
+    </button>
+  );
+}
+
+/* ============================================================ Tabs / segmented */
+export interface TabsProps {
+  tabs: string[];
+  value: string;
+  onChange?: (tab: string) => void;
+}
+export function Tabs({ tabs, value, onChange }: TabsProps) {
+  return (
+    <div className="sl-tabs" role="tablist">
+      {tabs.map((t) => (
+        <button key={t} role="tab" aria-selected={t === value} className={cx('sl-tab', t === value && 'is-active')} onClick={() => onChange?.(t)}>
+          {t}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export interface SegmentedProps {
+  options: string[];
+  value: string;
+  onChange?: (option: string) => void;
+}
+export function Segmented({ options, value, onChange }: SegmentedProps) {
+  return (
+    <div className="sl-segmented" role="tablist">
+      {options.map((o) => (
+        <button key={o} role="tab" aria-selected={o === value} className={cx('sl-segmented__item', o === value && 'is-active')} onClick={() => onChange?.(o)}>
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ============================================================ Banner */
+export interface BannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'success' | 'danger';
+}
+export function Banner({ variant = 'success', className, children, ...rest }: BannerProps) {
+  return (
+    <div className={cx('sl-banner', `sl-banner--${variant}`, className)} {...rest}>
+      <span className="sl-banner__icon">
+        <Icon name={variant === 'success' ? 'check-circle' : 'alert'} size={17} strokeWidth={2.1} />
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+/* ============================================================ Avatar */
+export interface AvatarProps {
+  initials?: string;
+  src?: string;
+  alt?: string;
+  size?: number;
+}
+export function Avatar({ initials, src, alt = '', size = 32 }: AvatarProps) {
+  return (
+    <span className="sl-avatar" style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}>
+      {src ? <img src={src} alt={alt} /> : initials}
+    </span>
+  );
+}
+
+/* ============================================================ Table */
+export interface Column<T> {
+  key: keyof T & string;
+  header: string;
+}
+export interface TableProps<T> {
+  columns: Column<T>[];
+  rows: T[];
+  rowKey: (row: T) => string;
+  actions?: (row: T) => React.ReactNode;
+}
+export function Table<T>({ columns, rows, rowKey, actions }: TableProps<T>) {
+  return (
+    <table className="sl-table">
+      <thead>
+        <tr>
+          {columns.map((c) => <th key={c.key}>{c.header}</th>)}
+          {actions && <th style={{ textAlign: 'right' }}>Actions</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={rowKey(row)}>
+            {columns.map((c) => <td key={c.key}>{String(row[c.key])}</td>)}
+            {actions && <td style={{ textAlign: 'right' }}>{actions(row)}</td>}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/* ============================================================ Breadcrumb / PageHeader */
+export interface BreadcrumbProps {
+  items: string[];
+}
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav style={{ display: 'flex', alignItems: 'center', gap: 8, font: '500 13px/1 inherit', color: 'var(--text-muted)' }}>
+      {items.map((item, i) => (
+        <React.Fragment key={item}>
+          {i > 0 && <Icon name="chevron-right" size={13} strokeWidth={2} />}
+          <span style={i === items.length - 1 ? { color: 'var(--text)' } : undefined}>{item}</span>
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+}
+
+export interface PageHeaderProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 16 }}>
+      <div>
+        <h1 style={{ margin: 0, font: '700 25px/1 inherit', letterSpacing: '-0.7px', color: 'var(--text)' }}>{title}</h1>
+        {description && <p style={{ margin: '8px 0 0', font: '400 14px/1.5 inherit', color: 'var(--text-muted)', maxWidth: 600 }}>{description}</p>}
+      </div>
+      {actions}
+    </div>
+  );
+}
+
+export { Icon } from './icons';
+export type { IconName } from './icons';

--- a/packages/design-system/react/src/icons.tsx
+++ b/packages/design-system/react/src/icons.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+export type IconName =
+  | 'trophy' | 'grid' | 'compass' | 'users' | 'target' | 'calendar'
+  | 'layers' | 'upload' | 'card' | 'search' | 'plus' | 'x' | 'check'
+  | 'check-circle' | 'chevron-down' | 'chevron-up' | 'chevron-right'
+  | 'chevron-vertical' | 'sun' | 'moon' | 'alert' | 'user' | 'logout'
+  | 'pencil' | 'trash' | 'bell';
+
+const PATHS: Record<IconName, React.ReactNode> = {
+  trophy: <><path d="M6 9a6 6 0 0 0 12 0V4H6Z" /><path d="M9 20h6M12 14v6" /></>,
+  grid: <><rect x="3" y="3" width="7" height="7" rx="1.2" /><rect x="14" y="3" width="7" height="7" rx="1.2" /><rect x="3" y="14" width="7" height="7" rx="1.2" /><rect x="14" y="14" width="7" height="7" rx="1.2" /></>,
+  compass: <><circle cx="12" cy="12" r="9" /><path d="m15 9-2 5-4 1 2-5z" /></>,
+  users: <><circle cx="9" cy="8" r="3.2" /><path d="M3.5 20a5.5 5.5 0 0 1 11 0" /><path d="M16 6.2a3 3 0 0 1 0 5.6" /><path d="M20.5 20a5 5 0 0 0-4-4.9" /></>,
+  target: <><circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="2.4" /></>,
+  calendar: <><rect x="3" y="4.5" width="18" height="16" rx="2" /><path d="M3 9h18M8 2.5v4M16 2.5v4" /></>,
+  layers: <><path d="m12 3 9 5-9 5-9-5Z" /><path d="m3 13 9 5 9-5" /></>,
+  upload: <><path d="M12 15V3M8 7l4-4 4 4" /><path d="M4 17v2a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-2" /></>,
+  card: <><rect x="2.5" y="5" width="19" height="14" rx="2.5" /><path d="M2.5 10h19" /></>,
+  search: <><circle cx="11" cy="11" r="7" /><path d="m21 21-3.6-3.6" /></>,
+  plus: <path d="M12 5v14M5 12h14" />,
+  x: <path d="M18 6 6 18M6 6l12 12" />,
+  check: <path d="M20 6 9 17l-5-5" />,
+  'check-circle': <><circle cx="12" cy="12" r="9" /><path d="m9 12 2 2 4-4" /></>,
+  'chevron-down': <path d="m6 9 6 6 6-6" />,
+  'chevron-up': <path d="m18 15-6-6-6 6" />,
+  'chevron-right': <path d="m9 6 6 6-6 6" />,
+  'chevron-vertical': <path d="m8 9 4-4 4 4M8 15l4 4 4-4" />,
+  sun: <><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.4 1.4M17.6 17.6 19 19M19 5l-1.4 1.4M6.4 17.6 5 19" /></>,
+  moon: <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />,
+  alert: <><path d="M12 3 2 20h20Z" /><path d="M12 10v4M12 17.5v.5" /></>,
+  user: <><circle cx="12" cy="8" r="4" /><path d="M5 21a7 7 0 0 1 14 0" /></>,
+  logout: <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />,
+  pencil: <path d="M12 20h9M16.5 3.5a2.05 2.05 0 0 1 3 3L7 19l-4 1 1-4Z" />,
+  trash: <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />,
+  bell: <><path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6Z" /><path d="M10 20a2 2 0 0 0 4 0" /></>,
+};
+
+export interface IconProps extends React.SVGProps<SVGSVGElement> {
+  name: IconName;
+  size?: number;
+}
+
+export function Icon({ name, size = 16, strokeWidth = 1.9, ...rest }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth as number}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      {PATHS[name]}
+    </svg>
+  );
+}

--- a/packages/design-system/react/src/index.ts
+++ b/packages/design-system/react/src/index.ts
@@ -1,0 +1,4 @@
+export * from './theme';
+export * from './components';
+export { Icon } from './icons';
+export type { IconName } from './icons';

--- a/packages/design-system/react/src/theme.tsx
+++ b/packages/design-system/react/src/theme.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+export type Theme = 'light' | 'dark';
+export type Accent = 'green' | 'blue' | 'violet' | 'orange';
+export type Round = 'sharp' | 'default' | 'soft';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
+  accent: Accent;
+  setAccent: (a: Accent) => void;
+  round: Round;
+  setRound: (r: Round) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export interface ThemeProviderProps {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  defaultAccent?: Accent;
+  defaultRound?: Round;
+  /** Extra className merged onto the root element. */
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Wraps the app, owns theme state, and writes `data-theme` / `data-accent`
+ * / `data-round` onto a `.sl-root` element so every CSS variable resolves.
+ * Import `tokens.css` once at your app entry.
+ */
+export function ThemeProvider({
+  children,
+  defaultTheme = 'dark',
+  defaultAccent = 'green',
+  defaultRound = 'default',
+  className = '',
+  style,
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(defaultTheme);
+  const [accent, setAccent] = useState<Accent>(defaultAccent);
+  const [round, setRound] = useState<Round>(defaultRound);
+
+  const toggleTheme = useCallback(
+    () => setTheme((t) => (t === 'dark' ? 'light' : 'dark')),
+    []
+  );
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, setTheme, toggleTheme, accent, setAccent, round, setRound }),
+    [theme, toggleTheme, accent, round]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <div
+        className={`sl-root ${className}`.trim()}
+        data-theme={theme}
+        data-accent={accent}
+        data-round={round}
+        style={style}
+      >
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within a <ThemeProvider>');
+  return ctx;
+}

--- a/packages/design-system/react/tokens.css
+++ b/packages/design-system/react/tokens.css
@@ -1,0 +1,271 @@
+/* ============================================================
+   Sports League — design tokens + component styles
+   One stylesheet: themeable CSS variables + component classes.
+   Theme/accent/radius are driven by data-* attributes set by
+   <ThemeProvider> (see src/theme.tsx).
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+
+/* ---- Color tokens : DARK is the default ---- */
+:root,
+[data-theme='dark'] {
+  --bg:#0a0a0b;
+  --surface:#161618;
+  --surface-2:#1d1d20;
+  --surface-3:#26262a;
+  --border:#2a2a2e;
+  --border-strong:#3a3a40;
+  --text:#fafafa;
+  --text-muted:#9b9ba3;
+  --text-subtle:#67676f;
+  --primary:#fafafa;
+  --primary-fg:#0c0c0d;
+  --primary-hover:#e6e6e8;
+  --danger:#f2555c;
+  --danger-strong:#ff6166;
+  --ring:rgba(250,250,250,.20);
+  --shadow:0 16px 40px rgba(0,0,0,.60);
+  --accent:#46c964;
+  --accent-soft:rgba(70,201,100,.16);
+}
+
+[data-theme='light'] {
+  --bg:#fbfbfc;
+  --surface:#ffffff;
+  --surface-2:#f4f4f5;
+  --surface-3:#eaeaec;
+  --border:#e6e6e9;
+  --border-strong:#d6d6da;
+  --text:#0c0c0d;
+  --text-muted:#5b5b61;
+  --text-subtle:#9a9aa1;
+  --primary:#0c0c0d;
+  --primary-fg:#ffffff;
+  --primary-hover:#2a2a2e;
+  --danger:#dc2626;
+  --danger-strong:#e5484d;
+  --ring:rgba(12,12,13,.15);
+  --shadow:0 12px 30px rgba(0,0,0,.13);
+  --accent:#18a558;
+  --accent-soft:rgba(24,165,88,.10);
+}
+
+/* ---- Accent overrides (the --accent token only) ---- */
+[data-accent='blue']   { --accent:#5b8dff; --accent-soft:rgba(91,141,255,.16); }
+[data-accent='violet'] { --accent:#a17bff; --accent-soft:rgba(161,123,255,.16); }
+[data-accent='orange'] { --accent:#ff9e4a; --accent-soft:rgba(255,158,74,.16); }
+[data-theme='light'][data-accent='blue']   { --accent:#2563eb; --accent-soft:rgba(37,99,235,.10); }
+[data-theme='light'][data-accent='violet'] { --accent:#7c3aed; --accent-soft:rgba(124,58,237,.10); }
+[data-theme='light'][data-accent='orange'] { --accent:#d9730a; --accent-soft:rgba(217,115,10,.10); }
+
+/* ---- Radius scale ---- */
+:root            { --r:10px; --r-lg:14px; }
+[data-round='sharp'] { --r:6px;  --r-lg:9px;  }
+[data-round='soft']  { --r:14px; --r-lg:20px; }
+
+/* ---- Spacing scale (4px base) ---- */
+:root {
+  --space-1:4px;  --space-2:8px;  --space-3:12px; --space-4:16px;
+  --space-5:20px; --space-6:24px; --space-8:32px; --space-10:40px;
+}
+
+/* ============================================================
+   Base
+   ============================================================ */
+.sl-root {
+  background:var(--bg);
+  color:var(--text);
+  font-family:'Hanken Grotesk', ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing:antialiased;
+}
+.sl-root *, .sl-root *::before, .sl-root *::after { box-sizing:border-box; }
+.sl-mono { font-family:'JetBrains Mono', ui-monospace, monospace; }
+
+/* ============================================================
+   Button
+   ============================================================ */
+.sl-btn {
+  display:inline-flex; align-items:center; justify-content:center; gap:7px;
+  height:38px; padding:0 14px;
+  border-radius:var(--r); border:1px solid transparent;
+  font:600 14px/1 inherit; font-family:inherit; cursor:pointer;
+  transition:background .12s ease, border-color .12s ease, filter .12s ease;
+}
+.sl-btn--primary   { background:var(--primary); border-color:var(--primary); color:var(--primary-fg); }
+.sl-btn--primary:hover   { background:var(--primary-hover); border-color:var(--primary-hover); }
+.sl-btn--secondary { background:var(--surface-2); border-color:var(--border-strong); color:var(--text); }
+.sl-btn--secondary:hover { background:var(--surface-3); }
+.sl-btn--ghost     { background:transparent; color:var(--text-muted); }
+.sl-btn--ghost:hover     { background:var(--surface-2); color:var(--text); }
+.sl-btn--danger    { background:var(--danger-strong); border-color:var(--danger-strong); color:#fff; }
+.sl-btn--danger:hover    { filter:brightness(1.08); }
+.sl-btn--sm { height:32px; padding:0 11px; font-size:13px; }
+.sl-btn--lg { height:44px; padding:0 18px; font-size:15px; }
+.sl-btn:focus-visible { outline:none; box-shadow:0 0 0 3px var(--ring); }
+.sl-btn:disabled { background:var(--surface-2); border-color:var(--surface-2); color:var(--text-subtle); cursor:not-allowed; filter:none; }
+
+.sl-iconbtn {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:34px; height:34px; border-radius:var(--r);
+  border:1px solid var(--border); background:transparent; color:var(--text-muted);
+  cursor:pointer; transition:background .12s ease;
+}
+.sl-iconbtn:hover { background:var(--surface-2); color:var(--text); }
+
+/* ============================================================
+   Badge
+   ============================================================ */
+.sl-badge {
+  display:inline-flex; align-items:center; gap:5px;
+  height:24px; padding:0 10px; border-radius:999px;
+  font:600 12px/1 inherit; white-space:nowrap;
+}
+.sl-badge--outline { border:1px solid var(--border-strong); color:var(--text-muted); }
+.sl-badge--neutral { background:var(--surface-2); color:var(--text-muted); }
+.sl-badge--solid   { background:var(--surface-3); color:var(--text); }
+.sl-badge--success { background:var(--accent-soft); color:var(--accent); }
+.sl-badge--danger  { border:1px solid var(--danger); color:var(--danger); }
+.sl-badge__dot { width:7px; height:7px; border-radius:999px; background:var(--accent); }
+
+/* ============================================================
+   Inputs
+   ============================================================ */
+.sl-input {
+  width:100%; height:38px; padding:0 12px;
+  border-radius:var(--r); border:1px solid var(--border);
+  background:var(--surface); color:var(--text);
+  font:500 14px/1 inherit; font-family:inherit; outline:none;
+  transition:border-color .12s ease, box-shadow .12s ease;
+}
+.sl-input::placeholder { color:var(--text-subtle); }
+.sl-input:focus { border-color:var(--text); box-shadow:0 0 0 3px var(--ring); }
+.sl-input:disabled { background:var(--surface-2); color:var(--text-subtle); cursor:not-allowed; }
+.sl-input--sm { height:32px; }
+.sl-input--lg { height:48px; font-size:15px; }
+
+.sl-select-wrap { position:relative; display:inline-block; width:100%; }
+.sl-select {
+  width:100%; height:38px; padding:0 36px 0 12px;
+  border-radius:var(--r); border:1px solid var(--border);
+  background:var(--surface); color:var(--text);
+  font:500 14px/1 inherit; font-family:inherit; outline:none;
+  appearance:none; -webkit-appearance:none; cursor:pointer;
+}
+.sl-select:focus { border-color:var(--text); box-shadow:0 0 0 3px var(--ring); }
+.sl-select-wrap__chevron {
+  position:absolute; right:12px; top:50%; transform:translateY(-50%);
+  color:var(--text-subtle); pointer-events:none;
+}
+
+.sl-search {
+  display:flex; align-items:center; gap:9px;
+  height:38px; padding:0 12px; border-radius:var(--r);
+  border:1px solid var(--border); background:var(--surface-2); color:var(--text-subtle);
+  font:500 14px/1 inherit;
+}
+.sl-search input { flex:1; border:none; background:none; outline:none; color:var(--text); font:inherit; }
+.sl-kbd {
+  font:500 11px/1 'JetBrains Mono', monospace;
+  border:1px solid var(--border); border-radius:6px; padding:3px 6px; color:var(--text-subtle);
+}
+
+/* ---- Switch ---- */
+.sl-switch {
+  position:relative; width:42px; height:25px; padding:0;
+  border-radius:999px; background:var(--surface-3); border:1px solid var(--border-strong);
+  cursor:pointer; transition:background .15s ease, border-color .15s ease; flex:none;
+}
+.sl-switch.is-on { background:var(--accent); border-color:var(--accent); }
+.sl-switch__knob {
+  position:absolute; top:2px; left:2px; width:19px; height:19px;
+  border-radius:999px; background:var(--text-subtle);
+  transition:transform .15s ease, background .15s ease;
+}
+.sl-switch.is-on .sl-switch__knob { transform:translateX(17px); background:#fff; }
+
+/* ---- Checkbox / Radio ---- */
+.sl-control { display:inline-flex; align-items:center; gap:10px; font:500 14px/1 inherit; color:var(--text); cursor:pointer; }
+.sl-control--muted { color:var(--text-muted); }
+.sl-check {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:18px; height:18px; border-radius:5px;
+  border:1px solid var(--border-strong); background:var(--surface);
+  color:transparent; flex:none; transition:background .12s ease, border-color .12s ease;
+}
+.sl-check.is-on { background:var(--primary); border-color:var(--primary); color:var(--primary-fg); }
+.sl-radio { width:18px; height:18px; border-radius:999px; border:1px solid var(--border-strong); background:var(--surface); flex:none; }
+.sl-radio.is-on { border:5px solid var(--accent); box-shadow:inset 0 0 0 1px var(--accent); }
+
+/* ============================================================
+   Surfaces
+   ============================================================ */
+.sl-card { border:1px solid var(--border); background:var(--surface); border-radius:var(--r-lg); padding:18px; }
+
+.sl-stat__value { font:700 30px/1 inherit; color:var(--text); letter-spacing:-.5px; }
+.sl-stat__label { font:600 11px/1 inherit; letter-spacing:.5px; text-transform:uppercase; color:var(--text-muted); }
+
+/* ---- Nav ---- */
+.sl-nav {
+  display:flex; align-items:center; gap:10px; width:100%;
+  height:38px; padding:0 12px; border-radius:var(--r);
+  font:600 14px/1 inherit; font-family:inherit; color:var(--text-muted);
+  background:none; border:none; text-align:left; cursor:pointer;
+  transition:background .12s ease, color .12s ease;
+}
+.sl-nav:hover { background:var(--surface-2); color:var(--text); }
+.sl-nav.is-active { background:var(--primary); color:var(--primary-fg); }
+
+/* ---- Tabs ---- */
+.sl-tabs { display:flex; gap:18px; border-bottom:1px solid var(--border); }
+.sl-tab {
+  padding:0 2px 11px; margin-bottom:-1px;
+  font:600 14px/1 inherit; font-family:inherit; color:var(--text-muted);
+  background:none; border:none; border-bottom:2px solid transparent; cursor:pointer;
+  transition:color .12s ease;
+}
+.sl-tab:hover { color:var(--text); }
+.sl-tab.is-active { color:var(--text); border-bottom-color:var(--text); }
+
+/* ---- Segmented ---- */
+.sl-segmented { display:inline-flex; gap:3px; padding:3px; border-radius:var(--r); background:var(--surface-2); border:1px solid var(--border); }
+.sl-segmented__item { padding:6px 13px; border-radius:7px; font:600 13px/1 inherit; font-family:inherit; color:var(--text-muted); background:none; border:none; cursor:pointer; }
+.sl-segmented__item:hover { color:var(--text); }
+.sl-segmented__item.is-active { background:var(--surface); border:1px solid var(--border); color:var(--text); }
+
+/* ---- Banner ---- */
+.sl-banner { display:flex; align-items:flex-start; gap:10px; padding:12px 14px; border-radius:var(--r); font:500 14px/1.4 inherit; }
+.sl-banner--success { background:var(--accent-soft); color:var(--text); }
+.sl-banner--success .sl-banner__icon { color:var(--accent); }
+.sl-banner--danger { border:1px solid var(--danger); color:var(--text); }
+.sl-banner--danger .sl-banner__icon { color:var(--danger); }
+.sl-banner__icon { flex:none; margin-top:1px; }
+
+/* ---- Avatar ---- */
+.sl-avatar {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:32px; height:32px; border-radius:999px;
+  background:var(--accent-soft); color:var(--accent);
+  font:700 13px/1 inherit; flex:none; overflow:hidden;
+}
+.sl-avatar img { width:100%; height:100%; object-fit:cover; }
+
+/* ---- Menu ---- */
+.sl-menu { width:206px; border-radius:var(--r-lg); border:1px solid var(--border); background:var(--surface); box-shadow:var(--shadow); padding:5px; }
+.sl-menu__item { display:flex; align-items:center; gap:9px; width:100%; padding:8px 10px; border-radius:8px; font:500 13px/1 inherit; font-family:inherit; color:var(--text); background:none; border:none; text-align:left; cursor:pointer; }
+.sl-menu__item:hover { background:var(--surface-2); }
+.sl-menu__item--danger { color:var(--danger); }
+.sl-menu__sep { height:1px; background:var(--border); margin:5px 0; }
+
+/* ---- Table ---- */
+.sl-table { width:100%; border-collapse:collapse; border:1px solid var(--border); border-radius:var(--r); overflow:hidden; }
+.sl-table th { text-align:left; font:600 11px/1 'JetBrains Mono', monospace; text-transform:uppercase; letter-spacing:.3px; color:var(--text-muted); padding:11px 14px; background:var(--surface-2); }
+.sl-table td { font:500 14px/1 inherit; color:var(--text); padding:12px 14px; border-top:1px solid var(--border); }
+
+/* ---- Dialog ---- */
+.sl-dialog { border-radius:var(--r-lg); border:1px solid var(--border); background:var(--surface); box-shadow:var(--shadow); padding:20px; max-width:420px; }
+.sl-dialog__title { font:700 18px/1.2 inherit; color:var(--text); margin:0 0 8px; }
+.sl-dialog__body { font:400 14px/20px inherit; color:var(--text-muted); margin:0 0 18px; }
+
+/* ---- Dropzone ---- */
+.sl-dropzone { display:flex; flex-direction:column; align-items:center; gap:9px; padding:24px; text-align:center; border:1.5px dashed var(--border-strong); border-radius:var(--r-lg); color:var(--text-subtle); }

--- a/packages/design-system/styles.css
+++ b/packages/design-system/styles.css
@@ -1,0 +1,7 @@
+/* Sports League — global stylesheet entry point.
+   Consumers link THIS one file. Keep it @import lines only. */
+@import "./tokens/fonts.css";
+@import "./tokens/colors.css";
+@import "./tokens/typography.css";
+@import "./tokens/spacing.css";
+@import "./tokens/components.css";

--- a/packages/design-system/tokens/colors.css
+++ b/packages/design-system/tokens/colors.css
@@ -1,0 +1,63 @@
+/* ============================================================
+   COLOR TOKENS — semantic, not literal.
+   Dark is the default theme; [data-theme='light'] overrides.
+   Accent + radius are independent axes set via data-attributes.
+   ============================================================ */
+
+:root,
+[data-theme='dark'] {
+  /* surfaces */
+  --bg:#0a0a0b;
+  --surface:#161618;
+  --surface-2:#1d1d20;
+  --surface-3:#26262a;
+  /* lines */
+  --border:#2a2a2e;
+  --border-strong:#3a3a40;
+  /* text ranks */
+  --text:#fafafa;
+  --text-muted:#9b9ba3;
+  --text-subtle:#67676f;
+  /* high-contrast action */
+  --primary:#fafafa;
+  --primary-fg:#0c0c0d;
+  --primary-hover:#e6e6e8;
+  /* destructive */
+  --danger:#f2555c;
+  --danger-strong:#ff6166;
+  /* focus + elevation */
+  --ring:rgba(250,250,250,.20);
+  --shadow:0 16px 40px rgba(0,0,0,.60);
+  /* success / live-data accent (green default) */
+  --accent:#46c964;
+  --accent-soft:rgba(70,201,100,.16);
+}
+
+[data-theme='light'] {
+  --bg:#fbfbfc;
+  --surface:#ffffff;
+  --surface-2:#f4f4f5;
+  --surface-3:#eaeaec;
+  --border:#e6e6e9;
+  --border-strong:#d6d6da;
+  --text:#0c0c0d;
+  --text-muted:#5b5b61;
+  --text-subtle:#9a9aa1;
+  --primary:#0c0c0d;
+  --primary-fg:#ffffff;
+  --primary-hover:#2a2a2e;
+  --danger:#dc2626;
+  --danger-strong:#e5484d;
+  --ring:rgba(12,12,13,.15);
+  --shadow:0 12px 30px rgba(0,0,0,.13);
+  --accent:#18a558;
+  --accent-soft:rgba(24,165,88,.10);
+}
+
+/* ---- Accent axis (overrides the --accent pair only) ---- */
+[data-accent='blue']   { --accent:#5b8dff; --accent-soft:rgba(91,141,255,.16); }
+[data-accent='violet'] { --accent:#a17bff; --accent-soft:rgba(161,123,255,.16); }
+[data-accent='orange'] { --accent:#ff9e4a; --accent-soft:rgba(255,158,74,.16); }
+[data-theme='light'][data-accent='blue']   { --accent:#2563eb; --accent-soft:rgba(37,99,235,.10); }
+[data-theme='light'][data-accent='violet'] { --accent:#7c3aed; --accent-soft:rgba(124,58,237,.10); }
+[data-theme='light'][data-accent='orange'] { --accent:#d9730a; --accent-soft:rgba(217,115,10,.10); }

--- a/packages/design-system/tokens/components.css
+++ b/packages/design-system/tokens/components.css
@@ -1,0 +1,206 @@
+/* ============================================================
+   COMPONENT CLASSES
+   Thin, theme-driven classes consumed by the React components and
+   the Design System cards. Every value references a token — no
+   literal colors here. Import order: this file comes last.
+   ============================================================ */
+
+/* ============================================================
+   Base
+   ============================================================ */
+.sl-root {
+  background:var(--bg);
+  color:var(--text);
+  font-family:'Hanken Grotesk', ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing:antialiased;
+}
+.sl-root *, .sl-root *::before, .sl-root *::after { box-sizing:border-box; }
+.sl-mono { font-family:'JetBrains Mono', ui-monospace, monospace; }
+
+/* ============================================================
+   Button
+   ============================================================ */
+.sl-btn {
+  display:inline-flex; align-items:center; justify-content:center; gap:7px;
+  height:38px; padding:0 14px;
+  border-radius:var(--r); border:1px solid transparent;
+  font:600 14px/1 inherit; font-family:inherit; cursor:pointer;
+  transition:background .12s ease, border-color .12s ease, filter .12s ease;
+}
+.sl-btn--primary   { background:var(--primary); border-color:var(--primary); color:var(--primary-fg); }
+.sl-btn--primary:hover   { background:var(--primary-hover); border-color:var(--primary-hover); }
+.sl-btn--secondary { background:var(--surface-2); border-color:var(--border-strong); color:var(--text); }
+.sl-btn--secondary:hover { background:var(--surface-3); }
+.sl-btn--ghost     { background:transparent; color:var(--text-muted); }
+.sl-btn--ghost:hover     { background:var(--surface-2); color:var(--text); }
+.sl-btn--danger    { background:var(--danger-strong); border-color:var(--danger-strong); color:#fff; }
+.sl-btn--danger:hover    { filter:brightness(1.08); }
+.sl-btn--sm { height:32px; padding:0 11px; font-size:13px; }
+.sl-btn--lg { height:44px; padding:0 18px; font-size:15px; }
+.sl-btn:focus-visible { outline:none; box-shadow:0 0 0 3px var(--ring); }
+.sl-btn:disabled { background:var(--surface-2); border-color:var(--surface-2); color:var(--text-subtle); cursor:not-allowed; filter:none; }
+
+.sl-iconbtn {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:34px; height:34px; border-radius:var(--r);
+  border:1px solid var(--border); background:transparent; color:var(--text-muted);
+  cursor:pointer; transition:background .12s ease;
+}
+.sl-iconbtn:hover { background:var(--surface-2); color:var(--text); }
+
+/* ============================================================
+   Badge
+   ============================================================ */
+.sl-badge {
+  display:inline-flex; align-items:center; gap:5px;
+  height:24px; padding:0 10px; border-radius:999px;
+  font:600 12px/1 inherit; white-space:nowrap;
+}
+.sl-badge--outline { border:1px solid var(--border-strong); color:var(--text-muted); }
+.sl-badge--neutral { background:var(--surface-2); color:var(--text-muted); }
+.sl-badge--solid   { background:var(--surface-3); color:var(--text); }
+.sl-badge--success { background:var(--accent-soft); color:var(--accent); }
+.sl-badge--danger  { border:1px solid var(--danger); color:var(--danger); }
+.sl-badge__dot { width:7px; height:7px; border-radius:999px; background:var(--accent); }
+
+/* ============================================================
+   Inputs
+   ============================================================ */
+.sl-input {
+  width:100%; height:38px; padding:0 12px;
+  border-radius:var(--r); border:1px solid var(--border);
+  background:var(--surface); color:var(--text);
+  font:500 14px/1 inherit; font-family:inherit; outline:none;
+  transition:border-color .12s ease, box-shadow .12s ease;
+}
+.sl-input::placeholder { color:var(--text-subtle); }
+.sl-input:focus { border-color:var(--text); box-shadow:0 0 0 3px var(--ring); }
+.sl-input:disabled { background:var(--surface-2); color:var(--text-subtle); cursor:not-allowed; }
+.sl-input--sm { height:32px; }
+.sl-input--lg { height:48px; font-size:15px; }
+
+.sl-select-wrap { position:relative; display:inline-block; width:100%; }
+.sl-select {
+  width:100%; height:38px; padding:0 36px 0 12px;
+  border-radius:var(--r); border:1px solid var(--border);
+  background:var(--surface); color:var(--text);
+  font:500 14px/1 inherit; font-family:inherit; outline:none;
+  appearance:none; -webkit-appearance:none; cursor:pointer;
+}
+.sl-select:focus { border-color:var(--text); box-shadow:0 0 0 3px var(--ring); }
+.sl-select-wrap__chevron {
+  position:absolute; right:12px; top:50%; transform:translateY(-50%);
+  color:var(--text-subtle); pointer-events:none;
+}
+
+.sl-search {
+  display:flex; align-items:center; gap:9px;
+  height:38px; padding:0 12px; border-radius:var(--r);
+  border:1px solid var(--border); background:var(--surface-2); color:var(--text-subtle);
+  font:500 14px/1 inherit;
+}
+.sl-search input { flex:1; border:none; background:none; outline:none; color:var(--text); font:inherit; }
+.sl-kbd {
+  font:500 11px/1 'JetBrains Mono', monospace;
+  border:1px solid var(--border); border-radius:6px; padding:3px 6px; color:var(--text-subtle);
+}
+
+/* ---- Switch ---- */
+.sl-switch {
+  position:relative; width:42px; height:25px; padding:0;
+  border-radius:999px; background:var(--surface-3); border:1px solid var(--border-strong);
+  cursor:pointer; transition:background .15s ease, border-color .15s ease; flex:none;
+}
+.sl-switch.is-on { background:var(--accent); border-color:var(--accent); }
+.sl-switch__knob {
+  position:absolute; top:2px; left:2px; width:19px; height:19px;
+  border-radius:999px; background:var(--text-subtle);
+  transition:transform .15s ease, background .15s ease;
+}
+.sl-switch.is-on .sl-switch__knob { transform:translateX(17px); background:#fff; }
+
+/* ---- Checkbox / Radio ---- */
+.sl-control { display:inline-flex; align-items:center; gap:10px; font:500 14px/1 inherit; color:var(--text); cursor:pointer; }
+.sl-control--muted { color:var(--text-muted); }
+.sl-check {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:18px; height:18px; border-radius:5px;
+  border:1px solid var(--border-strong); background:var(--surface);
+  color:transparent; flex:none; transition:background .12s ease, border-color .12s ease;
+}
+.sl-check.is-on { background:var(--primary); border-color:var(--primary); color:var(--primary-fg); }
+.sl-radio { width:18px; height:18px; border-radius:999px; border:1px solid var(--border-strong); background:var(--surface); flex:none; }
+.sl-radio.is-on { border:5px solid var(--accent); box-shadow:inset 0 0 0 1px var(--accent); }
+
+/* ============================================================
+   Surfaces
+   ============================================================ */
+.sl-card { border:1px solid var(--border); background:var(--surface); border-radius:var(--r-lg); padding:18px; }
+
+.sl-stat__value { font:700 30px/1 inherit; color:var(--text); letter-spacing:-.5px; }
+.sl-stat__label { font:600 11px/1 inherit; letter-spacing:.5px; text-transform:uppercase; color:var(--text-muted); }
+
+/* ---- Nav ---- */
+.sl-nav {
+  display:flex; align-items:center; gap:10px; width:100%;
+  height:38px; padding:0 12px; border-radius:var(--r);
+  font:600 14px/1 inherit; font-family:inherit; color:var(--text-muted);
+  background:none; border:none; text-align:left; cursor:pointer;
+  transition:background .12s ease, color .12s ease;
+}
+.sl-nav:hover { background:var(--surface-2); color:var(--text); }
+.sl-nav.is-active { background:var(--primary); color:var(--primary-fg); }
+
+/* ---- Tabs ---- */
+.sl-tabs { display:flex; gap:18px; border-bottom:1px solid var(--border); }
+.sl-tab {
+  padding:0 2px 11px; margin-bottom:-1px;
+  font:600 14px/1 inherit; font-family:inherit; color:var(--text-muted);
+  background:none; border:none; border-bottom:2px solid transparent; cursor:pointer;
+  transition:color .12s ease;
+}
+.sl-tab:hover { color:var(--text); }
+.sl-tab.is-active { color:var(--text); border-bottom-color:var(--text); }
+
+/* ---- Segmented ---- */
+.sl-segmented { display:inline-flex; gap:3px; padding:3px; border-radius:var(--r); background:var(--surface-2); border:1px solid var(--border); }
+.sl-segmented__item { padding:6px 13px; border-radius:7px; font:600 13px/1 inherit; font-family:inherit; color:var(--text-muted); background:none; border:none; cursor:pointer; }
+.sl-segmented__item:hover { color:var(--text); }
+.sl-segmented__item.is-active { background:var(--surface); border:1px solid var(--border); color:var(--text); }
+
+/* ---- Banner ---- */
+.sl-banner { display:flex; align-items:flex-start; gap:10px; padding:12px 14px; border-radius:var(--r); font:500 14px/1.4 inherit; }
+.sl-banner--success { background:var(--accent-soft); color:var(--text); }
+.sl-banner--success .sl-banner__icon { color:var(--accent); }
+.sl-banner--danger { border:1px solid var(--danger); color:var(--text); }
+.sl-banner--danger .sl-banner__icon { color:var(--danger); }
+.sl-banner__icon { flex:none; margin-top:1px; }
+
+/* ---- Avatar ---- */
+.sl-avatar {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:32px; height:32px; border-radius:999px;
+  background:var(--accent-soft); color:var(--accent);
+  font:700 13px/1 inherit; flex:none; overflow:hidden;
+}
+.sl-avatar img { width:100%; height:100%; object-fit:cover; }
+
+/* ---- Menu ---- */
+.sl-menu { width:206px; border-radius:var(--r-lg); border:1px solid var(--border); background:var(--surface); box-shadow:var(--shadow); padding:5px; }
+.sl-menu__item { display:flex; align-items:center; gap:9px; width:100%; padding:8px 10px; border-radius:8px; font:500 13px/1 inherit; font-family:inherit; color:var(--text); background:none; border:none; text-align:left; cursor:pointer; }
+.sl-menu__item:hover { background:var(--surface-2); }
+.sl-menu__item--danger { color:var(--danger); }
+.sl-menu__sep { height:1px; background:var(--border); margin:5px 0; }
+
+/* ---- Table ---- */
+.sl-table { width:100%; border-collapse:collapse; border:1px solid var(--border); border-radius:var(--r); overflow:hidden; }
+.sl-table th { text-align:left; font:600 11px/1 'JetBrains Mono', monospace; text-transform:uppercase; letter-spacing:.3px; color:var(--text-muted); padding:11px 14px; background:var(--surface-2); }
+.sl-table td { font:500 14px/1 inherit; color:var(--text); padding:12px 14px; border-top:1px solid var(--border); }
+
+/* ---- Dialog ---- */
+.sl-dialog { border-radius:var(--r-lg); border:1px solid var(--border); background:var(--surface); box-shadow:var(--shadow); padding:20px; max-width:420px; }
+.sl-dialog__title { font:700 18px/1.2 inherit; color:var(--text); margin:0 0 8px; }
+.sl-dialog__body { font:400 14px/20px inherit; color:var(--text-muted); margin:0 0 18px; }
+
+/* ---- Dropzone ---- */
+.sl-dropzone { display:flex; flex-direction:column; align-items:center; gap:9px; padding:24px; text-align:center; border:1.5px dashed var(--border-strong); border-radius:var(--r-lg); color:var(--text-subtle); }

--- a/packages/design-system/tokens/fonts.css
+++ b/packages/design-system/tokens/fonts.css
@@ -1,0 +1,3 @@
+/* Webfonts. Hanken Grotesk (UI + prose) and JetBrains Mono (data + keys).
+   Hosted via Google Fonts; the @font-face rules live in the imported sheet. */
+@import url('https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');

--- a/packages/design-system/tokens/spacing.css
+++ b/packages/design-system/tokens/spacing.css
@@ -1,0 +1,20 @@
+/* ============================================================
+   SPACING + SHAPE TOKENS
+   4px base grid. Radius is its own axis ([data-round]).
+   ============================================================ */
+:root {
+  --space-1:4px;
+  --space-2:8px;
+  --space-3:12px;
+  --space-4:16px;
+  --space-5:20px;
+  --space-6:24px;
+  --space-8:32px;
+  --space-10:40px;
+
+  /* radius — control vs card */
+  --r:10px;
+  --r-lg:14px;
+}
+[data-round='sharp'] { --r:6px;  --r-lg:9px;  }
+[data-round='soft']  { --r:14px; --r-lg:20px; }

--- a/packages/design-system/tokens/typography.css
+++ b/packages/design-system/tokens/typography.css
@@ -1,0 +1,25 @@
+/* ============================================================
+   TYPOGRAPHY TOKENS
+   Hanken Grotesk for UI + prose, JetBrains Mono for data + keys.
+   ============================================================ */
+:root {
+  --font-sans:'Hanken Grotesk', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono:'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+
+  /* weights */
+  --weight-regular:400;
+  --weight-medium:500;
+  --weight-semibold:600;
+  --weight-bold:700;
+  --weight-extrabold:800;
+
+  /* type ramp — size / line-height pairs used across the system */
+  --text-display:700 32px/38px var(--font-sans);   /* page hero */
+  --text-stat:700 30px/32px var(--font-sans);       /* big numbers */
+  --text-title:700 22px/28px var(--font-sans);      /* card titles */
+  --text-heading:600 18px/24px var(--font-sans);    /* section heads */
+  --text-body:400 15px/23px var(--font-sans);       /* prose */
+  --text-label:500 14px/20px var(--font-sans);      /* controls */
+  --text-caption:500 12px/16px var(--font-sans);    /* meta */
+  --text-mono:500 13px/18px var(--font-mono);       /* data, keys, paths */
+}

--- a/packages/design-system/ui_kits/dashboard/DiscoverScreen.jsx
+++ b/packages/design-system/ui_kits/dashboard/DiscoverScreen.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { NavItem } from '../../components/navigation/NavItem.jsx';
+import { Breadcrumb } from '../../components/navigation/Breadcrumb.jsx';
+import { PageHeader } from '../../components/navigation/PageHeader.jsx';
+import { Search } from '../../components/forms/Search.jsx';
+import { Button } from '../../components/forms/Button.jsx';
+import { IconButton } from '../../components/forms/IconButton.jsx';
+import { Badge } from '../../components/data/Badge.jsx';
+import { Card } from '../../components/data/Card.jsx';
+import { Avatar } from '../../components/data/Avatar.jsx';
+import { Icon } from '../../components/icon/Icon.jsx';
+
+/**
+ * The Discover view, composed entirely from design-system components.
+ * Render inside an element carrying `class="sl-root" data-theme=…` so the
+ * CSS variables resolve. See index.html for a standalone interactive version.
+ */
+export function DiscoverScreen() {
+  const [open, setOpen] = useState('Class 4A');
+
+  return (
+    <div style={{ display: 'flex', height: '100%', minHeight: 560, border: '1px solid var(--border)', borderRadius: 16, overflow: 'hidden', background: 'var(--bg)' }}>
+      {/* Sidebar */}
+      <aside style={{ width: 198, flex: 'none', borderRight: '1px solid var(--border)', padding: '18px 12px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '4px 8px 16px' }}>
+          <span style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--primary)', color: 'var(--primary-fg)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Icon name="trophy" size={13} strokeWidth={2.4} />
+          </span>
+          <span style={{ font: '700 15px/1 var(--font-sans)', letterSpacing: '-0.2px' }}>Sports League</span>
+        </div>
+        <NavItem icon="grid">Overview</NavItem>
+        <NavItem icon="compass" active>Discover</NavItem>
+        <NavItem icon="users">Teams</NavItem>
+        <NavItem icon="target">Players</NavItem>
+        <NavItem icon="calendar">Seasons</NavItem>
+        <NavItem icon="layers">Divisions</NavItem>
+        <NavItem icon="upload">Import</NavItem>
+        <NavItem icon="card">Billing</NavItem>
+      </aside>
+
+      {/* Main */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        {/* Topbar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, height: 54, flex: 'none', padding: '0 20px', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, height: 36, padding: '0 12px', borderRadius: 9, border: '1px solid var(--border)', background: 'var(--surface)', font: '600 13px/1 var(--font-sans)' }}>
+            <Icon name="trophy" size={14} />Cobb County Football<Icon name="chevron-vertical" size={14} strokeWidth={2} />
+          </div>
+          <div style={{ flex: 1, maxWidth: 340 }}><Search /></div>
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 10 }}>
+            <IconButton icon="sun" aria-label="Toggle theme" />
+            <Avatar initials="AS" />
+          </div>
+        </div>
+
+        {/* Content */}
+        <div style={{ flex: 1, overflow: 'auto', padding: '22px 24px' }}>
+          <div style={{ marginBottom: 12 }}>
+            <Breadcrumb items={['Dashboard', 'Discover']} />
+          </div>
+          <PageHeader
+            title="Discover Leagues"
+            description="Browse leagues and add teams to your dashboard. Each team you add becomes your own private copy to manage."
+          />
+
+          <Card style={{ margin: '22px 0 16px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+              <Icon name="trophy" size={18} />
+              <span style={{ font: '700 18px/1 var(--font-sans)' }}>Cobb County Football</span>
+              <Badge variant="outline">Public</Badge>
+            </div>
+
+            <DivisionRow name="Class 4A" count={2} allAdded open={open === 'Class 4A'} onToggle={() => setOpen(open === 'Class 4A' ? null : 'Class 4A')} />
+            {open === 'Class 4A' && (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, margin: '6px 0' }}>
+                <TeamChip name="Allatoona" />
+                <TeamChip name="Kell" />
+              </div>
+            )}
+            <DivisionRow name="Class 5A" count={3} allAdded bordered open={false} onToggle={() => {}} />
+            <DivisionRow name="Class 6A" count={11} allAdded bordered open={false} onToggle={() => {}} />
+          </Card>
+
+          <Card>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <Icon name="trophy" size={18} />
+                <span style={{ font: '700 18px/1 var(--font-sans)' }}>NFL</span>
+                <Badge variant="outline">Public</Badge>
+              </div>
+              <Button size="sm">Add all (32)</Button>
+            </div>
+            <DivisionRow name="AFC East" count={4} bordered open={false} onToggle={() => {}} />
+            <DivisionRow name="AFC North" count={4} bordered open={false} onToggle={() => {}} />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DivisionRow({ name, count, allAdded, bordered, open, onToggle }) {
+  return (
+    <button
+      onClick={onToggle}
+      style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%',
+        padding: '12px 0', background: 'none', border: 'none', cursor: 'pointer',
+        borderTop: bordered ? '1px solid var(--border)' : 'none', color: 'var(--text)', font: 'inherit',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <span style={{ font: '700 15px/1 var(--font-sans)' }}>{name}</span>
+        <span style={{ font: '500 13px/1 var(--font-sans)', color: 'var(--text-subtle)' }}>({count})</span>
+        {allAdded && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--accent)', font: '600 12px/1 var(--font-sans)' }}>
+            <Icon name="check-circle" size={13} strokeWidth={2.4} />All added
+          </span>
+        )}
+      </span>
+      <Icon name={open ? 'chevron-up' : 'chevron-down'} size={16} strokeWidth={2} style={{ color: 'var(--text-muted)' }} />
+    </button>
+  );
+}
+
+function TeamChip({ name }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 14px', borderRadius: 'var(--r)', border: '1px solid var(--border)', background: 'var(--bg)' }}>
+      <span style={{ font: '600 14px/1 var(--font-sans)' }}>{name}</span>
+      <span style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--accent)', font: '600 12px/1 var(--font-sans)' }}>
+          <Icon name="check-circle" size={13} strokeWidth={2.4} />Added
+        </span>
+        <span style={{ color: 'var(--text-subtle)', display: 'inline-flex', cursor: 'pointer' }}><Icon name="x" size={13} strokeWidth={2} /></span>
+      </span>
+    </div>
+  );
+}

--- a/packages/design-system/ui_kits/dashboard/README.md
+++ b/packages/design-system/ui_kits/dashboard/README.md
@@ -1,0 +1,29 @@
+# Dashboard UI kit
+
+High-fidelity recreation of the Sports League **Discover** view — the league
+discovery surface where an operator browses public leagues and adds teams to
+their dashboard.
+
+## Files
+
+- `index.html` — self-contained, interactive recreation (React + Babel via CDN,
+  linking the real `styles.css`). Click divisions to expand, add/remove teams,
+  switch nav, toggle light/dark. This is the canvas thumbnail and the
+  click-through starting point.
+- `DiscoverScreen.jsx` — the same screen composed from the published
+  design-system components (`Button`, `Badge`, `Card`, `NavItem`, `Search`,
+  `Avatar`, `Breadcrumb`, `PageHeader`, `Icon`). Use this as the reference for
+  composition in a real React app.
+
+## Surfaces covered
+
+- **App shell** — fixed sidebar (logo + 8 nav items, one active), top bar
+  (league switcher, ⌘K search, theme toggle, avatar).
+- **Discover content** — breadcrumb, page header, league cards with division
+  accordions and add/added team chips.
+
+## Notes
+
+This is a visual + interaction recreation, not production code — state is local
+and data is mocked. It composes the system's component primitives rather than
+re-implementing them.

--- a/packages/design-system/ui_kits/dashboard/index.html
+++ b/packages/design-system/ui_kits/dashboard/index.html
@@ -1,0 +1,156 @@
+<!-- @dsCard group="Dashboard" viewport="1280x720" name="Discover" subtitle="League discovery — sidebar, league cards, division accordions" -->
+<!-- @startingPoint section="Dashboard" subtitle="Full app shell: sidebar, topbar, league discovery" viewport="1280x720" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sports League — Discover</title>
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  html,body{margin:0;height:100%}
+  .app{height:100%;display:flex;background:var(--bg)}
+  .side{width:212px;flex:none;border-right:1px solid var(--border);padding:18px 12px;display:flex;flex-direction:column;gap:4px}
+  .brand{display:flex;align-items:center;gap:9px;padding:4px 8px 16px}
+  .brand .tile{width:24px;height:24px;border-radius:7px;background:var(--primary);color:var(--primary-fg);display:flex;align-items:center;justify-content:center}
+  .brand .name{font:700 15px/1 var(--font-sans);letter-spacing:-.2px;color:var(--text)}
+  .main{flex:1;min-width:0;display:flex;flex-direction:column}
+  .top{display:flex;align-items:center;gap:12px;height:56px;flex:none;padding:0 22px;border-bottom:1px solid var(--border)}
+  .switcher{display:flex;align-items:center;gap:8px;height:36px;padding:0 12px;border-radius:9px;border:1px solid var(--border);background:var(--surface);font:600 13px/1 var(--font-sans);color:var(--text)}
+  .content{flex:1;overflow:auto;padding:22px 26px}
+  .crumb{display:flex;align-items:center;gap:8px;font:500 13px/1 var(--font-sans);color:var(--text-muted);margin-bottom:12px}
+  .h1{margin:0;font:700 25px/1 var(--font-sans);letter-spacing:-.7px;color:var(--text)}
+  .lead{margin:8px 0 22px;font:400 14px/1.5 var(--font-sans);color:var(--text-muted);max-width:620px}
+  .lhead{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
+  .ltitle{display:flex;align-items:center;gap:10px;color:var(--text)}
+  .ltitle .nm{font:700 18px/1 var(--font-sans)}
+  .div{border-top:1px solid var(--border)}
+  .div:first-of-type{border-top:none}
+  .drow{display:flex;align-items:center;justify-content:space-between;width:100%;padding:12px 0;background:none;border:none;cursor:pointer;color:var(--text);font:inherit}
+  .dleft{display:flex;align-items:center;gap:9px}
+  .dname{font:700 15px/1 var(--font-sans)}
+  .dcount{font:500 13px/1 var(--font-sans);color:var(--text-subtle)}
+  .added-lbl{display:inline-flex;align-items:center;gap:5px;color:var(--accent);font:600 12px/1 var(--font-sans)}
+  .teams{display:none;grid-template-columns:1fr 1fr;gap:12px;margin:2px 0 12px}
+  .div.open .teams{display:grid}
+  .div.open .chev{transform:rotate(180deg)}
+  .chev{transition:transform .15s ease;color:var(--text-muted);display:inline-flex}
+  .chip{display:flex;align-items:center;justify-content:space-between;padding:11px 14px;border-radius:var(--r);border:1px solid var(--border);background:var(--bg)}
+  .chip .tn{font:600 14px/1 var(--font-sans);color:var(--text)}
+  svg{display:block}
+</style>
+</head>
+<body>
+<div class="app sl-root" id="app" data-theme="dark" data-accent="green" data-round="default">
+  <aside class="side" id="nav"></aside>
+  <div class="main">
+    <div class="top">
+      <div class="switcher">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9a6 6 0 0 0 12 0V4H6Z"/><path d="M9 20h6M12 14v6"/></svg>
+        Cobb County Football
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 9 4-4 4 4M8 15l4 4 4-4"/></svg>
+      </div>
+      <label class="sl-search" style="flex:1;max-width:360px">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-3.6-3.6"/></svg>
+        <input placeholder="Search…"><span class="sl-kbd">⌘K</span>
+      </label>
+      <div style="margin-left:auto;display:flex;align-items:center;gap:10px">
+        <button class="sl-iconbtn" id="themeBtn" aria-label="Toggle theme"></button>
+        <span class="sl-avatar">AS</span>
+      </div>
+    </div>
+    <div class="content">
+      <nav class="crumb"><span>Dashboard</span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg><span style="color:var(--text)">Discover</span></nav>
+      <h1 class="h1">Discover Leagues</h1>
+      <p class="lead">Browse leagues and add teams to your dashboard. Each team you add becomes your own private copy to manage.</p>
+      <div id="leagues"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  var ICON = {
+    trophy:'<path d="M6 9a6 6 0 0 0 12 0V4H6Z"/><path d="M9 20h6M12 14v6"/>',
+    grid:'<rect x="3" y="3" width="7" height="7" rx="1.2"/><rect x="14" y="3" width="7" height="7" rx="1.2"/><rect x="3" y="14" width="7" height="7" rx="1.2"/><rect x="14" y="14" width="7" height="7" rx="1.2"/>',
+    compass:'<circle cx="12" cy="12" r="9"/><path d="m15 9-2 5-4 1 2-5z"/>',
+    users:'<circle cx="9" cy="8" r="3.2"/><path d="M3.5 20a5.5 5.5 0 0 1 11 0"/><path d="M16 6.2a3 3 0 0 1 0 5.6"/><path d="M20.5 20a5 5 0 0 0-4-4.9"/>',
+    target:'<circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2.4"/>',
+    calendar:'<rect x="3" y="4.5" width="18" height="16" rx="2"/><path d="M3 9h18M8 2.5v4M16 2.5v4"/>',
+    layers:'<path d="m12 3 9 5-9 5-9-5Z"/><path d="m3 13 9 5 9-5"/>',
+    upload:'<path d="M12 15V3M8 7l4-4 4 4"/><path d="M4 17v2a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-2"/>',
+    card:'<rect x="2.5" y="5" width="19" height="14" rx="2.5"/><path d="M2.5 10h19"/>',
+    plus:'<path d="M12 5v14M5 12h14"/>',
+    x:'<path d="M18 6 6 18M6 6l12 12"/>',
+    checkc:'<circle cx="12" cy="12" r="9"/><path d="m9 12 2 2 4-4"/>',
+    chevd:'<path d="m6 9 6 6 6-6"/>',
+    sun:'<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.4 1.4M17.6 17.6 19 19M19 5l-1.4 1.4M6.4 17.6 5 19"/>',
+    moon:'<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/>'
+  };
+  function svg(name, size, sw){
+    return '<svg width="'+(size||16)+'" height="'+(size||16)+'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="'+(sw||1.9)+'" stroke-linecap="round" stroke-linejoin="round">'+ICON[name]+'</svg>';
+  }
+
+  var NAV = [['grid','Overview'],['compass','Discover',1],['users','Teams'],['target','Players'],['calendar','Seasons'],['layers','Divisions'],['upload','Import'],['card','Billing']];
+  var nav = document.getElementById('nav');
+  nav.innerHTML = '<div class="brand"><span class="tile">'+svg('trophy',14,2.4)+'</span><span class="name">Sports League</span></div>' +
+    NAV.map(function(n){ return '<button class="sl-nav'+(n[2]?' is-active':'')+'">'+svg(n[0],18)+n[1]+'</button>'; }).join('');
+
+  var LEAGUES = [
+    { name:'Cobb County Football', addAll:false, divisions:[
+      { name:'Class 4A', teams:['Allatoona','Kell'], all:true, open:true },
+      { name:'Class 5A', teams:['Harrison','Hillgrove','Kennesaw Mtn'], all:true },
+      { name:'Class 6A', teams:['Marietta','Walton','Lassiter','Pope'], all:false }
+    ]},
+    { name:'NFL', addAll:true, divisions:[
+      { name:'AFC East', teams:['Bills','Dolphins','Patriots','Jets'], all:false },
+      { name:'AFC North', teams:['Ravens','Bengals','Browns','Steelers'], all:false }
+    ]}
+  ];
+
+  function teamChip(t, added){
+    return '<div class="chip"><span class="tn">'+t+'</span>'+
+      (added
+        ? '<span style="display:flex;align-items:center;gap:8px"><span class="added-lbl">'+svg('checkc',13,2.4)+'Added</span><button class="sl-iconbtn js-rm" style="width:26px;height:26px">'+svg('x',13,2)+'</button></span>'
+        : '<button class="sl-btn sl-btn--secondary sl-btn--sm js-add">'+svg('plus',13,2.2)+'Add</button>')+
+      '</div>';
+  }
+  function division(d){
+    return '<div class="div'+(d.open?' open':'')+'">'+
+      '<button class="drow js-toggle"><span class="dleft"><span class="dname">'+d.name+'</span>'+
+        '<span class="dcount">('+d.teams.length+')</span>'+
+        (d.all?'<span class="added-lbl">'+svg('checkc',13,2.4)+'All added</span>':'')+
+      '</span><span class="chev">'+svg('chevd',16,2)+'</span></button>'+
+      '<div class="teams">'+d.teams.map(function(t){return teamChip(t, d.all);}).join('')+'</div>'+
+    '</div>';
+  }
+  function league(l){
+    return '<div class="sl-card" style="margin-bottom:16px">'+
+      '<div class="lhead"><div class="ltitle">'+svg('trophy',18)+'<span class="nm">'+l.name+'</span>'+
+        '<span class="sl-badge sl-badge--outline">Public</span></div>'+
+        (l.addAll?'<button class="sl-btn sl-btn--secondary sl-btn--sm">Add all (32)</button>':'')+
+      '</div>'+ l.divisions.map(division).join('') +'</div>';
+  }
+  document.getElementById('leagues').innerHTML = LEAGUES.map(league).join('');
+
+  // interactions
+  document.getElementById('leagues').addEventListener('click', function(e){
+    var tog = e.target.closest('.js-toggle');
+    if(tog){ tog.parentNode.classList.toggle('open'); return; }
+    var add = e.target.closest('.js-add');
+    if(add){ add.closest('.chip').outerHTML = teamChip(add.closest('.chip').querySelector('.tn').textContent, true); return; }
+    var rm = e.target.closest('.js-rm');
+    if(rm){ rm.closest('.chip').outerHTML = teamChip(rm.closest('.chip').querySelector('.tn').textContent, false); return; }
+  });
+
+  var app = document.getElementById('app');
+  var tb = document.getElementById('themeBtn');
+  function paintTheme(){ tb.innerHTML = svg(app.getAttribute('data-theme')==='dark'?'sun':'moon',17); }
+  tb.addEventListener('click', function(){
+    app.setAttribute('data-theme', app.getAttribute('data-theme')==='dark'?'light':'dark'); paintTheme();
+  });
+  paintTheme();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds the token-driven, dual-theme **Sports League design system** as a self-contained workspace package at `packages/design-system` (79 files). It ships:

- **Tokens** — CSS-variable foundations (colors, typography, spacing, fonts) with a single `styles.css` entry
- **React component library** — 19 components across icon / forms / data / navigation / feedback
- **Guidelines** — foundation specimen cards (colors, type, spacing, radius/elevation, brand)
- **UI kit** — the interactive Dashboard "Discover" screen
- **SKILL.md** — Agent-Skill manifest

Picked up automatically by the pnpm workspace (`packages/*`). Two minor adjustments for monorepo fit: renamed the package to `@sports-management/design-system` (all internal imports are relative, so nothing broke) and fixed the `files` entry `readme.md` → `README.md` so the README ships on publish.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Salesforce metadata change
- [ ] Documentation
- [ ] Infrastructure/CI

## Test Plan
- [ ] Unit tests pass
- [ ] E2E tests pass (if applicable)
- [ ] Apex tests pass (if SF metadata changed)
- [x] Manual verification — package is additive and self-contained; no existing files modified

## Salesforce Package Impact
- [x] No Salesforce changes
- [ ] Core package changes
- [ ] Football package changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCoi6agT4Zgc6JKhYwpMHZ)_