### PR TITLE
feat(web): low-latency (LL-HLS) stream mode behind a dark flag (WSM-000200)

### DIFF
--- a/apps/web/convex/__tests__/gameStreamLatencyMode.test.ts
+++ b/apps/web/convex/__tests__/gameStreamLatencyMode.test.ts
@@ -1,0 +1,123 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+// WSM-000200 (#303 track 2): createGameStream records which latency mode the
+// Mux stream was created in, so the LL-HLS cost/quality tradeoff can be
+// evaluated per pilot. Legacy/omitted = standard behavior, field absent.
+
+async function seedFixture(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Stream League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const makeTeam = (name: string) =>
+      ctx.db.insert("teams", {
+        name,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Loc",
+        logoUrl: null,
+        rosterLimit: null,
+      });
+    const homeTeamId = await makeTeam("Home");
+    const awayTeamId = await makeTeam("Away");
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const fixtureId = await ctx.db.insert("fixtures", {
+      seasonId,
+      homeTeamId,
+      awayTeamId,
+      scheduledAt: null,
+      week: 1,
+      venue: null,
+      status: "scheduled",
+      createdAt: "2026-07-02T00:00:00.000Z",
+      createdBy: "user_admin",
+    });
+    return fixtureId;
+  });
+}
+
+// NB: no `.withIndex` here — TS truncates the per-table index map for
+// late-defined tables under convex-test's strict ctx (see the note in
+// playoffBracket.test.ts); gameStreams is affected. Runtime is unaffected.
+async function getStream(
+  t: ReturnType<typeof convexTest>,
+  fixtureId: Id<"fixtures">,
+) {
+  return t.run(async (ctx) =>
+    (await ctx.db.query("gameStreams").collect()).find(
+      (s) => s.fixtureId === fixtureId,
+    ),
+  );
+}
+
+describe("createGameStream latencyMode", () => {
+  it("persists the low-latency opt-in", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+
+    await t.mutation(internal.sports.createGameStream, {
+      fixtureId,
+      muxLiveStreamId: "ls_1",
+      muxPlaybackId: "pb_1",
+      latencyMode: "low",
+      startedBy: "user_admin",
+      maxDurationMinutes: 180,
+    });
+
+    const row = await getStream(t, fixtureId);
+    expect(row?.latencyMode).toBe("low");
+  });
+
+  it("leaves latencyMode unset when omitted (standard path unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+
+    await t.mutation(internal.sports.createGameStream, {
+      fixtureId,
+      muxLiveStreamId: "ls_1",
+      muxPlaybackId: "pb_1",
+      startedBy: "user_admin",
+      maxDurationMinutes: 180,
+    });
+
+    const row = await getStream(t, fixtureId);
+    expect(row?.latencyMode).toBeUndefined();
+  });
+
+  it("youtube streams are unaffected by the mux latency field", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+
+    await t.mutation(internal.sports.createGameStream, {
+      fixtureId,
+      provider: "youtube",
+      youtubeVideoId: "yt_video_1",
+      startedBy: "user_admin",
+      maxDurationMinutes: 180,
+    });
+
+    const row = await getStream(t, fixtureId);
+    expect(row?.status).toBe("active");
+    expect(row?.latencyMode).toBeUndefined();
+  });
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -317,6 +317,10 @@ export default defineSchema({
     // live muxPlaybackId only serves the live edge — replays need the asset's
     // own playback id. Optional: legacy rows predate it.
     vodPlaybackId: v.optional(v.union(v.string(), v.null())),
+    // "low" | "standard" (mux only; legacy/unset = standard). Records the
+    // LL-HLS opt-in per stream (WSM-000200) so the cost/quality tradeoff can
+    // be evaluated per pilot. Not exposed publicly.
+    latencyMode: v.optional(v.string()),
     startedBy: v.string(),
     startedAt: v.string(),
     endedAt: v.union(v.string(), v.null()),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4442,6 +4442,7 @@ export const createGameStream = internalMutationGeneric({
     muxLiveStreamId: v.optional(v.string()),
     muxPlaybackId: v.optional(v.string()),
     youtubeVideoId: v.optional(v.union(v.string(), v.null())),
+    latencyMode: v.optional(v.string()), // "low" | "standard" (mux only)
     startedBy: v.string(),
     maxDurationMinutes: v.number(),
   },
@@ -4461,6 +4462,7 @@ export const createGameStream = internalMutationGeneric({
       muxLiveStreamId: args.muxLiveStreamId,
       muxPlaybackId: args.muxPlaybackId,
       youtubeVideoId: args.youtubeVideoId ?? null,
+      latencyMode: args.latencyMode,
       // A pasted YouTube link is already live, so it starts "active"; Mux waits
       // for its webhook (video.live_stream.active) to confirm before flipping.
       status: provider === "youtube" ? "active" : "idle",

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const {
   mockLiveStreamingV1,
+  mockLowLatencyStreamingV1,
   mockAuth,
   mockGetFixture,
   mockGetPublicSeason,
@@ -15,6 +16,7 @@ const {
   mockDisableMuxLiveStream,
 } = vi.hoisted(() => ({
   mockLiveStreamingV1: vi.fn(),
+  mockLowLatencyStreamingV1: vi.fn(),
   mockAuth: vi.fn(),
   mockGetFixture: vi.fn(),
   mockGetPublicSeason: vi.fn(),
@@ -28,7 +30,10 @@ const {
   mockDisableMuxLiveStream: vi.fn(),
 }));
 
-vi.mock("@/lib/flags", () => ({ liveStreamingV1: mockLiveStreamingV1 }));
+vi.mock("@/lib/flags", () => ({
+  liveStreamingV1: mockLiveStreamingV1,
+  lowLatencyStreamingV1: mockLowLatencyStreamingV1,
+}));
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
 vi.mock("@/lib/data-api", () => ({
   getFixture: mockGetFixture,
@@ -59,6 +64,8 @@ const FIXTURE = "fixture_1";
 
 function happyFixture() {
   mockLiveStreamingV1.mockResolvedValue(true);
+  // LL-HLS is a separate opt-in (WSM-000200); default = standard HLS.
+  mockLowLatencyStreamingV1.mockResolvedValue(false);
   mockAuth.mockResolvedValue({ userId: "user_1" });
   mockGetFixture.mockResolvedValue({
     id: FIXTURE,
@@ -165,9 +172,31 @@ describe("startGameStream", () => {
       fixtureId: FIXTURE,
       muxLiveStreamId: "ls_1",
       muxPlaybackId: "pb_1",
+      latencyMode: "standard",
       startedBy: "user_1",
       maxDurationMinutes: 180,
     });
+  });
+
+  // WSM-000200 (#303 track 2): the LL-HLS opt-in flows flag → Mux creation →
+  // persisted latencyMode; with the flag off, standard mode is pinned.
+  it("creates the Mux stream in standard mode when the LL flag is off", async () => {
+    await startGameStream(LEAGUE, FIXTURE);
+    expect(mockCreateMuxLiveStream).toHaveBeenCalledWith(180, {
+      lowLatency: false,
+    });
+  });
+
+  it("creates the Mux stream in low-latency mode when the LL flag is on", async () => {
+    mockLowLatencyStreamingV1.mockResolvedValue(true);
+    const res = await startGameStream(LEAGUE, FIXTURE);
+    expect(res.ok).toBe(true);
+    expect(mockCreateMuxLiveStream).toHaveBeenCalledWith(180, {
+      lowLatency: true,
+    });
+    expect(mockCreateGameStream).toHaveBeenCalledWith(
+      expect.objectContaining({ latencyMode: "low" }),
+    );
   });
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -2,7 +2,7 @@
 
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
-import { liveStreamingV1 } from "@/lib/flags";
+import { liveStreamingV1, lowLatencyStreamingV1 } from "@/lib/flags";
 import {
   getFixture,
   getPublicSeason,
@@ -93,11 +93,16 @@ export async function startGameStream(
   }
 
   try {
-    const mux = await createMuxLiveStream(MAX_STREAM_DURATION_MINUTES);
+    // #303 track 2: LL-HLS is a per-env opt-in; off/unset = standard HLS.
+    const lowLatency = await lowLatencyStreamingV1();
+    const mux = await createMuxLiveStream(MAX_STREAM_DURATION_MINUTES, {
+      lowLatency,
+    });
     await createGameStream({
       fixtureId,
       muxLiveStreamId: mux.liveStreamId,
       muxPlaybackId: mux.playbackId,
+      latencyMode: lowLatency ? "low" : "standard",
       startedBy: guard.userId,
       maxDurationMinutes: MAX_STREAM_DURATION_MINUTES,
     });

--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -29,6 +29,7 @@ import {
   rosterSnapshotsV1,
   playerAttributesV1,
   schedulesStandingsV1,
+  lowLatencyStreamingV1,
   pageGuard,
   apiGuard,
 } from "../flags";
@@ -72,6 +73,35 @@ describe("schedulesStandingsV1 flag declaration", () => {
     expect(schedulesStandingsV1.description).toMatch(
       /schedule|standing|fixture/i,
     );
+  });
+});
+
+describe("lowLatencyStreamingV1 flag declaration (WSM-000200)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the canonical key", () => {
+    expect(lowLatencyStreamingV1.key).toBe("low_latency_streaming_v1");
+  });
+
+  it("has a description for the Vercel Toolbar", () => {
+    expect(lowLatencyStreamingV1.description).toMatch(/low.latency|LL-HLS/i);
+  });
+
+  it("is DARK by default — unset stays off even outside production", async () => {
+    // Unlike resolveFlag()-based flags (on outside prod), this must be off.
+    expect(await lowLatencyStreamingV1()).toBe(false);
+  });
+
+  it('only "on" enables it', async () => {
+    vi.stubEnv("FLAG_LOW_LATENCY_STREAMING_V1", "on");
+    expect(await lowLatencyStreamingV1()).toBe(true);
+  });
+
+  it("ignores other values", async () => {
+    vi.stubEnv("FLAG_LOW_LATENCY_STREAMING_V1", "true");
+    expect(await lowLatencyStreamingV1()).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/__tests__/mux-create-stream.test.ts
+++ b/apps/web/src/lib/__tests__/mux-create-stream.test.ts
@@ -4,14 +4,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("server-only", () => ({}));
 
 // Mock the Mux SDK so we can drive liveStreams.create's outcome without a
-// real account. The mock's create() reads from `createImpl`, set per test.
+// real account. The mock's create() reads from `createImpl`, set per test,
+// and records its params so tests can assert the creation payload.
 let createImpl: () => Promise<unknown>;
+let lastCreateParams: Record<string, unknown> | undefined;
 vi.mock("@mux/mux-node", () => {
   return {
     default: class MockMux {
       video = {
         liveStreams: {
-          create: () => createImpl(),
+          create: (params: Record<string, unknown>) => {
+            lastCreateParams = params;
+            return createImpl();
+          },
         },
       };
     },
@@ -23,6 +28,7 @@ describe("createMuxLiveStream", () => {
     vi.resetModules();
     vi.stubEnv("MUX_TOKEN_ID", "test-id");
     vi.stubEnv("MUX_TOKEN_SECRET", "test-secret");
+    lastCreateParams = undefined;
   });
 
   it("maps Mux's free-plan rejection to a clean mux_plan_required error", async () => {
@@ -59,5 +65,33 @@ describe("createMuxLiveStream", () => {
       playbackId: "pb_xyz",
       rtmpUrl: "rtmps://global-live.mux.com:443/app",
     });
+  });
+
+  // WSM-000200 (#303 track 2): latency mode is pinned explicitly at creation.
+  it("creates in standard latency mode by default", async () => {
+    createImpl = () =>
+      Promise.resolve({
+        id: "ls_123",
+        stream_key: "sk_abc",
+        playback_ids: [{ id: "pb_xyz" }],
+      });
+    const { createMuxLiveStream } = await import("../mux");
+    await createMuxLiveStream(180);
+    expect(lastCreateParams?.latency_mode).toBe("standard");
+  });
+
+  it("creates in low latency (LL-HLS) mode when opted in", async () => {
+    createImpl = () =>
+      Promise.resolve({
+        id: "ls_123",
+        stream_key: "sk_abc",
+        playback_ids: [{ id: "pb_xyz" }],
+      });
+    const { createMuxLiveStream } = await import("../mux");
+    await createMuxLiveStream(180, { lowLatency: true });
+    expect(lastCreateParams?.latency_mode).toBe("low");
+    // The rest of the payload is unchanged by the latency opt-in.
+    expect(lastCreateParams?.max_continuous_duration).toBe(180 * 60);
+    expect(lastCreateParams?.playback_policy).toEqual(["public"]);
   });
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -611,6 +611,7 @@ const refs = {
       muxLiveStreamId?: string;
       muxPlaybackId?: string;
       youtubeVideoId?: string | null;
+      latencyMode?: string;
       startedBy: string;
       maxDurationMinutes: number;
     },
@@ -1868,6 +1869,7 @@ export interface CreateGameStreamInput {
   muxLiveStreamId?: string;
   muxPlaybackId?: string;
   youtubeVideoId?: string | null;
+  latencyMode?: string; // "low" | "standard" (mux only, WSM-000200)
   startedBy: string;
   maxDurationMinutes: number;
 }

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -105,6 +105,30 @@ export const liveStreamingV1 = flag<boolean>({
   },
 });
 
+/*
+ * Low-latency (LL-HLS) sub-flag of `live_streaming_v1` (WSM-000200, #303
+ * track 2). Same dark idiom: default OFF in EVERY environment — low latency
+ * changes the cost/quality tradeoff of real paid Mux streams, so a pilot env
+ * opts in explicitly with `FLAG_LOW_LATENCY_STREAMING_V1=on`. Off (or unset)
+ * keeps standard HLS exactly as before. Only consulted at stream START, and
+ * only on the Mux path — it does nothing while `live_streaming_v1` is dark.
+ */
+export const lowLatencyStreamingV1 = flag<boolean>({
+  key: "low_latency_streaming_v1",
+  description:
+    "DARK — Mux low-latency (LL-HLS) stream creation (#303 track 2). OFF in every env unless FLAG_LOW_LATENCY_STREAMING_V1=on.",
+  defaultValue: false,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = process.env.FLAG_LOW_LATENCY_STREAMING_V1 === "on";
+    void trackFlagExposure("low_latency_streaming_v1", enabled);
+    return enabled;
+  },
+});
+
 export const statKeepingV1 = flag<boolean>({
   key: "stat_keeping_v1",
   description:

--- a/apps/web/src/lib/mux.ts
+++ b/apps/web/src/lib/mux.ts
@@ -47,9 +47,16 @@ export interface CreatedMuxLiveStream {
 /**
  * Create a public live stream with a hard max-duration cap so a forgotten
  * stream can never bill indefinitely. Recordings become public VOD assets.
+ *
+ * `lowLatency` (WSM-000200, #303 track 2) creates the stream in Mux LL-HLS
+ * mode (~5s glass-to-glass vs ~25-30s standard). Playback needs no player
+ * change — Mux Player >=1.0 handles LL-HLS natively, and non-supporting
+ * players fall back to standard HLS. Latency mode is fixed at creation and
+ * pinned explicitly so a Mux default change can never flip it under us.
  */
 export async function createMuxLiveStream(
   maxDurationMinutes: number,
+  options?: { lowLatency?: boolean },
 ): Promise<CreatedMuxLiveStream> {
   const mux = getMux();
   let liveStream;
@@ -59,6 +66,7 @@ export async function createMuxLiveStream(
       new_asset_settings: { playback_policy: ["public"] },
       // Mux expects seconds; this is the guardrail auto-stop.
       max_continuous_duration: maxDurationMinutes * 60,
+      latency_mode: options?.lowLatency ? "low" : "standard",
     });
   } catch (err) {
     // Mux rejects live-stream creation on the free plan with a 400. Surface a


### PR DESCRIPTION
## Summary
**#303 track 2 — low-latency mode.** Mux live streams can now be created in LL-HLS mode (~5 s glass-to-glass vs ~25–30 s standard), behind a new dark flag `FLAG_LOW_LATENCY_STREAMING_V1` that defaults **OFF in every environment** — the same idiom as `live_streaming_v1`, because low latency changes the cost/quality tradeoff of real paid Mux streams. With the flag off (or unset), `latency_mode: "standard"` is pinned explicitly, so current behavior is byte-for-byte unchanged and a Mux default change can never flip it silently.

Per the ticket's instruction, the API was verified against the **current Mux docs** (`latency_mode: "low" | "reduced" | "standard"` at stream creation) and the installed `@mux/mux-node` 14.1.1 types — not training data.

## Changes
- `src/lib/flags.ts` — `lowLatencyStreamingV1`, dark by default, per-env opt-in via `FLAG_LOW_LATENCY_STREAMING_V1=on`. Only consulted at stream start on the Mux path; inert while `live_streaming_v1` is dark.
- `src/lib/mux.ts` — `createMuxLiveStream(maxDurationMinutes, { lowLatency })` pins `latency_mode` explicitly.
- `stream-actions.ts` — `startGameStream` reads the flag once, passes it to Mux creation, and records the mode on the stream row.
- `convex/schema.ts` + `convex/sports.ts` + `src/lib/data-api.ts` — new **optional** `gameStreams.latencyMode` field ("low" | "standard", mux only, legacy rows unset), carried through `createGameStream` in lockstep. **Not exposed in any public projection** (no public validator drift risk); it exists so the LL cost/quality tradeoff — an open decision on #303 — can be evaluated per pilot from real data.
- **No player change**: `@mux/mux-player-react` ≥1.0 plays LL-HLS natively, and non-supporting players fall back to standard HLS automatically. YouTube path untouched.

## Testing (12 new tests, 762/762 passing)
- `mux-create-stream.test.ts` — creation payload pins `standard` by default / `low` when opted in; rest of payload unchanged.
- `stream-actions.test.ts` — flag off → `{ lowLatency: false }` + `latencyMode: "standard"` persisted; flag on → `low` end-to-end through both calls.
- `flags.test.ts` — dark-by-default (unset stays off even outside production), only `"on"` enables.
- `gameStreamLatencyMode.test.ts` (Convex) — persistence, absent-when-omitted (legacy compat), YouTube unaffected.
- `tsc --noEmit` clean, `eslint` clean, `next build` succeeds.

## Deploy note
Schema + `createGameStream` args changed → **manual Convex prod deploy alongside the Vercel promotion** (additive/optional field, so Convex-first is safe with zero window). Enabling LL for a pilot is a separate, later act: set `FLAG_LOW_LATENCY_STREAMING_V1=on` in that env and redeploy.

Part of #303 (track 2 of 4 — issue stays open for clips + multi-cam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)