### PR TITLE
fix(web): name the roster row actions + adopt Radix Select e2e pattern (WSM-000195 / #434)

### DIFF
--- a/apps/web/e2e/helpers/select.ts
+++ b/apps/web/e2e/helpers/select.ts
@@ -1,0 +1,18 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Drive a Radix/shadcn <Select> (WSM-000119 pick lists): the trigger is a
+ * combobox button, not an <input>, so .fill()/.clear() don't work. Click the
+ * trigger, then click the option in the portalled listbox. `exact` matching
+ * keeps short option names from colliding ("C" vs "CB", "Dallas" vs
+ * "Lake Dallas"). The option click auto-waits, which also covers selects
+ * whose option lists stream in after open (e.g. the lazy-loaded city list).
+ */
+export async function pickSelectOption(
+  page: Page,
+  triggerSelector: string,
+  optionName: string,
+): Promise<void> {
+  await page.locator(triggerSelector).click();
+  await page.getByRole("option", { name: optionName, exact: true }).click();
+}

--- a/apps/web/e2e/tests/player-crud.spec.ts
+++ b/apps/web/e2e/tests/player-crud.spec.ts
@@ -1,16 +1,27 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
+import { pickSelectOption } from "../helpers/select";
 import { TEAMS, PLAYERS } from "../helpers/test-data";
 
-// QUARANTINED (#419): the create/edit form fields are now Radix Selects
-// (role=combobox buttons), not <input>s, so every form-mutation test fails on
-// fill(). Whole serial group fixme'd until the specs adopt the Select pattern.
-test.describe.fixme("Player CRUD", () => {
+// Rewritten for #434: position/jersey/status are Radix <Select>s (combobox
+// trigger buttons), driven via pickSelectOption — only name/DOB/hometown are
+// still text inputs. Two more renames since the original spec: the roster
+// table abbreviates names ("E2E Test Player" renders as "E. Test Player"),
+// so rows match on the preserved tail; and the row actions are icon-only
+// buttons selected by their aria-labels ("Edit {name}" / "Delete {name}").
+//
+// The tests form an ordered chain (create → edit → delete) against the
+// canonical Cowboys roster; the suite runs serially (workers=1), and the
+// canonical fixture is re-seeded per run, so leftovers from a failed chain
+// don't leak across runs.
+test.describe("Player CRUD", () => {
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page });
+    await setActiveLeague(page, readCanonicalFixture().leagueId);
     // Navigate to Cowboys team detail page
     await page.goto("/dashboard/teams");
-    await page.getByText(TEAMS.COWBOYS.name).click();
+    await page.locator("a", { hasText: TEAMS.COWBOYS.name }).click();
     await expect(page.getByRole("heading", { name: TEAMS.COWBOYS.name })).toBeVisible();
   });
 
@@ -24,31 +35,29 @@ test.describe.fixme("Player CRUD", () => {
     await expect(page.locator("#player-status")).toBeVisible();
   });
 
-  // QUARANTINED (#419): #player-position is now a Radix Select (role=combobox
-  // button), not an <input> — the test fill()s it. Update to click + pick option.
-  test.fixme("create player with valid data", async ({ page }) => {
+  test("create player with valid data", async ({ page }) => {
     await page.getByRole("button", { name: "Add Player" }).click();
 
     await page.locator("#player-name").fill("E2E Test Player");
-    await page.locator("#player-position").fill("TE");
-    await page.locator("#player-jersey").fill("99");
+    await pickSelectOption(page, "#player-position", "TE");
+    await pickSelectOption(page, "#player-jersey", "99");
     // Status defaults to Active
 
     await page.getByRole("button", { name: "Add Player" }).last().click();
 
-    // Wait for success toast
     await expect(page.locator("[data-sonner-toast]")).toBeVisible({ timeout: 10000 });
 
-    // Verify player appears in roster
-    await expect(page.getByText("E2E Test Player")).toBeVisible();
+    // Verify player appears in roster (names render abbreviated).
+    await expect(
+      page.locator("tbody tr", { hasText: "Test Player" }),
+    ).toBeVisible();
   });
 
   test("form validation prevents empty name", async ({ page }) => {
     await page.getByRole("button", { name: "Add Player" }).click();
 
-    // Clear name and try to submit
-    await page.locator("#player-name").clear();
-    await page.locator("#player-position").fill("TE");
+    // Pick a position but leave the required name empty and try to submit.
+    await pickSelectOption(page, "#player-position", "TE");
     await page.getByRole("button", { name: "Add Player" }).last().click();
 
     // Dialog should stay open (validation error)
@@ -56,48 +65,53 @@ test.describe.fixme("Player CRUD", () => {
   });
 
   test("edit opens pre-populated dialog", async ({ page }) => {
-    // Find E2E Test Player row and click edit
-    const row = page.locator("tbody tr", { hasText: "E2E Test Player" });
-    await row.locator("button").first().click(); // Pencil icon button
+    const row = page.locator("tbody tr", { hasText: "Test Player" });
+    await row.getByRole("button", { name: /^Edit / }).click();
 
     await expect(page.getByRole("heading", { name: "Edit Player" })).toBeVisible();
     await expect(page.locator("#player-name")).toHaveValue("E2E Test Player");
+    // Select triggers render their selected value as text, not an input value.
+    await expect(page.locator("#player-position")).toContainText("TE");
+    await expect(page.locator("#player-jersey")).toContainText("99");
   });
 
   test("edit saves changes", async ({ page }) => {
-    const row = page.locator("tbody tr", { hasText: "E2E Test Player" });
-    await row.locator("button").first().click();
+    const row = page.locator("tbody tr", { hasText: "Test Player" });
+    await row.getByRole("button", { name: /^Edit / }).click();
 
-    await page.locator("#player-position").clear();
-    await page.locator("#player-position").fill("WR");
+    await pickSelectOption(page, "#player-position", "WR");
     await page.getByRole("button", { name: "Save Changes" }).click();
 
     await expect(page.locator("[data-sonner-toast]")).toBeVisible({ timeout: 10000 });
-    await expect(page.locator("tbody tr", { hasText: "E2E Test Player" })).toContainText("WR");
+    await expect(
+      page.locator("tbody tr", { hasText: "Test Player" }),
+    ).toContainText("WR");
   });
 
   test("delete with confirmation removes player", async ({ page }) => {
-    const row = page.locator("tbody tr", { hasText: "E2E Test Player" });
-    // Click delete button (the red-colored trash button)
-    await row.locator("button.text-red-600").click();
+    const row = page.locator("tbody tr", { hasText: "Test Player" });
+    await row.getByRole("button", { name: /^Delete / }).click();
 
     await expect(page.getByRole("heading", { name: "Delete Player" })).toBeVisible();
-    await page.getByRole("button", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
 
     await expect(page.locator("[data-sonner-toast]")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("E2E Test Player")).toBeHidden();
+    await expect(
+      page.locator("tbody tr", { hasText: "Test Player" }),
+    ).toHaveCount(0);
   });
 
   test("delete cancel keeps player in roster", async ({ page }) => {
-    // Find Prescott's row and click delete
-    const row = page.locator("tbody tr", { hasText: PLAYERS.PRESCOTT.name });
-    await row.locator("button.text-red-600").click();
+    // Rows show abbreviated names, so match on the surname.
+    const row = page.locator("tbody tr", { hasText: "Prescott" });
+    await row.getByRole("button", { name: /^Delete / }).click();
 
     await expect(page.getByRole("heading", { name: "Delete Player" })).toBeVisible();
     await page.getByRole("button", { name: "Cancel" }).click();
 
     // Prescott should still be visible
-    await expect(page.getByText(PLAYERS.PRESCOTT.name)).toBeVisible();
+    await expect(row).toBeVisible();
+    await expect(row).toContainText(String(PLAYERS.PRESCOTT.jersey));
   });
 
   test("error toast on failed mutation", async ({ page }) => {
@@ -111,7 +125,7 @@ test.describe.fixme("Player CRUD", () => {
 
     await page.getByRole("button", { name: "Add Player" }).click();
     await page.locator("#player-name").fill("Error Test Player");
-    await page.locator("#player-position").fill("QB");
+    await pickSelectOption(page, "#player-position", "QB");
     await page.getByRole("button", { name: "Add Player" }).last().click();
 
     // Error toast should appear

--- a/apps/web/e2e/tests/team-edit.spec.ts
+++ b/apps/web/e2e/tests/team-edit.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
+import { pickSelectOption } from "../helpers/select";
 import { TEAMS } from "../helpers/test-data";
 
 test.describe("Team Edit", () => {
@@ -28,25 +29,33 @@ test.describe("Team Edit", () => {
     await expect(page.locator("#team-city")).toContainText(TEAMS.COWBOYS.city);
   });
 
-  // QUARANTINED (#434): #team-city is a Radix Select; this test still
-  // .clear()/.fill()s it. Rewrite to drive the Select via option clicks.
-  test.fixme("saves changes and restores", async ({ page }) => {
-    await page.getByRole("button", { name: "Edit Team" }).click();
+  // #team-city is a Radix Select fed by a state-scoped city pick list (no
+  // free text since WSM-000136). The canonical Cowboys team has no location,
+  // so the State select is driven first — that scopes the city options (and
+  // lazy-loads the cities dataset). Success closes the dialog and refreshes
+  // the page, so the assertions read the team detail <dl> rather than the
+  // toast (a second identical toast would make the toast locator ambiguous).
+  test("saves changes and restores", async ({ page }) => {
+    const details = page.locator("dl");
 
-    await page.locator("#team-city").clear();
-    await page.locator("#team-city").fill("Dallas-FW");
+    await page.getByRole("button", { name: "Edit Team" }).click();
+    await pickSelectOption(page, "#team-state", "Texas");
+    await pickSelectOption(page, "#team-city", "Fort Worth");
     await page.getByRole("button", { name: "Save Changes" }).click();
 
-    await expect(page.locator("[data-sonner-toast]")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Dallas-FW")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Edit Team" })).toBeHidden();
+    await expect(details.getByText("Fort Worth", { exact: true })).toBeVisible();
 
-    // Restore original value
+    // Restore original value (the state now parses from "Fort Worth, TX",
+    // so only the city needs re-picking).
     await page.getByRole("button", { name: "Edit Team" }).click();
-    await page.locator("#team-city").clear();
-    await page.locator("#team-city").fill(TEAMS.COWBOYS.city);
+    await pickSelectOption(page, "#team-city", TEAMS.COWBOYS.city);
     await page.getByRole("button", { name: "Save Changes" }).click();
 
-    await expect(page.locator("[data-sonner-toast]")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "Edit Team" })).toBeHidden();
+    await expect(
+      details.getByText(TEAMS.COWBOYS.city, { exact: true }),
+    ).toBeVisible();
   });
 
   test("form validation prevents empty name", async ({ page }) => {

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -392,6 +392,7 @@ export default function TeamManagement({
                         <Button
                           variant="ghost"
                           size="sm"
+                          aria-label={`Edit ${player.name}`}
                           onClick={() =>
                             setModal({
                               type: "editPlayer",
@@ -405,6 +406,7 @@ export default function TeamManagement({
                           variant="ghost"
                           size="sm"
                           className="text-destructive hover:text-destructive"
+                          aria-label={`Delete ${player.name}`}
                           onClick={() =>
                             setModal({
                               type: "deletePlayer",


### PR DESCRIPTION
## Summary

Fixes #434 — un-quarantines the **Player CRUD** describe group and the last **Team Edit** test by adopting the Radix Select interaction pattern, plus one small real product fix that fell out of it.

### Product (a11y)
The roster table's per-row edit/delete buttons were icon-only with **no accessible name** — a genuine a11y gap, and the reason the old spec resorted to a stale CSS-class selector (`button.text-red-600`, which broke when the palette moved to `text-destructive`). They now carry `aria-label="Edit {name}"` / `"Delete {name}"`, and the spec selects them by role.

### e2e
- **New `e2e/helpers/select.ts`** — `pickSelectOption(page, trigger, option)`: click the combobox trigger, click the option (`exact` names so "C" doesn't collide with "CB"). The option click auto-waits, which also covers the lazy-loaded city list.
- **player-crud.spec.ts** — full rewrite of the group (8 tests, no fixmes): position/jersey driven via Selects; rows matched on the abbreviated-name tail (`"E2E Test Player"` renders as `"E. Test Player"`); edit pre-population asserted via trigger text (`toContainText`), not `toHaveValue`; delete via the new aria-labels; `beforeEach` aligned with the canonical-fixture specs (`setActiveLeague`).
- **team-edit.spec.ts** — un-fixme'd `saves changes and restores`: `#team-city` is a state-scoped pick list (no free text since WSM-000136), so the test drives State ("Texas") → City ("Fort Worth"), saves, then restores Dallas. Both cities verified present in `src/data/us-cities.json` (TX has 1,837 entries). Save assertions read the refreshed team `<dl>` rather than toasts (a second identical toast would make the toast locator strict-mode ambiguous).

Both #419-offspring spec issues are now done once this lands (#435 merged in #439); #436 (schedules-standings rebuild) remains.

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [x] `playwright test --list` collects 13 tests across the two files, zero fixmes in these groups
- [ ] CI Playwright job green (seeded suite runs only in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls9N5DBiXh7esUP3jTCHHq