### PR TITLE
test(web): harden roster-limit badge selector against responsive duplicate (WSM-000187)

### DIFF
--- a/apps/web/e2e/tests/coach-roster.spec.ts
+++ b/apps/web/e2e/tests/coach-roster.spec.ts
@@ -194,11 +194,14 @@ test.describe.serial(
       if (!fixture) test.skip();
       await page.goto(`/dashboard/teams/${fixture!.teamId}/roster`);
 
+      // The slots badge renders in both the desktop and mobile layouts (one is
+      // CSS-hidden), so scope to the visible instance to avoid a strict-mode
+      // clash on the duplicate aria-label.
       await expect(
-        page.getByLabel("2 of 2 roster slots used"),
+        page.getByLabel("2 of 2 roster slots used").filter({ visible: true }),
       ).toBeVisible();
       await expect(
-        page.getByRole("button", { name: "Add to Roster" }),
+        page.getByRole("button", { name: "Add to Roster" }).first(),
       ).toBeDisabled();
     });
   },


### PR DESCRIPTION
## What
Hardens the one remaining latent flake in the e2e suite: `coach-roster`'s "Add to Roster is disabled when active count meets limit" asserted `getByLabel("2 of 2 roster slots used").toBeVisible()`, but that badge renders in **both** the desktop and mobile roster layouts (one CSS-hidden), so the locator can resolve to 2 elements and trip a strict-mode violation. Scope to the visible instance (`.filter({ visible: true })`) and take the first "Add to Roster" button for the same reason.

## Why
The full e2e stabilization (WSM-000172/187) is already on `main` — shared-auth `storageState` setup, the canonical NFL/MLS seed fixture, the active-league cookie, and the WSM-000136 redesign selector rewrites — and the blocking **Playwright (apps/web)** job is green in CI. This was the last spot where a responsive-duplicate selector could flake; CI's `retries: 2` was absorbing it. Deterministic locally after this change.

## Verify
Full functional run locally (chromium + api) against current dev: **92 passed, 22 skipped (quarantined + org-gated), 0 failed**, server stable (0 connection drops). `coach-roster` describe: 13/13.

Closes #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
