### PR TITLE
feat(web): highlight clips from game stream recordings (WSM-000201 / #303)

### DIFF
--- a/apps/web/convex/__tests__/gameClips.test.ts
+++ b/apps/web/convex/__tests__/gameClips.test.ts
@@ -1,0 +1,227 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+// WSM-000201 (#303 track 3): highlight clips. Writes are internalMutation;
+// the public read lists READY clips through a playback-only projection (the
+// clip's Mux asset id must never transit a public query).
+
+async function seedFixture(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Clip League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const makeTeam = (name: string) =>
+      ctx.db.insert("teams", {
+        name,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Loc",
+        logoUrl: null,
+        rosterLimit: null,
+      });
+    const homeTeamId = await makeTeam("Home");
+    const awayTeamId = await makeTeam("Away");
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const fixtureId = await ctx.db.insert("fixtures", {
+      seasonId,
+      homeTeamId,
+      awayTeamId,
+      scheduledAt: null,
+      week: 1,
+      venue: null,
+      status: "final",
+      createdAt: "2026-07-03T00:00:00.000Z",
+      createdBy: "user_admin",
+    });
+    return fixtureId;
+  });
+}
+
+function clipArgs(fixtureId: Id<"fixtures">, n = 1) {
+  return {
+    fixtureId,
+    muxAssetId: `clip_asset_${n}`,
+    playbackId: `pb_clip_${n}`,
+    label: `Highlight ${n}`,
+    startTime: 60 * n,
+    endTime: 60 * n + 30,
+    createdBy: "user_admin",
+  };
+}
+
+// NB: no `.withIndex` in t.run reads — TS truncates the per-table index map
+// for late-defined tables under convex-test's strict ctx (see the note in
+// playoffBracket.test.ts); gameClips is affected. Runtime is unaffected.
+async function allClips(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ctx.db.query("gameClips").collect());
+}
+
+describe("gameClips write path (internal)", () => {
+  it("createGameClip persists a preparing clip", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+
+    const { id } = await t.mutation(
+      internal.sports.createGameClip,
+      clipArgs(fixtureId),
+    );
+    expect(id).toBeTruthy();
+
+    const rows = await allClips(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      fixtureId,
+      muxAssetId: "clip_asset_1",
+      playbackId: "pb_clip_1",
+      label: "Highlight 1",
+      status: "preparing",
+    });
+  });
+
+  it("createGameClip rejects an unknown fixture", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+    // Delete the fixture so the id is dangling.
+    await t.run(async (ctx) => ctx.db.delete(fixtureId));
+    await expect(
+      t.mutation(internal.sports.createGameClip, clipArgs(fixtureId)),
+    ).rejects.toThrow("fixture_not_found");
+  });
+
+  it("updateGameClipStatus flips the clip ready (webhook path, keyed by asset id)", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+    await t.mutation(internal.sports.createGameClip, {
+      ...clipArgs(fixtureId),
+      playbackId: null, // creation raced — the webhook attaches it
+    });
+
+    const flipped = await t.mutation(internal.sports.updateGameClipStatus, {
+      muxAssetId: "clip_asset_1",
+      status: "ready",
+      playbackId: "pb_clip_1",
+    });
+    expect(flipped).toBe(true);
+
+    const rows = await allClips(t);
+    expect(rows[0]).toMatchObject({ status: "ready", playbackId: "pb_clip_1" });
+  });
+
+  it("updateGameClipStatus is a no-op for unknown asset ids (idempotent webhooks)", async () => {
+    const t = convexTest(schema, modules);
+    await seedFixture(t);
+    const flipped = await t.mutation(internal.sports.updateGameClipStatus, {
+      muxAssetId: "clip_asset_ghost",
+      status: "ready",
+    });
+    expect(flipped).toBe(false);
+  });
+
+  it("deleteGameClip removes the row only when the fixture matches", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+    const otherFixtureId = await seedFixture(t);
+    const { id } = await t.mutation(
+      internal.sports.createGameClip,
+      clipArgs(fixtureId),
+    );
+
+    // Wrong fixture → refused, row survives.
+    const cross = await t.mutation(internal.sports.deleteGameClip, {
+      clipId: id as Id<"gameClips">,
+      fixtureId: otherFixtureId,
+    });
+    expect(cross).toBe(false);
+    expect(await allClips(t)).toHaveLength(1);
+
+    // Right fixture → deleted.
+    const ok = await t.mutation(internal.sports.deleteGameClip, {
+      clipId: id as Id<"gameClips">,
+      fixtureId,
+    });
+    expect(ok).toBe(true);
+    expect(await allClips(t)).toHaveLength(0);
+  });
+});
+
+describe("listClipsByFixture (public projection)", () => {
+  it("returns READY clips only, projected to playback-only fields", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+
+    await t.mutation(internal.sports.createGameClip, clipArgs(fixtureId, 1));
+    await t.mutation(internal.sports.createGameClip, clipArgs(fixtureId, 2));
+    await t.mutation(internal.sports.createGameClip, {
+      ...clipArgs(fixtureId, 3),
+      playbackId: null, // ready but somehow playback-less → still hidden
+    });
+    await t.mutation(internal.sports.updateGameClipStatus, {
+      muxAssetId: "clip_asset_1",
+      status: "ready",
+    });
+    await t.mutation(internal.sports.updateGameClipStatus, {
+      muxAssetId: "clip_asset_3",
+      status: "ready",
+    });
+    // clip 2 stays "preparing".
+
+    const clips = await t.query(api.sports.listClipsByFixture, { fixtureId });
+    expect(clips).toHaveLength(1);
+    // PUBLIC PROJECTION: playback fields only — the Mux asset id must not leak.
+    expect(clips[0]).toEqual({
+      playbackId: "pb_clip_1",
+      label: "Highlight 1",
+      createdAt: expect.any(String),
+    });
+  });
+
+  it("returns an empty list for a fixture with no clips", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+    expect(
+      await t.query(api.sports.listClipsByFixture, { fixtureId }),
+    ).toEqual([]);
+  });
+});
+
+describe("listClipsAdminByFixture (internal read)", () => {
+  it("returns every clip with lifecycle status + asset id for the trusted server", async () => {
+    const t = convexTest(schema, modules);
+    const fixtureId = await seedFixture(t);
+    await t.mutation(internal.sports.createGameClip, clipArgs(fixtureId, 1));
+    await t.mutation(internal.sports.createGameClip, clipArgs(fixtureId, 2));
+    await t.mutation(internal.sports.updateGameClipStatus, {
+      muxAssetId: "clip_asset_2",
+      status: "errored",
+    });
+
+    const clips = await t.query(internal.sports.listClipsAdminByFixture, {
+      fixtureId,
+    });
+    expect(clips).toHaveLength(2);
+    expect(clips.map((c) => c.status).sort()).toEqual([
+      "errored",
+      "preparing",
+    ]);
+    expect(clips[0].muxAssetId).toBeTruthy();
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -160,6 +160,7 @@ type AllowedPublicSportsReads =
   | "getTeamRosterLimitStatus"
   | "getVisibleLeagueContext"
   | "healthSummary"
+  | "listClipsByFixture"
   | "listConferences"
   | "listDivisions"
   | "listFixturesBySeason"

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -332,6 +332,31 @@ export default defineSchema({
     .index("by_muxLiveStreamId", ["muxLiveStreamId"]),
 
   /*
+   * Shareable highlight clips cut from a game's stream recording (WSM-000201,
+   * #303 track 3). Each clip is its OWN Mux asset (created from the VOD asset
+   * via a `mux://assets/{id}` input) with its own public playback id. Writes
+   * are internalMutation only; the public read lists READY clips projected to
+   * playback-only fields — the clip's Mux asset id never transits a public
+   * query.
+   */
+  gameClips: defineTable({
+    fixtureId: v.id("fixtures"),
+    muxAssetId: v.string(), // the clip's own asset id — server-side only
+    playbackId: v.union(v.string(), v.null()), // public playback id
+    label: v.string(),
+    // Clip range in seconds within the source recording (admin display).
+    startTime: v.number(),
+    endTime: v.number(),
+    // "preparing" | "ready" | "errored" — flipped by the Mux asset webhooks.
+    status: v.string(),
+    createdBy: v.string(),
+    createdAt: v.string(),
+  })
+    .index("by_fixtureId", ["fixtureId"])
+    // Mux asset webhooks identify a clip by its own asset id.
+    .index("by_muxAssetId", ["muxAssetId"]),
+
+  /*
    * Stat-keeping keystone (WSM-000112). One row per player per game — the
    * player's box-score line, stored as typed JSON (`statsJson`, validated at the
    * edge like playerAttributes). Supersedes the reserved gameResults.player-

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4627,6 +4627,143 @@ export const getActiveStreamCountForLeague = queryGeneric({
 });
 
 /*
+ * Highlight clips (WSM-000201, #303 track 3). A clip is its own Mux asset cut
+ * from the stream's VOD recording. Writes are internalMutation (trusted server
+ * code only); the public read lists READY clips projected to playback-only
+ * fields — the clip's Mux asset id never transits a public query, mirroring
+ * how gameStreams hides the live-stream id.
+ */
+
+export const createGameClip = internalMutationGeneric({
+  args: {
+    fixtureId: v.id("fixtures"),
+    muxAssetId: v.string(),
+    playbackId: v.union(v.string(), v.null()),
+    label: v.string(),
+    startTime: v.number(),
+    endTime: v.number(),
+    createdBy: v.string(),
+  },
+  returns: v.object({ id: v.string() }),
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+    const id = await ctx.db.insert("gameClips", {
+      fixtureId: args.fixtureId,
+      muxAssetId: args.muxAssetId,
+      playbackId: args.playbackId,
+      label: args.label,
+      startTime: args.startTime,
+      endTime: args.endTime,
+      status: "preparing",
+      createdBy: args.createdBy,
+      createdAt: new Date().toISOString(),
+    });
+    return { id };
+  },
+});
+
+export const updateGameClipStatus = internalMutationGeneric({
+  args: {
+    muxAssetId: v.string(),
+    status: v.string(), // "ready" | "errored"
+    playbackId: v.optional(v.union(v.string(), v.null())),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gameClips")
+      .withIndex("by_muxAssetId", (q) => q.eq("muxAssetId", args.muxAssetId))
+      .first();
+    // Idempotent: an unknown asset id (e.g. a late event for a clip deleted
+    // meanwhile, or a duplicate delivery) is a no-op, not an error.
+    if (!row) return false;
+    const patch: { status: string; playbackId?: string | null } = {
+      status: args.status,
+    };
+    if (args.playbackId !== undefined) patch.playbackId = args.playbackId;
+    await ctx.db.patch(row._id, patch);
+    return true;
+  },
+});
+
+export const deleteGameClip = internalMutationGeneric({
+  args: { clipId: v.id("gameClips"), fixtureId: v.id("fixtures") },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.clipId);
+    // The fixture check pins the delete to the fixture the caller was
+    // authorized for — a clip id from another game can't be deleted sideways.
+    if (!row || row.fixtureId !== args.fixtureId) return false;
+    await ctx.db.delete(args.clipId);
+    return true;
+  },
+});
+
+// Public projection — READY clips only, playback fields only.
+export const listClipsByFixture = queryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.array(
+    v.object({
+      playbackId: v.string(),
+      label: v.string(),
+      createdAt: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("gameClips")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    // PUBLIC PROJECTION ONLY — never return muxAssetId here.
+    return rows
+      .filter((r) => r.status === "ready" && r.playbackId)
+      .map((r) => ({
+        playbackId: r.playbackId as string,
+        label: r.label,
+        createdAt: r.createdAt,
+      }));
+  },
+});
+
+/*
+ * INTERNAL read — full clip rows (incl. the Mux asset id + status) for the
+ * admin-keyed server: the clips dialog also lists preparing/errored clips, and
+ * deleting a clip needs its asset id to tear down the Mux asset.
+ */
+export const listClipsAdminByFixture = internalQueryGeneric({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      muxAssetId: v.string(),
+      playbackId: v.union(v.string(), v.null()),
+      label: v.string(),
+      startTime: v.number(),
+      endTime: v.number(),
+      status: v.string(),
+      createdAt: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("gameClips")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    return rows.map((r) => ({
+      id: r._id,
+      muxAssetId: r.muxAssetId,
+      playbackId: r.playbackId,
+      label: r.label,
+      startTime: r.startTime,
+      endTime: r.endTime,
+      status: r.status,
+      createdAt: r.createdAt,
+    }));
+  },
+});
+
+/*
  * Stat-keeping keystone (WSM-000112) — per-player box-score lines.
  *
  * Writes are internalMutation (only the admin-keyed server reaches them). One

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/clip-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/clip-actions.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockLiveStreamingV1,
+  mockAuth,
+  mockGetFixture,
+  mockGetPublicSeason,
+  mockCanAdministerTeam,
+  mockGetStreamByFixture,
+  mockListClipsAdminByFixture,
+  mockCreateGameClip,
+  mockDeleteGameClip,
+  mockCreateMuxClip,
+  mockDeleteMuxAsset,
+} = vi.hoisted(() => ({
+  mockLiveStreamingV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetFixture: vi.fn(),
+  mockGetPublicSeason: vi.fn(),
+  mockCanAdministerTeam: vi.fn(),
+  mockGetStreamByFixture: vi.fn(),
+  mockListClipsAdminByFixture: vi.fn(),
+  mockCreateGameClip: vi.fn(),
+  mockDeleteGameClip: vi.fn(),
+  mockCreateMuxClip: vi.fn(),
+  mockDeleteMuxAsset: vi.fn(),
+}));
+
+// stream-auth.ts (the shared auth chain) is `import "server-only"`.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/flags", () => ({ liveStreamingV1: mockLiveStreamingV1 }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  getFixture: mockGetFixture,
+  getPublicSeason: mockGetPublicSeason,
+  getStreamByFixture: mockGetStreamByFixture,
+  listClipsAdminByFixture: mockListClipsAdminByFixture,
+  createGameClip: mockCreateGameClip,
+  deleteGameClip: mockDeleteGameClip,
+}));
+vi.mock("@/lib/authorization", () => ({
+  canAdministerTeam: mockCanAdministerTeam,
+}));
+vi.mock("@/lib/mux", () => ({
+  createMuxClip: mockCreateMuxClip,
+  deleteMuxAsset: mockDeleteMuxAsset,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { createClip, deleteClip, getClipsForAdmin } from "../clip-actions";
+
+const LEAGUE = "league_1";
+const FIXTURE = "fixture_1";
+
+function happyFixture() {
+  mockLiveStreamingV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockGetFixture.mockResolvedValue({
+    id: FIXTURE,
+    seasonId: "season_1",
+    homeTeamId: "team_home",
+    awayTeamId: "team_away",
+    homeTeamName: "Home",
+    awayTeamName: "Away",
+    status: "final",
+  });
+  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
+  mockCanAdministerTeam.mockResolvedValue(true);
+  mockGetStreamByFixture.mockResolvedValue({
+    status: "ended",
+    provider: "mux",
+    muxPlaybackId: "pb_live",
+    youtubeVideoId: null,
+    vodAssetId: "asset_9",
+    vodPlaybackId: "pb_vod",
+  });
+  mockListClipsAdminByFixture.mockResolvedValue([]);
+  mockCreateMuxClip.mockResolvedValue({
+    assetId: "clip_asset_1",
+    playbackId: "pb_clip",
+  });
+  mockCreateGameClip.mockResolvedValue({ id: "clip_1" });
+}
+
+const RANGE = { startSec: 60, endSec: 90, label: "Big touchdown" };
+
+describe("createClip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+  });
+
+  it("cuts the clip from the stream's VOD asset and persists the row", async () => {
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: true });
+    expect(mockCreateMuxClip).toHaveBeenCalledWith("asset_9", 60, 90);
+    expect(mockCreateGameClip).toHaveBeenCalledWith({
+      fixtureId: FIXTURE,
+      muxAssetId: "clip_asset_1",
+      playbackId: "pb_clip",
+      label: "Big touchdown",
+      startTime: 60,
+      endTime: 90,
+      createdBy: "user_1",
+    });
+  });
+
+  it("refuses when the dark flag is off (no Mux call)", async () => {
+    mockLiveStreamingV1.mockResolvedValue(false);
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockCreateMuxClip).not.toHaveBeenCalled();
+  });
+
+  it("refuses signed-out callers", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "unauthorized" });
+  });
+
+  it("refuses non-admins of both teams", async () => {
+    mockCanAdministerTeam.mockResolvedValue(false);
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+  });
+
+  it("refuses a fixture from another league (cross-league guard)", async () => {
+    mockGetPublicSeason.mockResolvedValue({
+      id: "season_1",
+      leagueId: "other_league",
+    });
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "fixture_not_in_league" });
+  });
+
+  it.each([
+    ["end before start", { startSec: 90, endSec: 60 }],
+    ["zero length", { startSec: 60, endSec: 60 }],
+    ["negative start", { startSec: -5, endSec: 30 }],
+    ["over the 10-minute cap", { startSec: 0, endSec: 601 }],
+    ["non-finite", { startSec: Number.NaN, endSec: 30 }],
+  ])("rejects an invalid range: %s", async (_name, range) => {
+    const res = await createClip(LEAGUE, FIXTURE, {
+      ...range,
+      label: "Clip",
+    });
+    expect(res).toEqual({ ok: false, error: "invalid_clip_range" });
+    expect(mockCreateMuxClip).not.toHaveBeenCalled();
+  });
+
+  it("rejects a blank or over-long label", async () => {
+    expect(
+      await createClip(LEAGUE, FIXTURE, { ...RANGE, label: "   " }),
+    ).toEqual({ ok: false, error: "invalid_label" });
+    expect(
+      await createClip(LEAGUE, FIXTURE, { ...RANGE, label: "x".repeat(81) }),
+    ).toEqual({ ok: false, error: "invalid_label" });
+  });
+
+  it("refuses when there is no Mux recording (YouTube stream)", async () => {
+    mockGetStreamByFixture.mockResolvedValue({
+      status: "ended",
+      provider: "youtube",
+      muxPlaybackId: null,
+      youtubeVideoId: "yt_1",
+      vodAssetId: null,
+      vodPlaybackId: null,
+    });
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "no_recording" });
+  });
+
+  it("refuses when the VOD hasn't landed yet", async () => {
+    mockGetStreamByFixture.mockResolvedValue({
+      status: "active",
+      provider: "mux",
+      muxPlaybackId: "pb_live",
+      youtubeVideoId: null,
+      vodAssetId: null,
+      vodPlaybackId: null,
+    });
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "no_recording" });
+  });
+
+  it("enforces the per-fixture clip cap", async () => {
+    mockListClipsAdminByFixture.mockResolvedValue(
+      Array.from({ length: 20 }, (_, i) => ({ id: `clip_${i}` })),
+    );
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "clip_cap_reached" });
+    expect(mockCreateMuxClip).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Mux failures as an error result, not a throw", async () => {
+    mockCreateMuxClip.mockRejectedValue(new Error("mux_down"));
+    const res = await createClip(LEAGUE, FIXTURE, RANGE);
+    expect(res).toEqual({ ok: false, error: "mux_down" });
+    expect(mockCreateGameClip).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteClip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+    mockListClipsAdminByFixture.mockResolvedValue([
+      {
+        id: "clip_1",
+        muxAssetId: "clip_asset_1",
+        playbackId: "pb_clip",
+        label: "Big touchdown",
+        startTime: 60,
+        endTime: 90,
+        status: "ready",
+        createdAt: "2026-07-03T00:00:00.000Z",
+      },
+    ]);
+    mockDeleteGameClip.mockResolvedValue(true);
+    mockDeleteMuxAsset.mockResolvedValue(undefined);
+  });
+
+  it("tears down the Mux asset then removes the row", async () => {
+    const res = await deleteClip(LEAGUE, FIXTURE, "clip_1");
+    expect(res).toEqual({ ok: true });
+    expect(mockDeleteMuxAsset).toHaveBeenCalledWith("clip_asset_1");
+    expect(mockDeleteGameClip).toHaveBeenCalledWith("clip_1", FIXTURE);
+  });
+
+  it("refuses a clip id that doesn't belong to this fixture", async () => {
+    const res = await deleteClip(LEAGUE, FIXTURE, "clip_other");
+    expect(res).toEqual({ ok: false, error: "clip_not_found" });
+    expect(mockDeleteMuxAsset).not.toHaveBeenCalled();
+  });
+
+  it("runs the same auth chain as creation", async () => {
+    mockCanAdministerTeam.mockResolvedValue(false);
+    const res = await deleteClip(LEAGUE, FIXTURE, "clip_1");
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+  });
+});
+
+describe("getClipsForAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    happyFixture();
+  });
+
+  it("returns clips WITHOUT the server-side Mux asset id", async () => {
+    mockListClipsAdminByFixture.mockResolvedValue([
+      {
+        id: "clip_1",
+        muxAssetId: "clip_asset_1",
+        playbackId: "pb_clip",
+        label: "Big touchdown",
+        startTime: 60,
+        endTime: 90,
+        status: "ready",
+        createdAt: "2026-07-03T00:00:00.000Z",
+      },
+    ]);
+    const res = await getClipsForAdmin(LEAGUE, FIXTURE);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.clips).toHaveLength(1);
+      expect(res.clips[0]).not.toHaveProperty("muxAssetId");
+      expect(res.clips[0]).toMatchObject({
+        id: "clip_1",
+        playbackId: "pb_clip",
+        status: "ready",
+      });
+    }
+  });
+
+  it("is gated by the same auth chain", async () => {
+    mockLiveStreamingV1.mockResolvedValue(false);
+    const res = await getClipsForAdmin(LEAGUE, FIXTURE);
+    expect(res).toEqual({ ok: false, error: "flag_disabled" });
+    expect(mockListClipsAdminByFixture).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -30,6 +30,8 @@ const {
   mockDisableMuxLiveStream: vi.fn(),
 }));
 
+// stream-auth.ts (the extracted auth chain) is `import "server-only"`.
+vi.mock("server-only", () => ({}));
 vi.mock("@/lib/flags", () => ({
   liveStreamingV1: mockLiveStreamingV1,
   lowLatencyStreamingV1: mockLowLatencyStreamingV1,

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/clip-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/clip-actions.ts
@@ -1,0 +1,142 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getStreamByFixture,
+  createGameClip as persistGameClip,
+  deleteGameClip as removeGameClip,
+  listClipsAdminByFixture,
+} from "@/lib/data-api";
+import { createMuxClip, deleteMuxAsset } from "@/lib/mux";
+import { authorizeStreamAction } from "./stream-auth";
+
+/*
+ * Highlight-clip server actions (WSM-000201, #303 track 3; dark behind
+ * `live_streaming_v1` like the rest of streaming). Creation/deletion is
+ * authenticated + team-admin-gated via the same chain as go-live; the public
+ * game page only ever sees READY clips through the playback-only projection.
+ *
+ * Cost posture mirrors streaming (absorbed + capped): bounded clip length, a
+ * per-fixture clip cap, and `video_quality: "basic"` at the Mux layer.
+ */
+
+const MIN_CLIP_SECONDS = 1; // Mux's floor is 500ms; whole seconds keep the UI simple
+const MAX_CLIP_SECONDS = 10 * 60; // a highlight, not a re-broadcast
+const MAX_LABEL_LENGTH = 80;
+const PER_FIXTURE_CLIP_CAP = 20; // bound per-game Mux asset spend
+
+/** Admin clip shape safe to hand a client component — no Mux asset id. */
+export interface ClientGameClip {
+  id: string;
+  playbackId: string | null;
+  label: string;
+  startTime: number;
+  endTime: number;
+  status: string; // "preparing" | "ready" | "errored"
+  createdAt: string;
+}
+
+type ClipResult = { ok: true } | { ok: false; error: string };
+
+export async function createClip(
+  leagueId: string,
+  fixtureId: string,
+  input: { startSec: number; endSec: number; label: string },
+): Promise<ClipResult> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  const label = input.label.trim();
+  if (!label || label.length > MAX_LABEL_LENGTH) {
+    return { ok: false, error: "invalid_label" };
+  }
+  const { startSec, endSec } = input;
+  if (
+    !Number.isFinite(startSec) ||
+    !Number.isFinite(endSec) ||
+    startSec < 0 ||
+    endSec - startSec < MIN_CLIP_SECONDS ||
+    endSec - startSec > MAX_CLIP_SECONDS
+  ) {
+    return { ok: false, error: "invalid_clip_range" };
+  }
+
+  // The clip source is the stream's recorded asset. YouTube recordings live on
+  // YouTube — nothing to clip on our side.
+  const stream = await getStreamByFixture(fixtureId);
+  if (!stream || stream.provider !== "mux" || !stream.vodAssetId) {
+    return { ok: false, error: "no_recording" };
+  }
+
+  const existing = await listClipsAdminByFixture(fixtureId);
+  if (existing.length >= PER_FIXTURE_CLIP_CAP) {
+    return { ok: false, error: "clip_cap_reached" };
+  }
+
+  try {
+    const clip = await createMuxClip(stream.vodAssetId, startSec, endSec);
+    await persistGameClip({
+      fixtureId,
+      muxAssetId: clip.assetId,
+      playbackId: clip.playbackId,
+      label,
+      startTime: startSec,
+      endTime: endSec,
+      createdBy: guard.userId,
+    });
+    revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+    revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export async function deleteClip(
+  leagueId: string,
+  fixtureId: string,
+  clipId: string,
+): Promise<ClipResult> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  // Resolving the clip through the fixture's own list (not a get-by-id) pins
+  // the delete to the fixture the caller was just authorized for.
+  const clips = await listClipsAdminByFixture(fixtureId);
+  const clip = clips.find((c) => c.id === clipId);
+  if (!clip) return { ok: false, error: "clip_not_found" };
+
+  try {
+    // Tear down the Mux asset first; the row delete is the commit. Mux 404s
+    // are swallowed in deleteMuxAsset, so a retry after a partial failure
+    // converges instead of erroring.
+    await deleteMuxAsset(clip.muxAssetId);
+    await removeGameClip(clipId, fixtureId);
+    revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+    revalidatePath(`/leagues/${leagueId}/games/${fixtureId}`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/** Load the fixture's clips for the admin dialog. Strips the Mux asset id
+ *  before anything reaches the client (server-side identifiers stay server-side,
+ *  same posture as the stream key / live-stream id). */
+export async function getClipsForAdmin(
+  leagueId: string,
+  fixtureId: string,
+): Promise<
+  { ok: true; clips: ClientGameClip[] } | { ok: false; error: string }
+> {
+  const guard = await authorizeStreamAction(leagueId, fixtureId);
+  if (!guard.ok) return guard;
+
+  const clips = await listClipsAdminByFixture(fixtureId);
+  return {
+    ok: true,
+    clips: clips.map(({ muxAssetId: _muxAssetId, ...safe }) => safe),
+  };
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -18,6 +18,7 @@ import {
   getStreamByFixture,
   getTeamsByLeague,
   listFixturesBySeason,
+  type PublicGameStream,
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
@@ -28,6 +29,7 @@ import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
+import ClipsControl from "@/components/schedule/ClipsControl";
 import {
   SimulateGameButton,
   SimulateSeasonButton,
@@ -99,14 +101,15 @@ export default async function LeagueSchedulePage({
     }),
   );
 
-  // Per-fixture live-stream status — only fetched when the dark flag is on for
-  // an admin, so the default (flag off) path adds zero reads.
-  const streamStatuses = new Map<string, StreamStatus | null>();
+  // Per-fixture live-stream state — only fetched when the dark flag is on for
+  // an admin, so the default (flag off) path adds zero reads. The full public
+  // projection is kept (not just status): the clips control (WSM-000201)
+  // needs vodAssetId/vodPlaybackId to know a recording exists.
+  const streams = new Map<string, PublicGameStream | null>();
   if (canStream) {
     await Promise.all(
       fixtures.map(async (f) => {
-        const stream = await getStreamByFixture(f.id);
-        streamStatuses.set(f.id, (stream?.status as StreamStatus) ?? null);
+        streams.set(f.id, await getStreamByFixture(f.id));
       }),
     );
   }
@@ -304,8 +307,26 @@ export default async function LeagueSchedulePage({
                                     fixtureId={fixture.id}
                                     homeTeamName={fixture.homeTeamName}
                                     awayTeamName={fixture.awayTeamName}
-                                    status={streamStatuses.get(fixture.id) ?? null}
+                                    status={
+                                      (streams.get(fixture.id)?.status as
+                                        | StreamStatus
+                                        | undefined) ?? null
+                                    }
                                     gameStatus={fixture.status}
+                                  />
+                                ) : null}
+                                {canStream &&
+                                streams.get(fixture.id)?.provider === "mux" &&
+                                streams.get(fixture.id)?.vodAssetId ? (
+                                  <ClipsControl
+                                    leagueId={leagueId}
+                                    fixtureId={fixture.id}
+                                    homeTeamName={fixture.homeTeamName}
+                                    awayTeamName={fixture.awayTeamName}
+                                    vodPlaybackId={
+                                      streams.get(fixture.id)?.vodPlaybackId ??
+                                      null
+                                    }
                                   />
                                 ) : null}
                                 {statsEnabled ? (

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -1,20 +1,17 @@
 "use server";
 
-import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
-import { liveStreamingV1, lowLatencyStreamingV1 } from "@/lib/flags";
+import { lowLatencyStreamingV1 } from "@/lib/flags";
 import {
-  getFixture,
-  getPublicSeason,
   createGameStream,
   updateGameStreamStatus,
   endGameStreamByFixture,
   getActiveStreamCountForLeague,
   getStreamAdminByFixture,
 } from "@/lib/data-api";
-import { canAdministerTeam } from "@/lib/authorization";
 import { createMuxLiveStream, disableMuxLiveStream } from "@/lib/mux";
 import { parseYoutubeVideoId } from "@/lib/youtube";
+import { authorizeStreamAction } from "./stream-auth";
 
 /*
  * Live-stream start/stop server actions (WSM-000144, dark behind
@@ -38,41 +35,8 @@ type StartResult =
 
 type StopResult = { ok: true } | { ok: false; error: string };
 
-/**
- * Shared auth chain: dark flag on → Clerk session → caller administers EITHER
- * the home or away team (WSM-000121 team ownership) → fixture's season actually
- * belongs to the league in the URL (cross-league guard, mirrors the public page).
- * Returns the resolved leagueId for cap-checking + revalidation.
- */
-async function authorizeStreamAction(
-  leagueId: string,
-  fixtureId: string,
-): Promise<
-  { ok: true; userId: string; fixtureStatus: string } | { ok: false; error: string }
-> {
-  const enabled = await liveStreamingV1();
-  if (!enabled) return { ok: false, error: "flag_disabled" };
-
-  const { userId } = await auth();
-  if (!userId) return { ok: false, error: "unauthorized" };
-
-  const fixture = await getFixture(fixtureId);
-  if (!fixture) return { ok: false, error: "fixture_not_found" };
-
-  // Cross-league guard: the fixture's season must live in THIS league.
-  const season = await getPublicSeason(fixture.seasonId);
-  if (!season || season.leagueId !== leagueId) {
-    return { ok: false, error: "fixture_not_in_league" };
-  }
-
-  const [canHome, canAway] = await Promise.all([
-    canAdministerTeam(fixture.homeTeamId, userId),
-    canAdministerTeam(fixture.awayTeamId, userId),
-  ]);
-  if (!canHome && !canAway) return { ok: false, error: "not_authorized" };
-
-  return { ok: true, userId, fixtureStatus: fixture.status };
-}
+// Shared auth chain lives in ./stream-auth (plain server-only module, NOT a
+// "use server" action) so the clip actions (WSM-000201) reuse it verbatim.
 
 export async function startGameStream(
   leagueId: string,

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-auth.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-auth.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import { auth } from "@clerk/nextjs/server";
+import { liveStreamingV1 } from "@/lib/flags";
+import { getFixture, getPublicSeason } from "@/lib/data-api";
+import { canAdministerTeam } from "@/lib/authorization";
+
+/*
+ * Shared auth chain for streaming server actions (WSM-000144; extracted for
+ * reuse by the clip actions, WSM-000201). NOT a "use server" module — this is
+ * a plain server-only helper, so it never becomes a client-callable action.
+ *
+ * Chain: dark flag on → Clerk session → caller administers EITHER the home or
+ * away team (WSM-000121 team ownership) → fixture's season actually belongs to
+ * the league in the URL (cross-league guard, mirrors the public page).
+ */
+export async function authorizeStreamAction(
+  leagueId: string,
+  fixtureId: string,
+): Promise<
+  | { ok: true; userId: string; fixtureStatus: string }
+  | { ok: false; error: string }
+> {
+  const enabled = await liveStreamingV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const fixture = await getFixture(fixtureId);
+  if (!fixture) return { ok: false, error: "fixture_not_found" };
+
+  // Cross-league guard: the fixture's season must live in THIS league.
+  const season = await getPublicSeason(fixture.seasonId);
+  if (!season || season.leagueId !== leagueId) {
+    return { ok: false, error: "fixture_not_in_league" };
+  }
+
+  const [canHome, canAway] = await Promise.all([
+    canAdministerTeam(fixture.homeTeamId, userId),
+    canAdministerTeam(fixture.awayTeamId, userId),
+  ]);
+  if (!canHome && !canAway) return { ok: false, error: "not_authorized" };
+
+  return { ok: true, userId, fixtureStatus: fixture.status };
+}

--- a/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
+++ b/apps/web/src/app/leagues/[id]/games/[gameId]/page.tsx
@@ -10,6 +10,7 @@ import {
   getResultByFixture,
   getStreamByFixture,
   getLiveGameState,
+  listClipsByFixture,
 } from "@/lib/data-api";
 import { publicLeagueGuard } from "@/lib/public-league-guard";
 import { resolveStreamView } from "@/lib/stream-view";
@@ -119,6 +120,12 @@ export default async function PublicGamePage({
   const stream = streamingEnabled
     ? await getStreamByFixture(gameId).catch(() => null)
     : null;
+  // Highlight clips (WSM-000201, #303 track 3) — READY clips only, via the
+  // playback-only public projection. Clips can only exist where a stream row
+  // does, so the read is skipped otherwise; same fail-soft posture as above.
+  const clips = stream
+    ? await listClipsByFixture(gameId).catch(() => [])
+    : [];
 
   // Live scoring (WSM-000152): when on, seed the running scoreboard from the
   // server so first paint has the score; the client component then polls. Skip
@@ -216,6 +223,30 @@ export default async function PublicGamePage({
         <Card className="mb-6">
           <CardContent className="p-6 text-center text-sm text-muted-foreground">
             The live stream has ended.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {clips.length > 0 ? (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>Highlights</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {clips.map((clip) => (
+              <div key={clip.playbackId}>
+                <p className="mb-1 text-sm font-medium text-foreground">
+                  {clip.label}
+                </p>
+                <GameStreamPlayer
+                  provider="mux"
+                  muxPlaybackId={clip.playbackId}
+                  youtubeVideoId={null}
+                  live={false}
+                  title={clip.label}
+                />
+              </div>
+            ))}
           </CardContent>
         </Card>
       ) : null}

--- a/apps/web/src/components/schedule/ClipsControl.tsx
+++ b/apps/web/src/components/schedule/ClipsControl.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Link2, Scissors, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import GameStreamPlayer from "@/components/games/GameStreamPlayer";
+import { parseTimecode, formatTimecode } from "@/lib/timecode";
+import {
+  createClip,
+  deleteClip,
+  getClipsForAdmin,
+  type ClientGameClip,
+} from "@/app/dashboard/leagues/[id]/schedule/clip-actions";
+
+/*
+ * Highlight-clips control (WSM-000201, #303 track 3). Shown on a schedule row
+ * once the game's Mux stream has a recording (the VOD asset lands ~10s into
+ * the broadcast, so clipping works during AND after the game). The dialog
+ * previews the recording, takes a start/end/label, and lists existing clips
+ * with a shareable player.mux.com link per READY clip.
+ */
+export interface ClipsControlProps {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  /** Public playback id of the recording — powers the in-dialog preview. */
+  vodPlaybackId: string | null;
+}
+
+export default function ClipsControl({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+  vodPlaybackId,
+}: ClipsControlProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [clips, setClips] = useState<ClientGameClip[] | null>(null);
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [label, setLabel] = useState("");
+
+  function loadClips() {
+    startTransition(async () => {
+      const res = await getClipsForAdmin(leagueId, fixtureId);
+      if (res.ok) setClips(res.clips);
+      else toast.error(errorLabel(res.error));
+    });
+  }
+
+  function openDialog() {
+    setOpen(true);
+    if (clips === null) loadClips();
+  }
+
+  function create() {
+    const startSec = parseTimecode(start);
+    const endSec = parseTimecode(end);
+    if (startSec === null || endSec === null || endSec <= startSec) {
+      toast.error("Enter a valid start and end time (mm:ss), end after start.");
+      return;
+    }
+    if (!label.trim()) {
+      toast.error("Give the clip a short label first.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await createClip(leagueId, fixtureId, {
+        startSec,
+        endSec,
+        label,
+      });
+      if (res.ok) {
+        toast.success(
+          "Clip requested — it'll appear on the game page once Mux finishes cutting it.",
+        );
+        setStart("");
+        setEnd("");
+        setLabel("");
+        loadClips();
+        router.refresh();
+      } else {
+        toast.error(errorLabel(res.error));
+      }
+    });
+  }
+
+  function remove(clip: ClientGameClip) {
+    if (!window.confirm(`Delete the clip “${clip.label}”?`)) return;
+    startTransition(async () => {
+      const res = await deleteClip(leagueId, fixtureId, clip.id);
+      if (res.ok) {
+        toast.success("Clip deleted.");
+        loadClips();
+        router.refresh();
+      } else {
+        toast.error(errorLabel(res.error));
+      }
+    });
+  }
+
+  async function copyLink(clip: ClientGameClip) {
+    if (!clip.playbackId) return;
+    await navigator.clipboard.writeText(
+      `https://player.mux.com/${clip.playbackId}`,
+    );
+    toast.success("Shareable clip link copied.");
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={openDialog}
+        aria-label={`Manage clips for ${homeTeamName} vs ${awayTeamName}`}
+      >
+        <Scissors className="mr-1 h-4 w-4" /> Clips
+      </Button>
+
+      <Dialog open={open} onOpenChange={(o) => !pending && setOpen(o)}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Highlight clips</DialogTitle>
+            <DialogDescription>
+              Cut shareable highlights from the {homeTeamName} vs{" "}
+              {awayTeamName} recording. Scrub the preview to find your moment,
+              then enter the start and end times.
+            </DialogDescription>
+          </DialogHeader>
+
+          {vodPlaybackId ? (
+            <GameStreamPlayer
+              provider="mux"
+              muxPlaybackId={vodPlaybackId}
+              youtubeVideoId={null}
+              live={false}
+              title={`${homeTeamName} vs ${awayTeamName} — recording`}
+            />
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-2">
+            <div className="grid gap-1">
+              <Label htmlFor="clip-start">Start (mm:ss)</Label>
+              <Input
+                id="clip-start"
+                inputMode="numeric"
+                placeholder="12:05"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="clip-end">End (mm:ss)</Label>
+              <Input
+                id="clip-end"
+                inputMode="numeric"
+                placeholder="12:35"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="clip-label">Label</Label>
+            <Input
+              id="clip-label"
+              maxLength={80}
+              placeholder="Game-winning touchdown"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <p className="text-sm font-medium text-foreground">
+              Clips{clips ? ` (${clips.length})` : ""}
+            </p>
+            {clips === null ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : clips.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No clips yet — cut the first highlight above.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border rounded-md border border-border">
+                {clips.map((clip) => (
+                  <li
+                    key={clip.id}
+                    className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium text-foreground">
+                        {clip.label}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatTimecode(clip.startTime)} –{" "}
+                        {formatTimecode(clip.endTime)}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {clip.status === "ready" ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => copyLink(clip)}
+                          aria-label={`Copy shareable link for ${clip.label}`}
+                        >
+                          <Link2 className="h-4 w-4" />
+                        </Button>
+                      ) : (
+                        <Badge
+                          variant={
+                            clip.status === "errored"
+                              ? "destructive"
+                              : "secondary"
+                          }
+                        >
+                          {clip.status === "errored" ? "Error" : "Preparing"}
+                        </Badge>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={pending}
+                        onClick={() => remove(clip)}
+                        aria-label={`Delete clip ${clip.label}`}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Close
+            </Button>
+            <Button
+              onClick={create}
+              disabled={pending || !start.trim() || !end.trim() || !label.trim()}
+            >
+              {pending ? "Working…" : "Create clip"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function errorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Live streaming isn't enabled for this environment.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "Only an admin of one of the two teams can manage clips.";
+    case "invalid_clip_range":
+      return "Clips must be 1 second to 10 minutes long, within the recording.";
+    case "invalid_label":
+      return "Give the clip a short label (up to 80 characters).";
+    case "no_recording":
+      return "No recording to clip yet — clips unlock once the stream has been live for a moment.";
+    case "clip_cap_reached":
+      return "This game already has the maximum number of clips.";
+    case "clip_not_found":
+      return "That clip no longer exists.";
+    case "fixture_not_found":
+    case "fixture_not_in_league":
+      return "Game not found.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/lib/__tests__/mux-create-clip.test.ts
+++ b/apps/web/src/lib/__tests__/mux-create-clip.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// mux.ts is `import "server-only"`; neutralize that guard for the test runner.
+vi.mock("server-only", () => ({}));
+
+// Mock the Mux SDK to capture asset create/delete calls (WSM-000201).
+let createImpl: (params: unknown) => Promise<unknown>;
+let deleteImpl: (assetId: string) => Promise<void>;
+let lastCreateParams: unknown;
+vi.mock("@mux/mux-node", () => {
+  return {
+    default: class MockMux {
+      video = {
+        assets: {
+          create: (params: unknown) => {
+            lastCreateParams = params;
+            return createImpl(params);
+          },
+          delete: (assetId: string) => deleteImpl(assetId),
+        },
+      };
+    },
+  };
+});
+
+describe("createMuxClip", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("MUX_TOKEN_ID", "test-id");
+    vi.stubEnv("MUX_TOKEN_SECRET", "test-secret");
+    lastCreateParams = undefined;
+  });
+
+  it("creates a public basic-quality asset clipped from the source (mux://assets/…)", async () => {
+    createImpl = () =>
+      Promise.resolve({
+        id: "clip_asset_1",
+        playback_ids: [{ id: "pb_clip", policy: "public" }],
+      });
+    const { createMuxClip } = await import("../mux");
+    const result = await createMuxClip("src_asset_9", 65, 95);
+    expect(lastCreateParams).toEqual({
+      inputs: [
+        { url: "mux://assets/src_asset_9", start_time: 65, end_time: 95 },
+      ],
+      playback_policies: ["public"],
+      video_quality: "basic",
+    });
+    expect(result).toEqual({ assetId: "clip_asset_1", playbackId: "pb_clip" });
+  });
+
+  it("returns a null playbackId when Mux hasn't attached a public one", async () => {
+    createImpl = () =>
+      Promise.resolve({
+        id: "clip_asset_1",
+        playback_ids: [{ id: "pb_signed", policy: "signed" }],
+      });
+    const { createMuxClip } = await import("../mux");
+    const result = await createMuxClip("src_asset_9", 0, 30);
+    expect(result).toEqual({ assetId: "clip_asset_1", playbackId: null });
+  });
+
+  it("throws mux_clip_incomplete when the created asset has no id", async () => {
+    createImpl = () => Promise.resolve({});
+    const { createMuxClip } = await import("../mux");
+    await expect(createMuxClip("src_asset_9", 0, 30)).rejects.toThrow(
+      "mux_clip_incomplete",
+    );
+  });
+});
+
+describe("deleteMuxAsset", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("MUX_TOKEN_ID", "test-id");
+    vi.stubEnv("MUX_TOKEN_SECRET", "test-secret");
+  });
+
+  it("deletes the asset", async () => {
+    const seen: string[] = [];
+    deleteImpl = (assetId) => {
+      seen.push(assetId);
+      return Promise.resolve();
+    };
+    const { deleteMuxAsset } = await import("../mux");
+    await deleteMuxAsset("clip_asset_1");
+    expect(seen).toEqual(["clip_asset_1"]);
+  });
+
+  it("swallows Mux 404s so a double-delete converges", async () => {
+    deleteImpl = () =>
+      Promise.reject(Object.assign(new Error("not found"), { status: 404 }));
+    const { deleteMuxAsset } = await import("../mux");
+    await expect(deleteMuxAsset("clip_asset_1")).resolves.toBeUndefined();
+  });
+
+  it("rethrows non-404 errors", async () => {
+    deleteImpl = () =>
+      Promise.reject(Object.assign(new Error("boom"), { status: 500 }));
+    const { deleteMuxAsset } = await import("../mux");
+    await expect(deleteMuxAsset("clip_asset_1")).rejects.toThrow("boom");
+  });
+});

--- a/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
+++ b/apps/web/src/lib/__tests__/mux-webhook-handlers.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockUpdateGameStreamStatus } = vi.hoisted(() => ({
-  mockUpdateGameStreamStatus: vi.fn(),
-}));
+const { mockUpdateGameStreamStatus, mockUpdateGameClipStatus } = vi.hoisted(
+  () => ({
+    mockUpdateGameStreamStatus: vi.fn(),
+    mockUpdateGameClipStatus: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/data-api", () => ({
   updateGameStreamStatus: mockUpdateGameStreamStatus,
+  updateGameClipStatus: mockUpdateGameClipStatus,
 }));
 
 import {
   mapMuxEventToUpdate,
+  mapMuxEventToClipUpdate,
   handleMuxEvent,
 } from "../mux-webhook-handlers";
 
@@ -137,6 +142,79 @@ describe("mapMuxEventToUpdate (pure)", () => {
       mapMuxEventToUpdate({ type: "video.live_stream.active", data: {} }, NOW),
     ).toBeNull();
   });
+
+  it("NEVER attaches a CLIP asset as the stream's VOD (WSM-000201)", () => {
+    // A clip cut from the recording carries source_asset_id; if Mux also
+    // stamps live_stream_id on it, attaching it would clobber the replay ids.
+    expect(
+      mapMuxEventToUpdate(
+        {
+          type: "video.asset.ready",
+          data: {
+            id: "clip_asset_1",
+            live_stream_id: "ls_1",
+            source_asset_id: "asset_9",
+            playback_ids: [{ id: "pb_clip", policy: "public" }],
+          },
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("mapMuxEventToClipUpdate (pure, WSM-000201)", () => {
+  it("maps a clip's asset.ready → status ready with its public playback id", () => {
+    expect(
+      mapMuxEventToClipUpdate({
+        type: "video.asset.ready",
+        data: {
+          id: "clip_asset_1",
+          source_asset_id: "asset_9",
+          playback_ids: [
+            { id: "pb_signed", policy: "signed" },
+            { id: "pb_clip", policy: "public" },
+          ],
+        },
+      }),
+    ).toEqual({ muxAssetId: "clip_asset_1", status: "ready", playbackId: "pb_clip" });
+  });
+
+  it("omits playbackId when the clip has no public playback id", () => {
+    expect(
+      mapMuxEventToClipUpdate({
+        type: "video.asset.ready",
+        data: { id: "clip_asset_1", source_asset_id: "asset_9" },
+      }),
+    ).toEqual({ muxAssetId: "clip_asset_1", status: "ready" });
+  });
+
+  it("maps a clip's asset.errored → status errored", () => {
+    expect(
+      mapMuxEventToClipUpdate({
+        type: "video.asset.errored",
+        data: { id: "clip_asset_1", source_asset_id: "asset_9" },
+      }),
+    ).toEqual({ muxAssetId: "clip_asset_1", status: "errored" });
+  });
+
+  it("ignores non-clip assets (no source_asset_id) — the stream recording path", () => {
+    expect(
+      mapMuxEventToClipUpdate({
+        type: "video.asset.ready",
+        data: { id: "asset_9", live_stream_id: "ls_1" },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores other event types for clip assets", () => {
+    expect(
+      mapMuxEventToClipUpdate({
+        type: "video.asset.created",
+        data: { id: "clip_asset_1", source_asset_id: "asset_9" },
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("handleMuxEvent (side effect)", () => {
@@ -159,5 +237,24 @@ describe("handleMuxEvent (side effect)", () => {
       data: { id: "ls_1" },
     });
     expect(mockUpdateGameStreamStatus).not.toHaveBeenCalled();
+    expect(mockUpdateGameClipStatus).not.toHaveBeenCalled();
+  });
+
+  it("routes a clip's asset.ready to the CLIP row, not the stream (WSM-000201)", async () => {
+    await handleMuxEvent({
+      type: "video.asset.ready",
+      data: {
+        id: "clip_asset_1",
+        live_stream_id: "ls_1",
+        source_asset_id: "asset_9",
+        playback_ids: [{ id: "pb_clip", policy: "public" }],
+      },
+    });
+    expect(mockUpdateGameStreamStatus).not.toHaveBeenCalled();
+    expect(mockUpdateGameClipStatus).toHaveBeenCalledWith({
+      muxAssetId: "clip_asset_1",
+      status: "ready",
+      playbackId: "pb_clip",
+    });
   });
 });

--- a/apps/web/src/lib/__tests__/timecode.test.ts
+++ b/apps/web/src/lib/__tests__/timecode.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { parseTimecode, formatTimecode } from "../timecode";
+
+describe("parseTimecode", () => {
+  it("parses bare seconds", () => {
+    expect(parseTimecode("45")).toBe(45);
+  });
+
+  it("parses mm:ss", () => {
+    expect(parseTimecode("12:05")).toBe(725);
+  });
+
+  it("parses hh:mm:ss", () => {
+    expect(parseTimecode("1:02:03")).toBe(3723);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseTimecode("  2:30 ")).toBe(150);
+  });
+
+  it("rejects empty, malformed, and out-of-base-60 segments", () => {
+    expect(parseTimecode("")).toBeNull();
+    expect(parseTimecode("abc")).toBeNull();
+    expect(parseTimecode("1:2:3:4")).toBeNull();
+    expect(parseTimecode("1:75")).toBeNull(); // 75s isn't a valid ss segment
+    expect(parseTimecode("-1:30")).toBeNull();
+    expect(parseTimecode("1:")).toBeNull();
+  });
+});
+
+describe("formatTimecode", () => {
+  it("formats sub-hour as m:ss", () => {
+    expect(formatTimecode(725)).toBe("12:05");
+    expect(formatTimecode(5)).toBe("0:05");
+  });
+
+  it("formats past an hour as h:mm:ss", () => {
+    expect(formatTimecode(3723)).toBe("1:02:03");
+  });
+
+  it("clamps negatives to 0:00", () => {
+    expect(formatTimecode(-10)).toBe("0:00");
+  });
+
+  it("round-trips with parseTimecode", () => {
+    expect(parseTimecode(formatTimecode(754))).toBe(754);
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -643,6 +643,33 @@ const refs = {
     { fixtureId: string },
     { provider: string; muxLiveStreamId: string | null; status: string } | null
   >("sports:getStreamAdminByFixture"),
+  // Highlight clips (WSM-000201, #303 track 3)
+  createGameClip: mutationRef<
+    {
+      fixtureId: string;
+      muxAssetId: string;
+      playbackId: string | null;
+      label: string;
+      startTime: number;
+      endTime: number;
+      createdBy: string;
+    },
+    { id: string }
+  >("sports:createGameClip"),
+  updateGameClipStatus: mutationRef<
+    { muxAssetId: string; status: string; playbackId?: string | null },
+    boolean
+  >("sports:updateGameClipStatus"),
+  deleteGameClip: mutationRef<{ clipId: string; fixtureId: string }, boolean>(
+    "sports:deleteGameClip",
+  ),
+  listClipsByFixture: queryRef<{ fixtureId: string }, PublicGameClip[]>(
+    "sports:listClipsByFixture",
+  ),
+  // Internal query (not on public api) — admin-keyed server code only.
+  listClipsAdminByFixture: queryRef<{ fixtureId: string }, AdminGameClip[]>(
+    "sports:listClipsAdminByFixture",
+  ),
   // Stat-keeping keystone (WSM-000112)
   upsertPlayerGameStats: mutationRef<
     {
@@ -1913,6 +1940,72 @@ export async function getActiveStreamCountForLeague(
   leagueId: string,
 ): Promise<number> {
   return queryConvex(refs.getActiveStreamCountForLeague, { leagueId });
+}
+
+// --- Highlight clips (WSM-000201, #303 track 3) ---
+
+/** Public projection of a clip — READY clips only, playback fields only. */
+export interface PublicGameClip {
+  playbackId: string;
+  label: string;
+  createdAt: string;
+}
+
+/** Admin projection — includes the server-side Mux asset id and lifecycle
+ *  status. Server-side use only; strip `muxAssetId` before anything reaches a
+ *  client component. */
+export interface AdminGameClip {
+  id: string;
+  muxAssetId: string;
+  playbackId: string | null;
+  label: string;
+  startTime: number;
+  endTime: number;
+  status: string; // "preparing" | "ready" | "errored"
+  createdAt: string;
+}
+
+export async function createGameClip(input: {
+  fixtureId: string;
+  muxAssetId: string;
+  playbackId: string | null;
+  label: string;
+  startTime: number;
+  endTime: number;
+  createdBy: string;
+}): Promise<{ id: string }> {
+  return mutateConvex(refs.createGameClip, input);
+}
+
+/** Flip a clip's lifecycle status from the Mux asset webhooks (keyed by the
+ *  clip's own asset id). */
+export async function updateGameClipStatus(input: {
+  muxAssetId: string;
+  status: string;
+  playbackId?: string | null;
+}): Promise<boolean> {
+  return mutateConvex(refs.updateGameClipStatus, input);
+}
+
+export async function deleteGameClip(
+  clipId: string,
+  fixtureId: string,
+): Promise<boolean> {
+  return mutateConvex(refs.deleteGameClip, { clipId, fixtureId });
+}
+
+/** Public read — READY clips only, projected to playback fields only. */
+export async function listClipsByFixture(
+  fixtureId: string,
+): Promise<PublicGameClip[]> {
+  return queryConvex(refs.listClipsByFixture, { fixtureId });
+}
+
+/** Internal admin read — all clips (incl. preparing/errored) with asset ids. */
+export async function listClipsAdminByFixture(
+  fixtureId: string,
+): Promise<AdminGameClip[]> {
+  return queryConvex(refs.listClipsAdminByFixture, { fixtureId });
 }
 
 /** Internal admin read — returns the server-side Mux live-stream id so a server

--- a/apps/web/src/lib/mux-webhook-handlers.ts
+++ b/apps/web/src/lib/mux-webhook-handlers.ts
@@ -1,4 +1,4 @@
-import { updateGameStreamStatus } from "@/lib/data-api";
+import { updateGameStreamStatus, updateGameClipStatus } from "@/lib/data-api";
 
 /*
  * Mux webhook event handling (WSM-000144). The event→action mapping is a PURE
@@ -36,6 +36,9 @@ export interface MuxWebhookEvent {
   data: {
     id?: string;
     live_stream_id?: string | null;
+    // Present ONLY on assets created FROM another asset — i.e. clips
+    // (WSM-000201). The stream's own recording never carries it.
+    source_asset_id?: string | null;
     playback_ids?: { id?: string; policy?: string }[];
   };
 }
@@ -73,6 +76,11 @@ export function mapMuxEventToUpdate(
       const liveStreamId = event.data.live_stream_id;
       const assetId = event.data.id;
       if (!liveStreamId || !assetId) return null;
+      // A CLIP asset (WSM-000201) carries source_asset_id. Whether or not Mux
+      // also stamps live_stream_id on it, it must NEVER attach itself as the
+      // stream's VOD recording — that would clobber the real replay ids. Clip
+      // readiness is handled separately (mapMuxEventToClipUpdate).
+      if (event.data.source_asset_id) return null;
       // The asset's PUBLIC playback id is what the replay player uses. Phase 1
       // creates streams with new_asset_settings.playback_policy ["public"], so
       // one should always exist; tolerate its absence (attach the asset id only).
@@ -90,9 +98,47 @@ export function mapMuxEventToUpdate(
   }
 }
 
+export interface ClipStatusUpdate {
+  muxAssetId: string;
+  status: "ready" | "errored";
+  playbackId?: string;
+}
+
+/**
+ * Pure mapping from a Mux event to a CLIP status update (WSM-000201), or null
+ * for non-clip events. Clips are the only assets we create with a
+ * `mux://assets/…` input, so `source_asset_id` is the discriminator; the row
+ * is keyed by the clip's own asset id.
+ */
+export function mapMuxEventToClipUpdate(
+  event: MuxWebhookEvent,
+): ClipStatusUpdate | null {
+  const assetId = event.data.id;
+  if (!event.data.source_asset_id || !assetId) return null;
+  switch (event.type) {
+    case "video.asset.ready": {
+      // Belt-and-braces: the playback id is stored at creation, but re-attach
+      // it from the event in case creation raced or the row predates it.
+      const playbackId = event.data.playback_ids?.find(
+        (p) => p.policy === "public" && p.id,
+      )?.id;
+      return {
+        muxAssetId: assetId,
+        status: "ready",
+        ...(playbackId ? { playbackId } : {}),
+      };
+    }
+    case "video.asset.errored":
+      return { muxAssetId: assetId, status: "errored" };
+    default:
+      return null;
+  }
+}
+
 /** Apply a verified Mux event. No-op for ignored events and unknown streams. */
 export async function handleMuxEvent(event: MuxWebhookEvent): Promise<void> {
   const update = mapMuxEventToUpdate(event, new Date().toISOString());
-  if (!update) return;
-  await updateGameStreamStatus(update);
+  if (update) await updateGameStreamStatus(update);
+  const clipUpdate = mapMuxEventToClipUpdate(event);
+  if (clipUpdate) await updateGameClipStatus(clipUpdate);
 }

--- a/apps/web/src/lib/mux.ts
+++ b/apps/web/src/lib/mux.ts
@@ -91,6 +91,58 @@ export async function createMuxLiveStream(
   };
 }
 
+export interface CreatedMuxClip {
+  assetId: string;
+  /** Public playback id — present from creation; playable once the asset is
+   *  ready (the webhook flips our row's status). */
+  playbackId: string | null;
+}
+
+/**
+ * Cut a highlight clip from an existing asset (WSM-000201, #303 track 3). Mux
+ * clipping = create a NEW asset whose input is `mux://assets/{sourceAssetId}`
+ * with start/end offsets in seconds (Mux minimum clip length: 500ms). The clip
+ * gets its own public playback id; `video_quality: "basic"` pins per-clip
+ * encoding cost at the floor — highlights don't need the premium ladder.
+ */
+export async function createMuxClip(
+  sourceAssetId: string,
+  startTimeSec: number,
+  endTimeSec: number,
+): Promise<CreatedMuxClip> {
+  const mux = getMux();
+  const asset = await mux.video.assets.create({
+    inputs: [
+      {
+        url: `mux://assets/${sourceAssetId}`,
+        start_time: startTimeSec,
+        end_time: endTimeSec,
+      },
+    ],
+    playback_policies: ["public"],
+    video_quality: "basic",
+  });
+  if (!asset.id) throw new Error("mux_clip_incomplete");
+  return {
+    assetId: asset.id,
+    playbackId:
+      asset.playback_ids?.find((p) => p.policy === "public")?.id ?? null,
+  };
+}
+
+/** Delete a clip's Mux asset (admin moderation/cleanup). Mux 404s are swallowed
+ *  so a double-delete converges instead of surfacing an error. */
+export async function deleteMuxAsset(assetId: string): Promise<void> {
+  const mux = getMux();
+  try {
+    await mux.video.assets.delete(assetId);
+  } catch (err) {
+    const status = (err as { status?: number } | null)?.status;
+    if (status === 404) return;
+    throw err;
+  }
+}
+
 /** Disable a live stream (admin manual stop). Idempotent-ish: Mux 404s are
  *  swallowed so a double-stop doesn't surface an error to the coach. */
 export async function disableMuxLiveStream(liveStreamId: string): Promise<void> {

--- a/apps/web/src/lib/timecode.ts
+++ b/apps/web/src/lib/timecode.ts
@@ -1,0 +1,30 @@
+/*
+ * Tiny mm:ss (or hh:mm:ss) timecode helpers for the clip-range inputs
+ * (WSM-000201). Pure + dependency-free so they're trivially unit-testable.
+ */
+
+/** Parse "SS", "MM:SS", or "HH:MM:SS" into whole seconds; null if malformed.
+ *  Minute/second segments past the first must be 0–59. */
+export function parseTimecode(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(":");
+  if (parts.length > 3) return null;
+  const nums = parts.map((p) => (/^\d{1,4}$/.test(p) ? Number(p) : NaN));
+  if (nums.some((n) => Number.isNaN(n))) return null;
+  // Every segment after the leading one is a base-60 position.
+  if (nums.slice(1).some((n) => n > 59)) return null;
+  return nums.reduce((total, n) => total * 60 + n, 0);
+}
+
+/** Format whole seconds as "M:SS" (or "H:MM:SS" past an hour). */
+export function formatTimecode(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  const mmss = `${minutes}:${String(seconds).padStart(2, "0")}`;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+    : mmss;
+}


### PR DESCRIPTION
## Summary

**#303 track 3 — clips/highlights.** Team admins cut shareable highlight clips from a game's Mux stream recording; the public game page gains a **Highlights** section. Fully dark behind the existing `live_streaming_v1` flag (clips can only exist where a stream does), so this ships with zero exposure and zero cost until a pilot enables streaming.

## How it works

- **Mux** (`lib/mux.ts`): `createMuxClip(sourceAssetId, start, end)` creates a new asset from `mux://assets/{vodAssetId}` with `start_time`/`end_time` (verified against live Mux docs + the installed `@mux/mux-node` 14.1.1 types, per the ticket's warning). `playback_policies: ["public"]`, `video_quality: "basic"` to pin per-clip encoding cost at the floor. `deleteMuxAsset` is 404-tolerant so deletes converge.
- **Convex**: new `gameClips` table — writes are `internalMutation` only. Public read `listClipsByFixture` projects **READY clips to playback-only fields**; the clip's Mux asset id never transits a public query (same posture as the hidden live-stream id). `listClipsAdminByFixture` (internal) keeps full rows for the trusted server. `listClipsByFixture` added to `AllowedPublicSportsReads`.
- **Webhook safety** (`mux-webhook-handlers.ts`): a clip asset fires its own `video.asset.ready`. Clips carry `source_asset_id`, so the VOD-attach path now **ignores any asset with `source_asset_id`** — without this, a clip could clobber the stream's real replay ids. Clip events route to the clip row instead (`ready` / `errored`), keyed by asset id, idempotent for unknown/late deliveries.
- **Server actions** (`clip-actions.ts`): `createClip` / `deleteClip` / `getClipsForAdmin` reuse the streaming auth chain — extracted verbatim into `stream-auth.ts` (plain server-only module, not a `"use server"` action) and shared with `stream-actions.ts`. Validation: 1s–10min range, ≤80-char label, 20 clips per fixture (cost cap). YouTube streams return `no_recording` (their recording lives on YouTube). `getClipsForAdmin` strips `muxAssetId` before anything reaches the client.
- **UI**: `ClipsControl` dialog on the schedule row (appears once the Mux recording exists — ~10s into the broadcast, so clipping works during and after the game): recording preview, mm:ss range inputs, label, list with per-clip `player.mux.com/{playbackId}` share link + delete. Public game page renders ready clips as a Highlights card.

## Testing

- `mux-create-clip.test.ts` — exact Mux create params (input url / offsets / policy / quality), null-playback tolerance, incomplete-asset throw, 404-tolerant delete.
- `mux-webhook-handlers.test.ts` — **regression: a clip's `asset.ready` never attaches as the stream's VOD**; clip ready/errored mapping; routing in `handleMuxEvent`.
- `clip-actions.test.ts` — full auth chain (flag/session/team-admin/cross-league), every validation branch, cap, YouTube/no-VOD refusal, Mux-failure surfacing, asset-id stripping.
- `gameClips.test.ts` (convex-test) — write path, webhook flip idempotency, fixture-pinned delete, **public projection returns ready-only playback fields**.
- `timecode.test.ts` — mm:ss parsing/formatting round-trip.

Gates: `tsc` ✓ · `eslint --max-warnings=0` ✓ · `vitest` 812/812 ✓ · `next build` ✓

Refs #303 (tracks 1, 2, 3 now done — track 4 multi-cam docs remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sadcKPsuZryoW8TweKjL3