### PR TITLE
fix(web): 404 instead of 500 on invalid team id (WSM-000190)

### DIFF
--- a/apps/web/e2e/tests/team-detail.spec.ts
+++ b/apps/web/e2e/tests/team-detail.spec.ts
@@ -108,3 +108,27 @@ test.describe("Team Detail Page", () => {
     ).toHaveCount(0);
   });
 });
+
+// Regression for WSM-000190: a bad/legacy team id (e.g. a Salesforce id leaking
+// in via a stale link) used to crash the page with an unhandled
+// ArgumentValidationError from Convex's `v.id("teams")` validator → 500. The
+// route must now 404 instead. No fixture/active-league needed — a bad id 404s
+// regardless of seeded data; just an authed session.
+test.describe("Team Detail Page — invalid id", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("a Salesforce-format team id returns 404, not 500", async ({ page }) => {
+    // The exact 18-char SF id from the prod runtime log (WSM-000190).
+    const resp = await page.goto("/dashboard/teams/a00bm00001npL2UAAU");
+    expect(resp?.status()).toBe(404);
+  });
+
+  test("an arbitrary malformed team id returns 404", async ({ page }) => {
+    // Any id that doesn't resolve to a team (validation failure or unknown id)
+    // must 404 — the guard catches both and falls through to notFound().
+    const resp = await page.goto("/dashboard/teams/not-a-real-team-id");
+    expect(resp?.status()).toBe(404);
+  });
+});

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
   getTeam,
   getPlayersByTeam,
@@ -38,10 +38,18 @@ export default async function TeamDetailPage({
         : { href: "/dashboard/teams", label: "Back to Teams" };
   const orgContext = await resolveOrgContext(userId);
 
+  // Resolve the team first, guarded: a bad/legacy team id (e.g. a Salesforce
+  // id like `a00b…` leaking in via a stale link) fails Convex's `v.id("teams")`
+  // validation and throws ArgumentValidationError; an unknown-but-valid id
+  // resolves to null. Either way the route must 404, not 500 (WSM-000190).
+  // Matches the players/[id] + divisions/[id] guard pattern.
+  const team = await getTeam(id, orgContext).catch(() => null);
+  if (!team) notFound();
+
   // canManage = admin or coach (roster/players/edit); canDelete = admin only
-  // (removing the whole team). WSM-000121 intra-org roles.
-  const [team, players, canManage, canDelete] = await Promise.all([
-    getTeam(id, orgContext),
+  // (removing the whole team). WSM-000121 intra-org roles. Safe to run now that
+  // the team id is known-valid.
+  const [players, canManage, canDelete] = await Promise.all([
     getPlayersByTeam(id, orgContext),
     canManageTeam(id, userId),
     canAdministerTeam(id, userId),


### PR DESCRIPTION
## Bug
`/dashboard/teams/[id]` threw an unhandled `ArgumentValidationError` (→ 500 / error boundary) when `[id]` was a legacy **Salesforce id** (e.g. `a00bm00001npL2UAAU`) instead of a Convex id. The route passed the param straight into Convex's `v.id("teams")` query with no guard, so a bad/legacy team link crashed the page instead of 404ing. Found by the prod screenshot sweep (WSM-000188); sibling of #423.

## Root cause
`apps/web/src/app/dashboard/teams/[id]/page.tsx` awaited `getTeam(id, orgContext)` inside a `Promise.all` with **no try/catch** — the validation error propagated and the Server Component render failed. The sibling routes (`players/[id]`, `divisions/[id]`, `teams/[id]/roster`) already guard this; the team detail page did not.

## What changed
- Resolve the team **first**, guarded with `.catch(() => null)` + `notFound()`, then parallelize the dependent reads (`getPlayersByTeam` / `canManageTeam` / `canAdministerTeam`) only once the id is known-valid. Handles both failure modes: a malformed id (validator throws → caught) and an unknown-but-valid id (resolves to null).
- Mirrors the existing guard pattern in `players/[id]` / `divisions/[id]`.

## Verification
- `pnpm exec tsc --noEmit` ✓
- `pnpm exec eslint` (changed files) ✓
- `pnpm run build` ✓ (compiled successfully)
- **Regression test** (`e2e/tests/team-detail.spec.ts`): the exact SF-format id from the prod log and an arbitrary malformed id both assert `resp.status() === 404`. Runs in the authed `chromium` e2e project in CI.

## Notes / follow-up
This is fix #1 (the guard — stops *any* bad team URL 500ing, the recommended Option A in the ticket). The ticket's Option 2 — tracing **why** a `team.id` is ever a Salesforce id (legacy SF data leaking into a team link at the import/mapping layer) — is a separate data investigation not addressed here.

Fixes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)