### PR TITLE
chore: ignore local dogfood-output sweep artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ validation.md
 
 # TypeScript incremental build info
 *.tsbuildinfo
+
+# Local dogfood sweep artifacts (report + screenshots/videos)
+dogfood-output/


### PR DESCRIPTION
## What
Adds `dogfood-output/` to the root `.gitignore`.

## Why
`dogfood-output/` holds a locally-generated dogfood report plus screenshots/videos from prod sweeps — a run artifact, not source. This stops it from showing up as untracked noise, mirroring the existing `prod-screenshots/` ignore in `apps/web/.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)