### PR TITLE
perf(web): collapse public live-score poll to 1 Convex call (WSM-000192)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -141,6 +141,7 @@ type AllowedPublicSportsReads =
   | "getPlayerMaddenRating"
   | "getPlayerSeasonAttributes"
   | "getPlayerSeasonTotals"
+  | "getPublicLiveGameState"
   | "getActiveStreamCountForLeague"
   | "getResultByFixture"
   | "getRosterAssignmentHistory"

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -5101,6 +5101,56 @@ export const getLiveGameState = query({
   },
 });
 
+// Single-call public live-state read for the client poll (cost: WSM-000192).
+// The poll route used to run FOUR separate public queries every few seconds
+// (league visibility + fixture + season + live state) — the dominant prod
+// function-call driver. This folds the same public + cross-league leak guard
+// and the live-state read into ONE function call.
+//   - returns `null`            → guard failed → the route answers 404
+//   - returns `{ live: ... }`   → guard passed (live may be null = not started)
+export const getPublicLiveGameState = queryGeneric({
+  args: { leagueId: v.id("leagues"), fixtureId: v.id("fixtures") },
+  returns: v.union(
+    v.null(),
+    v.object({
+      live: v.union(
+        v.object({
+          homeScore: v.number(),
+          awayScore: v.number(),
+          period: v.number(),
+          clock: v.union(v.string(), v.null()),
+          status: v.string(),
+        }),
+        v.null(),
+      ),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league || !league.isPublic) return null;
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) return null;
+    // Cross-league leak guard: the fixture's season must belong to THIS league.
+    const season = await ctx.db.get(fixture.seasonId);
+    if (!season || season.leagueId !== args.leagueId) return null;
+    const row = await ctx.db
+      .query("liveGameState")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    return {
+      live: row
+        ? {
+            homeScore: row.homeScore,
+            awayScore: row.awayScore,
+            period: row.period,
+            clock: row.clock,
+            status: row.status,
+          }
+        : null,
+    };
+  },
+});
+
 /* ───────────────────────── Playoffs (WSM-000164) ───────────────────────── */
 
 /** Ordered team ids by league standings (regular season only), seeds 1..N. */

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/route.ts
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/route.ts
@@ -1,11 +1,6 @@
 import { NextResponse } from "next/server";
 import { liveScoringV1 } from "@/lib/flags";
-import {
-  getFixture,
-  getLeagueVisibility,
-  getPublicSeason,
-  getLiveGameState,
-} from "@/lib/data-api";
+import { getPublicLiveGameState } from "@/lib/data-api";
 
 /*
  * Public live game-state poll (WSM-000152, keystone v3). The seam #302's
@@ -37,30 +32,29 @@ export async function GET(
 
   const { id: leagueId, gameId } = await params;
 
-  const visibility = await getLeagueVisibility(leagueId);
-  if (!visibility || !visibility.isPublic) {
+  // ONE Convex call does the public + cross-league leak guard AND the live-state
+  // read (was four separate queries polled every few seconds — WSM-000192). A
+  // null result means the guard failed; otherwise `{ live }` (live null = not
+  // started yet). Invalid ids throw at Convex arg validation → treat as 404.
+  let result: Awaited<ReturnType<typeof getPublicLiveGameState>>;
+  try {
+    result = await getPublicLiveGameState(leagueId, gameId);
+  } catch {
+    result = null;
+  }
+  if (!result) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
 
-  const fixture = await getFixture(gameId);
-  if (!fixture) {
-    return NextResponse.json({ error: "not_found" }, { status: 404 });
-  }
-  // Cross-league leak guard — the fixture must live in THIS public league.
-  const season = await getPublicSeason(fixture.seasonId);
-  if (!season || season.leagueId !== leagueId) {
-    return NextResponse.json({ error: "not_found" }, { status: 404 });
-  }
-
-  const live = await getLiveGameState(gameId);
-
-  // Short-lived edge cache so a crowd refreshing doesn't hammer Convex, while
-  // the score still feels live (≤5s stale). The overlay polls on its own cadence.
+  // Edge cache long enough to collapse a crowd's polls of the SAME game into ~one
+  // Convex hit per window, aligned with the client's 10s cadence — while staying
+  // live-feeling (stale-while-revalidate serves instantly and refreshes behind).
   return NextResponse.json(
-    { live },
+    { live: result.live },
     {
       headers: {
-        "Cache-Control": "public, max-age=0, s-maxage=3, stale-while-revalidate=5",
+        "Cache-Control":
+          "public, max-age=0, s-maxage=10, stale-while-revalidate=20",
       },
     },
   );

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -709,6 +709,10 @@ const refs = {
     { fixtureId: string },
     LiveGameStatePublic | null
   >("sports:getLiveGameState"),
+  getPublicLiveGameState: queryRef<
+    { leagueId: string; fixtureId: string },
+    { live: LiveGameStatePublic | null } | null
+  >("sports:getPublicLiveGameState"),
 };
 
 /** Full live game-state (operator UI). */
@@ -2048,6 +2052,19 @@ export async function getLiveGameState(
   fixtureId: string,
 ): Promise<LiveGameStatePublic | null> {
   return queryConvex(refs.getLiveGameState, { fixtureId });
+}
+
+/**
+ * Single-call public live-state read for the poll (WSM-000192): folds the
+ * public + cross-league leak guard and the live-state read into ONE Convex
+ * function call (the poll used to make four). Returns null when the guard fails
+ * (the route answers 404), else `{ live }` (live is null until the game starts).
+ */
+export async function getPublicLiveGameState(
+  leagueId: string,
+  fixtureId: string,
+): Promise<{ live: LiveGameStatePublic | null } | null> {
+  return queryConvex(refs.getPublicLiveGameState, { leagueId, fixtureId });
 }
 
 // --- Phase 3 — standings wrappers ---

--- a/apps/web/src/lib/use-live-score.ts
+++ b/apps/web/src/lib/use-live-score.ts
@@ -29,7 +29,10 @@ export function useLiveScore(
   leagueId: string,
   gameId: string,
   initial: LiveScorePublic | null,
-  intervalMs = 5000,
+  // 10s cadence (was 5s): a scoreboard reads fine at 10s, and it halves poll
+  // volume — paired with the route's single-call read + s-maxage=10 edge cache,
+  // this cuts prod Convex function calls from this surface ~8x (WSM-000192).
+  intervalMs = 10_000,
 ): LiveScorePublic | null {
   const router = useRouter();
   const [live, setLive] = useState<LiveScorePublic | null>(initial);


### PR DESCRIPTION
## Why
Prod is over the Convex **free-tier function-call** ceiling. Investigation found the **public live-score poll** is the dominant driver: every open non-final game page polls `/leagues/[id]/games/[gameId]/live-score` every **5s**, and **each poll ran 4 separate public queries** (visibility + fixture + season + live state) — ~48 calls/min per viewer per game. 3 of the 4 are static-per-game guards re-fetched every tick.

## Change
- **`getPublicLiveGameState`** — one Convex query that folds the public + cross-league leak guard **and** the live-state read into a single function call. `null` → guard failed (route 404); `{ live }` → guard passed (`live` null until kickoff).
- Route calls it **once** (4 → 1); invalid ids now → 404 instead of an unhandled throw.
- Edge cache **`s-maxage` 3 → 10** so a crowd's polls of the same game collapse to ~one Convex hit per window.
- Client poll cadence **5s → 10s**.

**Net: ~8× fewer prod function calls from this surface** (4× per-poll × 2× cadence, plus multi-viewer cache collapse). Old per-step queries are retained (other callers use them).

## ⚠️ Deploy order
This adds a Convex function the route calls. **Deploy Convex from `main` before the new web goes live.** Old functions are untouched, so there's no break window as long as Convex is deployed promptly on merge.

## Verification
`pnpm type-check` clean. Guard semantics preserved (public-only, cross-league leak guard, 404 on miss/invalid). Follow-up: dashboard `getResultByFixture` N+1 (secondary driver) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)