### PR TITLE
feat(web): season stat-leaders board (WSM-000186)

### DIFF
--- a/apps/web/convex/__tests__/statLeaders.test.ts
+++ b/apps/web/convex/__tests__/statLeaders.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  categoryValues,
+  computeStatLeaders,
+  LEADER_CATEGORIES,
+  type LeaderInput,
+} from "../lib/statLeaders";
+
+describe("categoryValues", () => {
+  it("extracts per-category scalars from an aggregated stat line", () => {
+    const totals = {
+      passing: { yards: 2400, td: 22 },
+      rushing: { yards: 800, td: 9 },
+      receiving: { yards: 1100, rec: 64 },
+      defense: { tacklesSolo: 40, tacklesAst: 18, sacks: 7, int: 3 },
+    };
+    expect(categoryValues(totals)).toEqual({
+      passYards: 2400,
+      passTD: 22,
+      rushYards: 800,
+      rushTD: 9,
+      recYards: 1100,
+      receptions: 64,
+      tackles: 58, // solo + assisted
+      sacks: 7,
+      interceptions: 3,
+    });
+  });
+
+  it("treats missing groups/fields as zero", () => {
+    expect(categoryValues({})).toEqual({
+      passYards: 0,
+      passTD: 0,
+      rushYards: 0,
+      rushTD: 0,
+      recYards: 0,
+      receptions: 0,
+      tackles: 0,
+      sacks: 0,
+      interceptions: 0,
+    });
+  });
+});
+
+describe("computeStatLeaders", () => {
+  const players: LeaderInput[] = [
+    {
+      playerId: "p1",
+      playerName: "Alpha QB",
+      teamName: "Hawks",
+      jerseyNumber: 7,
+      values: { passYards: 3000, rushYards: 0 },
+    },
+    {
+      playerId: "p2",
+      playerName: "Bravo QB",
+      teamName: "Eagles",
+      jerseyNumber: 12,
+      values: { passYards: 3000, rushYards: 500 },
+    },
+    {
+      playerId: "p3",
+      playerName: "Charlie RB",
+      teamName: "Hawks",
+      jerseyNumber: 22,
+      values: { passYards: 0, rushYards: 1500 },
+    },
+  ];
+
+  it("returns every category, ranked desc with name tiebreak, zeros excluded", () => {
+    const board = computeStatLeaders(players, 5);
+    expect(board).toHaveLength(LEADER_CATEGORIES.length);
+
+    const passing = board.find((c) => c.key === "passYards")!;
+    // Both QBs at 3000 — tiebreak by name (Alpha before Bravo). RB excluded (0).
+    expect(passing.leaders.map((l) => l.playerId)).toEqual(["p1", "p2"]);
+
+    const rushing = board.find((c) => c.key === "rushYards")!;
+    expect(rushing.leaders.map((l) => l.playerId)).toEqual(["p3", "p2"]);
+    expect(rushing.leaders[0].value).toBe(1500);
+
+    // A category with no data is present but empty.
+    const sacks = board.find((c) => c.key === "sacks")!;
+    expect(sacks.leaders).toEqual([]);
+  });
+
+  it("caps each category at topN", () => {
+    const many: LeaderInput[] = Array.from({ length: 10 }, (_, i) => ({
+      playerId: `p${i}`,
+      playerName: `Player ${i}`,
+      teamName: "T",
+      jerseyNumber: i,
+      values: { sacks: 10 - i },
+    }));
+    const board = computeStatLeaders(many, 3);
+    expect(board.find((c) => c.key === "sacks")!.leaders).toHaveLength(3);
+  });
+});

--- a/apps/web/convex/lib/statLeaders.ts
+++ b/apps/web/convex/lib/statLeaders.ts
@@ -1,0 +1,99 @@
+/*
+ * Season stat-leaders (WSM-000186) — pure ranking over aggregated box-score
+ * totals. `getSeasonStatLeaders` in sports.ts gathers each player's season
+ * totals (via aggregateStatLines), flattens them to the per-category scalars
+ * below, and calls computeStatLeaders. Kept dependency-light (operates on the
+ * parsed JSON shape, no cross-package import) so it stays in the Convex bundle
+ * and is trivially unit-testable.
+ */
+
+type StatGroup = Record<string, number>;
+type StatLine = Record<string, StatGroup>;
+
+export interface LeaderCategory {
+  key: string;
+  label: string;
+}
+
+/** The leaderboard categories a HS football coach/fan expects, in display order. */
+export const LEADER_CATEGORIES: readonly LeaderCategory[] = [
+  { key: "passYards", label: "Passing yards" },
+  { key: "passTD", label: "Passing TDs" },
+  { key: "rushYards", label: "Rushing yards" },
+  { key: "rushTD", label: "Rushing TDs" },
+  { key: "recYards", label: "Receiving yards" },
+  { key: "receptions", label: "Receptions" },
+  { key: "tackles", label: "Tackles" },
+  { key: "sacks", label: "Sacks" },
+  { key: "interceptions", label: "Interceptions" },
+];
+
+function num(group: StatGroup | undefined, field: string): number {
+  const v = group?.[field];
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/** Flatten an aggregated season stat line to the leaderboard scalar per category. */
+export function categoryValues(totals: StatLine): Record<string, number> {
+  return {
+    passYards: num(totals.passing, "yards"),
+    passTD: num(totals.passing, "td"),
+    rushYards: num(totals.rushing, "yards"),
+    rushTD: num(totals.rushing, "td"),
+    recYards: num(totals.receiving, "yards"),
+    receptions: num(totals.receiving, "rec"),
+    // Total tackles = solo + assisted.
+    tackles: num(totals.defense, "tacklesSolo") + num(totals.defense, "tacklesAst"),
+    sacks: num(totals.defense, "sacks"),
+    interceptions: num(totals.defense, "int"),
+  };
+}
+
+export interface LeaderInput {
+  playerId: string;
+  playerName: string;
+  teamName: string;
+  jerseyNumber: number | null;
+  values: Record<string, number>;
+}
+
+export interface LeaderEntry {
+  playerId: string;
+  playerName: string;
+  teamName: string;
+  jerseyNumber: number | null;
+  value: number;
+}
+
+export interface CategoryLeaders {
+  key: string;
+  label: string;
+  leaders: LeaderEntry[];
+}
+
+/**
+ * Rank players within each category: descending by value, ties broken by name
+ * (stable + deterministic), zero values excluded, top `topN` kept. Every
+ * category is returned (even if empty) so the board renders a consistent grid.
+ */
+export function computeStatLeaders(
+  players: readonly LeaderInput[],
+  topN = 5,
+): CategoryLeaders[] {
+  return LEADER_CATEGORIES.map((cat) => {
+    const leaders = players
+      .map((p) => ({
+        playerId: p.playerId,
+        playerName: p.playerName,
+        teamName: p.teamName,
+        jerseyNumber: p.jerseyNumber,
+        value: p.values[cat.key] ?? 0,
+      }))
+      .filter((e) => e.value > 0)
+      .sort(
+        (a, b) => b.value - a.value || a.playerName.localeCompare(b.playerName),
+      )
+      .slice(0, topN);
+    return { key: cat.key, label: cat.label, leaders };
+  });
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -11,6 +11,11 @@ import { writeAuditLog } from "./lib/auditLog";
 import { computeStandingsPure } from "./lib/standings";
 import { aggregateStatLines, parseStatLine } from "./lib/playerStats";
 import {
+  categoryValues,
+  computeStatLeaders,
+  type LeaderInput,
+} from "./lib/statLeaders";
+import {
   computeHsSprtRatings,
   positionToRatingGroup,
   type HsRatingInput,
@@ -4741,6 +4746,66 @@ export const computeSeasonSprt = query({
       });
     }
     return out;
+  },
+});
+
+/*
+ * Season stat-leaders (WSM-000186) — top players per category for a season,
+ * computed on-read from entered game stats. Aggregates each player's lines,
+ * flattens to leaderboard scalars, and ranks (see lib/statLeaders.ts). Called
+ * server-side (admin-keyed) by the dashboard league stats page.
+ */
+const statLeadersValidator = v.array(
+  v.object({
+    key: v.string(),
+    label: v.string(),
+    leaders: v.array(
+      v.object({
+        playerId: v.string(),
+        playerName: v.string(),
+        teamName: v.string(),
+        jerseyNumber: v.union(v.number(), v.null()),
+        value: v.number(),
+      }),
+    ),
+  }),
+);
+
+export const getSeasonStatLeaders = query({
+  args: { seasonId: v.id("seasons") },
+  returns: statLeadersValidator,
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    const byPlayer = new Map<string, string[]>();
+    for (const r of rows) {
+      const arr = byPlayer.get(r.playerId) ?? [];
+      arr.push(r.statsJson);
+      byPlayer.set(r.playerId, arr);
+    }
+
+    const players: LeaderInput[] = [];
+    for (const [playerId, jsons] of byPlayer) {
+      const totals = aggregateStatLines(jsons.map(parseStatLine));
+      const values = categoryValues(totals);
+      // Skip players with no leaderboard-relevant stats this season.
+      if (Object.values(values).every((v2) => v2 === 0)) continue;
+      const player = await ctx.db.get(playerId as Id<"players">);
+      if (!player) continue;
+      const team = await ctx.db.get(player.teamId);
+      players.push({
+        playerId,
+        playerName: player.name,
+        teamName: team?.name ?? "(unknown)",
+        jerseyNumber: player.jerseyNumber ?? null,
+        values,
+      });
+    }
+
+    return computeStatLeaders(players, 5);
   },
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/stats/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/stats/page.tsx
@@ -1,0 +1,70 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { statKeepingV1 } from "@/lib/flags";
+import { getLeague, getSeasons, getSeasonStatLeaders } from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { Card, CardContent } from "@/components/ui/card";
+import { StatLeadersBoard } from "@/components/stats/StatLeadersBoard";
+
+export default async function LeagueStatLeadersPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  // Same dark-flag gate as the rest of stat-keeping (WSM-000112).
+  const enabled = await statKeepingV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: leagueId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  const allSeasons = await getSeasons([leagueId]);
+  const activeSeason =
+    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+
+  return (
+    <div>
+      <Link
+        href={`/dashboard/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">{league.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            Stat leaders{activeSeason ? ` · ${activeSeason.name}` : ""}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Link
+            href={`/dashboard/leagues/${leagueId}/standings`}
+            className="text-sm text-primary hover:underline"
+          >
+            Standings &rarr;
+          </Link>
+        </div>
+      </header>
+
+      {!activeSeason ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            No seasons in this league yet — stat leaders unavailable.
+          </CardContent>
+        </Card>
+      ) : (
+        <StatLeadersBoard
+          categories={await getSeasonStatLeaders(activeSeason.id)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -3,11 +3,12 @@ import { redirect } from "next/navigation";
 import { getDivisions, getTeams, getLeagueOrgId } from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
 import { getUserRoleInOrg } from "@/lib/org-context";
+import { statKeepingV1 } from "@/lib/flags";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
-import { Trophy, BarChart3, CalendarDays } from "lucide-react";
+import { Trophy, BarChart3, CalendarDays, ListOrdered } from "lucide-react";
 import { LeagueSwitcher } from "../_components/league-switcher";
 import {
   CreateLeagueButton,
@@ -44,6 +45,7 @@ export default async function LeaguesPage() {
   const orgId = await getLeagueOrgId(activeLeague.id);
   const role = orgId ? await getUserRoleInOrg(orgId, userId) : null;
   const isAdmin = role === "org:admin";
+  const statsEnabled = await statKeepingV1();
 
   const [divisions, teams] = await Promise.all([
     getDivisions([activeLeague.id]),
@@ -120,6 +122,15 @@ export default async function LeaguesPage() {
               <CalendarDays className="h-4 w-4" />
               Schedule
             </Link>
+            {statsEnabled ? (
+              <Link
+                href={`/dashboard/leagues/${activeLeague.id}/stats`}
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <ListOrdered className="h-4 w-4" />
+                Stat leaders
+              </Link>
+            ) : null}
           </div>
           <LeaguesAccordion
             leagueId={activeLeague.id}

--- a/apps/web/src/components/stats/StatLeadersBoard.tsx
+++ b/apps/web/src/components/stats/StatLeadersBoard.tsx
@@ -1,0 +1,66 @@
+import type { SeasonStatCategoryLeaders } from "@/lib/data-api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/*
+ * Season stat-leaders board (WSM-000186) — a card per stat category with the
+ * top players. Only categories that have data render, so a pass-only week
+ * doesn't show empty defensive cards. Read-only display.
+ */
+export function StatLeadersBoard({
+  categories,
+}: {
+  categories: SeasonStatCategoryLeaders[];
+}) {
+  const withData = categories.filter((c) => c.leaders.length > 0);
+
+  if (withData.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center text-sm text-muted-foreground">
+          No stats entered yet this season. Leaders appear here once coaches
+          record game stats.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {withData.map((cat) => (
+        <Card key={cat.key}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">{cat.label}</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ol className="divide-y divide-border">
+              {cat.leaders.map((leader, i) => (
+                <li
+                  key={leader.playerId}
+                  className="flex items-center justify-between gap-2 px-4 py-2 text-sm"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="w-4 shrink-0 text-right tabular-nums text-muted-foreground">
+                      {i + 1}
+                    </span>
+                    <span className="min-w-0 truncate">
+                      <span className="font-medium text-foreground">
+                        {leader.jerseyNumber != null ? `#${leader.jerseyNumber} ` : ""}
+                        {leader.playerName}
+                      </span>
+                      <span className="ml-1 text-muted-foreground">
+                        · {leader.teamName}
+                      </span>
+                    </span>
+                  </span>
+                  <span className="shrink-0 font-mono tabular-nums font-semibold text-foreground">
+                    {leader.value}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -98,6 +98,20 @@ export interface PlayoffBracketDto {
   matchups: PlayoffMatchupDto[];
 }
 
+/** Season stat-leaders (WSM-000186). */
+export interface StatLeaderEntry {
+  playerId: string;
+  playerName: string;
+  teamName: string;
+  jerseyNumber: number | null;
+  value: number;
+}
+export interface SeasonStatCategoryLeaders {
+  key: string;
+  label: string;
+  leaders: StatLeaderEntry[];
+}
+
 const refs = {
   getVisibleLeagueContext: queryRef<
     { orgIds: string[]; userId: string },
@@ -657,6 +671,10 @@ const refs = {
       attributesJson: string;
     }>
   >("sports:computeSeasonSprt"),
+  getSeasonStatLeaders: queryRef<
+    { seasonId: string },
+    SeasonStatCategoryLeaders[]
+  >("sports:getSeasonStatLeaders"),
   // Live game-state (WSM-000152, keystone v3)
   startLiveGame: mutationRef<
     { fixtureId: string; actorUserId: string },
@@ -1935,6 +1953,14 @@ export async function getPlayerSeasonTotals(
 ): Promise<{ stats: PlayerGameStatLine; gameCount: number }> {
   const res = await queryConvex(refs.getPlayerSeasonTotals, { playerId, seasonId });
   return { stats: parseStatLine(res.statsJson), gameCount: res.gameCount };
+}
+
+/** Season stat-leaders per category (WSM-000186). Server-side read; callers
+ *  resolve the season via getSeason first, which enforces league access. */
+export async function getSeasonStatLeaders(
+  seasonId: string,
+): Promise<SeasonStatCategoryLeaders[]> {
+  return queryConvex(refs.getSeasonStatLeaders, { seasonId });
 }
 
 export interface HsSprtRating {


### PR DESCRIPTION
## What & why
Surfaces the stat-keeping investment with a **league stat-leaders board** — the top players per category for the active season, computed on-read from entered game stats. Previously stats were only visible one player at a time on profiles; this is the league-wide view a coach/fan expects.

## Changes
- **`convex/lib/statLeaders.ts`** (pure, tested): flattens an aggregated stat line to leaderboard scalars (passing/rushing/receiving yards & TDs, receptions, total tackles, sacks, INTs) and ranks — desc, name tiebreak, zeros excluded, top 5 per category.
- **`getSeasonStatLeaders` query**: aggregates each player's season lines (reuses `aggregateStatLines`), resolves player/team, ranks via the pure lib. Uses the **existing `by_seasonId` index — no schema change**.
- **data-api** wrapper + DTOs (`SeasonStatCategoryLeaders`/`StatLeaderEntry`).
- New page **`/dashboard/leagues/[id]/stats`** — gated by `statKeepingV1`, league access via `getSeason`; `StatLeadersBoard` renders a card per non-empty category.
- **"Stat leaders"** quick-nav link on the leagues screen (flag-gated).

## Verification
- `pnpm exec vitest run convex` — 214 pass (incl. new statLeaders: extraction, ranking, tiebreak, top-N).
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Notes
- Read-only, coach/member-facing (no public/fan route yet — easy follow-up). Live in-game stat entry and a per-player game log remain open follow-ups.
- New Convex query (no schema/index change) — ship web + Convex together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)