### PR TITLE
feat(web): VOD replay for ended game streams (WSM-000198 / #303)

### DIFF
--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -313,6 +313,10 @@ export default defineSchema({
     youtubeVideoId: v.optional(v.union(v.string(), v.null())), // youtube: public
     status: v.string(), // "idle" | "active" | "ended"
     vodAssetId: v.union(v.string(), v.null()),
+    // Public playback id of the RECORDED asset (WSM-000198, #303 track 1). The
+    // live muxPlaybackId only serves the live edge — replays need the asset's
+    // own playback id. Optional: legacy rows predate it.
+    vodPlaybackId: v.optional(v.union(v.string(), v.null())),
     startedBy: v.string(),
     startedAt: v.string(),
     endedAt: v.union(v.string(), v.null()),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4429,6 +4429,9 @@ const publicStreamDtoValidator = v.union(
     muxPlaybackId: v.union(v.string(), v.null()),
     youtubeVideoId: v.union(v.string(), v.null()),
     vodAssetId: v.union(v.string(), v.null()),
+    // Public playback id of the recorded asset — what a replay actually plays
+    // (WSM-000198). Distinct from muxPlaybackId, which serves the live edge.
+    vodPlaybackId: v.union(v.string(), v.null()),
   }),
   v.null(),
 );
@@ -4463,6 +4466,7 @@ export const createGameStream = internalMutationGeneric({
       // for its webhook (video.live_stream.active) to confirm before flipping.
       status: provider === "youtube" ? "active" : "idle",
       vodAssetId: null,
+      vodPlaybackId: null,
       startedBy: args.startedBy,
       startedAt: new Date().toISOString(),
       endedAt: null,
@@ -4513,10 +4517,11 @@ export const endGameStreamByFixture = internalMutationGeneric({
 export const updateGameStreamStatus = internalMutationGeneric({
   args: {
     muxLiveStreamId: v.string(),
-    // Optional so a `video.asset.ready` webhook can attach the VOD id without
-    // changing status (the stream has already ended by then).
+    // Optional so a `video.asset.ready` webhook can attach the VOD ids without
+    // changing status (status flips separately on live_stream.idle).
     status: v.optional(v.string()),
     vodAssetId: v.optional(v.union(v.string(), v.null())),
+    vodPlaybackId: v.optional(v.union(v.string(), v.null())),
     endedAt: v.optional(v.union(v.string(), v.null())),
   },
   returns: v.boolean(),
@@ -4534,10 +4539,13 @@ export const updateGameStreamStatus = internalMutationGeneric({
     const patch: {
       status?: string;
       vodAssetId?: string | null;
+      vodPlaybackId?: string | null;
       endedAt?: string | null;
     } = {};
     if (args.status !== undefined) patch.status = args.status;
     if (args.vodAssetId !== undefined) patch.vodAssetId = args.vodAssetId;
+    if (args.vodPlaybackId !== undefined)
+      patch.vodPlaybackId = args.vodPlaybackId;
     if (args.endedAt !== undefined) patch.endedAt = args.endedAt;
 
     await ctx.db.patch(row._id, patch);
@@ -4561,6 +4569,7 @@ export const getStreamByFixture = queryGeneric({
       muxPlaybackId: row.muxPlaybackId ?? null,
       youtubeVideoId: row.youtubeVideoId ?? null,
       vodAssetId: row.vodAssetId,
+      vodPlaybackId: row.vodPlaybackId ?? null,
     };
   },
 });

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/__tests__/route.test.ts
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/live-score/__tests__/route.test.ts
@@ -1,25 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const {
-  mockLiveScoringV1,
-  mockGetFixture,
-  mockGetLeagueVisibility,
-  mockGetPublicSeason,
-  mockGetLiveGameState,
-} = vi.hoisted(() => ({
+const { mockLiveScoringV1, mockGetPublicLiveGameState } = vi.hoisted(() => ({
   mockLiveScoringV1: vi.fn(),
-  mockGetFixture: vi.fn(),
-  mockGetLeagueVisibility: vi.fn(),
-  mockGetPublicSeason: vi.fn(),
-  mockGetLiveGameState: vi.fn(),
+  mockGetPublicLiveGameState: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({ liveScoringV1: mockLiveScoringV1 }));
 vi.mock("@/lib/data-api", () => ({
-  getFixture: mockGetFixture,
-  getLeagueVisibility: mockGetLeagueVisibility,
-  getPublicSeason: mockGetPublicSeason,
-  getLiveGameState: mockGetLiveGameState,
+  getPublicLiveGameState: mockGetPublicLiveGameState,
 }));
 
 import { GET } from "../route";
@@ -41,10 +29,9 @@ const LIVE = {
 
 function happy() {
   mockLiveScoringV1.mockResolvedValue(true);
-  mockGetLeagueVisibility.mockResolvedValue({ isPublic: true });
-  mockGetFixture.mockResolvedValue({ id: GAME, seasonId: "season_1" });
-  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
-  mockGetLiveGameState.mockResolvedValue(LIVE);
+  // One Convex call does the public + cross-league guard AND the live-state
+  // read (WSM-000192); a non-null result means every guard passed.
+  mockGetPublicLiveGameState.mockResolvedValue({ live: LIVE });
 }
 
 beforeEach(() => {
@@ -57,40 +44,31 @@ describe("GET /leagues/[id]/games/[gameId]/live-score", () => {
     mockLiveScoringV1.mockResolvedValue(false);
     const res = await call();
     expect(res.status).toBe(404);
-    expect(mockGetLiveGameState).not.toHaveBeenCalled();
+    expect(mockGetPublicLiveGameState).not.toHaveBeenCalled();
   });
 
-  it("404s when the league isn't public", async () => {
-    mockGetLeagueVisibility.mockResolvedValue({ isPublic: false });
-    const res = await call();
-    expect(res.status).toBe(404);
-    expect(mockGetLiveGameState).not.toHaveBeenCalled();
-  });
-
-  it("404s when the fixture doesn't exist", async () => {
-    mockGetFixture.mockResolvedValue(null);
+  it("404s when the guarded read denies (private league / missing / cross-league fixture)", async () => {
+    mockGetPublicLiveGameState.mockResolvedValue(null);
     expect((await call()).status).toBe(404);
   });
 
-  it("404s on a cross-league fixture (leak guard)", async () => {
-    mockGetPublicSeason.mockResolvedValue({
-      id: "season_1",
-      leagueId: "other_league",
-    });
-    const res = await call();
-    expect(res.status).toBe(404);
-    expect(mockGetLiveGameState).not.toHaveBeenCalled();
+  it("404s when the read throws (e.g. invalid Convex id)", async () => {
+    mockGetPublicLiveGameState.mockRejectedValue(
+      new Error("ArgumentValidationError"),
+    );
+    expect((await call()).status).toBe(404);
   });
 
   it("returns the live projection for a public, in-league fixture", async () => {
     const res = await call();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ live: LIVE });
-    expect(res.headers.get("Cache-Control")).toContain("s-maxage=3");
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage=10");
+    expect(mockGetPublicLiveGameState).toHaveBeenCalledWith(LEAGUE, GAME);
   });
 
   it("returns { live: null } before kickoff", async () => {
-    mockGetLiveGameState.mockResolvedValue(null);
+    mockGetPublicLiveGameState.mockResolvedValue({ live: null });
     const res = await call();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ live: null });

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -12,6 +12,7 @@ import {
   getLiveGameState,
 } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
+import { resolveStreamView } from "@/lib/stream-view";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import GameStreamPlayer from "@/components/games/GameStreamPlayer";
@@ -127,13 +128,13 @@ export default async function PublicGamePage({
     liveEnabled && view.fixture.status !== "final"
       ? await getLiveGameState(gameId).catch(() => null)
       : null;
-  const liveActive = stream?.status === "active";
-  // A replay exists when Mux has attached a VOD asset, or — for YouTube — the
-  // same broadcast video id keeps serving the recording after it ends.
-  const hasReplay =
-    stream?.status === "ended" &&
-    (stream.vodAssetId !== null || stream.youtubeVideoId !== null);
-  const streamEndedNoReplay = stream?.status === "ended" && !hasReplay;
+  // Replay-vs-live decision (WSM-000198): live plays the live playback id;
+  // an ended Mux stream replays the recorded asset's own public playback id
+  // (vodPlaybackId); an ended YouTube stream replays the same video id.
+  const streamView = resolveStreamView(stream);
+  const liveActive = streamView.mode === "live";
+  const hasReplay = streamView.mode === "replay";
+  const streamEndedNoReplay = streamView.mode === "ended-no-replay";
 
   const { fixture, result, seasonName } = view;
   const isFinal = fixture.status === "final" && result !== null;
@@ -191,8 +192,8 @@ export default async function PublicGamePage({
             <div className="relative">
               <GameStreamPlayer
                 provider={stream!.provider}
-                muxPlaybackId={stream!.muxPlaybackId}
-                youtubeVideoId={stream!.youtubeVideoId}
+                muxPlaybackId={streamView.muxPlaybackId}
+                youtubeVideoId={streamView.youtubeVideoId}
                 live={liveActive}
                 title={`${fixture.homeTeamName} vs ${fixture.awayTeamName}`}
               />

--- a/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
+++ b/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
@@ -55,6 +55,65 @@ describe("mapMuxEventToUpdate (pure)", () => {
     ).toEqual({ muxLiveStreamId: "ls_1", vodAssetId: "asset_9" });
   });
 
+  it("attaches the asset's PUBLIC playback id on asset.ready (WSM-000198)", () => {
+    expect(
+      mapMuxEventToUpdate(
+        {
+          type: "video.asset.ready",
+          data: {
+            id: "asset_9",
+            live_stream_id: "ls_1",
+            playback_ids: [
+              { id: "pb_signed", policy: "signed" },
+              { id: "pb_public", policy: "public" },
+            ],
+          },
+        },
+        NOW,
+      ),
+    ).toEqual({
+      muxLiveStreamId: "ls_1",
+      vodAssetId: "asset_9",
+      vodPlaybackId: "pb_public",
+    });
+  });
+
+  it("attaches VOD ids on asset.live_stream_completed (finalized recording)", () => {
+    expect(
+      mapMuxEventToUpdate(
+        {
+          type: "video.asset.live_stream_completed",
+          data: {
+            id: "asset_9",
+            live_stream_id: "ls_1",
+            playback_ids: [{ id: "pb_public", policy: "public" }],
+          },
+        },
+        NOW,
+      ),
+    ).toEqual({
+      muxLiveStreamId: "ls_1",
+      vodAssetId: "asset_9",
+      vodPlaybackId: "pb_public",
+    });
+  });
+
+  it("omits vodPlaybackId when the asset has no PUBLIC playback id", () => {
+    expect(
+      mapMuxEventToUpdate(
+        {
+          type: "video.asset.ready",
+          data: {
+            id: "asset_9",
+            live_stream_id: "ls_1",
+            playback_ids: [{ id: "pb_signed", policy: "signed" }],
+          },
+        },
+        NOW,
+      ),
+    ).toEqual({ muxLiveStreamId: "ls_1", vodAssetId: "asset_9" });
+  });
+
   it("ignores asset.ready for uploads (no live_stream_id)", () => {
     expect(
       mapMuxEventToUpdate(

--- a/apps/web/src/lib/__tests__/stream-view.test.ts
+++ b/apps/web/src/lib/__tests__/stream-view.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { resolveStreamView } from "../stream-view";
+import type { PublicGameStream } from "@/lib/data-api";
+
+const base: PublicGameStream = {
+  status: "idle",
+  provider: "mux",
+  muxPlaybackId: "pb_live",
+  youtubeVideoId: null,
+  vodAssetId: null,
+  vodPlaybackId: null,
+};
+
+describe("resolveStreamView (pure replay-vs-live decision, WSM-000198)", () => {
+  it("no stream → none", () => {
+    expect(resolveStreamView(null)).toEqual({
+      mode: "none",
+      muxPlaybackId: null,
+      youtubeVideoId: null,
+    });
+  });
+
+  it("idle stream → none (nothing public to show yet)", () => {
+    expect(resolveStreamView(base).mode).toBe("none");
+  });
+
+  it("active mux stream → live with the LIVE playback id", () => {
+    expect(resolveStreamView({ ...base, status: "active" })).toEqual({
+      mode: "live",
+      muxPlaybackId: "pb_live",
+      youtubeVideoId: null,
+    });
+  });
+
+  it("ended mux stream with a VOD playback id → replay playing the VOD id, not the live id", () => {
+    expect(
+      resolveStreamView({
+        ...base,
+        status: "ended",
+        vodAssetId: "asset_9",
+        vodPlaybackId: "pb_vod",
+      }),
+    ).toEqual({
+      mode: "replay",
+      muxPlaybackId: "pb_vod",
+      youtubeVideoId: null,
+    });
+  });
+
+  it("ended mux stream WITHOUT a VOD playback id → ended-no-replay (even if the asset id landed)", () => {
+    // Legacy rows / asset webhooks not yet delivered: the live playback id
+    // cannot serve the recording, so there is nothing playable.
+    expect(
+      resolveStreamView({ ...base, status: "ended", vodAssetId: "asset_9" })
+        .mode,
+    ).toBe("ended-no-replay");
+  });
+
+  it("ended youtube stream → replay via the same video id", () => {
+    expect(
+      resolveStreamView({
+        ...base,
+        provider: "youtube",
+        muxPlaybackId: null,
+        youtubeVideoId: "yt_1",
+        status: "ended",
+      }),
+    ).toEqual({
+      mode: "replay",
+      muxPlaybackId: null,
+      youtubeVideoId: "yt_1",
+    });
+  });
+
+  it("ended youtube stream without a video id → ended-no-replay", () => {
+    expect(
+      resolveStreamView({
+        ...base,
+        provider: "youtube",
+        muxPlaybackId: null,
+        status: "ended",
+      }).mode,
+    ).toBe("ended-no-replay");
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -625,6 +625,7 @@ const refs = {
       muxLiveStreamId: string;
       status?: string;
       vodAssetId?: string | null;
+      vodPlaybackId?: string | null;
       endedAt?: string | null;
     },
     boolean
@@ -1856,6 +1857,9 @@ export interface PublicGameStream {
   muxPlaybackId: string | null;
   youtubeVideoId: string | null;
   vodAssetId: string | null;
+  /** Public playback id of the recorded asset (WSM-000198) — what a replay
+   *  plays. The live muxPlaybackId only serves the live edge. */
+  vodPlaybackId: string | null;
 }
 
 export interface CreateGameStreamInput {
@@ -1890,6 +1894,7 @@ export async function updateGameStreamStatus(input: {
   muxLiveStreamId: string;
   status?: string;
   vodAssetId?: string | null;
+  vodPlaybackId?: string | null;
   endedAt?: string | null;
 }): Promise<boolean> {
   return mutateConvex(refs.updateGameStreamStatus, input);

--- a/apps/web/src/lib/mux-webhook-handlers.ts
+++ b/apps/web/src/lib/mux-webhook-handlers.ts
@@ -14,9 +14,20 @@ import { updateGameStreamStatus } from "@/lib/data-api";
  *                                      NOT end on it (idle is authoritative).
  *                                      Ending here would kill a stream on a
  *                                      brief network blip.
- *   video.asset.ready               → the recording's VOD asset is ready; attach
- *                                      vodAssetId (keyed by live_stream_id).
+ *   video.asset.ready               → the recording's VOD asset is playable
+ *                                      (fires EARLY, ~10s in); attach vodAssetId
+ *                                      + the asset's public playback id (keyed
+ *                                      by live_stream_id).
+ *   video.asset.live_stream_completed → the recording is FINALIZED (fires when
+ *                                      the live stream goes idle). Same attach —
+ *                                      belt-and-braces in case asset.ready was
+ *                                      missed (WSM-000198, #303 track 1).
  * Everything else is a no-op.
+ *
+ * Replay needs the ASSET's own playback id: the live stream's playback id only
+ * serves the live edge, not the recording (Mux "Stream recordings of live
+ * streams" guide). Asset events carry the full Asset object, including
+ * `playback_ids` and `live_stream_id` (Mux webhook reference).
  */
 
 // Minimal shape we depend on — avoids coupling tests to the full Mux SDK type.
@@ -25,6 +36,7 @@ export interface MuxWebhookEvent {
   data: {
     id?: string;
     live_stream_id?: string | null;
+    playback_ids?: { id?: string; policy?: string }[];
   };
 }
 
@@ -32,6 +44,7 @@ export interface StreamStatusUpdate {
   muxLiveStreamId: string;
   status?: "active" | "ended";
   vodAssetId?: string;
+  vodPlaybackId?: string;
   endedAt?: string;
 }
 
@@ -53,13 +66,24 @@ export function mapMuxEventToUpdate(
       const id = event.data.id;
       return id ? { muxLiveStreamId: id, status: "ended", endedAt: nowIso } : null;
     }
-    case "video.asset.ready": {
+    case "video.asset.ready":
+    case "video.asset.live_stream_completed": {
       // Only assets created FROM a live stream carry live_stream_id; uploads
       // (no live_stream_id) aren't ours — ignore them.
       const liveStreamId = event.data.live_stream_id;
       const assetId = event.data.id;
       if (!liveStreamId || !assetId) return null;
-      return { muxLiveStreamId: liveStreamId, vodAssetId: assetId };
+      // The asset's PUBLIC playback id is what the replay player uses. Phase 1
+      // creates streams with new_asset_settings.playback_policy ["public"], so
+      // one should always exist; tolerate its absence (attach the asset id only).
+      const vodPlaybackId = event.data.playback_ids?.find(
+        (p) => p.policy === "public" && p.id,
+      )?.id;
+      return {
+        muxLiveStreamId: liveStreamId,
+        vodAssetId: assetId,
+        ...(vodPlaybackId ? { vodPlaybackId } : {}),
+      };
     }
     default:
       return null;

--- a/apps/web/src/lib/stream-view.ts
+++ b/apps/web/src/lib/stream-view.ts
@@ -1,0 +1,58 @@
+import type { PublicGameStream } from "@/lib/data-api";
+
+/*
+ * Replay-vs-live rendering decision for the public game page (WSM-000198,
+ * #303 track 1). PURE — no IO — so it's unit-testable like mapMuxEventToUpdate.
+ *
+ * Provider semantics:
+ *   mux     — while live, play the live playback id (muxPlaybackId). Once ended,
+ *             the live id no longer serves the recording; the replay must play
+ *             the recorded ASSET's own public playback id (vodPlaybackId),
+ *             attached by the video.asset.* webhooks.
+ *   youtube — the same public video id serves both the broadcast and its
+ *             recording, so an ended stream with a video id is a replay.
+ */
+
+export type StreamViewMode = "live" | "replay" | "ended-no-replay" | "none";
+
+export interface StreamView {
+  mode: StreamViewMode;
+  /** Mux playback id to hand the player: live id while live, VOD id for replay. */
+  muxPlaybackId: string | null;
+  youtubeVideoId: string | null;
+}
+
+export function resolveStreamView(stream: PublicGameStream | null): StreamView {
+  if (!stream) return { mode: "none", muxPlaybackId: null, youtubeVideoId: null };
+
+  if (stream.status === "active") {
+    return {
+      mode: "live",
+      muxPlaybackId: stream.muxPlaybackId,
+      youtubeVideoId: stream.youtubeVideoId,
+    };
+  }
+
+  if (stream.status === "ended") {
+    if (stream.provider === "youtube" && stream.youtubeVideoId !== null) {
+      return {
+        mode: "replay",
+        muxPlaybackId: null,
+        youtubeVideoId: stream.youtubeVideoId,
+      };
+    }
+    if (stream.provider === "mux" && stream.vodPlaybackId !== null) {
+      return {
+        mode: "replay",
+        muxPlaybackId: stream.vodPlaybackId,
+        youtubeVideoId: null,
+      };
+    }
+    // Ended with no playable recording (e.g. legacy Mux rows that predate
+    // vodPlaybackId, or the asset webhooks haven't landed yet).
+    return { mode: "ended-no-replay", muxPlaybackId: null, youtubeVideoId: null };
+  }
+
+  // "idle" (created, not yet live) — nothing to show the public.
+  return { mode: "none", muxPlaybackId: null, youtubeVideoId: null };
+}


### PR DESCRIPTION
## Summary

Track 1 of the streaming Phase 3 plan: when a Mux live stream's recording becomes a playable asset, store the asset's **public playback id** (`vodPlaybackId`), and play it on the public game page once the stream has ended — with the existing **Replay** affordance instead of the live player / "stream ended" card. Stays behind the Phase 1 `live_streaming_v1` dark flag (no new flag, no new env vars).

Part of #303 (track 1 — VOD replay). Tracks 2–4 (low-latency, clips, multi-cam) are NOT in this PR.

## Why the asset's playback id

Per Mux's docs (verified at build time, as the plan requires):
- A live stream's playback id serves the **live edge only**; the recording must be played via the recorded **asset's own playback id** — https://www.mux.com/docs/guides/stream-recordings-of-live-streams
- Asset webhook events carry the **full Asset object**, including `playback_ids[] {id, policy}` and `live_stream_id` — https://www.mux.com/docs/webhook-reference
- `video.asset.ready` fires **early** (~10s of content, around when the stream goes active); `video.asset.live_stream_completed` fires when the recording is **finalized** — both are handled (idempotent patch), and the replay only renders after `video.live_stream.idle` flips the stream to `ended`, so early attach is safe.
- Phase 1 already creates streams with `new_asset_settings.playback_policy: ["public"]`, so the recorded asset gets a public playback id with **no extra Mux API call** — the webhook payload has everything.

## What changed

- `apps/web/convex/schema.ts` — `gameStreams.vodPlaybackId` (optional; legacy rows predate it).
- `apps/web/convex/sports.ts` — `publicStreamDtoValidator` + `getStreamByFixture` projection + `updateGameStreamStatus` / `createGameStream` carry `vodPlaybackId`. No new Convex functions; writes stay `internalMutation` (WSM-000096 backstop untouched), return validators updated in lockstep with the DTO (WSM-000166 class of drift avoided).
- `apps/web/src/lib/mux-webhook-handlers.ts` — `video.asset.ready` **and** `video.asset.live_stream_completed` now attach `vodAssetId` + the asset's public `vodPlaybackId` (pure `mapMuxEventToUpdate`; same signature-verified webhook route as Phase 1, unchanged).
- `apps/web/src/lib/stream-view.ts` (new) — pure `resolveStreamView()`: live plays the live id, ended Mux replays the VOD id, ended YouTube replays the same video id, ended without a playable recording → "stream ended" card.
- `apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx` — uses the helper; the replay card now hands the player the **VOD** playback id (previously it passed the live id, which cannot serve the recording).
- `apps/web/src/lib/data-api.ts` — `PublicGameStream.vodPlaybackId` + mutation ref types.
- Tests: 3 new webhook-mapping cases (public-id attach, live_stream_completed, no-public-id) + 7 new `resolveStreamView` cases.
- Separate commit: rebuilt the **pre-existing-broken** `live-score` route test (mocked the four pre-WSM-000192 data-api fns; the refactored route uses one `getPublicLiveGameState` call) so the suite verifies green — it was failing on main.

## Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm --filter @sports-management/api-contracts build` ✅
- `pnpm --filter @sports-management/web type-check` ✅ clean
- `pnpm exec eslint <changed files>` ✅ no errors
- `pnpm --filter @sports-management/web test:unit` ✅ **98 files / 743 tests passed** (was 2 failing on main from the stale live-score test)
- `pnpm --filter @sports-management/web build` ✅
- `convex/_generated` unchanged (types derive generically from `schema.ts`); no cloud `convex dev/deploy` run — deploy Convex from merged main per project convention.

## Notes / follow-ups

- Existing ended streams recorded before this change have `vodAssetId` but no `vodPlaybackId`; they render the "stream ended" card (they were never actually playable via the live id anyway). A one-off backfill via the Mux assets API could resurrect them if ever needed.
- No new env vars: uses the Phase 1 `MUX_TOKEN_ID` / `MUX_TOKEN_SECRET` / `MUX_WEBHOOK_SECRET` and the same `FLAG_LIVE_STREAMING_V1` dark flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)