### PR TITLE
test(web): prod screenshot sweep — every authed page, desktop + mobile (WSM-000188)

### DIFF
--- a/.github/workflows/prod-screenshots.yml
+++ b/.github/workflows/prod-screenshots.yml
@@ -1,0 +1,91 @@
+name: Prod Screenshots
+
+# Manually-triggered visual sweep of PRODUCTION (WSM-000188). Signs in once as
+# the example e2e user against the live deployment and full-page-screenshots
+# every authed app page at desktop + mobile widths, uploaded as an artifact.
+# Read-only: it never seeds or mutates prod data.
+#
+# Reuses the same Clerk creds as the functional suite — works today because prod
+# still runs the Clerk DEVELOPMENT instance (#386 cutover pending). After the
+# cutover, set these to a prod-instance secret key + a prod test user.
+#
+# Required repo SECRETS: CLERK_SECRET_KEY, NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+#   E2E_CLERK_USER_ID
+# Optional repo VARIABLE: PROD_BASE_URL (defaults to the custom domain).
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to screenshot (overrides PROD_BASE_URL / default)"
+        required: false
+        type: string
+
+concurrency:
+  group: prod-screenshots
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Prod screenshot sweep
+    runs-on: ubuntu-latest
+    env:
+      PROD_BASE_URL: ${{ inputs.base_url || vars.PROD_BASE_URL || 'https://sprtsmng.andrewsolomon.dev' }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      E2E_CLERK_USER_ID: ${{ secrets.E2E_CLERK_USER_ID }}
+    steps:
+      - name: Check Clerk secrets
+        id: secrets
+        run: |
+          if [ -z "${CLERK_SECRET_KEY}" ] || [ -z "${E2E_CLERK_USER_ID}" ]; then
+            echo "::warning::Clerk secrets not configured (CLERK_SECRET_KEY / E2E_CLERK_USER_ID) — skipping the prod screenshot sweep."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.secrets.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        if: steps.secrets.outputs.run == 'true'
+        run: corepack enable
+
+      - name: Setup Node.js
+        if: steps.secrets.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm --filter @sports-management/web exec playwright install --with-deps chromium
+
+      - name: Run prod screenshot sweep
+        if: steps.secrets.outputs.run == 'true'
+        run: pnpm --filter @sports-management/web test:prod:screenshots
+
+      - name: Upload screenshots
+        if: ${{ always() && steps.secrets.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-screenshots
+          path: apps/web/prod-screenshots
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Playwright report (on failure)
+        if: ${{ failure() && steps.secrets.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-screenshots-report
+          path: apps/web/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -14,3 +14,6 @@ e2e/.canonical-fixture.json
 
 # e2e shared Clerk session persisted by auth.setup.ts, WSM-000172
 e2e/.auth/
+
+# Prod screenshot sweep artifacts (WSM-000188)
+prod-screenshots/

--- a/apps/web/e2e/playwright.prod.ts
+++ b/apps/web/e2e/playwright.prod.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+
+// Load .env.local for LOCAL runs (the functional suite gets this for free via
+// its convex imports; the prod sweep imports no convex, so load it explicitly).
+// In CI the file is absent — a no-op — and env comes from the workflow.
+dotenv.config({ path: path.resolve(".env.local") });
+
+/**
+ * PROD screenshot sweep (WSM-000188) — separate from the functional suite.
+ *
+ * Signs in ONCE as the example e2e user against the LIVE production deployment
+ * and full-page-screenshots every authed app page at desktop + mobile widths,
+ * saving them under `prod-screenshots/<viewport>/`. Read-only: it navigates and
+ * screenshots, never seeds or mutates prod data.
+ *
+ * Target: PROD_BASE_URL (defaults to the custom domain). NO `webServer` — prod
+ * is already deployed; we hit it over the network.
+ *
+ * Auth note: this reuses the same Clerk creds as the functional suite
+ * (CLERK_SECRET_KEY + E2E_CLERK_USER_ID). That works today because prod still
+ * runs the Clerk DEVELOPMENT instance (#386 cutover pending). After the cutover
+ * to a production Clerk instance, point these at a prod-instance secret key +
+ * a prod test user (e.g. PROD_CLERK_* secrets).
+ */
+const PROD_STORAGE_STATE = path.resolve("e2e", ".auth", "prod-user.json");
+const BASE_URL =
+  process.env.PROD_BASE_URL ?? "https://sprtsmng.andrewsolomon.dev";
+
+export default defineConfig({
+  testDir: "./prod",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["html", { open: "never" }]],
+  globalSetup: "./prod/global-setup.ts",
+  use: {
+    baseURL: BASE_URL,
+    // Capture a trace + screenshot on failure so a broken sweep is debuggable.
+    trace: "on-first-retry",
+    navigationTimeout: 45_000,
+    actionTimeout: 15_000,
+  },
+  projects: [
+    { name: "setup", testMatch: /auth\.setup\.ts/ },
+    {
+      name: "desktop",
+      testMatch: /screenshots\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 },
+        storageState: PROD_STORAGE_STATE,
+      },
+      dependencies: ["setup"],
+    },
+    {
+      name: "mobile",
+      testMatch: /screenshots\.spec\.ts/,
+      // Chromium at a phone viewport — NOT devices["iPhone 13"], which defaults
+      // to WebKit (a second browser to install in CI). isMobile/hasTouch are
+      // chromium-supported and give us the mobile layout for the sweep.
+      use: {
+        browserName: "chromium",
+        viewport: { width: 390, height: 844 },
+        isMobile: true,
+        hasTouch: true,
+        storageState: PROD_STORAGE_STATE,
+      },
+      dependencies: ["setup"],
+    },
+  ],
+});

--- a/apps/web/e2e/prod/auth.setup.ts
+++ b/apps/web/e2e/prod/auth.setup.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test as setup, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+/**
+ * Prod sweep auth (WSM-000188). Signs in ONCE as the example e2e user against
+ * the live prod deployment (baseURL = PROD_BASE_URL) and persists the session
+ * so the desktop/mobile screenshot projects reuse it. Mirrors the functional
+ * suite's auth.setup but writes a separate prod state file.
+ */
+const PROD_STORAGE_STATE = path.resolve("e2e", ".auth", "prod-user.json");
+
+setup("authenticate against prod", async ({ page }) => {
+  await setupClerkTestingToken({ page });
+  await signInTestUser(page);
+  fs.mkdirSync(path.dirname(PROD_STORAGE_STATE), { recursive: true });
+
+  // Confirm the SESSION is live before persisting — assert the authenticated
+  // shell (sidebar nav), NOT the dashboard content. The sweep must still
+  // capture pages whose body renders the error boundary (that's the point of a
+  // prod sweep), so liveness must not depend on the content rendering cleanly.
+  await page.goto("/dashboard");
+  await expect(
+    page.getByRole("link", { name: "Overview", exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await page.context().storageState({ path: PROD_STORAGE_STATE });
+});

--- a/apps/web/e2e/prod/global-setup.ts
+++ b/apps/web/e2e/prod/global-setup.ts
@@ -1,0 +1,11 @@
+import { clerkSetup } from "@clerk/testing/playwright";
+
+/**
+ * Prod sweep global setup (WSM-000188). Only fetches the Clerk testing token
+ * (bot-bypass) so `setupClerkTestingToken` works against the prod Clerk
+ * instance. Unlike the functional suite's global-setup it does NOT seed Convex
+ * — the prod sweep is strictly read-only.
+ */
+export default async function globalSetup() {
+  await clerkSetup();
+}

--- a/apps/web/e2e/prod/screenshots.spec.ts
+++ b/apps/web/e2e/prod/screenshots.spec.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+
+/**
+ * Prod screenshot sweep (WSM-000188). One full-page screenshot per route, per
+ * viewport project (desktop / mobile), written to
+ * `prod-screenshots/<project>/<slug>.png` and uploaded as a CI artifact.
+ *
+ * Read-only: navigate + screenshot only. Authed pages rely on the prod
+ * storageState (see playwright.prod.ts); `setupClerkTestingToken` keeps the
+ * session refreshable. The two legal pages are public and render the same
+ * signed-in or out.
+ */
+const ROUTES: Array<{ slug: string; path: string }> = [
+  { slug: "dashboard-overview", path: "/dashboard" },
+  { slug: "leagues", path: "/dashboard/leagues" },
+  { slug: "teams", path: "/dashboard/teams" },
+  { slug: "players", path: "/dashboard/players" },
+  { slug: "seasons", path: "/dashboard/seasons" },
+  { slug: "divisions", path: "/dashboard/divisions" },
+  { slug: "discover", path: "/dashboard/discover" },
+  { slug: "import", path: "/dashboard/import" },
+  { slug: "billing", path: "/dashboard/billing" },
+  { slug: "roles", path: "/dashboard/roles" },
+  { slug: "legal-privacy", path: "/privacy" },
+  { slug: "legal-terms", path: "/terms" },
+];
+
+test.describe("Prod screenshot sweep", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  for (const route of ROUTES) {
+    test(`screenshot ${route.slug}`, async ({ page }, testInfo) => {
+      const dir = path.resolve("prod-screenshots", testInfo.project.name);
+      fs.mkdirSync(dir, { recursive: true });
+
+      // `load` (not networkidle): the Convex client holds a persistent
+      // websocket, so networkidle never settles. Then a short pause lets
+      // data-driven content (charts, tables) finish rendering before the shot.
+      await page.goto(route.path, { waitUntil: "load" });
+      await page.waitForTimeout(2_000);
+
+      await page.screenshot({
+        path: path.join(dir, `${route.slug}.png`),
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "test:e2e:report": "playwright test --config e2e/playwright.config.ts --reporter=html && playwright show-report",
     "test:visual": "playwright test --config e2e/playwright.config.ts --project visual",
     "test:visual:update": "playwright test --config e2e/playwright.config.ts --project visual --update-snapshots",
+    "test:prod:screenshots": "playwright test --config e2e/playwright.prod.ts",
     "test:unit": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## What
A manually-triggered **prod visual sweep** (`Prod Screenshots` workflow, `workflow_dispatch`). Signs in ONCE as the example e2e user against the **live** deployment and full-page-screenshots **every authed app page** (10 dashboard routes + 2 legal pages) at **desktop (1440)** and **mobile (390)** widths — 24 screenshots — uploaded as a CI artifact. Strictly **read-only**: navigate + screenshot, never seeds or mutates prod.

## Pieces
- `e2e/playwright.prod.ts` — no `webServer` (hits live `PROD_BASE_URL`, default the custom domain); `setup` + `desktop` + `mobile` projects; loads `.env.local` for local runs.
- `e2e/prod/auth.setup.ts` — prod sign-in → `e2e/.auth/prod-user.json`. Liveness asserts the authed **shell** (sidebar nav), not page content, so the sweep still captures pages whose body renders the error boundary.
- `e2e/prod/screenshots.spec.ts` — route × viewport → `prod-screenshots/<viewport>/<slug>.png`.
- `.github/workflows/prod-screenshots.yml` — `workflow_dispatch` (optional `base_url` input), secret-gated, uploads the `prod-screenshots` artifact.
- `pnpm --filter @sports-management/web test:prod:screenshots` to run locally.

Mobile uses chromium at a phone viewport (not `devices["iPhone 13"]`, which defaults to WebKit — a second browser to install). Reuses the functional suite's Clerk creds; works while prod runs the Clerk dev instance (#386 pending) — point at prod-instance creds after the cutover.

## ⚠️ First run already caught a real prod bug
`/dashboard` (overview) renders **"Something went wrong — An error occurred in the Server Components render"** for the test user's active league (Cobb County Football). **Leagues / other pages render fine**, so it's scoped to the overview's server-side aggregation (standings/scoring/fixtures reads). Likely a server read failing for that league's data — possibly the prod Convex deployment lagging `main` (the WSM-000166 validator-drift class). Needs prod-log confirmation; filing separately.

Verified locally: 25 passed (setup + 12 desktop + 12 mobile), 24 PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
