### PR TITLE
fix(web): fail production build on Clerk development keys (WSM-000168)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,10 @@
 import type { NextConfig } from "next";
+import { runClerkEnvGuard } from "./src/lib/clerk-env-guard";
+
+// Fail the PRODUCTION build if Clerk is configured with development keys
+// (WSM-000168). Build-time (not boot-time) so a misconfig blocks promotion and
+// Vercel keeps the last good deployment serving instead of booting a broken one.
+runClerkEnvGuard();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,

--- a/apps/web/src/lib/__tests__/clerk-env-guard.test.ts
+++ b/apps/web/src/lib/__tests__/clerk-env-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { assertClerkKeysForEnv, runClerkEnvGuard } from "../clerk-env-guard";
+
+/*
+ * Regression guard for WSM-000168 (production ran Clerk DEVELOPMENT keys).
+ *
+ * Encodes the ticket's acceptance criteria: a production build MUST fail when a
+ * `pk_test_`/`sk_test_` key is present, and MUST pass with `pk_live_`/`sk_live_`.
+ * Preview/local builds legitimately use development keys and must not throw.
+ */
+
+describe("assertClerkKeysForEnv (WSM-000168)", () => {
+  it("throws when a development publishable key is used in production", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_live_realproduction",
+      }),
+    ).toThrow(/WSM-000168/);
+  });
+
+  it("throws when a development secret key is used in production", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_live_realproduction",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).toThrow(/DEVELOPMENT/);
+  });
+
+  it("passes when production uses live keys", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_live_realproduction",
+        secretKey: "sk_live_realproduction",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows development keys on preview deployments", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "preview",
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows development keys locally (VERCEL_ENV undefined)", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: undefined,
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not leak the raw key value in the error message", () => {
+    let message = "";
+    try {
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_test_SUPERSECRETVALUE123",
+        secretKey: undefined,
+      });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toContain("SUPERSECRETVALUE123");
+    expect(message).toContain("pk_test_");
+  });
+});
+
+describe("runClerkEnvGuard (reads process.env)", () => {
+  const original = {
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env.VERCEL_ENV = original.VERCEL_ENV;
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      original.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    process.env.CLERK_SECRET_KEY = original.CLERK_SECRET_KEY;
+  });
+
+  it("throws for a dev publishable key when VERCEL_ENV=production", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_ZXhhbXBsZQ");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_ZXhhbXBsZQ");
+    expect(() => runClerkEnvGuard()).toThrow(/WSM-000168/);
+  });
+
+  it("is a no-op for a live key in production", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_live_realproduction");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_live_realproduction");
+    expect(() => runClerkEnvGuard()).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/clerk-env-guard.ts
+++ b/apps/web/src/lib/clerk-env-guard.ts
@@ -1,0 +1,58 @@
+/*
+ * Production Clerk-key guard (WSM-000168).
+ *
+ * Clerk development instances have strict rate limits and a hard user cap and
+ * must never serve production traffic — but a `pk_test_`/`sk_test_` key set in
+ * Vercel Production only surfaces as a console warning + a "Development mode"
+ * badge, which shipped silently once already. This guard turns that silent
+ * misconfig into a hard failure.
+ *
+ * It runs at BUILD time (from `next.config.ts`), not boot time, on purpose: a
+ * failed build is never promoted, so Vercel keeps the previous good deployment
+ * serving instead of booting a broken one. Only fires when `VERCEL_ENV` is
+ * "production" — preview and local builds legitimately use development keys.
+ *
+ * Never logs a key value; only the `pk_test_`/`sk_test_` prefix is named.
+ */
+
+export interface ClerkKeyEnv {
+  /** Vercel's deployment environment: "production" | "preview" | "development" | undefined (local). */
+  vercelEnv: string | undefined;
+  /** NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY (pk_test_… on a dev instance, pk_live_… on prod). */
+  publishableKey: string | undefined;
+  /** CLERK_SECRET_KEY (sk_test_… on a dev instance, sk_live_… on prod). */
+  secretKey: string | undefined;
+}
+
+/**
+ * Throws if a Clerk **development** key is configured while `vercelEnv` is
+ * "production". Pure (no `process.env` access) so it is trivially testable.
+ */
+export function assertClerkKeysForEnv(env: ClerkKeyEnv): void {
+  if (env.vercelEnv !== "production") return;
+
+  const devKey = env.publishableKey?.startsWith("pk_test_")
+    ? "publishable (pk_test_…)"
+    : env.secretKey?.startsWith("sk_test_")
+      ? "secret (sk_test_…)"
+      : null;
+
+  if (devKey) {
+    throw new Error(
+      `[WSM-000168] Refusing to build for production: the Clerk ${devKey} key is a ` +
+        `DEVELOPMENT key but VERCEL_ENV=production. Clerk development instances have ` +
+        `strict rate limits and a hard user cap and must not serve production traffic. ` +
+        `Set production keys (pk_live_/sk_live_) in Vercel Production and redeploy. ` +
+        `See https://github.com/andysolomon/sports-league-management/issues/386`,
+    );
+  }
+}
+
+/** Reads the process environment and applies {@link assertClerkKeysForEnv}. */
+export function runClerkEnvGuard(): void {
+  assertClerkKeysForEnv({
+    vercelEnv: process.env.VERCEL_ENV,
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    secretKey: process.env.CLERK_SECRET_KEY,
+  });
+}


### PR DESCRIPTION
Regression guard for **#386 [WSM-000168]** — production ran Clerk with development keys.

## ⚠️ Merge sequencing (read first)
This guard **fails the production build when a `pk_test_`/`sk_test_` Clerk key is set with `VERCEL_ENV=production`**. Production **currently holds dev keys**, so **merging this before the Clerk prod-key cutover will fail the next prod build.** That's the intended safety behavior (Vercel keeps the last good deploy live), but it means:

> **Do the operator cutover on #386 first (Clerk prod instance + `pk_live_`/`sk_live_` in Vercel Production), then merge this.** The runbook is posted on #386.

## What & why
Root cause is env config, not code: `layout.tsx` renders `<ClerkProvider>` reading `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`; there are no hardcoded keys. Dev keys only surfaced as a console warning + a "Development mode" badge, and shipped silently once. This makes that impossible to repeat:

- **`src/lib/clerk-env-guard.ts`** — pure `assertClerkKeysForEnv()` + `runClerkEnvGuard()`. Throws when a `pk_test_`/`sk_test_` key is present and `VERCEL_ENV === "production"`. Never logs a key value (prefix only). No-op on preview/local.
- **`next.config.ts`** — calls the guard at config load. **Build-time** (not boot-time) on purpose: a failed build is never promoted, so Vercel keeps serving the previous deployment rather than booting a broken server.
- **tests** — 8 cases: dev-key-in-prod throws, live-key passes, preview/local no-op, no raw key leaked.

## Verification
- `VERCEL_ENV=production NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_… next build` → aborts at config load with the `[WSM-000168]` message (no key value in output).
- `vitest` 8/8 green; `type-check` clean.

## Scope
Guard only. The Clerk production instance + DNS + Vercel key swap + Google OAuth re-config are operator steps on #386 (runbook there). Does **not** close #386 on its own — #386 closes when prod actually runs live keys.

Refs #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)