### PR TITLE
test(web): depth-chart e2e seed harness + un-quarantine 3 specs (WSM-000197 / #419)

### DIFF
--- a/apps/web/convex/__tests__/e2eSeed.test.ts
+++ b/apps/web/convex/__tests__/e2eSeed.test.ts
@@ -16,6 +16,7 @@ interface FixtureResult {
   teamId: Id<"teams">;
   playerIds: Id<"players">[];
   activeAssignmentIds: Id<"rosterAssignments">[];
+  depthChartEntryIds: Id<"depthChartEntries">[];
 }
 
 function asFixture(r: unknown): FixtureResult {
@@ -141,6 +142,61 @@ describe("e2eSeed", () => {
       const team = await ctx.db.get(second.teamId);
       expect(team?.rosterLimit).toBe(40);
     });
+  });
+
+  it("seeds depthChartEntries for the active players when requested", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+        seedActivePlayers: 3,
+        extraBenchPlayers: 0,
+        positionSlot: "QB",
+        seedDepthChartEntries: true,
+      }),
+    );
+
+    expect(result.depthChartEntryIds).toHaveLength(3);
+
+    await t.run(async (ctx) => {
+      const entries = await ctx.db
+        .query("depthChartEntries")
+        .withIndex("by_team_season_position", (q) =>
+          q
+            .eq("teamId", result.teamId)
+            .eq("seasonId", result.seasonId)
+            .eq("positionSlot", "QB"),
+        )
+        .collect();
+      expect(entries).toHaveLength(3);
+      const bySortOrder = [...entries].sort((a, b) => a.sortOrder - b.sortOrder);
+      expect(bySortOrder.map((e) => e.sortOrder)).toEqual([0, 1, 2]);
+      expect(bySortOrder.map((e) => e.playerId)).toEqual(result.playerIds);
+    });
+
+    // Teardown cascades through the new rows too.
+    await t.mutation(anyApi.e2eSeed.resetRosterFixture, {
+      fixtureKey: FIXTURE_KEY,
+    });
+    await t.run(async (ctx) => {
+      const stray = await ctx.db.get(result.depthChartEntryIds[0]);
+      expect(stray).toBeNull();
+    });
+  });
+
+  it("omits depthChartEntries by default", async () => {
+    const t = convexTest(schema, modules);
+    const result = asFixture(
+      await t.mutation(anyApi.e2eSeed.createRosterFixture, {
+        fixtureKey: FIXTURE_KEY,
+        clerkOrgId: null,
+        rosterLimit: 53,
+        seedActivePlayers: 2,
+      }),
+    );
+    expect(result.depthChartEntryIds).toHaveLength(0);
   });
 
   it("respects rosterLocked=true when requested", async () => {

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -73,6 +73,7 @@ const fixtureResultValidator = v.object({
   teamId: v.id("teams"),
   playerIds: v.array(v.id("players")),
   activeAssignmentIds: v.array(v.id("rosterAssignments")),
+  depthChartEntryIds: v.array(v.id("depthChartEntries")),
 });
 
 // Cascade-delete a single league and every child row that references it.
@@ -204,6 +205,10 @@ export const createRosterFixture = internalMutation({
     seedActivePlayers: v.optional(v.number()),
     extraBenchPlayers: v.optional(v.number()),
     positionSlot: v.optional(v.string()),
+    // Depth-chart e2e (WSM-000197): also insert one depthChartEntries row per
+    // active player (sortOrder = seed index) so the board renders a
+    // deterministic initial order that reorders can be asserted against.
+    seedDepthChartEntries: v.optional(v.boolean()),
   },
   returns: fixtureResultValidator,
   handler: async (ctx, args) => {
@@ -280,6 +285,21 @@ export const createRosterFixture = internalMutation({
       activeAssignmentIds.push(assignmentId);
     }
 
+    const depthChartEntryIds: Id<"depthChartEntries">[] = [];
+    if (args.seedDepthChartEntries) {
+      for (let i = 0; i < seedActive; i++) {
+        const entryId = await ctx.db.insert("depthChartEntries", {
+          teamId,
+          seasonId,
+          playerId: playerIds[i],
+          positionSlot,
+          sortOrder: i,
+          updatedAt: assignedAt,
+        });
+        depthChartEntryIds.push(entryId);
+      }
+    }
+
     return {
       fixtureKey: args.fixtureKey,
       leagueId,
@@ -287,6 +307,7 @@ export const createRosterFixture = internalMutation({
       teamId,
       playerIds,
       activeAssignmentIds,
+      depthChartEntryIds,
     };
   },
 });

--- a/apps/web/e2e/helpers/seed-roster.ts
+++ b/apps/web/e2e/helpers/seed-roster.ts
@@ -23,6 +23,8 @@ export interface RosterFixtureConfig {
   seedActivePlayers?: number;
   extraBenchPlayers?: number;
   positionSlot?: string;
+  /** Also insert depthChartEntries for the active players (WSM-000197). */
+  seedDepthChartEntries?: boolean;
 }
 
 export interface RosterFixtureResult {
@@ -32,6 +34,7 @@ export interface RosterFixtureResult {
   teamId: string;
   playerIds: string[];
   activeAssignmentIds: string[];
+  depthChartEntryIds: string[];
 }
 
 const createFixtureRef = makeFunctionReference<

--- a/apps/web/e2e/tests/coach-depth-chart.spec.ts
+++ b/apps/web/e2e/tests/coach-depth-chart.spec.ts
@@ -1,10 +1,11 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
 import { TEAMS } from "../helpers/test-data";
 import {
   withRosterFixture,
   getTestOrgId,
+  getTestOrgIdB,
   type RosterFixtureResult,
 } from "../helpers/seed-roster";
 
@@ -96,33 +97,237 @@ test.describe("Depth Chart — mobile touch targets (WSM-000085)", () => {
       expect(box!.width).toBeGreaterThanOrEqual(44);
     }
   });
+});
 
-  test.fixme(
-    "coach can drag-reorder players within a position slot",
-    async () => {
-      // Requires a Convex seed harness (team, season rosterLocked=false,
-      // 3 players at the same positionSlot, 3 depthChartEntries). When the
-      // harness lands, drive the sortable via @dnd-kit/core pointer events
-      // and assert sortOrder persists after refresh.
-    },
-  );
+// Seeded depth-chart scenarios (WSM-000197, un-quarantines the #419 fixmes).
+// The roster fixture now also seeds depthChartEntries (sortOrder = seed index)
+// so the QB column renders a deterministic initial order to reorder against.
+// All three describes run against the shared signed-in storageState (user A,
+// admin of E2E_CLERK_ORG_ID) — same auth model as the mobile describe above.
 
-  test.fixme(
-    "admin roster-lock disables drag handles for coach",
-    async () => {
-      // Requires two Clerk test users (coach + admin) + Convex seed. Admin
-      // toggles setRosterLocked(true); coach reloads and drag handles
-      // become disabled; calling reorderDepthChartAction should reject
-      // with `season_locked`.
-    },
-  );
+/** The ordered player rows inside one position column. */
+function columnRows(page: Page, positionSlot: string) {
+  return page
+    .getByRole("region", { name: `${positionSlot} depth chart` })
+    .locator("ol > li");
+}
 
-  test.fixme(
-    "coach of team A cannot reorder team B",
-    async () => {
-      // Requires two teams in different orgs. Invoke reorderDepthChart
-      // for team B while authenticated as coach of team A; expect the
-      // server action to throw `not_authorized`.
-    },
+/**
+ * The server actions (reorderDepthChartAction / setRosterLockedAction) POST
+ * back to the depth-chart page URL — awaiting that response is how we know
+ * the Convex write landed before we reload and assert persistence.
+ */
+function waitForDepthChartAction(page: Page) {
+  return page.waitForResponse(
+    (res) =>
+      res.request().method() === "POST" && res.url().includes("/depth-chart"),
   );
+}
+
+test.describe.serial("Depth Chart — drag reorder (WSM-000197)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withRosterFixture({
+      fixtureKey: "depth-chart-reorder",
+      clerkOrgId: orgId,
+      teamName: "E2E Depth Chart Reorder Team",
+      rosterLimit: 53,
+      seedActivePlayers: 3,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+      seedDepthChartEntries: true,
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("coach can drag-reorder players within a position slot", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    await page.goto(`/dashboard/teams/${fixture!.teamId}/depth-chart`);
+
+    // Seeded order from the depthChartEntries (sortOrder 0..2).
+    const rows = columnRows(page, "QB");
+    await expect(rows).toHaveCount(3);
+    await expect(rows.nth(0)).toContainText("E2E Player 1");
+    await expect(rows.nth(1)).toContainText("E2E Player 2");
+    await expect(rows.nth(2)).toContainText("E2E Player 3");
+
+    // Drag Player 1's handle onto Player 3's row. The MouseSensor activates
+    // after 4px of travel (see PositionColumn), so: press, nudge past the
+    // activation distance, then glide to the target in small steps so
+    // @dnd-kit's collision detection tracks the pointer.
+    const handle = page.getByRole("button", { name: "Drag E2E Player 1" });
+    const source = await handle.boundingBox();
+    const target = await rows.nth(2).boundingBox();
+    expect(source).not.toBeNull();
+    expect(target).not.toBeNull();
+
+    const actionDone = waitForDepthChartAction(page);
+    await page.mouse.move(
+      source!.x + source!.width / 2,
+      source!.y + source!.height / 2,
+    );
+    await page.mouse.down();
+    // Clear the 4px activation constraint before heading to the target.
+    await page.mouse.move(
+      source!.x + source!.width / 2,
+      source!.y + source!.height / 2 + 8,
+    );
+    await page.mouse.move(
+      target!.x + target!.width / 2,
+      target!.y + target!.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    // Optimistic UI: Player 1 moved to the bottom.
+    await expect(rows.nth(0)).toContainText("E2E Player 2");
+    await expect(rows.nth(1)).toContainText("E2E Player 3");
+    await expect(rows.nth(2)).toContainText("E2E Player 1");
+
+    // Wait for the reorder server action to land, then refresh — the new
+    // sortOrder must come back from Convex, not client state.
+    await actionDone;
+    await page.reload();
+    const rowsAfter = columnRows(page, "QB");
+    await expect(rowsAfter).toHaveCount(3);
+    await expect(rowsAfter.nth(0)).toContainText("E2E Player 2");
+    await expect(rowsAfter.nth(1)).toContainText("E2E Player 3");
+    await expect(rowsAfter.nth(2)).toContainText("E2E Player 1");
+  });
+});
+
+test.describe.serial("Depth Chart — roster lock (WSM-000197)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withRosterFixture({
+      fixtureKey: "depth-chart-lock",
+      clerkOrgId: orgId,
+      teamName: "E2E Depth Chart Lock Team",
+      rosterLimit: 53,
+      seedActivePlayers: 3,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+      seedDepthChartEntries: true,
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  // The CI test users are org admins, and admins share the coach's edit path:
+  // `disabled = rosterLocked || !canEdit` (DepthChartBoard → PositionColumn),
+  // so locked handles behave identically for both roles. The server-side
+  // `season_locked` rejection of reorderDepthChart is unit-covered in
+  // convex/__tests__/depthChart.test.ts; this spec covers the UI enforcement
+  // plus persistence of the lock across a reload.
+  test("admin roster-lock disables drag handles for coach", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    await page.goto(`/dashboard/teams/${fixture!.teamId}/depth-chart`);
+
+    // Unlocked: banner reports it and the handles are draggable.
+    await expect(page.getByText("Roster is unlocked")).toBeVisible();
+    const handles = page.getByRole("button", { name: /^Drag / });
+    await expect(handles.first()).toBeEnabled();
+
+    // Admin flips the lock; the action persists it via setRosterLocked.
+    const actionDone = waitForDepthChartAction(page);
+    await page.getByRole("button", { name: "Lock roster" }).click();
+    await actionDone;
+
+    await expect(
+      page.getByText("Roster locked — drag handles are disabled"),
+    ).toBeVisible();
+    await expect(handles.first()).toBeDisabled();
+
+    // Reload — the lock came back from Convex, and every handle is disabled.
+    await page.reload();
+    await expect(
+      page.getByText("Roster locked — drag handles are disabled"),
+    ).toBeVisible();
+    const handlesAfter = page.getByRole("button", { name: /^Drag / });
+    await expect(handlesAfter).toHaveCount(3);
+    for (let i = 0; i < 3; i++) {
+      await expect(handlesAfter.nth(i)).toBeDisabled();
+    }
+  });
+});
+
+test.describe.serial("Depth Chart — cross-org isolation (WSM-000197)", () => {
+  let fixture: RosterFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgIdB = getTestOrgIdB();
+    test.skip(!orgIdB, "E2E_CLERK_ORG_ID_B not set");
+    // Team B lives in Org B; the shared storageState user (A) is a member of
+    // Org A only.
+    const handle = await withRosterFixture({
+      fixtureKey: "depth-chart-cross-org",
+      clerkOrgId: orgIdB,
+      teamName: "E2E Depth Chart Org B Team",
+      rosterLimit: 53,
+      seedActivePlayers: 3,
+      extraBenchPlayers: 0,
+      positionSlot: "QB",
+      seedDepthChartEntries: true,
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  // The depth-chart page and reorderDepthChartAction enforce the same guard:
+  // resolveOrgRole(league org, caller) returns null for a non-member, which
+  // the page turns into notFound() and the action into `not_authorized`.
+  // Invoking the server action directly would require the build-specific
+  // Next-Action ID, so we assert the shared guard at the page boundary —
+  // the coach of team A never reaches team B's board (no handles to drag),
+  // matching the cross-org pattern in coach-roster.spec.ts (WSM-000025).
+  test("coach of team A cannot reorder team B", async ({ page }) => {
+    if (!fixture) test.skip();
+    await page.goto(`/dashboard/teams/${fixture!.teamId}/depth-chart`);
+
+    await expect(page.getByRole("heading", { name: /^404$/ })).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "E2E Depth Chart Org B Team — Depth Chart",
+      }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Drag / })).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

Un-quarantines the 3 remaining `test.fixme` placeholders in `apps/web/e2e/tests/coach-depth-chart.spec.ts` (the last open scope of #419) and extends the Convex e2e seed harness with the depth-chart data they need.

Closes #419

## Harness additions (`apps/web/convex/e2eSeed.ts`)

- `createRosterFixture` gains an optional `seedDepthChartEntries` arg: inserts one `depthChartEntries` row per seeded active player (`sortOrder` = seed index, same `positionSlot`) so the board renders a deterministic initial order.
- Result (and its return validator, kept exactly in sync) now includes `depthChartEntryIds` — empty array when not requested, so existing callers are unaffected.
- Stays `internalMutation` + `assertSeedEnabled()` gated on `CONVEX_ENABLE_E2E_SEED`, matching the existing harness pattern. Teardown already cascades through `depthChartEntries`.
- Playwright-side types updated in `e2e/helpers/seed-roster.ts`; 2 new unit tests in `convex/__tests__/e2eSeed.test.ts` (seeded entries + default-off + cascade delete).

## The 3 tests (new WSM-000197 describes, shared user-A storageState)

1. **coach can drag-reorder players within a position slot** — seeds 3 QBs + 3 entries (`rosterLocked=false`), drives the @dnd-kit sortable via low-level `mouse.down/move/up` (clears the MouseSensor 4px activation constraint, then glides in 12 steps), waits for the reorder server-action POST, reloads, and asserts the new sortOrder came back from Convex.
2. **admin roster-lock disables drag handles for coach** — admin (user A) clicks "Lock roster"; banner flips to "Roster locked — drag handles are disabled", all handles disable, and the lock + disabled handles persist across reload. Note: CI has no dedicated coach user — admins and coaches share the identical `disabled = rosterLocked || !canEdit` path in `DepthChartBoard`/`PositionColumn`, and the server-side `season_locked` rejection of `reorderDepthChart` is already unit-covered in `convex/__tests__/depthChart.test.ts`.
3. **coach of team A cannot reorder team B** — seeds the team in Org B (`E2E_CLERK_ORG_ID_B`); the Org A user gets a 404 (no board, no drag handles). Invoking `reorderDepthChartAction` directly would require the build-specific `Next-Action` ID, so the spec asserts the shared guard (`resolveOrgRole` returning null → page `notFound()` / action `not_authorized`) at the page boundary, matching the accepted cross-org pattern in `coach-roster.spec.ts` (WSM-000025).

## Verification (local, static — real e2e run happens in this PR's CI)

- `pnpm install --frozen-lockfile` + `pnpm --filter @sports-management/api-contracts build` — OK
- `pnpm run type-check` (apps/web, `tsc --noEmit`, e2e specs included) — clean
- `pnpm exec eslint` on the 4 changed files — no errors
- `playwright test --config e2e/playwright.config.ts --list` — suite parses; all 3 WSM-000197 tests listed, no fixmes left in the file (118 tests / 26 files total)
- `pnpm --filter @sports-management/web test:unit` — 734 passed, 2 failed in `live-score/__tests__/route.test.ts`; those 2 fail identically on clean HEAD (pre-existing, unrelated). `e2eSeed.test.ts`: 9/9 passing (7 existing + 2 new).

The e2e suite cannot run locally (Clerk test secrets + seed flag are CI-only) — the Playwright job on this PR is the real check for the 3 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)