### PR TITLE
fix(web): mobile roster overflow + un-quarantine clean e2e specs (WSM-000188 / #419)

### DIFF
--- a/apps/web/e2e/tests/mobile-overflow.spec.ts
+++ b/apps/web/e2e/tests/mobile-overflow.spec.ts
@@ -66,10 +66,10 @@ test.describe.serial("Mobile — no horizontal page overflow (WSM-000085)", () =
     await expectNoPageOverflow(page, "/dashboard/players");
   });
 
-  // QUARANTINED (#419): REAL BUG — team detail page scrolls horizontally on a
-  // 375px viewport (626px content). Fix the roster table's mobile layout, then
-  // un-fixme.
-  test.fixme("team page with a seeded roster table fits the viewport", async ({
+  // Was the real responsive bug (#419): the roster header (h3 + up to four
+  // action buttons) sat in a no-wrap flex row that pushed the page to ~626px on
+  // a 375px viewport. Fixed by letting that row wrap (team-management.tsx).
+  test("team page with a seeded roster table fits the viewport", async ({
     page,
   }) => {
     await expectNoPageOverflow(page, `/dashboard/teams/${fixture!.teamId}`);

--- a/apps/web/e2e/tests/team-detail.spec.ts
+++ b/apps/web/e2e/tests/team-detail.spec.ts
@@ -40,13 +40,16 @@ test.describe("Team Detail Page", () => {
     await expect(rosterHeading).toBeVisible();
   });
 
-  // QUARANTINED (#419): roster header row resolves to [] — column markup changed.
-  test.fixme("roster table shows the compact columns (no wide Status column)", async ({
+  test("roster table shows the compact columns (no wide Status column)", async ({
     page,
   }) => {
     // The roster table uses compact headers (Player / Pos / #) plus optional
     // ratings columns. WSM-000097 removed the dedicated wide Status column;
     // status is now a per-row indicator (WSM-000098), so it must NOT be a header.
+    //
+    // Wait for the header to render first: allInnerTexts() does not retry, so
+    // reading it before the table mounts returns [] (the original #419 rot).
+    await expect(page.locator("thead th").first()).toBeVisible();
     const headerText = await page.locator("thead th").allInnerTexts();
     expect(headerText).toEqual(expect.arrayContaining(["Player", "Pos", "#"]));
     expect(headerText).not.toContain("Status");

--- a/apps/web/e2e/tests/team-edit.spec.ts
+++ b/apps/web/e2e/tests/team-edit.spec.ts
@@ -1,15 +1,15 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
 import { TEAMS } from "../helpers/test-data";
 
-// QUARANTINED (#419): the team-edit form fields (e.g. #team-city) are now Radix
-// Selects, not <input>s, so the save/validation tests fail on fill()/clear().
-test.describe.fixme("Team Edit", () => {
+test.describe("Team Edit", () => {
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page });
+    await setActiveLeague(page, readCanonicalFixture().leagueId);
     // Navigate to Cowboys team detail page
     await page.goto("/dashboard/teams");
-    await page.getByText(TEAMS.COWBOYS.name).click();
+    await page.locator("a", { hasText: TEAMS.COWBOYS.name }).click();
     await expect(page.getByRole("heading", { name: TEAMS.COWBOYS.name })).toBeVisible();
   });
 
@@ -17,16 +17,20 @@ test.describe.fixme("Team Edit", () => {
     await expect(page.getByRole("button", { name: "Edit Team" })).toBeVisible();
   });
 
-  // QUARANTINED (#419): #team-city is no longer an <input> — toHaveValue fails.
-  test.fixme("dialog opens pre-populated with team data", async ({ page }) => {
+  test("dialog opens pre-populated with team data", async ({ page }) => {
     await page.getByRole("button", { name: "Edit Team" }).click();
 
     await expect(page.getByRole("heading", { name: "Edit Team" })).toBeVisible();
+    // #team-name is still a text <input>; #team-city is now a Radix Select
+    // trigger (a combobox button) whose selected value renders as its text, so
+    // assert on the rendered city rather than an input value.
     await expect(page.locator("#team-name")).toHaveValue(TEAMS.COWBOYS.name);
-    await expect(page.locator("#team-city")).toHaveValue(TEAMS.COWBOYS.city);
+    await expect(page.locator("#team-city")).toContainText(TEAMS.COWBOYS.city);
   });
 
-  test("saves changes and restores", async ({ page }) => {
+  // QUARANTINED (#434): #team-city is a Radix Select; this test still
+  // .clear()/.fill()s it. Rewrite to drive the Select via option clicks.
+  test.fixme("saves changes and restores", async ({ page }) => {
     await page.getByRole("button", { name: "Edit Team" }).click();
 
     await page.locator("#team-city").clear();

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -335,12 +335,16 @@ export default function TeamManagement({
         </CardContent>
       </Card>
 
-      <div className="mb-4 flex items-center justify-between">
+      {/* Wraps on a phone: the h3 + up to four action buttons exceed a 375px
+          viewport in a single no-wrap row, scrolling the whole page sideways
+          (WSM-000188/#419). flex-wrap drops the button group to its own line,
+          and the inner group wraps its buttons rather than overflowing. */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-lg font-semibold text-foreground">
           Player Roster ({players.length})
         </h3>
         {canManage && (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {canGenerateRoster && (
               <>
                 <SyntheticRosterButton kind="team" id={team.id} />


### PR DESCRIPTION
Closes the actionable parts of #419.

## 1. Real bug — team detail page scrolled sideways on a phone

`/dashboard/teams/[id]` hit ~626px of content on a 375px viewport. Not the roster table (it already scrolls inside its own `overflow-x-auto`) — the **roster header row**: the `Player Roster (N)` heading plus up to **four** action buttons (`Generate roster`, `Generate ratings`, `Clear synthetic`, `Add Player`) in a single **no-wrap** `flex justify-between` row. `syntheticRostersV1` defaults on outside production, so the e2e env rendered all four — exactly the measured overflow.

**Fix:** let the row wrap (`flex-wrap`/`gap-2` on the row and the button group), matching the pattern already used by the team-card and leagues-page headers.

## 2. Un-quarantined the clean spec-rot tests

- **team-detail** `roster table shows the compact columns` — `allInnerTexts()` doesn't auto-wait, so it read `[]` before the table mounted. Await the first header cell; assertions already match current markup.
- **team-edit** `dialog opens pre-populated` — `#team-city` is now a Radix Select trigger; assert `toContainText` not `toHaveValue`. Re-enabled the Team Edit group and hardened its navigation.
- **mobile-overflow** team-page test — un-`fixme`'d (verifies the §1 fix).

## Deferred (split out of #419 — larger than assertion swaps, CI-only verifiable)

- #434 — Radix Select form rewrite (player-crud group + team-edit `saves changes`)
- #435 — depth-chart route 404s in CI + drag-handle selector
- #436 — schedules-standings fixture-loop flow

## Verification

`tsc --noEmit` + `eslint` clean; `playwright --list` confirms the un-`fixme`'d tests are collected and the deferred ones stay skipped. The seeded specs themselves run in CI (seed + Clerk secrets are CI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)