### PR TITLE
perf(web): batch dashboard season results into one Convex call (WSM-000193)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -168,6 +168,7 @@ type AllowedPublicSportsReads =
   | "listPlayers"
   | "listPlayersByTeam"
   | "listPublicLeagues"
+  | "listResultsBySeason"
   | "listSeasons"
   | "listTeams"
   | "listTeamsByLeague";

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4149,6 +4149,51 @@ export const getResultByFixture = queryGeneric({
 });
 
 /*
+ * Batch results for a whole season in ONE query (WSM-000193).
+ *
+ * The dashboard used to call `getResultByFixture` once per fixture — an N+1 that
+ * fired ~one Convex function call per game per render (90+ for a full season),
+ * the dominant driver of prod function-call volume. This collapses that fan-out
+ * to a single call: the per-fixture `gameResults` lookups now happen as in-process
+ * DB reads inside one invocation (same pattern `computeStandings` already uses).
+ *
+ * Returns a SCORE-ONLY projection (no `playerStatsJson`) — the dashboard needs
+ * only scores keyed by fixture, and omitting the stats blob keeps the array
+ * payload small even for a fully stat-kept season.
+ */
+const seasonResultValidator = v.object({
+  fixtureId: v.string(),
+  homeScore: v.number(),
+  awayScore: v.number(),
+});
+
+export const listResultsBySeason = queryGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(seasonResultValidator),
+  handler: async (ctx, args) => {
+    const fixtures = await ctx.db
+      .query("fixtures")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    const rows = await Promise.all(
+      fixtures.map((f) =>
+        ctx.db
+          .query("gameResults")
+          .withIndex("by_fixtureId", (q) => q.eq("fixtureId", f._id))
+          .first(),
+      ),
+    );
+    return rows
+      .filter((r): r is NonNullable<typeof r> => r !== null)
+      .map((r) => ({
+        fixtureId: r.fixtureId,
+        homeScore: r.homeScore,
+        awayScore: r.awayScore,
+      }));
+  },
+});
+
+/*
  * Phase 3 — Standings compute (Sprint 7 / WSM-000070).
  *
  * Pure math lives in `convex/lib/standings.ts`. The queries below

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import {
   getDivisions,
   getLeagues,
   listFixturesBySeason,
-  getResultByFixture,
+  listResultsBySeason,
   computeStandings,
   listOrgMemberRoles,
 } from "@/lib/data-api";
@@ -140,12 +140,15 @@ export default async function DashboardPage() {
     // Incident hardening: a single failing season-data read must not crash the
     // whole dashboard. Degrade to empty widgets (defaults initialized above).
     try {
-    const fixtures = await listFixturesBySeason(activeSeason.id);
-    const results = await Promise.all(
-      fixtures.map((f) => getResultByFixture(f.id)),
-    );
+    // One batched read for the whole season instead of one call per fixture
+    // (WSM-000193): the old `getResultByFixture` fan-out fired ~one Convex
+    // function call per game on every dashboard render.
+    const [fixtures, results] = await Promise.all([
+      listFixturesBySeason(activeSeason.id),
+      listResultsBySeason(activeSeason.id),
+    ]);
     const resultByFixture = new Map(
-      fixtures.map((f, i) => [f.id, results[i]] as const),
+      results.map((r) => [r.fixtureId, r] as const),
     );
     fixturesTotal = fixtures.length;
     fixturesFinal = fixtures.filter((f) => f.status === "final").length;

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -590,6 +590,9 @@ const refs = {
   getResultByFixture: queryRef<{ fixtureId: string }, GameResultDto | null>(
     "sports:getResultByFixture",
   ),
+  listResultsBySeason: queryRef<{ seasonId: string }, SeasonResultLine[]>(
+    "sports:listResultsBySeason",
+  ),
   computeStandings: queryRef<{ seasonId: string }, Standing[]>(
     "sports:computeStandings",
   ),
@@ -1822,6 +1825,24 @@ export async function getResultByFixture(
   fixtureId: string,
 ): Promise<GameResultDto | null> {
   return queryConvex(refs.getResultByFixture, { fixtureId });
+}
+
+/** Score-only result line for a season, keyed by fixture (WSM-000193). */
+export interface SeasonResultLine {
+  fixtureId: string;
+  homeScore: number;
+  awayScore: number;
+}
+
+/**
+ * All recorded results for a season in ONE Convex call — replaces the dashboard's
+ * per-fixture `getResultByFixture` N+1. Score-only; use `getResultByFixture` when
+ * you need the full result (incl. `playerStatsJson`) for a single game.
+ */
+export async function listResultsBySeason(
+  seasonId: string,
+): Promise<SeasonResultLine[]> {
+  return queryConvex(refs.listResultsBySeason, { seasonId });
 }
 
 // --- Phase 1 live streaming wrappers (WSM-000144) ---


### PR DESCRIPTION
## Summary

The dashboard **Overview** fetched game results with a per-fixture `getResultByFixture` fan-out — **~one Convex function call per game** (90+ for a full 14-week season) on *every* render. This was the dominant multiplier of prod Convex function-call volume (the metric that pushed us over the Free plan limit).

This collapses that N+1 into a **single call**.

## Changes

- **`convex/sports.ts`** — new public read `listResultsBySeason(seasonId)`. Does the per-fixture `gameResults` lookups as in-process DB reads inside **one** invocation (the same pattern `computeStandings` already uses). Returns a **score-only** projection (`fixtureId`/`homeScore`/`awayScore`, no `playerStatsJson` blob) so the array stays small even for a fully stat-kept season.
- **`src/lib/data-api.ts`** — `SeasonResultLine` type + `listResultsBySeason` wrapper.
- **`src/app/dashboard/page.tsx`** — swap the `Promise.all(fixtures.map(getResultByFixture))` fan-out for a single `listResultsBySeason` call, run in parallel with `listFixturesBySeason`. The three consumers (per-week points, standings, recent-results feed) are unchanged.
- **`convex/__tests__/writeMutationsAreInternal.test.ts`** — add `listResultsBySeason` to the public-reads allow-list (required or tsc fails the WSM-000096 security backstop).

**Net:** result-fetching drops from **N+1 → 1** call per dashboard render.

## Verification

- `pnpm run type-check` — clean.
- **Ran against a local Convex backend**: seeded a season → `listResultsBySeason` returned `[]`; created a fixture + recorded a 21–14 result → returned exactly `[{fixtureId, homeScore: 21, awayScore: 14}]` in a single call. Confirms registration, arg-validator acceptance of a real season id, and strict return-validator acceptance of both empty and populated arrays (no WSM-000166 drift class). Test data cleaned up.

## Notes

- `computeStandings` is still a single call (unchanged) — it re-reads fixtures/results internally, so there's minor redundant *work*, but as a billed **function call** it's just one, not an N+1.
- Convex deploy to prod remains a separate step from merged `main`, per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)