### PR TITLE
feat(web): consume @sports-management/design-system as a workspace dependency

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   transpilePackages: [
     "@sports-management/shared-types",
     "@sports-management/api-contracts",
+    "@sports-management/design-system",
   ],
   images: {
     remotePatterns: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@sports-management/api-contracts": "workspace:*",
+    "@sports-management/design-system": "workspace:*",
     "@sports-management/shared-types": "workspace:*",
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.1",

--- a/apps/web/src/app/dev/ds/page.tsx
+++ b/apps/web/src/app/dev/ds/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/*
+ * Live demo that the `@sports-management/design-system` workspace package is
+ * wired into the web app. It renders the package's own React components
+ * (the `.sl-*` library — distinct from the app's shadcn `ui/*` primitives on
+ * /dev/ui) inside a `.sl-root` wrapper.
+ *
+ * Styling: we import ONLY the namespaced component classes from the package
+ * plus a small token bridge (sl-bridge.css) — see that file for why we don't
+ * import the package's global styles.css. Theme follows the app (next-themes
+ * toggles `.dark` on <html>), so the toggle top-right drives these too.
+ */
+import {
+  Badge,
+  Banner,
+  Button,
+  Card,
+  IconButton,
+  Input,
+  Stat,
+} from "@sports-management/design-system";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+// The package ships namespaced `.sl-*` classes; safe to import app-wide.
+import "@sports-management/design-system/tokens/components.css";
+// Supplies the few tokens the app doesn't already define, scoped to .sl-root.
+import "./sl-bridge.css";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <h2 className="sl-mono" style={{ fontSize: 12, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--text-muted)" }}>
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export default function DesignSystemPackageDemoPage() {
+  return (
+    <div className="sl-root" data-accent="green" style={{ minHeight: "100vh", padding: "40px 24px" }}>
+      <div style={{ maxWidth: 880, margin: "0 auto", display: "grid", gap: 40 }}>
+        <header style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ fontSize: 30, fontWeight: 700, letterSpacing: "-0.7px" }}>
+              @sports-management/design-system
+            </h1>
+            <p style={{ color: "var(--text-muted)", fontSize: 15 }}>
+              The standalone design-system package, rendered live inside the web
+              app. Toggle the theme top-right →
+            </p>
+          </div>
+          <ThemeToggle />
+        </header>
+
+        <Section title="01 — Buttons">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "center" }}>
+            <Button variant="primary" icon="plus">New Season</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="danger" icon="trash">Delete</Button>
+            <IconButton icon="search" aria-label="Search" />
+          </div>
+        </Section>
+
+        <Section title="02 — Badges">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <Badge variant="neutral">Neutral</Badge>
+            <Badge variant="solid">Solid</Badge>
+            <Badge variant="outline">Outline</Badge>
+            <Badge variant="success" dot>Active</Badge>
+            <Badge variant="danger" icon="alert">Failed</Badge>
+          </div>
+        </Section>
+
+        <Section title="03 — Stats">
+          <Card style={{ display: "flex", gap: 32, padding: 20 }}>
+            <Stat value="413" label="Teams" />
+            <Stat value="2,929" label="Players" accent />
+            <Stat value="32" label="Divisions" />
+          </Card>
+        </Section>
+
+        <Section title="04 — Input">
+          <div style={{ maxWidth: 360 }}>
+            <Input placeholder="Allatoona Buccaneers" />
+          </div>
+        </Section>
+
+        <Section title="05 — Banner">
+          <div style={{ display: "grid", gap: 10 }}>
+            <Banner variant="success">Last sync complete · 2,929 players updated</Banner>
+            <Banner variant="danger">Build failed. Bundle exceeds 50 MB.</Banner>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/ds/sl-bridge.css
+++ b/apps/web/src/app/dev/ds/sl-bridge.css
@@ -1,0 +1,46 @@
+/*
+ * Bridge: let @sports-management/design-system components render inside this
+ * Next app WITHOUT importing the package's global token files.
+ *
+ * The package ships its own token layer (tokens/colors.css etc.) that targets
+ * `:root` / `[data-theme]`. The web app already owns `:root` (light) and
+ * `.dark` (dark) for the SAME token names via next-themes, so importing the
+ * package's global `styles.css` would clobber the app theme. Instead we import
+ * ONLY the namespaced component classes (`.sl-*`) and supply the handful of
+ * tokens those classes need that the app doesn't already define — scoped under
+ * `.sl-root` so nothing leaks to the rest of the app.
+ *
+ * Shared tokens reused as-is from the app: --bg, --surface, --surface-2/3,
+ * --border, --border-strong, --text, --text-muted, --text-subtle, --primary,
+ * --accent, --danger. Values below mirror the package's own palette, which
+ * already matches the app's.
+ */
+
+/* Theme-independent + light-theme defaults (app default theme). */
+.sl-root {
+  --primary-fg: #ffffff;
+  --primary-hover: #2a2a2e;
+  --accent-soft: rgba(24, 165, 88, 0.1);
+  --danger-strong: #e5484d;
+  --ring: rgba(12, 12, 13, 0.15);
+  --shadow: 0 12px 30px rgba(0, 0, 0, 0.13);
+  --r: 10px;
+  --r-lg: 14px;
+
+  /* Use the app's loaded webfonts rather than the bare family names. */
+  font-family: var(--font-hanken), ui-sans-serif, system-ui, sans-serif;
+}
+
+.sl-root .sl-mono {
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+}
+
+/* Dark theme — the app toggles `.dark` on <html> (next-themes). */
+.dark .sl-root {
+  --primary-fg: #0c0c0d;
+  --primary-hover: #e6e6e8;
+  --accent-soft: rgba(70, 201, 100, 0.16);
+  --danger-strong: #ff6166;
+  --ring: rgba(250, 250, 250, 0.2);
+  --shadow: 0 16px 40px rgba(0, 0, 0, 0.6);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@sports-management/api-contracts':
         specifier: workspace:*
         version: link:../../packages/api-contracts
+      '@sports-management/design-system':
+        specifier: workspace:*
+        version: link:../../packages/design-system
       '@sports-management/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -324,6 +327,15 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@22.19.15)(jsdom@16.7.0)(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+
+  packages/design-system:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.7
+      react-dom:
+        specifier: '>=18'
+        version: 19.2.7(react@19.2.7)
 
   packages/shared-types:
     devDependencies:
@@ -12514,7 +12526,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -12537,7 +12549,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@9.4.0)
@@ -12552,14 +12564,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12594,7 +12606,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
Wires the `@sports-management/design-system` package into `apps/web` as a workspace dependency so its React component library is consumable from the app.

- Adds `@sports-management/design-system: workspace:*` to `apps/web` dependencies
- Registers it in `next.config.ts` `transpilePackages` (the package ships raw `.tsx` source)
- Adds a `/dev/ds` demo page rendering the package's `.sl-*` components (Button, Badge, Stat, Input, Banner) under a `.sl-root` wrapper, alongside the existing `/dev/ui` shadcn showcase
- Adds a **scoped token bridge** (`sl-bridge.css`) so the package's namespaced component CSS reuses the app's existing semantic tokens

**Why the bridge:** the app already defines the same semantic token names (`--bg`, `--surface`, `--primary`, `--accent`…) via next-themes (`.dark` on `<html>`), while the package defines them at `:root`/`[data-theme]`. Importing the package's global `styles.css` would clobber the app's theming. Instead we import only the namespaced `.sl-*` component classes and supply the 8 tokens the app doesn't already define (`--primary-fg`, `--primary-hover`, `--accent-soft`, `--danger-strong`, `--ring`, `--shadow`, `--r`, `--r-lg`), scoped to `.sl-root`. The demo follows the app's theme toggle — nothing leaks to the rest of the app.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Salesforce metadata change
- [ ] Documentation
- [ ] Infrastructure/CI

## Test Plan
- [x] Unit tests pass — no unit tests touched; integration is additive
- [ ] E2E tests pass (if applicable)
- [ ] Apex tests pass (if SF metadata changed)
- [x] Manual verification — `pnpm install` links the workspace package; `tsc --noEmit` on `apps/web` is clean (remaining errors are pre-existing implicit-`any` in unrelated test files)

## Salesforce Package Impact
- [x] No Salesforce changes
- [ ] Core package changes
- [ ] Football package changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCoi6agT4Zgc6JKhYwpMHZ)_