### PR TITLE
fix(web): dashboard survives Clerk org-API failures (WSM-000206 / #456)

### DIFF
--- a/apps/web/src/lib/__tests__/org-context.test.ts
+++ b/apps/web/src/lib/__tests__/org-context.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const {
   mockGetOrganizationMembershipList,
   mockGetVisibleLeagueContext,
+  mockGetOrgMemberRole,
 } = vi.hoisted(() => ({
   mockGetOrganizationMembershipList: vi.fn(),
   mockGetVisibleLeagueContext: vi.fn(),
+  mockGetOrgMemberRole: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({
@@ -18,6 +20,7 @@ vi.mock("@clerk/nextjs/server", () => ({
 
 vi.mock("../data-api", () => ({
   getVisibleLeagueContext: mockGetVisibleLeagueContext,
+  getOrgMemberRole: mockGetOrgMemberRole,
 }));
 
 vi.mock("react", () => ({
@@ -28,7 +31,33 @@ import {
   resolveOrgContext,
   requireLeagueAccess,
   requireOrgAdmin,
+  getUserRoleInOrg,
+  resolveBestOrgRole,
 } from "../org-context";
+
+/**
+ * Mirrors what Clerk's backend SDK actually throws when the Organizations
+ * feature is disabled on the instance (the WSM-000206 production incident):
+ * a ClerkAPIResponseError carrying an `errors` array of machine-readable codes.
+ */
+function clerkOrgsDisabledError(): Error {
+  const err = new Error(
+    "The organizations feature is not enabled for this instance. If you believe this is a mistake, please contact support.",
+  ) as Error & {
+    clerkError: boolean;
+    status: number;
+    errors: Array<{ code: string; message: string }>;
+  };
+  err.clerkError = true;
+  err.status = 403;
+  err.errors = [
+    {
+      code: "organization_not_enabled_in_instance",
+      message: "The organizations feature is not enabled for this instance.",
+    },
+  ];
+  return err;
+}
 
 describe("resolveOrgContext", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -188,6 +217,173 @@ describe("requireOrgAdmin", () => {
     await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
       "You must be an admin",
     );
+  });
+});
+
+// WSM-000206 / #456: the production Clerk instance lacked the Organizations
+// feature, so getOrganizationMembershipList threw a 403 ClerkAPIResponseError
+// and the unhandled throw 500'd the entire dashboard. The org-context layer
+// must fail SOFT: log one structured line and degrade to the same values a
+// user with no organizations gets.
+describe("Clerk org-API failure degrades gracefully (WSM-000206)", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("resolveOrgContext", () => {
+    it("returns the no-org context instead of throwing when Clerk orgs are disabled", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+      mockGetVisibleLeagueContext.mockResolvedValue({
+        visibleLeagueIds: [],
+        subscribedLeagueIds: [],
+        subscriptionScopes: [],
+      });
+
+      const ctx = await resolveOrgContext("user_123");
+
+      // Exactly the shape dashboard/page.tsx consumes: it reads
+      // ctx.visibleLeagueIds to fetch leagues, and with an empty array the
+      // page renders the "No leagues yet" empty-workspace bento — not a 500.
+      expect(ctx).toEqual({
+        userId: "user_123",
+        orgIds: [],
+        visibleLeagueIds: [],
+        subscribedLeagueIds: [],
+        subscriptionTeamScopes: {},
+      });
+    });
+
+    it("still resolves subscribed public leagues via Convex when Clerk fails", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+      mockGetVisibleLeagueContext.mockResolvedValue({
+        visibleLeagueIds: ["league_pub_1"],
+        subscribedLeagueIds: ["league_pub_1"],
+        subscriptionScopes: [],
+      });
+
+      const ctx = await resolveOrgContext("user_with_subs");
+
+      // Same degradation as a no-org user: Convex is still consulted with an
+      // empty org list, so subscriptions keep working.
+      expect(mockGetVisibleLeagueContext).toHaveBeenCalledWith(
+        "user_with_subs",
+        [],
+      );
+      expect(ctx.visibleLeagueIds).toEqual(["league_pub_1"]);
+      expect(ctx.subscribedLeagueIds).toEqual(["league_pub_1"]);
+    });
+
+    it("logs one structured JSON line including the Clerk error code", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+      mockGetVisibleLeagueContext.mockResolvedValue({
+        visibleLeagueIds: [],
+        subscribedLeagueIds: [],
+        subscriptionScopes: [],
+      });
+
+      await resolveOrgContext("user_123");
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const logged = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+      expect(logged).toMatchObject({
+        level: "error",
+        source: "org-context",
+        clerkErrorCode: "organization_not_enabled_in_instance",
+        userId: "user_123",
+      });
+    });
+
+    it("degrades on non-Clerk errors too, with a null error code", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        new Error("socket hang up"),
+      );
+      mockGetVisibleLeagueContext.mockResolvedValue({
+        visibleLeagueIds: [],
+        subscribedLeagueIds: [],
+        subscriptionScopes: [],
+      });
+
+      const ctx = await resolveOrgContext("user_123");
+
+      expect(ctx.orgIds).toEqual([]);
+      const logged = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+      expect(logged.clerkErrorCode).toBeNull();
+    });
+  });
+
+  describe("resolveBestOrgRole", () => {
+    it("returns null (no role anywhere) when Clerk orgs are disabled", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+
+      await expect(
+        resolveBestOrgRole(["org_league", "org_owner"], "user_123"),
+      ).resolves.toBeNull();
+    });
+
+    it("happy path unchanged: strongest role across candidate orgs wins", async () => {
+      mockGetOrganizationMembershipList.mockResolvedValue({
+        data: [
+          { organization: { id: "org_league" }, role: "org:member" },
+          { organization: { id: "org_owner" }, role: "org:admin" },
+        ],
+      });
+      mockGetOrgMemberRole.mockResolvedValue(null);
+
+      await expect(
+        resolveBestOrgRole(["org_league", "org_owner"], "user_123"),
+      ).resolves.toBe("admin");
+    });
+  });
+
+  describe("getUserRoleInOrg", () => {
+    it("returns null when Clerk orgs are disabled", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+
+      await expect(
+        getUserRoleInOrg("org_abc", "user_123"),
+      ).resolves.toBeNull();
+    });
+
+    it("happy path unchanged: returns the raw Clerk role", async () => {
+      mockGetOrganizationMembershipList.mockResolvedValue({
+        data: [{ organization: { id: "org_abc" }, role: "org:admin" }],
+      });
+
+      await expect(getUserRoleInOrg("org_abc", "user_123")).resolves.toBe(
+        "org:admin",
+      );
+    });
+  });
+
+  describe("requireOrgAdmin", () => {
+    it("fails CLOSED with the controlled admin error (never the raw Clerk crash)", async () => {
+      mockGetOrganizationMembershipList.mockRejectedValue(
+        clerkOrgsDisabledError(),
+      );
+
+      await expect(requireOrgAdmin("org_abc", "user_123")).rejects.toThrow(
+        "You must be an admin",
+      );
+    });
   });
 });
 

--- a/apps/web/src/lib/org-context.ts
+++ b/apps/web/src/lib/org-context.ts
@@ -6,6 +6,76 @@ import {
 } from "./data-api";
 import type { OrgRole } from "./permissions";
 
+/**
+ * Minimal structural shape of a Clerk org membership as consumed here. The
+ * SDK's OrganizationMembership satisfies this; keeping it structural lets the
+ * fail-soft helper below stay decoupled from Clerk SDK type churn.
+ */
+interface OrgMembershipLike {
+  organization: { id: string };
+  role: string;
+}
+
+/**
+ * Extracts the machine-readable error code from a ClerkAPIResponseError-shaped
+ * throw (e.g. "organization_not_enabled_in_instance" when the Clerk instance
+ * has the Organizations feature disabled — the WSM-000206 production incident).
+ * Returns null for non-Clerk errors.
+ */
+function extractClerkErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const errors = (error as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return null;
+  const code = (errors[0] as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : null;
+}
+
+/**
+ * Fetches ALL of a user's Clerk org memberships (paginated), failing SOFT:
+ * any Clerk org-API error is logged as one structured JSON line and treated
+ * as "user has no organizations" instead of propagating. A Clerk outage or
+ * misconfiguration (e.g. Organizations feature disabled on the instance) must
+ * degrade the dashboard to the empty-workspace view, never 500 it
+ * (WSM-000206 / #456).
+ */
+async function listOrgMembershipsFailSoft(
+  userId: string,
+  caller: string,
+): Promise<OrgMembershipLike[]> {
+  try {
+    const client = await clerkClient();
+    const memberships: OrgMembershipLike[] = [];
+    let offset = 0;
+    const limit = 100;
+    let hasMore = true;
+
+    while (hasMore) {
+      const page = await client.users.getOrganizationMembershipList({
+        userId,
+        limit,
+        offset,
+      });
+      memberships.push(...page.data);
+      hasMore = page.data.length === limit;
+      offset += limit;
+    }
+    return memberships;
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        source: "org-context",
+        message: `Clerk org membership lookup failed in ${caller}; degrading to no-org context`,
+        clerkErrorCode: extractClerkErrorCode(error),
+        error: error instanceof Error ? error.message : String(error),
+        userId,
+      }),
+    );
+    return [];
+  }
+}
+
 export interface OrgContext {
   userId: string;
   orgIds: string[];
@@ -33,27 +103,14 @@ export interface OrgContext {
  */
 export const resolveOrgContext = cache(
   async (userId: string): Promise<OrgContext> => {
-    const client = await clerkClient();
-
-    // Get all orgs the user belongs to (handle pagination).
-    const orgIds: string[] = [];
-    let offset = 0;
-    const limit = 100;
-    let hasMore = true;
-
-    while (hasMore) {
-      const memberships =
-        await client.users.getOrganizationMembershipList({
-          userId,
-          limit,
-          offset,
-        });
-      for (const m of memberships.data) {
-        orgIds.push(m.organization.id);
-      }
-      hasMore = memberships.data.length === limit;
-      offset += limit;
-    }
+    // Fail-soft: a Clerk org-API failure yields no org memberships, so the
+    // user degrades to the same context as a user with no organizations
+    // (subscribed public leagues still resolve via Convex below).
+    const memberships = await listOrgMembershipsFailSoft(
+      userId,
+      "resolveOrgContext",
+    );
+    const orgIds = memberships.map((m) => m.organization.id);
 
     // Single Convex query resolves both visible-league fan-out (via the
     // `leagues.by_orgId` index for each org the user belongs to) and the
@@ -94,19 +151,21 @@ export function requireLeagueAccess(
 /**
  * Check that the user is an admin of a specific Clerk Organization.
  * Used for mutations (create team, update player, etc.)
+ *
+ * Fail-soft note: if the Clerk org API itself fails, the user is treated as a
+ * non-member and gets the controlled "must be an admin" error below (fail
+ * CLOSED for mutations, but never a raw Clerk crash).
  */
 export async function requireOrgAdmin(
   orgId: string,
   userId: string,
 ): Promise<void> {
-  const client = await clerkClient();
-  const memberships = await client.users.getOrganizationMembershipList({
+  const memberships = await listOrgMembershipsFailSoft(
     userId,
-  });
-
-  const membership = memberships.data.find(
-    (m) => m.organization.id === orgId,
+    "requireOrgAdmin",
   );
+
+  const membership = memberships.find((m) => m.organization.id === orgId);
 
   if (!membership || membership.role !== "org:admin") {
     throw new Error("You must be an admin of this league to make changes");
@@ -118,18 +177,19 @@ export async function requireOrgAdmin(
  * they are not a member. Prefer `resolveOrgRole` for capability decisions — this
  * is the low-level Clerk read, used where the literal org:admin/org:member value
  * is needed (e.g. the members admin API).
+ *
+ * Fail-soft: a Clerk org-API failure resolves to null (not a member), which
+ * also protects resolveOrgRole / resolveBestOrgRole callers.
  */
 export async function getUserRoleInOrg(
   orgId: string,
   userId: string,
 ): Promise<"org:admin" | "org:member" | null> {
-  const client = await clerkClient();
-  const memberships = await client.users.getOrganizationMembershipList({
+  const memberships = await listOrgMembershipsFailSoft(
     userId,
-  });
-  const membership = memberships.data.find(
-    (m) => m.organization.id === orgId,
+    "getUserRoleInOrg",
   );
+  const membership = memberships.find((m) => m.organization.id === orgId);
   if (!membership) return null;
   return membership.role as "org:admin" | "org:member";
 }


### PR DESCRIPTION
## Root cause (Refs #456)

Production `/dashboard` returned a 500 for every signed-in user. `resolveOrgContext(userId)` in `apps/web/src/lib/org-context.ts` calls Clerk's organization-memberships API inside a server component; the new production Clerk instance lacks the Organizations feature, so Clerk threw a 403 `ClerkAPIResponseError` with code `organization_not_enabled_in_instance`, and the unhandled throw crashed the whole dashboard render. This PR is the code-hardening half of #456 — the operator fix (enabling Organizations on the Clerk instance) is tracked separately, so the issue stays open.

## What fail-soft means for UX

All Clerk org-membership reads in `org-context.ts` now go through one fail-soft helper. On any Clerk org-API error it logs a single structured JSON line (matching the webhook routes' idiom, including the Clerk error code when present, never any secret) and treats the user as having **no organizations**:

| Function | Degraded value on Clerk failure |
| --- | --- |
| `resolveOrgContext` | `orgIds: []`; Convex is still consulted, so subscribed public leagues keep resolving — a signed-in user sees the empty-workspace dashboard ("No leagues yet") instead of a 500 |
| `getUserRoleInOrg` | `null` (not a member) |
| `resolveOrgRole` / `resolveBestOrgRole` (transitively) | `null` (no role) — admin-only UI hidden |
| `requireOrgAdmin` | fails **closed** with the existing controlled "You must be an admin" error, never a raw Clerk crash |

Happy-path return types and call-site signatures are unchanged; catching lives inside `org-context.ts`, so every call site (dashboard pages, server actions, API routes) is protected.

## Test coverage (`apps/web/src/lib/__tests__/org-context.test.ts`)

New "Clerk org-API failure degrades gracefully (WSM-000206)" suite, using a `ClerkAPIResponseError`-shaped throw with `errors[0].code = "organization_not_enabled_in_instance"`:

- resolveOrgContext: returns the no-org context instead of throwing when Clerk orgs are disabled
- resolveOrgContext: still resolves subscribed public leagues via Convex when Clerk fails
- resolveOrgContext: logs one structured JSON line including the Clerk error code
- resolveOrgContext: degrades on non-Clerk errors too, with a null error code
- resolveBestOrgRole: returns null (no role anywhere) when Clerk orgs are disabled
- resolveBestOrgRole: happy path unchanged — strongest role across candidate orgs wins
- getUserRoleInOrg: returns null when Clerk orgs are disabled
- getUserRoleInOrg: happy path unchanged — returns the raw Clerk role
- requireOrgAdmin: fails CLOSED with the controlled admin error (never the raw Clerk crash)

All 12 pre-existing org-context tests (happy paths, pagination, requireLeagueAccess, requireOrgAdmin) still pass unchanged.

## Gates (run in apps/web)

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint src convex --max-warnings=0` — clean
- `pnpm exec vitest run` — 105 files, 829 tests, all passing

Refs #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sadcKPsuZryoW8TweKjL3