### PR TITLE
docs: deploy runbook + web E2E guide + README/CI refresh

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,10 +21,12 @@ name: E2E
 # WSM-000172: the suite kept failing because the shared dev Convex deployment
 # drifted behind main (a player-validator change shipped in code but was never
 # pushed to dev → data-dependent 500s on the dashboard, which bounced the health
-# gate and skipped everything). The "Deploy Convex functions to dev" step pushes
-# the PR's functions before testing, so the backend always matches the code under
-# test. Visual regression is a separate, non-blocking job (its OS-specific
-# screenshot baselines aren't committed for Linux, so it must not gate PRs).
+# gate and skipped everything). Fixed in #428 by running an ANONYMOUS LOCAL Convex
+# backend inside the runner (the "Start local Convex backend + deploy functions"
+# step below) instead of the shared cloud dev deployment: each run gets a hermetic
+# backend that matches its own code, and it costs zero cloud function calls.
+# Visual regression is a separate, non-blocking job (its OS-specific screenshot
+# baselines aren't committed for Linux, so it must not gate PRs).
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ A full-stack sports league management platform combining a Salesforce backend (A
 
 **Tooling:** pnpm workspaces + Turborepo for task orchestration, Corepack for pnpm version management.
 
+> **Backend note (current):** the web app (`apps/web`) now uses **[Convex](https://convex.dev)** as its primary data backend — see [apps/web/CLAUDE.md](apps/web/CLAUDE.md). The Salesforce-REST arrows in the diagram above and parts of [apps/web/README.md](apps/web/README.md) describe the original design and are being reconciled. Production deploy of the web app + Convex is documented in [docs/development/DEPLOY.md](docs/development/DEPLOY.md).
+
 ## Prerequisites
 
 - Node.js 18+
@@ -139,7 +141,7 @@ pnpm --filter @sports-management/tui test:unit
 # Web app tests (74 tests)
 pnpm --filter @sports-management/web test:unit
 
-# E2E tests — Playwright (81 tests across 14 specs)
+# E2E tests — Playwright, apps/web (~93 passing across 24 specs)
 pnpm --filter @sports-management/web test:e2e          # Headless
 pnpm --filter @sports-management/web test:e2e:headed    # Visible browser
 pnpm --filter @sports-management/web test:e2e:report    # With HTML report
@@ -202,7 +204,9 @@ sf project deploy validate --source-dir sportsmgmt
 | [sportsmgmt/README.md](sportsmgmt/README.md) | Core Salesforce package — objects, Apex classes, LWC |
 | [sportsmgmt-football/README.md](sportsmgmt-football/README.md) | Football extension package |
 | [docs/README.md](docs/README.md) | Documentation index |
-| [docs/guides/E2E_TESTING_GUIDE.md](docs/guides/E2E_TESTING_GUIDE.md) | E2E testing setup and patterns |
+| [docs/development/DEPLOY.md](docs/development/DEPLOY.md) | Production deploy runbook (web via Vercel + manual Convex deploy) |
+| [docs/guides/WEB_E2E_TESTING_GUIDE.md](docs/guides/WEB_E2E_TESTING_GUIDE.md) | Web app (apps/web) Playwright E2E — Clerk + Convex, and the CI setup |
+| [docs/guides/E2E_TESTING_GUIDE.md](docs/guides/E2E_TESTING_GUIDE.md) | E2E testing — **legacy Salesforce-Lightning** suite (root `e2e/`) |
 | [docs/guides/USER_SETUP.md](docs/guides/USER_SETUP.md) | User and permission configuration |
 | [docs/guides/SF_CLI_AND_OBJECT_REFERENCE_GUIDE.md](docs/guides/SF_CLI_AND_OBJECT_REFERENCE_GUIDE.md) | Salesforce CLI reference |
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,8 @@
 # Sports League Management — Web App
 
-External-facing Next.js application for sports league management, backed by Salesforce via JWT bearer flow.
+External-facing Next.js application for sports league management.
+
+> **Backend:** the app's primary data backend is **[Convex](https://convex.dev)** (see [CLAUDE.md](./CLAUDE.md) and the `convex/` directory). Sections of this README below describe an earlier **Salesforce JWT bearer** design and are being reconciled — treat CLAUDE.md + the code as authoritative for the current data layer. Deploy: [docs/development/DEPLOY.md](../../docs/development/DEPLOY.md). E2E: [docs/guides/WEB_E2E_TESTING_GUIDE.md](../../docs/guides/WEB_E2E_TESTING_GUIDE.md).
 
 ## Tech Stack
 
@@ -12,7 +14,7 @@ External-facing Next.js application for sports league management, backed by Sale
 - **Lucide React** for icons
 - **Sonner** for toast notifications
 - **Zod** for runtime validation (via `@sports-management/api-contracts`)
-- **Playwright** for E2E testing (81 tests across 14 specs)
+- **Playwright** for E2E testing (~93 passing across 24 specs — see [WEB_E2E_TESTING_GUIDE.md](../../docs/guides/WEB_E2E_TESTING_GUIDE.md))
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,14 @@
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Branch naming, conventional-commit format, PR process |
 | [development/RELEASE_STRATEGY.md](development/RELEASE_STRATEGY.md) | Lockstep versioning model, commit→version mapping, semantic-release flow |
 | [development/BRANCH_PROTECTION.md](development/BRANCH_PROTECTION.md) | Branch-protection rules on `main` (required checks, bypass paths) |
+| [development/DEPLOY.md](development/DEPLOY.md) | Production deploy runbook — web via Vercel (auto) + manual Convex deploy, deploy-order rule, verification |
 
 ## Guides
 
 | Document | Description |
 |---|---|
-| [guides/E2E_TESTING_GUIDE.md](guides/E2E_TESTING_GUIDE.md) | Playwright E2E test setup, patterns, and running tests |
+| [guides/WEB_E2E_TESTING_GUIDE.md](guides/WEB_E2E_TESTING_GUIDE.md) | Web app (apps/web) Playwright E2E — Clerk + Convex, canonical fixture, and the local-Convex CI setup |
+| [guides/E2E_TESTING_GUIDE.md](guides/E2E_TESTING_GUIDE.md) | **Legacy** Salesforce-Lightning E2E suite (root `e2e/`, scratch orgs) |
 | [guides/USER_SETUP.md](guides/USER_SETUP.md) | Scratch org user creation and permission set assignment |
 | [guides/SF_CLI_AND_OBJECT_REFERENCE_GUIDE.md](guides/SF_CLI_AND_OBJECT_REFERENCE_GUIDE.md) | Salesforce CLI commands and custom object reference |
 

--- a/docs/development/DEPLOY.md
+++ b/docs/development/DEPLOY.md
@@ -1,0 +1,102 @@
+# Production Deploy Runbook (apps/web)
+
+> **Status:** Canonical. Covers how the **web app** (`apps/web`) + its **Convex**
+> backend reach production. For versioning/tagging/semantic-release see
+> [RELEASE_STRATEGY.md](./RELEASE_STRATEGY.md); this doc is about *deploying*, not
+> versioning. Salesforce package deploys are separate (see the root README).
+
+Production is **two independent pipelines**, not one. This trips people up, so
+internalize it:
+
+| Surface | How it deploys | Trigger | Automatic? |
+| --- | --- | --- | --- |
+| **Web** (Next.js) | Vercel Git integration → **production** | every commit on `main` | ✅ automatic |
+| **Convex** (functions + schema) | manual `npx convex deploy` → prod deployment | run by a human from merged `main` | ❌ manual |
+
+- **Vercel project:** `prj_WxGOmhPZj3Y3cNHGPo6KVChOESFB` (team `andrewsolomonedus-projects`), custom domain **`sprtsmng.andrewsolomon.dev`**. The build command is plain `next build` — there is **no** `convex deploy` inside the Vercel build, and no Convex deploy in CI. Merging to `main` publishes the web automatically; nothing publishes Convex.
+- **Convex deployments:** prod = **`terrific-aardvark-395`**, dev = `laudable-reindeer-759`.
+
+## The deploy-order rule (why this matters)
+
+Because the web auto-promotes the instant a PR merges, **merging a PR that calls a
+new/changed Convex function publishes the web before Convex is updated.** If the
+prod Convex functions don't match, the live route errors (a missing function, or
+the return-validator drift class — see
+[reference: Convex return-validator drift]).
+
+**Therefore: deploy Convex to prod *before or immediately after* the web goes
+live, from the same `main` SHA.** In practice:
+
+1. Merge the PR(s) to `main`.
+2. If other merges are in flight, pause them for the minute this takes (so web
+   and Convex land from the same `main`).
+3. Deploy Convex from `main` (below).
+4. Verify (below).
+
+## Deploying Convex to prod
+
+Run from merged `main`, from `apps/web`, using your Convex **device auth**
+(interactive login already done via the Convex dashboard/CLI):
+
+```bash
+cd apps/web && CONVEX_DEPLOYMENT=prod:terrific-aardvark-395 npx convex deploy
+```
+
+`convex deploy` pushes **functions + schema only** — it does **not** touch prod
+data. Convex shows a diff and asks to confirm the push to production; confirm it.
+
+### ⚠️ `.env.local` gotcha (post-WSM-000172 / #428)
+
+After the local-Convex CI work, `apps/web/.env.local` may be left pointing at a
+**local anonymous backend**:
+
+```
+CONVEX_DEPLOYMENT=anonymous:anonymous-web
+NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3212
+```
+
+In that state a bare `npx convex deploy` will **not** target prod. The explicit
+`CONVEX_DEPLOYMENT=prod:terrific-aardvark-395` above overrides it (a shell-set env
+var beats the `.env.local` value). If the CLI still complains about the
+deployment/project link, move the file aside for the deploy:
+
+```bash
+cd apps/web && mv .env.local .env.local.bak && npx convex deploy --prod ; mv .env.local.bak .env.local
+```
+
+(Restore your normal dev `.env.local` afterward so local dev talks to the dev
+deployment again.)
+
+There is **no** production `CONVEX_DEPLOY_KEY` checked into the repo or the local
+env — prod deploys use device auth. A deploy key would only be used in a CI
+context (not currently wired).
+
+## Verifying a prod deploy
+
+After both surfaces are live, confirm they match:
+
+```bash
+# Health + a graceful-error probe (a bogus id must 404, not 500)
+curl -s -o /dev/null -w "%{http_code}\n" https://sprtsmng.andrewsolomon.dev/api/health          # 200
+curl -s -o /dev/null -w "%{http_code}\n" https://sprtsmng.andrewsolomon.dev/                     # 200
+curl -s -o /dev/null -w "%{http_code}\n" \
+  https://sprtsmng.andrewsolomon.dev/leagues/x/games/y/live-score                                # 404 (not 500)
+```
+
+Then check Vercel runtime errors for a "function not found" / validator signature
+(project `prj_WxGOmhPZj3Y3cNHGPo6KVChOESFB`, team `team_1h9Xca1fcyThRFdpK9runicq`)
+— via the Vercel MCP `get_runtime_errors` or the dashboard. Zero new errors after
+the deploy = web and Convex are consistent.
+
+## Rollback
+
+- **Web:** Vercel → the project's Deployments → promote a previous production
+  deployment (recent `main` deploys are marked `isRollbackCandidate`).
+- **Convex:** re-run `convex deploy` from an earlier known-good `main` commit.
+  There is no one-click Convex rollback; redeploy the prior code.
+
+## Related
+
+- [RELEASE_STRATEGY.md](./RELEASE_STRATEGY.md) — versioning, tags, semantic-release
+- [WEB_E2E_TESTING_GUIDE.md](../guides/WEB_E2E_TESTING_GUIDE.md) — the pre-merge gate
+- [launch/clerk-prod-cutover.md](../launch/clerk-prod-cutover.md) — Clerk prod instance cutover (separate)

--- a/docs/guides/E2E_TESTING_GUIDE.md
+++ b/docs/guides/E2E_TESTING_GUIDE.md
@@ -1,6 +1,12 @@
-# E2E Testing Guide
+# E2E Testing Guide (legacy Salesforce-Lightning suite)
 
-End-to-end tests for the Sports League Management app use [Playwright](https://playwright.dev/) to test against real Salesforce scratch orgs.
+> **Scope:** this documents the **Salesforce Lightning** e2e suite at the repo-root
+> `e2e/` (scratch orgs, `frontdoor.jsp` login, `c-*` Shadow-DOM locators, `.js`
+> specs). For the **Next.js web app** suite (`apps/web/e2e/`, Clerk + Convex,
+> TypeScript) — the one wired into the PR-gating CI workflow — see
+> [WEB_E2E_TESTING_GUIDE.md](./WEB_E2E_TESTING_GUIDE.md).
+
+End-to-end tests for the Salesforce Lightning app use [Playwright](https://playwright.dev/) to test against real Salesforce scratch orgs.
 
 ## Prerequisites
 

--- a/docs/guides/WEB_E2E_TESTING_GUIDE.md
+++ b/docs/guides/WEB_E2E_TESTING_GUIDE.md
@@ -1,0 +1,115 @@
+# Web App E2E Testing Guide (apps/web)
+
+> This covers the **Next.js web app** Playwright suite in `apps/web/e2e/`
+> (TypeScript specs, Clerk auth, Convex backend). It is **not** the legacy
+> Salesforce-Lightning e2e suite at the repo-root `e2e/` — that one uses scratch
+> orgs + `frontdoor.jsp` + `c-*` component locators and is documented separately
+> in [E2E_TESTING_GUIDE.md](./E2E_TESTING_GUIDE.md).
+
+The web suite is **24 spec files** (`apps/web/e2e/tests/*.ts`). A green CI run is
+~93 passing / ~22 skipped (quarantined specs tracked in #419).
+
+## What it tests against
+
+- **Auth:** [Clerk](https://clerk.com) — a real test user, signed in once.
+- **Backend:** [Convex](https://convex.dev) — locally a seedable dev deployment;
+  in CI a hermetic in-runner backend (see [CI](#ci)).
+- **App:** the Next.js dev server (`pnpm dev`, port 3000), auto-started by
+  Playwright's `webServer`.
+
+## Local quick start
+
+```bash
+cd apps/web
+pnpm exec playwright install chromium      # first time only
+
+# .env.local must have (dev deployment + Clerk test instance):
+#   NEXT_PUBLIC_CONVEX_URL      (dev deployment URL)
+#   CONVEX_ADMIN_KEY            (dev deployment admin key — used to seed)
+#   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, CLERK_SECRET_KEY
+#   E2E_CLERK_USER_ID, E2E_CLERK_ORG_ID  (+ _B variants for multi-user specs)
+# And on the dev Convex deployment: CONVEX_ENABLE_E2E_SEED=1
+
+pnpm test:e2e            # headless (chromium + api + health projects)
+pnpm test:e2e:headed     # visible browser
+pnpm test:e2e:report     # + open the HTML report
+```
+
+> ⚠️ If your `.env.local` is pointed at a **local anonymous** Convex backend
+> (`CONVEX_DEPLOYMENT=anonymous:...`, `127.0.0.1:3212`) from CI experiments,
+> restore your dev-deployment values first or the seed harness won't reach a
+> seedable backend. See [DEPLOY.md](../development/DEPLOY.md#envlocal-gotcha).
+
+## Architecture (WSM-000172 / WSM-000187)
+
+### Projects (`e2e/playwright.config.ts`)
+
+| Project | storageState | Purpose |
+| --- | --- | --- |
+| `setup` | — | Runs `auth.setup.ts`: signs in **once** via Clerk, persists the session to `e2e/.auth/user.json`. |
+| `health` | ✅ reuses `user.json` | Smoke gate; a dependency of `chromium`. |
+| `chromium` | ✅ reuses `user.json` | The authed suite (all specs except health/visual/api). |
+| `api` | ❌ none | Runs `api-auth.spec.ts` **unauthenticated** — asserts protected BFF routes return **401**. |
+| `visual` | — | `/dev/visual/*` component screenshots. **Non-blocking** (no committed Linux baselines). |
+
+- **Sign in once, not per test.** `auth.setup.ts` does one Clerk sign-in and
+  writes `storageState`; every authed spec reuses it (replaced ~110 per-test
+  sign-ins that rate-limited Clerk). Each test still calls
+  `setupClerkTestingToken()` to bypass bot detection and refresh the short-lived
+  JWT. Serial run (`workers: 1`), `retries: 2` in CI.
+
+### Canonical data fixture (`convex/e2eSeed.ts` + `e2e/helpers/seed-canonical.ts`)
+
+- `global-setup.ts` seeds the fixed dataset **once** via the
+  `e2eSeed:createCanonicalFixture` mutation (idempotent, org-scoped): one league
+  ("National Football League") with the `test-data.ts` teams/players/seasons/
+  divisions. It writes the resulting `leagueId` to `e2e/.canonical-fixture.json`.
+- Data-dependent specs read that file (`readCanonicalFixture()`) and set the
+  `activeLeagueId` cookie via `setActiveLeague()` in `beforeEach`, so the
+  active-league-scoped dashboard pages render exactly that league's data.
+- The seed mutations are gated on `CONVEX_ENABLE_E2E_SEED=1` set **on the target
+  deployment** — a safety interlock so they can never run against prod.
+
+## CI
+
+`.github/workflows/e2e.yml` — runs on `pull_request` → `main`, **secret-gated**
+(absent secrets → the job skips and still passes, so it can't falsely block a PR).
+
+Two jobs:
+
+- **`Playwright (apps/web)`** — blocking. Gates PRs.
+- **`Visual regression`** — **non-blocking** (`continue-on-error`); OS-specific
+  screenshot baselines aren't committed for Linux, so it must not gate.
+
+### In-runner local Convex backend (WSM-000172, #428)
+
+CI does **not** push to or test against the shared cloud dev deployment. Instead
+it runs a **hermetic anonymous Convex backend inside the runner**:
+
+- `CONVEX_AGENT_MODE=anonymous pnpm exec convex dev --local` downloads the
+  precompiled backend, deploys the PR's functions, and serves locally.
+- The step writes the generated `127.0.0.1` URL + admin key to a file; the test
+  step `source`s it so the dev server and seed harness hit the local backend, not
+  the cloud.
+
+Why: prod is over the Convex free-tier function-call ceiling and the suite was a
+heavy consumer; a per-run local backend is zero cloud calls **and** removes the
+shared-deployment drift/clobber that made the suite flaky (each run gets a
+backend matching its own code).
+
+Required repo **secrets**: `CLERK_SECRET_KEY`,
+`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CONVEX_ADMIN_KEY`, `E2E_CLERK_USER_ID`(`_B`),
+`E2E_CLERK_ORG_ID`(`_B`). Required **variables**: `NEXT_PUBLIC_CONVEX_URL`,
+`NEXT_PUBLIC_CONVEX_SITE_URL`, `CONVEX_DEPLOYMENT` (the cloud values still gate
+the job and back the non-blocking visual job; the blocking job overrides them
+with the local backend at run time).
+
+## Gotchas
+
+- **A `/dashboard/*` route that calls `notFound()` returns HTTP 200, not 404** —
+  the layout shell streams (flushing 200 headers) before the page resolves.
+  Assert the rendered not-found UI, not `response.status()` (WSM-000190). Public
+  `/leagues/*` routes render fully server-side and *can* return 404.
+- **Responsive DOM duplicates:** desktop/mobile variants both render; scope with
+  `.filter({ visible: true })` / `.first()`.
+- **Quarantined specs** use `test.fixme` and are tracked in #419.


### PR DESCRIPTION
Documents work from this session that had no accurate home in the repo. **Docs-only** — no product code touched.

## New
- **`docs/development/DEPLOY.md`** — prod deploy runbook. The key mental model: **two independent pipelines** — web **auto-promotes** on every `main` push (Vercel), while **Convex is a separate manual `convex deploy`** to `terrific-aardvark-395`. Covers the deploy-order rule (Convex before/with web so a live route never calls a missing function), the `.env.local` local-backend gotcha from #428, verification (curl probes + Vercel runtime errors), and rollback.
- **`docs/guides/WEB_E2E_TESTING_GUIDE.md`** — the `apps/web` Playwright suite (Clerk `storageState` sign-in-once, canonical Convex fixture + `activeLeagueId` cookie, projects) and the **#428 in-runner local-Convex CI** mechanism.

## Updated
- **`docs/guides/E2E_TESTING_GUIDE.md`** — banner marking it the **legacy Salesforce-Lightning** suite (root `e2e/`), pointing to the new web guide. (Both suites still exist; the old guide was accurate for the SF one but never covered the web one.)
- **`README.md` / `apps/web/README.md`** — note the web app is **Convex-backed** (the Salesforce-REST wording describes the original design and is being reconciled — code + `apps/web/CLAUDE.md` are authoritative); refresh E2E test counts (`81/14` → `~93/24`); link the new docs.
- **`docs/README.md`** — index the two new docs.
- **`.github/workflows/e2e.yml`** — fix the stale header comment still describing the removed "Deploy Convex functions to dev" step (now the in-runner local backend, #428).

## Notes
- Branched off `main` in an isolated worktree — a concurrent session was mid-work on `feat/WSM-000193` when these edits were made, so they were kept fully separate from that branch.
- Scope was deliberately conservative: I flagged but did **not** rewrite the larger pre-existing Salesforce→Convex architecture drift (that's a bigger reconciliation), only added an honest pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)