### PR TITLE
fix(web): add Manage link from Leagues list to league detail page (WSM-000191)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/page.tsx
@@ -8,7 +8,13 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
-import { Trophy, BarChart3, CalendarDays, ListOrdered } from "lucide-react";
+import {
+  Trophy,
+  BarChart3,
+  CalendarDays,
+  ListOrdered,
+  Settings,
+} from "lucide-react";
 import { LeagueSwitcher } from "../_components/league-switcher";
 import {
   CreateLeagueButton,
@@ -129,6 +135,15 @@ export default async function LeaguesPage() {
               >
                 <ListOrdered className="h-4 w-4" />
                 Stat leaders
+              </Link>
+            ) : null}
+            {isAdmin ? (
+              <Link
+                href={`/dashboard/leagues/${activeLeague.id}`}
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <Settings className="h-4 w-4" />
+                Manage
               </Link>
             ) : null}
           </div>


### PR DESCRIPTION
## What
Adds an admin-only **Manage** link (Settings icon) to the active league's action row on `/dashboard/leagues`, pointing at the league detail page `/dashboard/leagues/[id]`.

## Why
The Leagues list linked only to Standings/Schedule/Stat-leaders sub-pages — never to the detail route where `LeaguePublicToggle` and `LeagueClaimableToggle` render. The **Public viewer** / **Claimable** controls were only reachable by hand-editing the URL, blocking activation of seeded template leagues (e.g. GHSA football) for coach claiming.

## Change
- `apps/web/src/app/dashboard/leagues/page.tsx`: import `Settings` icon; add an `isAdmin`-gated `Link` to `/dashboard/leagues/<activeLeagueId>`.

## Verification
- `tsc --noEmit` clean
- `eslint` clean on the changed file
- Link mirrors the existing sibling links exactly; admin-gated like the rename/delete controls.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)