### PR TITLE
fix(web): scope dashboard overview reads to the active league (WSM-000189)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -56,17 +56,25 @@ export default async function DashboardPage() {
 
   const orgContext = await resolveOrgContext(userId);
   const ids = orgContext.visibleLeagueIds;
-  const [leagues, teams, players, seasons, divisions] = await Promise.all([
-    getLeagues(ids),
-    getTeams(ids),
-    getPlayers(ids),
-    getSeasons(ids),
-    getDivisions(ids),
-  ]);
 
+  // `leagues` stays org-wide — it feeds the "Leagues" count, the switcher, and
+  // active-league resolution. Everything else in the overview is only ever
+  // shown for the ACTIVE league (see the league-scoped slices below), so scope
+  // those reads to it. Fetching teams/players/etc. across ALL visible leagues
+  // can exceed Convex's 8192-element return-array cap — an org with ~19.9k
+  // players across its leagues 500'd the whole dashboard (WSM-000189).
+  const leagues = await getLeagues(ids);
   const { activeLeagueId } = await resolveActiveLeague(userId);
   const activeLeague =
     leagues.find((l) => l.id === activeLeagueId) ?? leagues[0] ?? null;
+
+  const leagueScope = activeLeague ? [activeLeague.id] : [];
+  const [teams, players, seasons, divisions] = await Promise.all([
+    getTeams(leagueScope),
+    getPlayers(leagueScope),
+    getSeasons(leagueScope),
+    getDivisions(leagueScope),
+  ]);
 
   // Role-aware bento (WSM-000136 P4): an admin of the active league's org gets
   // an extra org/members widget; coaches & viewers get the team-and-season view.


### PR DESCRIPTION
## Fixes #423 (WSM-000189) — prod `/dashboard` overview 500

### Root cause
The overview fetched **teams/players/seasons/divisions across all of the org's visible leagues** (`getPlayers(orgContext.visibleLeagueIds)` etc.), then filtered each down to the **active league** to build its stat counts. For an org with ~19.9k players across its leagues, `sports:listPlayers` exceeded **Convex's 8192-element return-array cap**:

```
Function sports.js:listPlayers return value invalid:
Array length is too long (19877 > maximum length 8192)
```

…so the query threw and the overview's Server Component render 500'd (the "Something went wrong" boundary). It was fetching ~19.9k full player DTOs purely to derive a count.

### Fix
Scope the four reads to the **active league** (the only scope the overview ever displays). `leagues` stays org-wide (the "Leagues" count + switcher + active-league resolution). Downstream league-scoped filters are unchanged, so behavior is identical for normal-sized orgs — the read just drops from ~19.9k rows to the active league's players, removing the cap exposure.

```diff
- const [leagues, teams, players, seasons, divisions] = await Promise.all([
-   getLeagues(ids), getTeams(ids), getPlayers(ids), getSeasons(ids), getDivisions(ids),
- ]);
- const { activeLeagueId } = await resolveActiveLeague(userId);
+ const leagues = await getLeagues(ids);
+ const { activeLeagueId } = await resolveActiveLeague(userId);
+ const activeLeague = leagues.find((l) => l.id === activeLeagueId) ?? leagues[0] ?? null;
+ const leagueScope = activeLeague ? [activeLeague.id] : [];
+ const [teams, players, seasons, divisions] = await Promise.all([
+   getTeams(leagueScope), getPlayers(leagueScope), getSeasons(leagueScope), getDivisions(leagueScope),
+ ]);
```

### Verified
- `dashboard-overview` e2e (chromium, dev): **14 passed / 0 failed** — overview renders, stat cards + counts correct.
- The dev suite can't reproduce >8192 (seeded data is small); the **prod screenshot sweep (#422)** is the post-deploy guard — re-run it after this deploys to confirm `/dashboard` renders on prod.

### Follow-up (not needed yet)
A count-only query / pagination for `listPlayers` is only required if a **single** league ever exceeds 8192 players (a HS league won't). Tracked as option 3 in #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
