### PR TITLE
fix(web): depth-chart route 404'd for every team (WSM-000194 / #435)

### DIFF
--- a/apps/web/e2e/tests/coach-depth-chart.spec.ts
+++ b/apps/web/e2e/tests/coach-depth-chart.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
 import { TEAMS } from "../helpers/test-data";
 import {
   withRosterFixture,
@@ -7,11 +8,14 @@ import {
   type RosterFixtureResult,
 } from "../helpers/seed-roster";
 
-// QUARANTINED (#419): the flag-gated depth-chart route now 404s in CI, so the
-// whole feature group is unreachable. Un-fixme once the route/flag is restored.
-test.describe.fixme("Depth Chart (WSM-000007)", () => {
+// Was quarantined via #419/#435: the route 404'd for EVERY team — the page
+// passed an empty visibleLeagueIds to getTeam, whose access check then always
+// threw, and the .catch() collapsed that into notFound(). Fixed by resolving
+// the team's leagueId first (page.tsx), the same pattern as roster/audit.
+test.describe("Depth Chart (WSM-000007)", () => {
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page });
+    await setActiveLeague(page, readCanonicalFixture().leagueId);
   });
 
   test("flag-gated route is reachable in dev (flag default: on)", async ({
@@ -23,12 +27,14 @@ test.describe.fixme("Depth Chart (WSM-000007)", () => {
     const href = await teamLink.getAttribute("href");
     expect(href).toBeTruthy();
     await page.goto(`${href}/depth-chart`);
-    const body = page.locator("body");
-    await expect(body).toBeVisible();
-    const notFoundHeading = page.getByRole("heading", {
-      name: /404|Not Found|Page not found/i,
-    });
-    await expect(notFoundHeading).toHaveCount(0);
+    // Assert the board actually rendered — checking for the ABSENCE of a 404
+    // heading is too weak (Next's not-found heading, "This page could not be
+    // found.", didn't even match the old regex, so a 404 could slip through).
+    await expect(
+      page.getByRole("heading", {
+        name: `${TEAMS.COWBOYS.name} — Depth Chart`,
+      }),
+    ).toBeVisible();
   });
 });
 
@@ -39,8 +45,7 @@ test.describe.fixme("Depth Chart (WSM-000007)", () => {
 // is brittle across engines.
 const PHONE = { width: 375, height: 812 };
 
-// QUARANTINED (#419): same depth-chart route + drag-handle markup rot.
-test.describe.fixme("Depth Chart — mobile touch targets (WSM-000085)", () => {
+test.describe("Depth Chart — mobile touch targets (WSM-000085)", () => {
   let fixture: RosterFixtureResult | null = null;
   let teardown: (() => Promise<void>) | null = null;
 
@@ -69,8 +74,10 @@ test.describe.fixme("Depth Chart — mobile touch targets (WSM-000085)", () => {
     await setupClerkTestingToken({ page });
   });
 
-  // QUARANTINED (#419): drag-handle button no longer matches name /^Drag /.
-  test.fixme("drag handles render and meet the 44px touch target", async ({
+  // The "selector rot" suspected in #419 was a misdiagnosis: the handle is
+  // still <button aria-label="Drag {name}">. The handles never rendered
+  // because the route itself 404'd (see the fix note at the top of this file).
+  test("drag handles render and meet the 44px touch target", async ({
     page,
   }) => {
     await page.goto(`/dashboard/teams/${fixture!.teamId}/depth-chart`);

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { depthChartV1 } from "@/lib/flags";
 import {
   getTeam,
+  getTeamLeagueId,
   getPlayersByTeam,
   getSeasons,
   getDepthChartByTeamSeason,
@@ -26,10 +27,17 @@ export default async function DepthChartPage({
 
   const { id: teamId } = await params;
 
+  // Resolve leagueId first so the access check inside getTeam has the
+  // correct visibleLeagueIds (an empty list made getTeam throw for every
+  // team, 404ing the whole route — #435); real auth runs against the
+  // league's Clerk org a few lines below via getLeagueOrgId + resolveOrgRole.
+  // Matches the roster + audit pages.
+  const leagueId = await getTeamLeagueId(teamId).catch(() => null);
+  if (!leagueId) notFound();
   const team = await getTeam(teamId, {
     userId,
     orgIds: [],
-    visibleLeagueIds: [],
+    visibleLeagueIds: [leagueId],
     subscribedLeagueIds: [],
     subscriptionTeamScopes: {},
   }).catch(() => null);


### PR DESCRIPTION
## Summary

Fixes #435 — and it turned out to be a **real product bug**, not just CI: the flag-gated `/dashboard/teams/[id]/depth-chart` route 404'd for **every team in every environment**.

### Root cause
`page.tsx` called `getTeam` with an empty access context (`visibleLeagueIds: []`). `getTeam`'s `requireLeagueAccessLocal` check throws whenever the team's league isn't in that list — i.e. always — and the `.catch(() => null)` collapsed the throw into `notFound()`. The roster (`/roster`) and audit (`/roster/audit`) pages were already fixed with the resolve-leagueId-first pattern; depth-chart was the one page missed.

### Fix
Resolve `getTeamLeagueId(teamId)` first and pass `visibleLeagueIds: [leagueId]`, mirroring the roster/audit pages. Real authorization is unchanged — it still runs against the league's Clerk org via `getLeagueOrgId` + `resolveOrgRole` immediately below.

### e2e (coach-depth-chart.spec.ts)
- Un-fixme'd both quarantined describes (route reachability + mobile 44px touch targets).
- The suspected drag-handle "selector rot" was a **misdiagnosis**: the handle is still `<button aria-label="Drag {name}">` with an `h-11 w-11` (44px) hit area — it never rendered because the route 404'd. Selector kept as-is.
- Strengthened the reachability test: it now positively asserts the board heading (`Dallas Cowboys — Depth Chart`). The old assertion only checked for the absence of a heading matching `/404|Not Found|Page not found/i`, which doesn't even match Next's actual "This page could not be found." heading — a 404 could have passed.
- Aligned the first describe's `beforeEach` with the other canonical-fixture specs (`setActiveLeague`).
- The three multi-user seed-harness placeholders stay `test.fixme`, as scoped in #435.

## Test plan
- [x] `tsc --noEmit` + eslint clean on both changed files
- [x] `playwright test --list` collects the spec (5 tests: 2 live, 3 placeholder fixmes)
- [ ] CI Playwright job green — the seeded suite needs CI-only secrets (`CONVEX_ENABLE_E2E_SEED`, Clerk test creds), so live validation happens here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls9N5DBiXh7esUP3jTCHHq