### PR TITLE
feat(web): public fan-facing stat-leaders page (WSM-000186)

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4771,41 +4771,79 @@ const statLeadersValidator = v.array(
   }),
 );
 
+/** Shared: compute a season's ranked stat-leaders from entered game stats. */
+async function seasonStatLeaders(
+  ctx: QueryCtx,
+  seasonId: Id<"seasons">,
+): Promise<ReturnType<typeof computeStatLeaders>> {
+  const rows = await ctx.db
+    .query("playerGameStats")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+
+  const byPlayer = new Map<string, string[]>();
+  for (const r of rows) {
+    const arr = byPlayer.get(r.playerId) ?? [];
+    arr.push(r.statsJson);
+    byPlayer.set(r.playerId, arr);
+  }
+
+  const players: LeaderInput[] = [];
+  for (const [playerId, jsons] of byPlayer) {
+    const totals = aggregateStatLines(jsons.map(parseStatLine));
+    const values = categoryValues(totals);
+    // Skip players with no leaderboard-relevant stats this season.
+    if (Object.values(values).every((v2) => v2 === 0)) continue;
+    const player = await ctx.db.get(playerId as Id<"players">);
+    if (!player) continue;
+    const team = await ctx.db.get(player.teamId);
+    players.push({
+      playerId,
+      playerName: player.name,
+      teamName: team?.name ?? "(unknown)",
+      jerseyNumber: player.jerseyNumber ?? null,
+      values,
+    });
+  }
+
+  return computeStatLeaders(players, 5);
+}
+
 export const getSeasonStatLeaders = query({
   args: { seasonId: v.id("seasons") },
   returns: statLeadersValidator,
+  handler: async (ctx, args) => seasonStatLeaders(ctx, args.seasonId),
+});
+
+/*
+ * Public stat-leaders (WSM-000186) — fan-facing, NO Clerk session. Re-checks
+ * `league.isPublic` here (defense in depth, mirroring computeStandingsPublic)
+ * so a stale/skipped middleware can't leak a private league's data, and
+ * resolves the season internally. Null when the league isn't public or has no
+ * season.
+ */
+export const getSeasonStatLeadersPublic = query({
+  args: { leagueId: v.id("leagues") },
+  returns: v.union(
+    v.object({ seasonName: v.string(), categories: statLeadersValidator }),
+    v.null(),
+  ),
   handler: async (ctx, args) => {
-    const rows = await ctx.db
-      .query("playerGameStats")
-      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+    const league = await ctx.db.get(args.leagueId);
+    if (!league || !league.isPublic) return null;
+
+    const seasonRows = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
       .collect();
+    if (seasonRows.length === 0) return null;
+    const activeSeason =
+      seasonRows.find((s) => s.status === "active") ?? seasonRows[0];
 
-    const byPlayer = new Map<string, string[]>();
-    for (const r of rows) {
-      const arr = byPlayer.get(r.playerId) ?? [];
-      arr.push(r.statsJson);
-      byPlayer.set(r.playerId, arr);
-    }
-
-    const players: LeaderInput[] = [];
-    for (const [playerId, jsons] of byPlayer) {
-      const totals = aggregateStatLines(jsons.map(parseStatLine));
-      const values = categoryValues(totals);
-      // Skip players with no leaderboard-relevant stats this season.
-      if (Object.values(values).every((v2) => v2 === 0)) continue;
-      const player = await ctx.db.get(playerId as Id<"players">);
-      if (!player) continue;
-      const team = await ctx.db.get(player.teamId);
-      players.push({
-        playerId,
-        playerName: player.name,
-        teamName: team?.name ?? "(unknown)",
-        jerseyNumber: player.jerseyNumber ?? null,
-        values,
-      });
-    }
-
-    return computeStatLeaders(players, 5);
+    return {
+      seasonName: activeSeason.name,
+      categories: await seasonStatLeaders(ctx, activeSeason._id),
+    };
   },
 });
 

--- a/apps/web/src/app/leagues/[id]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/page.tsx
@@ -3,7 +3,11 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { cache } from "react";
 import type { PlayerDto, TeamDto } from "@sports-management/shared-types";
-import { playerAttributesV1, schedulesStandingsV1 } from "@/lib/flags";
+import {
+  playerAttributesV1,
+  schedulesStandingsV1,
+  statKeepingV1,
+} from "@/lib/flags";
 import {
   getPlayers,
   getPublicLeagueImportTree,
@@ -68,9 +72,10 @@ export default async function PublicLeagueLandingPage({
   const league = await getPublicLeague(leagueId);
   if (!league) notFound();
 
-  const [standingsOn, attributesOn] = await Promise.all([
+  const [standingsOn, attributesOn, statsOn] = await Promise.all([
     schedulesStandingsV1(),
     playerAttributesV1(),
+    statKeepingV1(),
   ]);
 
   // Schedule shares the schedules_standings_v1 flag with standings. Surfacing
@@ -137,6 +142,19 @@ export default async function PublicLeagueLandingPage({
                 <CardTitle>Standings</CardTitle>
                 <CardDescription>
                   Season records, points for/against, and rankings.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        ) : null}
+
+        {statsOn ? (
+          <Link href={`/leagues/${leagueId}/stats`} className="group">
+            <Card className="h-full transition-colors group-hover:border-primary">
+              <CardHeader>
+                <CardTitle>Stat leaders</CardTitle>
+                <CardDescription>
+                  Season passing, rushing, receiving, and defensive leaders.
                 </CardDescription>
               </CardHeader>
             </Card>

--- a/apps/web/src/app/leagues/[id]/stats/page.tsx
+++ b/apps/web/src/app/leagues/[id]/stats/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { statKeepingV1 } from "@/lib/flags";
+import { getSeasonStatLeadersPublic } from "@/lib/data-api";
+import { publicLeagueGuard } from "@/lib/public-league-guard";
+import { StatLeadersBoard } from "@/components/stats/StatLeadersBoard";
+
+/*
+ * Public viewer route (WSM-000186) — fan-facing season stat leaders. NO Clerk
+ * session. `publicLeagueGuard` 404s a non-public league; the Convex query
+ * (`getSeasonStatLeadersPublic`) re-checks `isPublic` so a stale/skipped
+ * middleware can't leak a private league's data.
+ */
+export default async function PublicLeagueStatsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await statKeepingV1();
+  if (!enabled) notFound();
+
+  const { id: leagueId } = await params;
+  await publicLeagueGuard(leagueId);
+
+  const data = await getSeasonStatLeadersPublic(leagueId);
+  if (data === null) notFound();
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link
+        href={`/leagues/${leagueId}`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to League
+      </Link>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Stat leaders</h1>
+        <p className="text-sm text-muted-foreground">{data.seasonName}</p>
+      </header>
+
+      <StatLeadersBoard categories={data.categories} />
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -675,6 +675,10 @@ const refs = {
     { seasonId: string },
     SeasonStatCategoryLeaders[]
   >("sports:getSeasonStatLeaders"),
+  getSeasonStatLeadersPublic: queryRef<
+    { leagueId: string },
+    { seasonName: string; categories: SeasonStatCategoryLeaders[] } | null
+  >("sports:getSeasonStatLeadersPublic"),
   // Live game-state (WSM-000152, keystone v3)
   startLiveGame: mutationRef<
     { fixtureId: string; actorUserId: string },
@@ -1961,6 +1965,14 @@ export async function getSeasonStatLeaders(
   seasonId: string,
 ): Promise<SeasonStatCategoryLeaders[]> {
   return queryConvex(refs.getSeasonStatLeaders, { seasonId });
+}
+
+/** Public stat-leaders for a league (fan-facing). Convex re-checks the league
+ *  is public and resolves the season; returns null if not public / no season. */
+export async function getSeasonStatLeadersPublic(
+  leagueId: string,
+): Promise<{ seasonName: string; categories: SeasonStatCategoryLeaders[] } | null> {
+  return queryConvex(refs.getSeasonStatLeadersPublic, { leagueId });
 }
 
 export interface HsSprtRating {


### PR DESCRIPTION
## What & why
Makes the season stat-leaders **shareable** — a public viewer route (no Clerk session) for any opt-in **public** league, mirroring the existing public standings flow. Turns the leaders board from a coach-only dashboard view into something fans can open.

## Changes
- **`getSeasonStatLeadersPublic(leagueId)`**: re-checks `league.isPublic` in Convex (defense in depth, exactly like `computeStandingsPublic`) and resolves the season internally; returns `{ seasonName, categories }` or `null`. Refactored the shared aggregation into a `seasonStatLeaders()` helper reused by both the dashboard and public queries.
- **Public page `/leagues/[id]/stats`**: `publicLeagueGuard` (404s non-public leagues) + the shared `StatLeadersBoard` component.
- Linked as a **Stat leaders** card on the public league landing page (flag-gated by `statKeepingV1`).

## Security
Two layers gate it, same as public standings: the `publicLeagueGuard` middleware/guard and the in-query `isPublic` re-check — a private league's stats can't leak even if the guard is bypassed.

## Verification
- `pnpm exec vitest run convex/__tests__/statLeaders.test.ts` — pass (shared helper unchanged behavior).
- `pnpm exec eslint` — clean. `pnpm run build` — green.

## Deploy note
Adds a new Convex query (`getSeasonStatLeadersPublic`); no schema change. Ship web + Convex together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)