### PR TITLE
feat(web): coach/admin-editable player ratings (SPRT card)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -34,6 +34,7 @@ void internal.sports.deleteSeason;
 void internal.sports.clearSeasonPlayerAttributes;
 void internal.sports.ingestMaddenRatingsBatch;
 void internal.sports.ingestPlayerAttributesBatch;
+void internal.sports.updatePlayerAttributes;
 void internal.sports.setOrgMemberRole;
 void internal.sports.updateDivision;
 void internal.sports.deleteDivision;
@@ -67,6 +68,8 @@ void api.sports.deleteLeague;
 void api.sports.clearSeasonPlayerAttributes;
 // @ts-expect-error ingestMaddenRatingsBatch is internal, not public
 void api.sports.ingestMaddenRatingsBatch;
+// @ts-expect-error updatePlayerAttributes is internal, not public
+void api.sports.updatePlayerAttributes;
 // @ts-expect-error setOrgMemberRole is internal, not public
 void api.sports.setOrgMemberRole;
 // @ts-expect-error forkDivisionToWorkspace is internal, not public

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2966,6 +2966,68 @@ export const ingestPlayerAttributes = internalMutationGeneric({
 });
 
 /*
+ * Manual coach/admin edit of one player's current-season attribute snapshot.
+ * Resolves workspace forks (source player + source league season) like
+ * getPlayerSeasonAttributes, then upserts via the same storage path as
+ * ingestPlayerAttributes. Not season-state gated — curation works mid-season.
+ */
+export const updatePlayerAttributes = internalMutationGeneric({
+  args: {
+    playerId: v.id("players"),
+    positionGroup: v.string(),
+    attributesJson: v.string(),
+    weightedOverall: v.union(v.number(), v.null()),
+  },
+  returns: v.object({
+    id: v.string(),
+    created: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+
+    const attrPlayer = player.sourcePlayerId
+      ? ((await ctx.db.get(player.sourcePlayerId)) ?? player)
+      : player;
+    const seasonId = await currentSeasonId(
+      ctx as MutationCtx,
+      attrPlayer.leagueId,
+    );
+    if (!seasonId) throw new Error("no_season");
+
+    const candidates = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", attrPlayer._id),
+      )
+      .collect();
+    const existing =
+      candidates.find((row) => row.seasonId === seasonId) ?? null;
+
+    const ingestedAt = new Date().toISOString();
+    const payload = {
+      playerId: attrPlayer._id,
+      seasonId,
+      positionGroup: args.positionGroup,
+      attributesJson: args.attributesJson,
+      pffSourceJson: null,
+      maddenSourceJson: null,
+      pffWeight: 0,
+      maddenWeight: 1,
+      weightedOverall: args.weightedOverall,
+      ingestedAt,
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+      return { id: existing._id, created: false };
+    }
+    const id = await ctx.db.insert("playerAttributes", payload);
+    return { id, created: true };
+  },
+});
+
+/*
  * WSM-000090 — bulk form of ingestPlayerAttributes for whole-league
  * ratings loads (a per-row CLI loop takes ~75 min for an NFL-sized
  * league; this does it in a handful of calls). Same upsert semantics

--- a/apps/web/src/app/dashboard/players/[id]/__tests__/update-player-attributes-action.test.ts
+++ b/apps/web/src/app/dashboard/players/[id]/__tests__/update-player-attributes-action.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPlayerAttributesV1,
+  mockAuth,
+  mockGetPlayer,
+  mockGetTeamLeagueId,
+  mockGetLeagueOrgId,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockCanManageRoster,
+  mockGetPlayerSeasonAttributes,
+  mockUpdatePlayerAttributes,
+} = vi.hoisted(() => ({
+  mockPlayerAttributesV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetPlayer: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockCanManageRoster: vi.fn(),
+  mockGetPlayerSeasonAttributes: vi.fn(),
+  mockUpdatePlayerAttributes: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({
+  playerAttributesV1: mockPlayerAttributesV1,
+}));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  getPlayer: mockGetPlayer,
+  getTeamLeagueId: mockGetTeamLeagueId,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getPlayerSeasonAttributes: mockGetPlayerSeasonAttributes,
+  updatePlayerAttributes: mockUpdatePlayerAttributes,
+}));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/permissions", () => ({
+  canManageRoster: mockCanManageRoster,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { updatePlayerAttributesAction } from "../actions";
+
+const PLAYER_ID = "player_1";
+const VALID_ATTRS = { SPD: 80, STR: 75, AGI: 82 };
+
+function authorize(role: "admin" | "coach" | "viewer") {
+  mockPlayerAttributesV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: ["league_1"] });
+  mockGetPlayer.mockResolvedValue({
+    id: PLAYER_ID,
+    teamId: "team_1",
+    position: "QB",
+  });
+  mockGetTeamLeagueId.mockResolvedValue("league_1");
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue(role);
+  mockGetPlayerSeasonAttributes.mockResolvedValue({
+    weightedOverall: 78,
+    attributes: VALID_ATTRS,
+    positionGroup: "QB",
+  });
+  mockUpdatePlayerAttributes.mockResolvedValue({ id: "attr_1", created: false });
+}
+
+describe("updatePlayerAttributesAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects viewers", async () => {
+    authorize("viewer");
+    mockCanManageRoster.mockReturnValue(false);
+
+    const res = await updatePlayerAttributesAction(PLAYER_ID, VALID_ATTRS);
+
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockUpdatePlayerAttributes).not.toHaveBeenCalled();
+  });
+
+  it("allows coaches", async () => {
+    authorize("coach");
+    mockCanManageRoster.mockReturnValue(true);
+
+    const res = await updatePlayerAttributesAction(PLAYER_ID, VALID_ATTRS);
+
+    expect(res).toEqual({ ok: true });
+    expect(mockUpdatePlayerAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerId: PLAYER_ID,
+        positionGroup: "QB",
+      }),
+    );
+  });
+
+  it("allows admins", async () => {
+    authorize("admin");
+    mockCanManageRoster.mockReturnValue(true);
+
+    const res = await updatePlayerAttributesAction(PLAYER_ID, VALID_ATTRS);
+
+    expect(res).toEqual({ ok: true });
+    expect(mockUpdatePlayerAttributes).toHaveBeenCalled();
+  });
+
+  it("rejects invalid attribute values", async () => {
+    authorize("coach");
+    mockCanManageRoster.mockReturnValue(true);
+
+    const res = await updatePlayerAttributesAction(PLAYER_ID, { SPD: 120 });
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toMatch(/attribute_out_of_range/);
+    expect(mockUpdatePlayerAttributes).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown attribute keys", async () => {
+    authorize("coach");
+    mockCanManageRoster.mockReturnValue(true);
+
+    const res = await updatePlayerAttributesAction(PLAYER_ID, {
+      NOT_A_REAL_KEY: 50,
+    });
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.error).toMatch(/invalid_attribute_key/);
+    expect(mockUpdatePlayerAttributes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/players/[id]/actions.ts
+++ b/apps/web/src/app/dashboard/players/[id]/actions.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { playerAttributesV1 } from "@/lib/flags";
+import {
+  getPlayer,
+  getTeamLeagueId,
+  getLeagueOrgId,
+  updatePlayerAttributes,
+  getPlayerSeasonAttributes,
+} from "@/lib/data-api";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
+import { validatePlayerAttributeEdit } from "@/lib/attributes/known-keys";
+import { attributeGroupForPosition } from "@/lib/synthetic-attributes";
+
+/**
+ * Coach/admin manual edit of a player's current-season SPRT attribute snapshot.
+ * Viewers are rejected; validation enforces known keys and 0–99 integers.
+ */
+export async function updatePlayerAttributesAction(
+  playerId: string,
+  attributes: Record<string, number>,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const enabled = await playerAttributesV1();
+  if (!enabled) return { ok: false, error: "flag_disabled" };
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const player = await getPlayer(playerId, orgContext).catch(() => null);
+  if (!player) return { ok: false, error: "player_not_found" };
+
+  const leagueId = await getTeamLeagueId(player.teamId).catch(() => null);
+  if (!leagueId) return { ok: false, error: "league_not_found" };
+
+  const orgId = await getLeagueOrgId(leagueId);
+  if (!orgId) return { ok: false, error: "league_not_owned" };
+
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageRoster(role)) return { ok: false, error: "not_authorized" };
+
+  const validated = validatePlayerAttributeEdit(attributes);
+  if (!validated.ok) return { ok: false, error: validated.error };
+
+  const existing = await getPlayerSeasonAttributes(playerId, orgContext).catch(
+    () => null,
+  );
+  const positionGroup =
+    existing?.positionGroup ??
+    attributeGroupForPosition(player.position);
+
+  try {
+    await updatePlayerAttributes({
+      playerId,
+      positionGroup,
+      attributes: validated.normalized,
+      weightedOverall: validated.weightedOverall,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+
+  revalidatePath(`/dashboard/players/${playerId}`);
+  return { ok: true };
+}

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -10,14 +10,17 @@ import {
   getSeasons,
   getPlayerSeasonTotals,
   computeSeasonSprt,
+  getTeamLeagueId,
+  getLeagueOrgId,
 } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageRoster } from "@/lib/permissions";
 import { derivePositionGroup } from "@/lib/position-group";
-import { orderedComponents } from "@/lib/ratings/component-labels";
 import { orderedMaddenAttributes } from "@/lib/madden/attributes";
 import { playerAttributesV1, statKeepingV1 } from "@/lib/flags";
 import { SeasonStatsCard } from "@/components/stats/SeasonStatsCard";
 import { HsRatingCard } from "@/components/stats/HsRatingCard";
+import { SprtRatingCard } from "@/components/attributes/SprtRatingCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
@@ -78,7 +81,15 @@ export default async function PlayerProfilePage({
       () => null,
     );
   }
-  const components = rating ? orderedComponents(rating.attributes) : [];
+  // Coaches + admins may edit SPRT attributes on the profile card (WSM-000121).
+  const playerLeagueId = team
+    ? await getTeamLeagueId(team.id).catch(() => null)
+    : null;
+  const playerOrgId = playerLeagueId
+    ? await getLeagueOrgId(playerLeagueId)
+    : null;
+  const role = playerOrgId ? await resolveOrgRole(playerOrgId, userId) : null;
+  const canEditRating = canManageRoster(role);
 
   // Madden rating (WSM-000095) — the player's current Madden snapshot, shown
   // side-by-side with SPRT. Independent of season; never blocks the page.
@@ -245,56 +256,12 @@ export default async function PlayerProfilePage({
       )}
 
       {rating && (
-        <Card className="mt-6">
-          <CardContent className="pt-6">
-            <div className="flex items-baseline justify-between">
-              <h3 className="text-lg font-semibold text-foreground">
-                SPRT Rating
-              </h3>
-              {rating.weightedOverall != null && (
-                <span className="font-mono text-stat-30 tabular-nums text-accent">
-                  {Math.round(rating.weightedOverall)}
-                  <span className="ml-1 text-caption-12 font-normal text-text-muted">
-                    OVR
-                  </span>
-                </span>
-              )}
-            </div>
-
-            {components.length > 0 && (
-              <dl className="mt-4 space-y-2">
-                {components.map((c) => (
-                  <div key={c.key} className="flex items-center gap-3">
-                    <dt className="w-32 shrink-0 text-sm text-muted-foreground">
-                      {c.label}
-                    </dt>
-                    <div
-                      className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
-                      role="meter"
-                      aria-valuenow={Math.round(c.value)}
-                      aria-valuemin={0}
-                      aria-valuemax={99}
-                      aria-label={c.label}
-                    >
-                      <div
-                        className="h-full rounded-full bg-foreground"
-                        style={{ width: `${Math.min(100, (c.value / 99) * 100)}%` }}
-                      />
-                    </div>
-                    <dd className="w-8 shrink-0 text-right font-mono text-sm text-foreground">
-                      {Math.round(c.value)}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            )}
-
-            <p className="mt-4 text-xs text-muted-foreground">
-              SPRT Rating is our own metric derived from open NFL performance
-              data (nflverse).
-            </p>
-          </CardContent>
-        </Card>
+        <SprtRatingCard
+          playerId={playerId}
+          weightedOverall={rating.weightedOverall}
+          attributes={rating.attributes}
+          canEdit={canEditRating}
+        />
       )}
 
       {madden && (

--- a/apps/web/src/components/attributes/SprtRatingCard.tsx
+++ b/apps/web/src/components/attributes/SprtRatingCard.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Pencil } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { orderedComponents } from "@/lib/ratings/component-labels";
+import { updatePlayerAttributesAction } from "@/app/dashboard/players/[id]/actions";
+
+export interface SprtRatingCardProps {
+  playerId: string;
+  weightedOverall: number | null;
+  attributes: Record<string, number>;
+  /** Server-resolved: admin or coach may edit (WSM-000121). */
+  canEdit?: boolean;
+}
+
+export function SprtRatingCard({
+  playerId,
+  weightedOverall,
+  attributes,
+  canEdit = false,
+}: SprtRatingCardProps) {
+  const router = useRouter();
+  const components = orderedComponents(attributes);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [pending, startTransition] = useTransition();
+
+  function openEditor() {
+    const next: Record<string, string> = {};
+    for (const c of components) {
+      next[c.key] = String(Math.round(c.value));
+    }
+    setDraft(next);
+    setDialogOpen(true);
+  }
+
+  function handleSave() {
+    const parsed: Record<string, number> = {};
+    for (const c of components) {
+      const raw = draft[c.key]?.trim() ?? "";
+      const num = Number(raw);
+      if (raw === "" || !Number.isFinite(num)) {
+        toast.error(`Enter a valid number for ${c.label}.`);
+        return;
+      }
+      parsed[c.key] = num;
+    }
+
+    startTransition(async () => {
+      const result = await updatePlayerAttributesAction(playerId, parsed);
+      if (result.ok) {
+        toast.success("Ratings saved.");
+        setDialogOpen(false);
+        router.refresh();
+      } else {
+        toast.error(mapEditError(result.error));
+      }
+    });
+  }
+
+  return (
+    <>
+      <Card className="mt-6">
+        <CardContent className="pt-6">
+          <div className="flex items-baseline justify-between gap-2">
+            <h3 className="text-lg font-semibold text-foreground">
+              SPRT Rating
+            </h3>
+            <div className="flex items-baseline gap-2">
+              {weightedOverall != null && (
+                <span className="font-mono text-stat-30 tabular-nums text-accent">
+                  {Math.round(weightedOverall)}
+                  <span className="ml-1 text-caption-12 font-normal text-text-muted">
+                    OVR
+                  </span>
+                </span>
+              )}
+              {canEdit && components.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
+                  onClick={openEditor}
+                  aria-label="Edit SPRT ratings"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          {components.length > 0 && (
+            <dl className="mt-4 space-y-2">
+              {components.map((c) => (
+                <div key={c.key} className="flex items-center gap-3">
+                  <dt className="w-32 shrink-0 text-sm text-muted-foreground">
+                    {c.label}
+                  </dt>
+                  <div
+                    className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+                    role="meter"
+                    aria-valuenow={Math.round(c.value)}
+                    aria-valuemin={0}
+                    aria-valuemax={99}
+                    aria-label={c.label}
+                  >
+                    <div
+                      className="h-full rounded-full bg-foreground"
+                      style={{
+                        width: `${Math.min(100, (c.value / 99) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                  <dd className="w-8 shrink-0 text-right font-mono text-sm text-foreground">
+                    {Math.round(c.value)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          <p className="mt-4 text-xs text-muted-foreground">
+            SPRT Rating is our own metric derived from open NFL performance
+            data (nflverse).
+          </p>
+        </CardContent>
+      </Card>
+
+      {canEdit ? (
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Edit SPRT ratings</DialogTitle>
+              <DialogDescription>
+                Adjust attribute values (0–99). Overall is recomputed on save.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid max-h-[min(60vh,28rem)] gap-3 overflow-y-auto py-2">
+              {components.map((c) => (
+                <div key={c.key} className="grid grid-cols-[1fr_5rem] gap-3">
+                  <Label htmlFor={`attr-${c.key}`} className="self-center">
+                    {c.label}
+                  </Label>
+                  <Input
+                    id={`attr-${c.key}`}
+                    type="number"
+                    min={0}
+                    max={99}
+                    step={1}
+                    value={draft[c.key] ?? ""}
+                    onChange={(e) =>
+                      setDraft((prev) => ({ ...prev, [c.key]: e.target.value }))
+                    }
+                    className="font-mono"
+                    disabled={pending}
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                variant="ghost"
+                onClick={() => setDialogOpen(false)}
+                disabled={pending}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={pending}>
+                {pending ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
+  );
+}
+
+function mapEditError(code: string): string {
+  switch (code) {
+    case "flag_disabled":
+      return "Player attributes feature is disabled.";
+    case "unauthorized":
+      return "Sign in required.";
+    case "player_not_found":
+      return "Player not found in your visible leagues.";
+    case "league_not_found":
+    case "league_not_owned":
+      return "League access denied.";
+    case "not_authorized":
+      return "Only coaches and admins can edit ratings.";
+    case "empty_attributes":
+      return "Provide at least one attribute.";
+    case "no_season":
+      return "No season found for this player's league.";
+    default:
+      if (code.startsWith("invalid_attribute_key:")) {
+        return `Unknown attribute: ${code.slice("invalid_attribute_key:".length)}`;
+      }
+      if (code.startsWith("attribute_out_of_range:")) {
+        return `Value must be 0–99 for ${code.slice("attribute_out_of_range:".length)}`;
+      }
+      if (code.startsWith("invalid_attribute_value:")) {
+        return `Invalid number for ${code.slice("invalid_attribute_value:".length)}`;
+      }
+      return code;
+  }
+}

--- a/apps/web/src/lib/attributes/__tests__/known-keys.test.ts
+++ b/apps/web/src/lib/attributes/__tests__/known-keys.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import {
+  validatePlayerAttributeEdit,
+  computeRatingOverall,
+} from "../known-keys";
+
+describe("validatePlayerAttributeEdit", () => {
+  it("accepts Madden-style keys in 0–99", () => {
+    const res = validatePlayerAttributeEdit({ SPD: 80, STR: 75 });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.normalized.SPD).toBe(80);
+    expect(res.normalized.OVR).toBe(78);
+    expect(res.weightedOverall).toBe(78);
+  });
+
+  it("rejects out-of-range values", () => {
+    const res = validatePlayerAttributeEdit({ AGI: 100 });
+    expect(res).toEqual({ ok: false, error: "attribute_out_of_range:AGI" });
+  });
+});
+
+describe("computeRatingOverall", () => {
+  it("uses explicit OVR when present", () => {
+    expect(computeRatingOverall({ efficiency: 70, OVR: 88 })).toBe(88);
+  });
+
+  it("averages components when OVR absent", () => {
+    expect(computeRatingOverall({ efficiency: 80, production: 60 })).toBe(70);
+  });
+});

--- a/apps/web/src/lib/attributes/known-keys.ts
+++ b/apps/web/src/lib/attributes/known-keys.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical attribute codes accepted for manual rating edits (WSM ratings-edit).
+ * Unions Madden-style codes (synthetic roster / ingest) with SPRT component keys.
+ */
+import { GROUP_KEYS, COMMON_KEYS } from "@/lib/synthetic-attributes";
+
+/** SPRT model component keys (lib/ratings/sprt.ts) plus display OVR. */
+const SPRT_COMPONENT_KEYS = [
+  "efficiency",
+  "production",
+  "scoring",
+  "mobility",
+  "rushEff",
+  "volume",
+  "receiving",
+  "explosiveness",
+  "hands",
+  "passRush",
+  "pressure",
+  "runStop",
+  "tackling",
+  "coverage",
+  "ballHawk",
+  "OVR",
+] as const;
+
+const MADDEN_KEYS = new Set<string>([
+  ...COMMON_KEYS,
+  ...Object.values(GROUP_KEYS).flat(),
+]);
+
+const KNOWN_KEYS = new Set<string>([
+  ...SPRT_COMPONENT_KEYS,
+  ...MADDEN_KEYS,
+  // Admin / PFF canonical examples used in uploads and tests.
+  "armStrength",
+  "accuracy",
+  "decisionMaking",
+  "overall",
+]);
+
+export function isKnownAttributeKey(key: string): boolean {
+  return KNOWN_KEYS.has(key);
+}
+
+const OVERALL_KEYS = ["overall", "OVR", "OVERALL", "Overall"] as const;
+
+/** Recompute OVR from component attributes when not explicitly provided. */
+export function computeRatingOverall(
+  attributes: Record<string, number>,
+): number {
+  for (const key of OVERALL_KEYS) {
+    const v = attributes[key];
+    if (typeof v === "number" && Number.isFinite(v)) {
+      return Math.round(Math.max(0, Math.min(99, v)));
+    }
+  }
+  const componentKeys = Object.keys(attributes).filter(
+    (k) => !OVERALL_KEYS.includes(k as (typeof OVERALL_KEYS)[number]),
+  );
+  if (componentKeys.length === 0) return 0;
+  const sum = componentKeys.reduce((a, k) => a + attributes[k], 0);
+  return Math.round(Math.max(0, Math.min(99, sum / componentKeys.length)));
+}
+
+export function validatePlayerAttributeEdit(
+  attributes: Record<string, number>,
+):
+  | { ok: true; normalized: Record<string, number>; weightedOverall: number }
+  | { ok: false; error: string } {
+  const entries = Object.entries(attributes);
+  if (entries.length === 0) {
+    return { ok: false, error: "empty_attributes" };
+  }
+
+  const normalized: Record<string, number> = {};
+  for (const [key, value] of entries) {
+    if (!isKnownAttributeKey(key)) {
+      return { ok: false, error: `invalid_attribute_key:${key}` };
+    }
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return { ok: false, error: `invalid_attribute_value:${key}` };
+    }
+    const rounded = Math.round(value);
+    if (rounded < 0 || rounded > 99) {
+      return { ok: false, error: `attribute_out_of_range:${key}` };
+    }
+    normalized[key] = rounded;
+  }
+
+  const withoutStoredOvr = { ...normalized };
+  for (const k of OVERALL_KEYS) delete withoutStoredOvr[k];
+
+  const weightedOverall = computeRatingOverall(normalized);
+  const withOvr = { ...withoutStoredOvr, OVR: weightedOverall };
+
+  return { ok: true, normalized: withOvr, weightedOverall };
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -374,6 +374,15 @@ const refs = {
     },
     { id: string; created: boolean }
   >("sports:ingestPlayerAttributes"),
+  updatePlayerAttributes: mutationRef<
+    {
+      playerId: string;
+      positionGroup: string;
+      attributesJson: string;
+      weightedOverall: number | null;
+    },
+    { id: string; created: boolean }
+  >("sports:updatePlayerAttributes"),
   getPlayerDevelopment: queryRef<
     { playerId: string },
     Array<{
@@ -1710,6 +1719,21 @@ export async function ingestPlayerAttributes(
     pffWeight: input.pffWeight ?? 0.5,
     maddenWeight: input.maddenWeight ?? 0.5,
     weightedOverall,
+  });
+}
+
+/** Manual coach/admin edit — upserts the player's current-season snapshot. */
+export async function updatePlayerAttributes(input: {
+  playerId: string;
+  positionGroup: string;
+  attributes: Record<string, number>;
+  weightedOverall: number;
+}): Promise<{ id: string; created: boolean }> {
+  return mutateConvex(refs.updatePlayerAttributes, {
+    playerId: input.playerId,
+    positionGroup: input.positionGroup,
+    attributesJson: JSON.stringify(input.attributes),
+    weightedOverall: input.weightedOverall,
   });
 }
 

--- a/apps/web/src/lib/synthetic-attributes.ts
+++ b/apps/web/src/lib/synthetic-attributes.ts
@@ -29,10 +29,10 @@ export type AttributeGroup =
   | "P";
 
 /** Universal athletic attributes every group carries. */
-const COMMON_KEYS: readonly string[] = ["SPD", "STR", "AGI", "ACC", "AWR", "STA"];
+export const COMMON_KEYS: readonly string[] = ["SPD", "STR", "AGI", "ACC", "AWR", "STA"];
 
 /** Madden-style position-specific attribute codes per group. */
-const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
+export const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
   QB: ["THP", "SAC", "MAC", "DAC", "TUP", "PAC"],
   RB: ["CAR", "BCV", "TRK", "ELU", "JKM", "BTK"],
   WR: ["CTH", "SRR", "MRR", "DRR", "CIT", "RLS"],


### PR DESCRIPTION
## Summary

Coaches and admins can now edit player SPRT attribute values directly on the player detail page. Implements the "Ratings should be editable by coaches and admins" item from the 2026-07-03 prod review (orchestrated Composer implementation, independently verified).

- **UI**: SPRT Rating card extracted into `SprtRatingCard`; edit affordance (per-attribute number inputs, save/cancel, error states) renders only for admin/coach. The capability flag is resolved **server-side** (`resolveOrgRole` → `canManageRoster`) and passed down — no client-only role checks.
- **Server action**: `updatePlayerAttributesAction` validates attribute codes against a canonical list (`known-keys.ts`: Madden-style ingest codes ∪ SPRT component keys) and enforces 0–99 integer bounds; viewers get `not_authorized`.
- **Convex**: new `updatePlayerAttributes` **internal** mutation reusing the existing ingest snapshot path — no new tables, no public write surface. The `writeMutationsAreInternal` guard test is extended to cover it (WSM-000096 security model).
- **OVR**: stays derived via existing snapshot resolution (`weightedOverall`) — no stale stored overall.
- **No season gating** on manual edits: only generation is season-gated (#460); coaches must be able to curate ratings mid-season.

## Verification

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 107 files / 831 tests (9 new: permission matrix — viewer rejected, coach/admin allowed — and key/value validation)

## Notes

- No Convex schema changes; DTO ⇄ return-validator parity maintained.
- No changes to `packages/api-contracts` public contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)