### PR TITLE
fix(web): env-parity accepts the post-cutover Clerk key split (WSM-000168)

### DIFF
--- a/scripts/check-web-env-parity.js
+++ b/scripts/check-web-env-parity.js
@@ -30,6 +30,15 @@ const KEYS_TO_COMPARE = [
   "SF_PRIVATE_KEY",
 ];
 
+// Post-cutover (WSM-000168 / #386), the Clerk instance keys are EXPECTED to
+// differ: local/preview stay on the development instance (pk_test_/sk_test_)
+// while production runs the live instance (pk_live_/sk_live_). For these keys
+// "parity" means each side is on its expected instance type, not equal values.
+const CLERK_INSTANCE_KEYS = [
+  "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+  "CLERK_SECRET_KEY",
+];
+
 // Displayed for visibility but never counted as drift — flag overrides are
 // expected to differ between local dev and production (WSM-000079/80).
 const INFORMATIONAL_KEYS = [
@@ -93,12 +102,28 @@ function decodeClerkFrontendApi(publishableKey) {
   }
 }
 
+// The sanctioned post-cutover state for the Clerk instance keys: local on the
+// dev instance, prod on the live instance. Anything else (e.g. live keys in
+// .env.local, or prod back on test keys with a different value) still counts
+// as drift.
+function isExpectedClerkSplit(key, localValue, productionValue) {
+  return (
+    CLERK_INSTANCE_KEYS.includes(key) &&
+    clerkKeyType(normalizeValue(localValue)) === "test" &&
+    clerkKeyType(normalizeValue(productionValue)) === "live"
+  );
+}
+
 function formatStatusRow(key, localValue, productionValue) {
   const localNormalized = normalizeValue(localValue);
   const productionNormalized = normalizeValue(productionValue);
 
   if (!localNormalized && !productionNormalized) {
     return `${key}: missing in both local and production`;
+  }
+
+  if (isExpectedClerkSplit(key, localValue, productionValue)) {
+    return `${key}: expected split (local test / prod live)`;
   }
 
   if (!localNormalized) {
@@ -186,6 +211,7 @@ function main() {
     const hasDrift = KEYS_TO_COMPARE.some((key) => {
       const localValue = normalizeValue(localEnv[key]);
       const productionValue = normalizeValue(productionEnv[key]);
+      if (isExpectedClerkSplit(key, localValue, productionValue)) return false;
       return localValue !== productionValue;
     });
 


### PR DESCRIPTION
## Summary
The Clerk prod cutover (#386) intentionally leaves local/preview on the **development** Clerk instance while Production runs the **live** instance — so `check-web-env-parity`'s exact-equality check on `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` / `CLERK_SECRET_KEY` now fails forever by design (`pnpm run check:launch` reported drift right after the swap).

## Changes
- `scripts/check-web-env-parity.js`: `local=test + prod=live` on the two Clerk instance keys is reported as `expected split (local test / prod live)` and not counted as drift. Any other combination (live keys in `.env.local`, prod back on test keys, mismatched dev instances) still fails, and the `--launch` gate still hard-requires prod on `pk_live_/sk_live_`.

## Testing
- `node scripts/check-web-env-parity.js --launch` against the real post-cutover env: **Launch readiness: production Clerk is LIVE ✓ / Env parity check passed** (was: drift + exit 1).

Part of #386 (does not close it — that closes when the cutover is verified on prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01Ls9N5DBiXh7esUP3jTCHHq