### PR TITLE
feat(sf): League__c Amateur/Professional record types + admin visibility (WSM-000203)

### DIFF
--- a/sportsmgmt/main/default/objects/League__c/recordTypes/Amateur.recordType-meta.xml
+++ b/sportsmgmt/main/default/objects/League__c/recordTypes/Amateur.recordType-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RecordType xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Amateur</fullName>
+    <active>true</active>
+    <description>Amateur and recreational leagues</description>
+    <label>Amateur League</label>
+</RecordType>

--- a/sportsmgmt/main/default/objects/League__c/recordTypes/Professional.recordType-meta.xml
+++ b/sportsmgmt/main/default/objects/League__c/recordTypes/Professional.recordType-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RecordType xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Professional</fullName>
+    <active>true</active>
+    <description>Professional sports leagues</description>
+    <label>Professional League</label>
+</RecordType>

--- a/sportsmgmt/main/default/permissionsets/League_Administrator.permissionset-meta.xml
+++ b/sportsmgmt/main/default/permissionsets/League_Administrator.permissionset-meta.xml
@@ -109,6 +109,17 @@
         <readable>true</readable>
     </fieldPermissions>
 
+    <!-- League__c Record Types (WSM-000203): admins pick the league class at
+         creation; visibility here makes both selectable for this permission set. -->
+    <recordTypeVisibilities>
+        <recordType>League__c.Amateur</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <recordType>League__c.Professional</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+
     <!-- Tab Visibility -->
     <tabSettings>
         <tab>League__c</tab>


### PR DESCRIPTION
## Summary

Lands the long-parked Salesforce metadata: the `League__c` **Amateur** and **Professional** record types (created 2026-04-14, deliberately excluded from PR #176 as unrelated to that web chore, untracked in the working tree ever since) — plus the record-type-visibility pass the exclusion note called for.

- `objects/League__c/recordTypes/Amateur.recordType-meta.xml` + `Professional.recordType-meta.xml` (both active).
- `League_Administrator` permission set gains `recordTypeVisibilities` for both — it's the only set that creates leagues, so it's the only one that needs the picker. Read-only sets (`Team_Manager`, `Data_Viewer`) view records fine without visibility.
- `TeamDetailsControllerTest` already branches on the Professional record type existing; this makes that test path real.

## Validation (fresh scratch org)

- Full `sportsmgmt` deploy: **success** — both record types `Created`, permission set `Changed`.
- Apex: **242/242 tests pass, 100%**.
- One pre-existing fresh-deploy blocker surfaced on main and is **out of scope**: `NFL_Sync_Config__c.Last_Sync_Report__c` is a `LongTextArea` on a Hierarchy **custom setting**, which Salesforce rejects (`Invalid data type`) — from PR #82; filed separately as WSM-000204. Validation ignored that single field.

Web CI is unaffected (no `apps/`/`packages/` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sadcKPsuZryoW8TweKjL3