### PR TITLE
feat(web): schedule/standings/back-nav quick wins + roster generation gate

### DIFF
--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -93,9 +93,8 @@ test.describe("Schedules & standings — fixture loop (WSM-000074)", () => {
       .click();
     await expect(fixtureDialog).toBeHidden();
 
-    // The new row appears in Week 1. `exact` matters: the row's Actions cell
-    // ("Record result / Simulate / Delete …") also CONTAINS the team name, so
-    // a substring match is a strict-mode violation.
+    // The new row appears in Week 1. Home/Away cells use exact team names;
+    // action links use concise labels (Box score Home/Away, Live) instead.
     await expect(page.getByText("Week 1")).toBeVisible();
     await expect(
       page.getByRole("cell", { name: "E2E Home Hawks", exact: true }),

--- a/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
@@ -7,8 +7,12 @@ const {
   mockResolveOrgContext,
   mockResolveOrgRole,
   mockGetPlayersByTeam,
+  mockGetPlayers,
   mockGetTeamsByLeague,
+  mockGetTeamLeagueId,
   mockGetLeagueOrgId,
+  mockGetSeasons,
+  mockListFixturesBySeason,
   mockBulkCreatePlayers,
   mockClearSyntheticPlayers,
 } = vi.hoisted(() => ({
@@ -18,8 +22,12 @@ const {
   mockResolveOrgContext: vi.fn(),
   mockResolveOrgRole: vi.fn(),
   mockGetPlayersByTeam: vi.fn(),
+  mockGetPlayers: vi.fn(),
   mockGetTeamsByLeague: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
+  mockGetSeasons: vi.fn(),
+  mockListFixturesBySeason: vi.fn(),
   mockBulkCreatePlayers: vi.fn(),
   mockClearSyntheticPlayers: vi.fn(),
 }));
@@ -33,8 +41,12 @@ vi.mock("@/lib/org-context", () => ({
 }));
 vi.mock("@/lib/data-api", () => ({
   getPlayersByTeam: mockGetPlayersByTeam,
+  getPlayers: mockGetPlayers,
   getTeamsByLeague: mockGetTeamsByLeague,
+  getTeamLeagueId: mockGetTeamLeagueId,
   getLeagueOrgId: mockGetLeagueOrgId,
+  getSeasons: mockGetSeasons,
+  listFixturesBySeason: mockListFixturesBySeason,
   bulkCreatePlayers: mockBulkCreatePlayers,
   clearSyntheticPlayers: mockClearSyntheticPlayers,
 }));
@@ -57,6 +69,12 @@ beforeEach(() => {
   mockFlag.mockResolvedValue(true);
   mockAuth.mockResolvedValue({ userId: "user_1" });
   mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE], orgIds: [ORG] });
+  mockGetTeamLeagueId.mockResolvedValue(LEAGUE);
+  mockGetSeasons.mockResolvedValue([
+    { id: "season_1", status: "active", rosterLocked: false },
+  ]);
+  mockListFixturesBySeason.mockResolvedValue([]);
+  mockGetPlayers.mockResolvedValue([]);
 });
 
 describe("generateTeamRosterAction", () => {
@@ -100,6 +118,15 @@ describe("generateTeamRosterAction", () => {
     );
     const res = await generateTeamRosterAction({ teamId: TEAM, count: 48 });
     expect(res).toEqual({ ok: true, created: 0 });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the active season has started", async () => {
+    mockListFixturesBySeason.mockResolvedValue([{ status: "final" }]);
+    expect(await generateTeamRosterAction({ teamId: TEAM })).toEqual({
+      ok: false,
+      error: "season_started",
+    });
     expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -8,10 +8,12 @@ import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageOrgSettings } from "@/lib/permissions";
 import {
   getPlayersByTeam,
+  getPlayers,
   getTeamsByLeague,
   getTeamLeagueId,
   getLeagueOrgId,
   getSeasons,
+  listFixturesBySeason,
   bulkCreatePlayers,
   clearSyntheticPlayers,
   ingestPlayerAttributesBatch,
@@ -21,6 +23,7 @@ import {
   seedFromString,
 } from "@/lib/synthetic-roster";
 import { generateSyntheticAttributes } from "@/lib/synthetic-attributes";
+import { isSeasonStarted } from "@/lib/season-started";
 
 /*
  * Synthetic-roster generation (WSM-000173) — fills demo/test rosters with fake
@@ -55,6 +58,29 @@ async function resolveActiveSeasonId(leagueId: string): Promise<string | null> {
   if (seasons.length === 0) return null;
   const active = seasons.find((s) => s.status === "active") ?? seasons[0];
   return active.id;
+}
+
+/** Block roster/ratings generation once the active season has started. */
+async function assertSeasonNotStarted(
+  leagueId: string,
+): Promise<{ ok: true } | { ok: false; error: "season_started" }> {
+  const seasons = await getSeasons([leagueId]).catch(() => []);
+  if (seasons.length === 0) return { ok: true };
+  const active = seasons.find((s) => s.status === "active") ?? seasons[0];
+  const fixtures = await listFixturesBySeason(active.id).catch(() => []);
+  if (isSeasonStarted(active, fixtures)) {
+    return { ok: false, error: "season_started" };
+  }
+  return { ok: true };
+}
+
+async function leaguePlayerNames(
+  leagueId: string,
+  orgContext: Awaited<ReturnType<typeof resolveOrgContext>>,
+): Promise<string[]> {
+  if (!orgContext.visibleLeagueIds.includes(leagueId)) return [];
+  const players = await getPlayers([leagueId]).catch(() => []);
+  return players.map((p) => p.name);
 }
 
 /** Build attribute-snapshot rows for a team's players (seeded per player so
@@ -92,15 +118,21 @@ export async function generateTeamRosterAction(input: {
     return { ok: false, error: "not_authorized" };
   }
 
+  const leagueId = await getTeamLeagueId(input.teamId);
+  const seasonGuard = await assertSeasonNotStarted(leagueId);
+  if (!seasonGuard.ok) return seasonGuard;
+
   const target = Math.max(1, Math.min(input.count ?? DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE));
   const orgContext = await resolveOrgContext(userId);
   const existing = await getPlayersByTeam(input.teamId, orgContext).catch(() => []);
   const toCreate = Math.max(0, target - existing.length);
   if (toCreate === 0) return { ok: true, created: 0 };
 
+  const excludeNames = await leaguePlayerNames(leagueId, orgContext);
   const players = generateSyntheticRoster({
     count: toCreate,
     excludeJerseys: existingJerseys(existing),
+    excludeNames,
     seed: seedFromString(input.teamId) + existing.length,
   });
   try {
@@ -124,12 +156,17 @@ export async function generateLeagueRostersAction(input: {
   const role = orgId ? await resolveOrgRole(orgId, userId) : null;
   if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
 
+  const seasonGuard = await assertSeasonNotStarted(input.leagueId);
+  if (!seasonGuard.ok) return seasonGuard;
+
   const target = Math.max(1, Math.min(input.perTeam ?? DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE));
   const orgContext = await resolveOrgContext(userId);
   const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+  const excludeNames = await leaguePlayerNames(input.leagueId, orgContext);
 
   let created = 0;
   let touched = 0;
+  const usedNames = new Set(excludeNames);
   try {
     for (const team of teams) {
       const existing = await getPlayersByTeam(team.id, orgContext).catch(() => []);
@@ -138,8 +175,10 @@ export async function generateLeagueRostersAction(input: {
       const players = generateSyntheticRoster({
         count: toCreate,
         excludeJerseys: existingJerseys(existing),
+        excludeNames: Array.from(usedNames),
         seed: seedFromString(team.id),
       });
+      for (const p of players) usedNames.add(p.name);
       const res = await bulkCreatePlayers(team.id, players);
       created += res.created;
       touched += 1;
@@ -217,6 +256,9 @@ export async function generateTeamAttributesAction(input: {
   }
 
   const leagueId = await getTeamLeagueId(input.teamId);
+  const seasonGuard = await assertSeasonNotStarted(leagueId);
+  if (!seasonGuard.ok) return seasonGuard;
+
   const seasonId = await resolveActiveSeasonId(leagueId);
   if (!seasonId) return { ok: false, error: "no_season" };
 
@@ -243,6 +285,9 @@ export async function generateLeagueAttributesAction(input: {
   const orgId = await getLeagueOrgId(input.leagueId);
   const role = orgId ? await resolveOrgRole(orgId, userId) : null;
   if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
+
+  const seasonGuard = await assertSeasonNotStarted(input.leagueId);
+  if (!seasonGuard.ok) return seasonGuard;
 
   const seasonId = await resolveActiveSeasonId(input.leagueId);
   if (!seasonId) return { ok: false, error: "no_season" };

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -5,7 +5,10 @@ import {
   getLeague,
   getLeagueVisibility,
   getLeagueClaimable,
+  getSeasons,
+  listFixturesBySeason,
 } from "@/lib/data-api";
+import { isSeasonStarted } from "@/lib/season-started";
 import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -50,6 +53,16 @@ export default async function LeagueDetailPage({
 
   // WSM-000173: league-wide synthetic-roster generation — admins only, flagged.
   const canGenerateRosters = isAdmin && (await syntheticRostersV1());
+
+  const seasons = await getSeasons([id]).catch(() => []);
+  const activeSeason =
+    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  const seasonStarted = activeSeason
+    ? isSeasonStarted(
+        activeSeason,
+        await listFixturesBySeason(activeSeason.id).catch(() => []),
+      )
+    : false;
 
   return (
     <div>
@@ -113,13 +126,23 @@ export default async function LeagueDetailPage({
                   <div className="min-w-0">
                     <p className="text-label-14 text-foreground">Synthetic rosters</p>
                     <p className="text-caption-12 text-text-muted">
-                      Fill every team in this league with fake test players (~48
-                      each) for demos. Not real people.
+                      {seasonStarted
+                        ? "Season has started — roster and ratings generation is locked."
+                        : "Fill every team in this league with fake test players (~48 each) for demos. Not real people."}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <SyntheticRosterButton kind="league" id={id} />
-                    <SyntheticRosterButton kind="league" id={id} action="attributes" />
+                    <SyntheticRosterButton
+                      kind="league"
+                      id={id}
+                      seasonStarted={seasonStarted}
+                    />
+                    <SyntheticRosterButton
+                      kind="league"
+                      id={id}
+                      action="attributes"
+                      seasonStarted={seasonStarted}
+                    />
                     <SyntheticRosterButton kind="league" id={id} action="clear" />
                   </div>
                 </div>

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -23,6 +23,7 @@ import {
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import { formatFixtureWhen } from "@/lib/format";
+import { isSeasonStarted } from "@/lib/season-started";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
@@ -91,6 +92,10 @@ export default async function LeagueSchedulePage({
   const fixtures = activeSeason
     ? await listFixturesBySeason(activeSeason.id)
     : [];
+
+  const seasonStarted = activeSeason
+    ? isSeasonStarted(activeSeason, fixtures)
+    : false;
 
   // Hydrate per-fixture result for "Record result" pre-fill + score display.
   const fixturesWithResults = await Promise.all(
@@ -188,11 +193,16 @@ export default async function LeagueSchedulePage({
           ) : null}
           {canGenerateRosters ? (
             <>
-              <SyntheticRosterButton kind="league" id={leagueId} />
+              <SyntheticRosterButton
+                kind="league"
+                id={leagueId}
+                seasonStarted={seasonStarted}
+              />
               <SyntheticRosterButton
                 kind="league"
                 id={leagueId}
                 action="attributes"
+                seasonStarted={seasonStarted}
               />
             </>
           ) : null}
@@ -332,18 +342,21 @@ export default async function LeagueSchedulePage({
                                 {statsEnabled ? (
                                   <span className="flex items-center gap-1 text-xs">
                                     <ClipboardList className="h-3.5 w-3.5 text-muted-foreground" />
+                                    <span className="text-muted-foreground">
+                                      Box score
+                                    </span>
                                     <Link
                                       href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/stats`}
                                       className="text-primary hover:underline"
                                     >
-                                      {fixture.homeTeamName}
+                                      Home
                                     </Link>
                                     <span className="text-muted-foreground">/</span>
                                     <Link
                                       href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
                                       className="text-primary hover:underline"
                                     >
-                                      {fixture.awayTeamName}
+                                      Away
                                     </Link>
                                   </span>
                                 ) : null}
@@ -354,14 +367,14 @@ export default async function LeagueSchedulePage({
                                       href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
                                       className="text-primary hover:underline"
                                     >
-                                      {fixture.homeTeamName}
+                                      Live (Home)
                                     </Link>
                                     <span className="text-muted-foreground">/</span>
                                     <Link
                                       href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
                                       className="text-primary hover:underline"
                                     >
-                                      {fixture.awayTeamName}
+                                      Away
                                     </Link>
                                   </span>
                                 ) : null}

--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { schedulesStandingsV1 } from "@/lib/flags";
 import {
   computeStandings,
+  computeDivisionStandings,
   getDivisions,
   getLeague,
   getSeasons,
@@ -56,6 +57,17 @@ export default async function LeagueStandingsPage({
 
   const standings = await computeStandings(activeSeason.id);
   const divisions = await getDivisions([leagueId]);
+
+  const divisionStandings =
+    divisions.length > 0
+      ? await Promise.all(
+          divisions.map(async (division) => ({
+            division,
+            rows: await computeDivisionStandings(activeSeason.id, division.id),
+          })),
+        )
+      : [];
+
   void trackStandingsView({ leagueId, route: "dashboard" });
 
   return (
@@ -93,6 +105,18 @@ export default async function LeagueStandingsPage({
             <p className="px-6 py-8 text-center text-sm text-muted-foreground">
               No teams or no recorded results yet for {activeSeason.name}.
             </p>
+          ) : divisionStandings.length > 0 ? (
+            <div className="divide-y divide-border">
+              {divisionStandings.map(({ division, rows }) =>
+                rows.length > 0 ? (
+                  <StandingsTable
+                    key={division.id}
+                    divisionName={division.name}
+                    rows={rows}
+                  />
+                ) : null,
+              )}
+            </div>
           ) : (
             <StandingsTable rows={standings} />
           )}

--- a/apps/web/src/app/dashboard/players/[id]/development/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/development/page.tsx
@@ -19,8 +19,10 @@ import { trackPlayerAttributesView } from "@/lib/analytics";
 
 export default async function PlayerDevelopmentPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string }>;
 }) {
   const enabled = await playerAttributesV1();
   if (!enabled) notFound();
@@ -29,6 +31,7 @@ export default async function PlayerDevelopmentPage({
   if (!userId) redirect("/sign-in");
 
   const { id: playerId } = await params;
+  const { from } = await searchParams;
 
   // Resolve the user's visible leagues, then fetch the player through
   // the access check. Anything outside the user's org tree → 404.
@@ -62,13 +65,17 @@ export default async function PlayerDevelopmentPage({
   const last = development[development.length - 1] ?? null;
   const headlineDelta = last?.delta ?? null;
 
+  const playerBackHref = from
+    ? `/dashboard/players/${playerId}?from=${encodeURIComponent(from)}`
+    : `/dashboard/players/${playerId}`;
+
   return (
     <div>
       <Link
-        href={`/dashboard/players`}
+        href={playerBackHref}
         className="mb-4 inline-block text-sm text-primary hover:underline"
       >
-        &larr; Back to Players
+        &larr; Back to {player.name}
       </Link>
 
       <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -45,13 +45,16 @@ function ageFrom(dateOfBirth: string): number | null {
 
 export default async function PlayerProfilePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string }>;
 }) {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
   const { id: playerId } = await params;
+  const { from } = await searchParams;
 
   const orgContext = await resolveOrgContext(userId);
   const player = await getPlayer(playerId, orgContext).catch(() => null);
@@ -116,16 +119,32 @@ export default async function PlayerProfilePage({
     }
   }
 
+  const fromTeamId =
+    from?.startsWith("team-") ? from.slice("team-".length) : null;
+  const backHref =
+    fromTeamId && team && fromTeamId === team.id
+      ? `/dashboard/teams/${team.id}`
+      : team
+        ? `/dashboard/teams/${team.id}`
+        : "/dashboard/players";
+  const backLabel =
+    fromTeamId && team && fromTeamId === team.id
+      ? `Back to ${team.name}`
+      : team
+        ? `Back to ${team.name}`
+        : "Back to Players";
+  const developmentHref = from
+    ? `/dashboard/players/${player.id}/development?from=${encodeURIComponent(from)}`
+    : `/dashboard/players/${player.id}/development`;
+
   return (
     <div className="mx-auto max-w-2xl">
-      {team && (
-        <Link
-          href={`/dashboard/teams/${team.id}`}
-          className="mb-4 inline-block text-sm text-primary hover:underline"
-        >
-          &larr; Back to {team.name}
-        </Link>
-      )}
+      <Link
+        href={backHref}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; {backLabel}
+      </Link>
 
       <Card>
         <CardContent className="pt-6">
@@ -201,7 +220,7 @@ export default async function PlayerProfilePage({
           {attributesEnabled && (
             <div className="mt-6">
               <Button asChild variant="outline" size="sm">
-                <Link href={`/dashboard/players/${player.id}/development`}>
+                <Link href={developmentHref}>
                   View development chart
                 </Link>
               </Button>

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -7,7 +7,10 @@ import {
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
   getLeagueClaimable,
+  getSeasons,
+  listFixturesBySeason,
 } from "@/lib/data-api";
+import { isSeasonStarted } from "@/lib/season-started";
 import { resolveOrgContext } from "@/lib/org-context";
 import { canManageTeam, canAdministerTeam } from "@/lib/authorization";
 import { playerAttributesV1, syntheticRostersV1 } from "@/lib/flags";
@@ -67,6 +70,16 @@ export default async function TeamDetailPage({
   // WSM-000173: synthetic-roster generation — managers only, behind the flag.
   const canGenerateRoster = canManage && (await syntheticRostersV1());
 
+  const seasons = await getSeasons([team.leagueId]).catch(() => []);
+  const activeSeason =
+    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  const seasonStarted = activeSeason
+    ? isSeasonStarted(
+        activeSeason,
+        await listFixturesBySeason(activeSeason.id).catch(() => []),
+      )
+    : false;
+
   // WSM-000090: attribute snapshots feed the SPRT stat columns. Phase 2-gated;
   // the season is resolved server-side — including workspace forks, which read
   // their source league's current season (WSM-000122). Failure here must never
@@ -113,6 +126,7 @@ export default async function TeamDetailPage({
         canManage={canManage}
         canDelete={canDelete}
         canGenerateRoster={canGenerateRoster}
+        seasonStarted={seasonStarted}
         attributeSnapshots={Object.fromEntries(snapshots)}
         maddenOveralls={Object.fromEntries(maddenOveralls)}
       />

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -32,6 +32,8 @@ interface TeamManagementProps {
   canDelete?: boolean;
   /** WSM-000173: show the "Generate roster" (synthetic players) action. */
   canGenerateRoster?: boolean;
+  /** Active season started — blocks synthetic roster/ratings generation. */
+  seasonStarted?: boolean;
   /** WSM-000090: playerId → attribute snapshot; empty when Phase 2 is
       dark or the season has no ingested attributes. */
   attributeSnapshots?: Record<string, PlayerSnapshot>;
@@ -53,6 +55,7 @@ export default function TeamManagement({
   canManage,
   canDelete = false,
   canGenerateRoster = false,
+  seasonStarted = false,
   attributeSnapshots = {},
   maddenOveralls = {},
 }: TeamManagementProps) {
@@ -347,8 +350,17 @@ export default function TeamManagement({
           <div className="flex flex-wrap items-center gap-2">
             {canGenerateRoster && (
               <>
-                <SyntheticRosterButton kind="team" id={team.id} />
-                <SyntheticRosterButton kind="team" id={team.id} action="attributes" />
+                <SyntheticRosterButton
+                  kind="team"
+                  id={team.id}
+                  seasonStarted={seasonStarted}
+                />
+                <SyntheticRosterButton
+                  kind="team"
+                  id={team.id}
+                  action="attributes"
+                  seasonStarted={seasonStarted}
+                />
                 <SyntheticRosterButton kind="team" id={team.id} action="clear" />
               </>
             )}
@@ -383,7 +395,9 @@ export default function TeamManagement({
               searchPlaceholder="Search players..."
               searchKeys={["name", "position", "status"]}
               onRowClick={(p) =>
-                router.push(`/dashboard/players/${(p as RosterRow).id}`)
+                router.push(
+                  `/dashboard/players/${(p as RosterRow).id}?from=team-${team.id}`,
+                )
               }
               actions={
                 canManage

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -25,12 +25,15 @@ interface SyntheticRosterButtonProps {
   kind: "team" | "league";
   id: string;
   action?: "generate" | "clear" | "attributes";
+  /** When true, generate/attributes actions are disabled (season already started). */
+  seasonStarted?: boolean;
 }
 
 export function SyntheticRosterButton({
   kind,
   id,
   action = "generate",
+  seasonStarted = false,
 }: SyntheticRosterButtonProps) {
   const router = useRouter();
   const [pending, start] = useTransition();
@@ -112,6 +115,7 @@ export function SyntheticRosterButton({
 
   const isClear = action === "clear";
   const isAttributes = action === "attributes";
+  const blockedBySeason = seasonStarted && !isClear;
   const Icon = isClear ? Trash2 : isAttributes ? Gauge : Sparkles;
   const label = isClear
     ? pending
@@ -132,15 +136,17 @@ export function SyntheticRosterButton({
       type="button"
       variant={isClear ? "ghost" : "outline"}
       size="sm"
-      disabled={pending}
+      disabled={pending || blockedBySeason}
       onClick={run}
       className={isClear ? "text-destructive hover:text-destructive" : undefined}
       title={
-        isClear
-          ? "Delete generated test players (keeps real players)"
-          : isAttributes
-            ? "Generate Madden-style ratings for this roster's players (test data)"
-            : "Generate fake players to populate this roster for testing/demos"
+        blockedBySeason
+          ? SEASON_STARTED_HINT
+          : isClear
+            ? "Delete generated test players (keeps real players)"
+            : isAttributes
+              ? "Generate Madden-style ratings for this roster's players (test data)"
+              : "Generate fake players to populate this roster for testing/demos"
       }
     >
       <Icon className="mr-1 h-4 w-4" />
@@ -170,6 +176,9 @@ const CONFIRM: Record<
   },
 };
 
+const SEASON_STARTED_HINT =
+  "Season has started — roster and ratings generation is locked.";
+
 function errorLabel(error: string): string {
   switch (error) {
     case "flag_disabled":
@@ -180,6 +189,8 @@ function errorLabel(error: string): string {
       return "You don't have permission to do that.";
     case "no_season":
       return "This league has no season yet — create one first.";
+    case "season_started":
+      return SEASON_STARTED_HINT;
     default:
       return error;
   }

--- a/apps/web/src/components/schedule/StandingsTable.tsx
+++ b/apps/web/src/components/schedule/StandingsTable.tsx
@@ -1,7 +1,10 @@
+import Link from "next/link";
 import type { Standing } from "@sports-management/shared-types";
 
 export interface StandingsTableProps {
   rows: Standing[];
+  /** When set, renders a division header above this table block. */
+  divisionName?: string;
 }
 
 /**
@@ -10,11 +13,20 @@ export interface StandingsTableProps {
  * and the public viewer (WSM-000073), so any shape changes ripple to
  * both surfaces in one place.
  */
-export default function StandingsTable({ rows }: StandingsTableProps) {
+export default function StandingsTable({
+  rows,
+  divisionName,
+}: StandingsTableProps) {
   return (
-    // Nine columns never fit a phone — scroll the table inside its own
-    // container instead of widening the page (WSM-000085).
-    <div className="w-full overflow-x-auto">
+    <div className="w-full">
+      {divisionName ? (
+        <h3 className="border-b border-border bg-muted/50 px-4 py-2 text-sm font-semibold text-foreground">
+          {divisionName}
+        </h3>
+      ) : null}
+      {/* Nine columns never fit a phone — scroll the table inside its own
+          container instead of widening the page (WSM-000085). */}
+      <div className="w-full overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b-2 border-border bg-muted text-left">
@@ -55,7 +67,14 @@ export default function StandingsTable({ rows }: StandingsTableProps) {
                 <td className="px-4 py-2 font-mono tabular-nums text-foreground">
                   {row.leagueRank}
                 </td>
-                <td className="px-4 py-2 text-foreground">{row.teamName}</td>
+                <td className="px-4 py-2 text-foreground">
+                  <Link
+                    href={`/dashboard/teams/${row.teamId}`}
+                    className="text-primary hover:underline"
+                  >
+                    {row.teamName}
+                  </Link>
+                </td>
                 <td className="px-4 py-2 text-right font-mono tabular-nums text-foreground">
                   {row.wins}
                 </td>
@@ -91,6 +110,7 @@ export default function StandingsTable({ rows }: StandingsTableProps) {
           })}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/synthetic-roster.test.ts
+++ b/apps/web/src/lib/__tests__/synthetic-roster.test.ts
@@ -39,6 +39,16 @@ describe("generateSyntheticRoster", () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  it("avoids names already used in the league when possible", () => {
+    const roster = generateSyntheticRoster({
+      count: 10,
+      seed: 11,
+      excludeNames: ["Aaron Adams", "Aaliyah Abbott"],
+    });
+    expect(roster.map((p) => p.name)).not.toContain("Aaron Adams");
+    expect(roster.map((p) => p.name)).not.toContain("Aaliyah Abbott");
+  });
+
   it("gives a believable position spread (not all one position)", () => {
     const roster = generateSyntheticRoster({ count: 48, seed: 3 });
     const positions = new Set(roster.map((p) => p.position));

--- a/apps/web/src/lib/season-started.ts
+++ b/apps/web/src/lib/season-started.ts
@@ -1,0 +1,10 @@
+import type { FixtureDto, SeasonDto } from "@sports-management/shared-types";
+
+/** True when roster edits / synthetic generation should be blocked for a season. */
+export function isSeasonStarted(
+  season: SeasonDto,
+  fixtures: FixtureDto[],
+): boolean {
+  if (season.rosterLocked) return true;
+  return fixtures.some((f) => f.status === "final");
+}

--- a/apps/web/src/lib/synthetic-roster.ts
+++ b/apps/web/src/lib/synthetic-roster.ts
@@ -51,19 +51,96 @@ const ROSTER_TEMPLATE: readonly string[] = [
 ];
 
 const FIRST_NAMES: readonly string[] = [
-  "Jalen", "Marcus", "Devin", "Tyler", "Cameron", "Isaiah", "Mason", "Elijah",
-  "Xavier", "Caleb", "Jordan", "Brayden", "Damari", "Zion", "Carter", "Trey",
-  "Malik", "Gavin", "Bryce", "Kaden", "Jaxon", "Amari", "Dominic", "Hunter",
-  "Micah", "Tristan", "Khalil", "Owen", "Cole", "Darius", "Landon", "Jamarcus",
-  "Reece", "Aiden", "Quentin", "Silas", "Roman", "Davion", "Beckham", "Tate",
+  "Aaliyah", "Aaron", "Abigail", "Adrian", "Aiden", "Aisha", "Alejandro", "Alex",
+  "Alexis", "Ali", "Amara", "Amari", "Amir", "Ananya", "Andre", "Andrea",
+  "Andrew", "Angela", "Anthony", "Aria", "Ariana", "Arjun", "Ashley", "Ava",
+  "Benjamin", "Bianca", "Blake", "Brandon", "Brayden", "Brianna", "Bryce", "Caleb",
+  "Cameron", "Carlos", "Carmen", "Carter", "Catherine", "Cesar", "Chloe", "Christian",
+  "Christopher", "Claire", "Cole", "Connor", "Daniel", "Daniela", "Darius", "David",
+  "Destiny", "Devin", "Diego", "Dominic", "Dylan", "Elena", "Elijah", "Elizabeth",
+  "Emily", "Emma", "Enrique", "Ethan", "Eva", "Evan", "Fatima", "Gabriel",
+  "Gavin", "Genesis", "George", "Grace", "Grayson", "Hannah", "Harper", "Hassan",
+  "Hector", "Henry", "Hunter", "Ian", "Imani", "Isaac", "Isabella", "Isaiah",
+  "Ivan", "Jack", "Jackson", "Jacob", "Jaden", "Jake", "Jamal", "James",
+  "Jamie", "Jasmine", "Jason", "Javier", "Jayden", "Jenna", "Jeremiah", "Jessica",
+  "Jin", "Joel", "John", "Jose", "Joseph", "Joshua", "Juan", "Julia",
+  "Julian", "Justin", "Kai", "Kaitlyn", "Kaleb", "Karen", "Karla", "Katherine",
+  "Kayla", "Keisha", "Kenneth", "Kevin", "Khalil", "Kim", "Kyle", "Laila",
+  "Landon", "Laura", "Lauren", "Leah", "Leo", "Liam", "Lily", "Logan",
+  "Lucas", "Luis", "Luke", "Madison", "Malik", "Manuel", "Marco", "Maria",
+  "Mason", "Mateo", "Matthew", "Maya", "Megan", "Mia", "Michael", "Micah",
+  "Miguel", "Miles", "Morgan", "Nadia", "Nathan", "Nia", "Nicholas", "Nicole",
+  "Noah", "Nolan", "Oliver", "Olivia", "Omar", "Owen", "Pablo", "Paige",
+  "Patrick", "Paul", "Priya", "Quentin", "Rachel", "Rafael", "Raymond", "Rebecca",
+  "Riley", "Robert", "Roman", "Ryan", "Samantha", "Samuel", "Santiago", "Sarah",
+  "Savannah", "Sean", "Sebastian", "Serena", "Sergio", "Sofia", "Sophia", "Steven",
+  "Tariq", "Taylor", "Terrence", "Thomas", "Tiana", "Timothy", "Travis", "Trevor",
+  "Trinity", "Tyler", "Valeria", "Vanessa", "Victor", "Vincent", "Violet", "William",
+  "Xavier", "Yasmin", "Yosef", "Zachary", "Zoe", "Zion",
 ];
 
 const LAST_NAMES: readonly string[] = [
-  "Carter", "Brooks", "Hayes", "Coleman", "Reed", "Bennett", "Foster", "Bryant",
-  "Greer", "Mathis", "Dawson", "Pierce", "Ellison", "Holland", "Ferguson", "Sutton",
-  "Vance", "Whitfield", "Barlow", "Crawford", "Sterling", "Maddox", "Calloway", "Rhodes",
-  "Yates", "Beckett", "Lowery", "Tatum", "Goodwin", "Hampton", "Fields", "Mercer",
-  "Underwood", "Padgett", "Larkin", "Easton", "Boone", "Cross", "Maxwell", "Vaughn",
+  "Abbott", "Abrams", "Acosta", "Adams", "Aguilar", "Ahmed", "Alexander", "Ali",
+  "Allen", "Alvarez", "Anderson", "Andrews", "Archer", "Arias", "Armstrong", "Arnold",
+  "Ashley", "Atkins", "Austin", "Avery", "Bailey", "Baker", "Baldwin", "Banks",
+  "Barber", "Barker", "Barnes", "Barrett", "Barton", "Bates", "Beck", "Becker",
+  "Bell", "Bennett", "Benson", "Berg", "Berry", "Bishop", "Black", "Blair",
+  "Blake", "Boone", "Bowen", "Boyd", "Bradley", "Brady", "Branch", "Brennan",
+  "Briggs", "Brock", "Brooks", "Brown", "Bryant", "Buchanan", "Burke", "Burns",
+  "Butler", "Byrd", "Cabrera", "Cain", "Calderon", "Caldwell", "Campos", "Cannon",
+  "Carlson", "Carpenter", "Carr", "Carroll", "Carson", "Carter", "Castillo", "Castro",
+  "Chambers", "Chan", "Chang", "Chapman", "Chen", "Choi", "Clark", "Clarke",
+  "Clayton", "Cobb", "Cohen", "Cole", "Coleman", "Collins", "Conner", "Cook",
+  "Cooper", "Cortez", "Cox", "Craig", "Crawford", "Cross", "Cruz", "Cummings",
+  "Cunningham", "Curtis", "Daniel", "Daniels", "Davenport", "Davidson", "Davis", "Dawson",
+  "Day", "Dean", "Delgado", "Diaz", "Dixon", "Douglas", "Doyle", "Drake",
+  "Duncan", "Dunn", "Edwards", "Elliott", "Ellis", "Erickson", "Espinoza", "Evans",
+  "Farmer", "Ferguson", "Fernandez", "Fields", "Fisher", "Fleming", "Fletcher", "Flores",
+  "Ford", "Foster", "Fowler", "Fox", "Francis", "Franklin", "Freeman", "Fuller",
+  "Garcia", "Gardner", "Garner", "Garrett", "Garrison", "George", "Gibson", "Gilbert",
+  "Gill", "Gomez", "Gonzalez", "Goodwin", "Gordon", "Graham", "Grant", "Graves",
+  "Gray", "Green", "Greene", "Greer", "Griffin", "Gross", "Guerrero", "Gutierrez",
+  "Hall", "Hamilton", "Hammond", "Hampton", "Hansen", "Hanson", "Hardy", "Harmon",
+  "Harper", "Harris", "Harrison", "Hart", "Harvey", "Hawkins", "Hayes", "Heath",
+  "Henderson", "Henry", "Hernandez", "Herrera", "Hicks", "Hill", "Hines", "Hodges",
+  "Hoffman", "Holland", "Holmes", "Holt", "Hopkins", "Howard", "Howell", "Huang",
+  "Hudson", "Hughes", "Hunt", "Hunter", "Ingram", "Irwin", "Jackson", "Jacobs",
+  "James", "Jarvis", "Jenkins", "Jennings", "Jensen", "Jimenez", "Johnson", "Johnston",
+  "Jones", "Jordan", "Joseph", "Joyce", "Keller", "Kelley", "Kelly", "Kennedy",
+  "Kim", "King", "Kirk", "Klein", "Knight", "Koch", "Kramer", "Lamb",
+  "Lambert", "Lane", "Larson", "Lawrence", "Lawson", "Lee", "Leon", "Lewis",
+  "Lindsay", "Little", "Liu", "Lloyd", "Logan", "Long", "Lopez", "Lowe",
+  "Lucas", "Luna", "Lynch", "Lyons", "Mack", "Maddox", "Maldonado", "Malone",
+  "Mann", "Manning", "Marks", "Marsh", "Marshall", "Martin", "Martinez", "Mason",
+  "Matthews", "Maxwell", "May", "McBride", "McCarthy", "McCoy", "McDonald", "McGee",
+  "Medina", "Mejia", "Mendez", "Mendoza", "Mercer", "Meyer", "Miles", "Miller",
+  "Mills", "Mitchell", "Montgomery", "Moore", "Morales", "Moran", "Moreno", "Morgan",
+  "Morris", "Morrison", "Morton", "Moss", "Mueller", "Mullins", "Murphy", "Murray",
+  "Myers", "Nash", "Navarro", "Neal", "Nelson", "Newman", "Nguyen", "Nichols",
+  "Nixon", "Norman", "Norris", "Norton", "Nunez", "Obrien", "Ochoa", "Oliver",
+  "Olson", "Ortega", "Ortiz", "Osborne", "Owen", "Owens", "Padilla", "Page",
+  "Palmer", "Park", "Parker", "Parks", "Parsons", "Patel", "Patrick", "Patterson",
+  "Patton", "Paul", "Payne", "Pearson", "Peck", "Pena", "Perez", "Perkins",
+  "Perry", "Peters", "Peterson", "Pham", "Phelps", "Phillips", "Pierce", "Pittman",
+  "Porter", "Potter", "Powell", "Pratt", "Price", "Quinn", "Ramirez", "Ramos",
+  "Randall", "Ray", "Reed", "Reese", "Reeves", "Reid", "Reyes", "Reynolds",
+  "Rhodes", "Rice", "Richards", "Richardson", "Riley", "Rios", "Rivera", "Robbins",
+  "Roberts", "Robertson", "Robinson", "Rodgers", "Rodriguez", "Rogers", "Romero", "Rose",
+  "Ross", "Rowe", "Ruiz", "Russell", "Ryan", "Salazar", "Sanchez", "Sanders",
+  "Santiago", "Santos", "Saunders", "Schmidt", "Schneider", "Schultz", "Scott", "Shaw",
+  "Shelton", "Shepherd", "Sherman", "Silva", "Simmons", "Simon", "Simpson", "Sims",
+  "Singh", "Smith", "Snyder", "Soto", "Spencer", "Stanley", "Steele", "Stein",
+  "Stephens", "Stevens", "Stewart", "Stone", "Strickland", "Sullivan", "Summers", "Sutton",
+  "Swanson", "Sweeney", "Tanner", "Tate", "Taylor", "Terrell", "Thomas", "Thompson",
+  "Thornton", "Todd", "Torres", "Townsend", "Tran", "Tucker", "Turner", "Tyler",
+  "Underwood", "Valdez", "Valencia", "Vance", "Vargas", "Vasquez", "Vaughn", "Vega",
+  "Velez", "Wade", "Wagner", "Walker", "Wallace", "Waller", "Walsh", "Walter",
+  "Walters", "Ward", "Warner", "Warren", "Washington", "Waters", "Watkins", "Watson",
+  "Watts", "Weaver", "Webb", "Weber", "Webster", "Wells", "West", "Wheeler",
+  "Whitaker", "White", "Whitfield", "Wiggins", "Wilcox", "Wiley", "Wilkerson", "Wilkins",
+  "Williams", "Williamson", "Willis", "Wilson", "Winters", "Wise", "Wolfe", "Wong",
+  "Wood", "Woods", "Woodward", "Wright", "Wyatt", "Yang", "Yates", "Young",
+  "Zamora", "Zhang", "Zimmerman",
 ];
 
 /** mulberry32 — tiny deterministic PRNG so generation is seedable + testable. */
@@ -92,19 +169,43 @@ export interface GenerateOptions {
   count: number;
   /** Jersey numbers already used on the team — never reused. */
   excludeJerseys?: number[];
+  /** Player names already used in the league — avoided when possible. */
+  excludeNames?: string[];
   /** Seed for deterministic output (e.g. seedFromString(teamId)). */
   seed?: number;
+}
+
+function pickUniqueName(
+  rand: () => number,
+  usedNames: Set<string>,
+): string {
+  const maxAttempts = FIRST_NAMES.length * LAST_NAMES.length;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const first =
+      FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)] ?? FIRST_NAMES[0];
+    const last =
+      LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)] ?? LAST_NAMES[0];
+    const name = `${first} ${last}`;
+    if (!usedNames.has(name)) return name;
+  }
+  // Pool exhausted — allow a duplicate as last resort.
+  const first =
+    FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)] ?? FIRST_NAMES[0];
+  const last =
+    LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)] ?? LAST_NAMES[0];
+  return `${first} ${last}`;
 }
 
 export function generateSyntheticRoster({
   count,
   excludeJerseys = [],
+  excludeNames = [],
   seed = 1,
 }: GenerateOptions): SyntheticPlayer[] {
   const n = Math.max(0, Math.min(count, 99)); // cap at a sane jersey-bound size
   const rand = rng(seed);
   const used = new Set<number>(excludeJerseys);
-  const usedNames = new Set<string>();
+  const usedNames = new Set<string>(excludeNames);
   const players: SyntheticPlayer[] = [];
 
   for (let i = 0; i < n; i++) {
@@ -120,13 +221,7 @@ export function generateSyntheticRoster({
     }
     used.add(jersey);
 
-    // Unique name within the batch.
-    let name = `${FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)]} ${LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)]}`;
-    let nameGuard = 0;
-    while (usedNames.has(name) && nameGuard < 200) {
-      name = `${FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)]} ${LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)]}`;
-      nameGuard++;
-    }
+    const name = pickUniqueName(rand, usedNames);
     usedNames.add(name);
 
     const grade = 9 + Math.floor(rand() * 4); // 9–12


### PR DESCRIPTION
## Summary

Five bounded fixes from the 2026-07-03 prod review (implemented via orchestrated Composer worker, independently verified):

1. **Schedule rows — duplicate team names**: the trailing box-score and live link groups each re-printed "Home / Away" team names. They now use concise labels — `Box score: Home / Away` and `Live` — so each team name appears once per row.
2. **Standings — clickable teams + visible divisions**: team names link to their team pages, and standings render grouped by division with division-name headers using the existing `computeDivisionStandings` query. Flat table retained as fallback when no divisions exist.
3. **Back navigation preserves origin**: `?from=team-{id}` threads team → player → development chart. The development page's back link returns to the player detail page (previously hardcoded to the global players list), and the player page shows "Back to {team}" when arriving from a team roster.
4. **Player name diversity**: name pools expanded to 206 first / 483 last names, and dedup is now league-scoped — generation excludes all existing player names in the league, fixing the many exact duplicates (e.g. 3× "Aiden Calloway") in a 768-player league.
5. **Season-start generation gate**: new `isSeasonStarted()` helper (rosterLocked OR any final fixture result); all four generate roster/attributes server actions return `{ok:false, error:"season_started"}` once the active season has started, and the Generate buttons are disabled with an explanation.

## Verification

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 105 files / 822 tests (includes new season-gate and name-dedup tests)
- `apps/web/e2e/tests/schedules-standings.spec.ts` updated for the new row-link labels

## Notes

- No Convex schema changes; no public contract changes in `packages/api-contracts`.
- Server-side gate is authoritative; button state is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)