### PR TITLE
ci(web): run e2e against an in-runner local Convex backend (WSM-000172)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,13 +107,16 @@ jobs:
       - name: Start local Convex backend + deploy functions
         if: steps.secrets.outputs.run == 'true'
         working-directory: apps/web
-        env:
-          CONVEX_AGENT_MODE: anonymous
-          CONVEX_DEPLOYMENT: ''
-          CONVEX_ADMIN_KEY: ''
-          CONVEX_SELF_HOSTED_URL: ''
         run: |
-          nohup pnpm exec convex dev > /tmp/convex-dev.log 2>&1 &
+          # UNSET the cloud Convex env the workflow injected — an empty-but-set
+          # CONVEX_DEPLOYMENT makes the CLI error "No CONVEX_DEPLOYMENT set"
+          # instead of falling back to the local config it writes.
+          unset CONVEX_DEPLOYMENT CONVEX_ADMIN_KEY CONVEX_SELF_HOSTED_URL
+          unset NEXT_PUBLIC_CONVEX_URL NEXT_PUBLIC_CONVEX_SITE_URL
+          export CONVEX_AGENT_MODE=anonymous
+          # `--local` configures + serves an anonymous local deployment on a fresh
+          # runner (no prior .convex/local); AGENT_MODE alone isn't enough there.
+          nohup pnpm exec convex dev --local > /tmp/convex-dev.log 2>&1 &
           echo "Waiting for the local Convex backend to deploy functions..."
           for i in $(seq 1 150); do
             grep -q "Convex functions ready" /tmp/convex-dev.log && break

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,10 +134,12 @@ jobs:
           # The test step sources this so `export` overrides the (cloud) workflow
           # env for the dev server + Playwright seed harness without GITHUB_ENV
           # precedence quirks.
+          # Single-quote values: the anonymous admin key contains a '|' which
+          # bash would otherwise read as a pipe (exit 127, "command not found").
           {
-            echo "export NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:${CLOUD_PORT}"
-            echo "export NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:${SITE_PORT}"
-            echo "export CONVEX_ADMIN_KEY=${ADMIN_KEY}"
+            echo "export NEXT_PUBLIC_CONVEX_URL='http://127.0.0.1:${CLOUD_PORT}'"
+            echo "export NEXT_PUBLIC_CONVEX_SITE_URL='http://127.0.0.1:${SITE_PORT}'"
+            echo "export CONVEX_ADMIN_KEY='${ADMIN_KEY}'"
             echo "export CONVEX_DEPLOYMENT="
           } > /tmp/convex-local.env
           # e2eSeed mutations are gated on this flag set ON the deployment.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,18 +96,50 @@ jobs:
         if: steps.secrets.outputs.run == 'true'
         run: pnpm --filter @sports-management/api-contracts build
 
-      # Push the PR's Convex functions to the shared dev deployment so the
-      # backend matches the code under test (WSM-000172). Uses the admin key +
-      # URL (self-hosted addressing); CONVEX_DEPLOYMENT must be UNSET here or
-      # the CLI refuses the self-hosted form.
-      - name: Deploy Convex functions to dev
+      # Run an ANONYMOUS LOCAL Convex backend in the runner instead of pushing to
+      # the shared cloud dev deployment (WSM-000172, cost): zero cloud function
+      # calls, plus a hermetic per-run backend (no shared-deployment drift or
+      # cross-PR clobber). CONVEX_AGENT_MODE=anonymous + no TTY makes `convex dev`
+      # download the precompiled backend, deploy the PR's functions, and serve
+      # locally. We background it (it serves for the whole job) and write its
+      # generated URL + admin key to a file the test step sources, so the dev
+      # server and seed harness talk to the local backend, not the cloud.
+      - name: Start local Convex backend + deploy functions
         if: steps.secrets.outputs.run == 'true'
         working-directory: apps/web
         env:
+          CONVEX_AGENT_MODE: anonymous
           CONVEX_DEPLOYMENT: ''
-          CONVEX_SELF_HOSTED_URL: ${{ vars.NEXT_PUBLIC_CONVEX_URL }}
-          CONVEX_SELF_HOSTED_ADMIN_KEY: ${{ secrets.CONVEX_ADMIN_KEY }}
-        run: pnpm exec convex deploy --yes
+          CONVEX_ADMIN_KEY: ''
+          CONVEX_SELF_HOSTED_URL: ''
+        run: |
+          nohup pnpm exec convex dev > /tmp/convex-dev.log 2>&1 &
+          echo "Waiting for the local Convex backend to deploy functions..."
+          for i in $(seq 1 150); do
+            grep -q "Convex functions ready" /tmp/convex-dev.log && break
+            sleep 1
+          done
+          if ! grep -q "Convex functions ready" /tmp/convex-dev.log; then
+            echo "::error::Local Convex backend did not become ready in time"
+            cat /tmp/convex-dev.log
+            exit 1
+          fi
+          CFG=.convex/local/default/config.json
+          CLOUD_PORT=$(jq -r '.ports.cloud' "$CFG")
+          SITE_PORT=$(jq -r '.ports.site' "$CFG")
+          ADMIN_KEY=$(jq -r '.adminKey' "$CFG")
+          # The test step sources this so `export` overrides the (cloud) workflow
+          # env for the dev server + Playwright seed harness without GITHUB_ENV
+          # precedence quirks.
+          {
+            echo "export NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:${CLOUD_PORT}"
+            echo "export NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:${SITE_PORT}"
+            echo "export CONVEX_ADMIN_KEY=${ADMIN_KEY}"
+            echo "export CONVEX_DEPLOYMENT="
+          } > /tmp/convex-local.env
+          # e2eSeed mutations are gated on this flag set ON the deployment.
+          pnpm exec convex env set CONVEX_ENABLE_E2E_SEED 1
+          echo "Local Convex ready at http://127.0.0.1:${CLOUD_PORT}"
 
       - name: Install Playwright browser
         if: steps.secrets.outputs.run == 'true'
@@ -119,7 +151,12 @@ jobs:
         # `health` dependency; the `visual` project runs in its own non-blocking
         # job below. (A dedicated script avoids `pnpm … -- --project=…` arg
         # forwarding mangling the flag into a positional "no tests found" filter.)
-        run: pnpm --filter @sports-management/web test:e2e:ci
+        # Source the local-Convex env so the dev server + seed harness point at
+        # the in-runner backend (overrides the cloud workflow env for this shell).
+        run: |
+          source /tmp/convex-local.env
+          echo "Using Convex at $NEXT_PUBLIC_CONVEX_URL"
+          pnpm --filter @sports-management/web test:e2e:ci
 
       # The HTML report is an artifact, invisible in the job log. Surface the
       # failed-spec page snapshots inline so a red run is diagnosable from the


### PR DESCRIPTION
## Why
Prod is over the Convex **free-tier function-call** ceiling. The e2e suite was the heavy *controllable* consumer — every PR pushed functions to the shared cloud **dev** deployment and ran hundreds of query calls against it.

## What
Replace the cloud-dev deploy with an **anonymous local Convex backend in the runner**:
- `CONVEX_AGENT_MODE=anonymous` + no TTY → `convex dev` downloads the precompiled backend, deploys the PR's functions, and serves locally (background process, lives for the whole job).
- The test step sources the generated URL + admin key so the dev server + Playwright seed harness hit `127.0.0.1`, not the cloud.
- Enables `CONVEX_ENABLE_E2E_SEED` on the local deployment.
- The non-blocking **visual** job stays on cloud (negligible usage).

## Bonus
Removes the shared-dev-deployment coupling that caused the WSM-000172 drift/clobber fragility — each run gets a **hermetic** backend matching its own code.

## Validation
This PR's own E2E run is the test: if `Playwright (apps/web)` is green, the suite runs fully against the local backend with zero cloud calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)