### PR TITLE
feat(web): wire play-by-play engine into sim paths + persist logs and stats (Slice B)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -48,6 +48,8 @@ void internal.sports.unforkTeamFromWorkspace;
 void internal.sports.createGameStream;
 void internal.sports.updateGameStreamStatus;
 void internal.sports.upsertPlayerGameStats;
+void internal.sports.bulkUpsertPlayerGameStats;
+void internal.sports.upsertGamePlayLog;
 void internal.sports.deletePlayerGameStats;
 void internal.sports.startLiveGame;
 void internal.sports.addLiveScore;
@@ -126,6 +128,7 @@ type AllowedPublicSportsReads =
   | "getDepthChartByTeamSeason"
   | "getDivision"
   | "getFixture"
+  | "getGamePlayLog"
   | "getLeague"
   | "getLeagueByInviteToken"
   | "getLeagueByName"

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -298,6 +298,20 @@ export default defineSchema({
   }).index("by_fixtureId", ["fixtureId"]),
 
   /*
+   * Play-by-play game log (Slice B). One row per simulated fixture — the full
+   * `PbpGameLog` JSON blob plus engine version for Slice C Gamecast stepping.
+   * Upsert-by-fixture: re-sim replaces the prior log.
+   */
+  gamePlayLogs: defineTable({
+    fixtureId: v.id("fixtures"),
+    seasonId: v.id("seasons"),
+    logJson: v.string(),
+    engineVersion: v.string(),
+    createdAt: v.string(),
+    createdBy: v.string(),
+  }).index("by_fixtureId", ["fixtureId"]),
+
+  /*
    * One live stream per fixture (WSM-000144, streaming epic #225). Two
    * providers (WSM-000180): "mux" (RTMP ingest, paid) keeps the server-side
    * live-stream id + public HLS playback id; "youtube" (free, paste-a-link)

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -4888,6 +4888,125 @@ export const upsertPlayerGameStats = internalMutation({
   },
 });
 
+const bulkStatLineValidator = v.object({
+  playerId: v.id("players"),
+  teamId: v.id("teams"),
+  statsJson: v.string(),
+});
+
+export const bulkUpsertPlayerGameStats = internalMutation({
+  args: {
+    fixtureId: v.id("fixtures"),
+    seasonId: v.id("seasons"),
+    actorUserId: v.string(),
+    lines: v.array(bulkStatLineValidator),
+  },
+  returns: v.object({ upserted: v.number() }),
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+
+    const updatedAt = new Date().toISOString();
+    let upserted = 0;
+
+    for (const line of args.lines) {
+      const payload = {
+        fixtureId: args.fixtureId,
+        playerId: line.playerId,
+        teamId: line.teamId,
+        seasonId: args.seasonId,
+        statsJson: line.statsJson,
+        enteredBy: args.actorUserId,
+        updatedAt,
+      };
+
+      const existing = await ctx.db
+        .query("playerGameStats")
+        .withIndex("by_fixtureId_playerId", (q) =>
+          q.eq("fixtureId", args.fixtureId).eq("playerId", line.playerId),
+        )
+        .first();
+
+      if (existing) {
+        await ctx.db.replace(existing._id, payload);
+      } else {
+        await ctx.db.insert("playerGameStats", payload);
+      }
+      upserted += 1;
+    }
+
+    return { upserted };
+  },
+});
+
+const gamePlayLogDtoValidator = v.object({
+  fixtureId: v.string(),
+  seasonId: v.string(),
+  logJson: v.string(),
+  engineVersion: v.string(),
+  createdAt: v.string(),
+  createdBy: v.string(),
+});
+
+export const upsertGamePlayLog = internalMutation({
+  args: {
+    fixtureId: v.id("fixtures"),
+    seasonId: v.id("seasons"),
+    logJson: v.string(),
+    engineVersion: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({ id: v.string() }),
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+
+    const createdAt = new Date().toISOString();
+    const payload = {
+      fixtureId: args.fixtureId,
+      seasonId: args.seasonId,
+      logJson: args.logJson,
+      engineVersion: args.engineVersion,
+      createdAt,
+      createdBy: args.actorUserId,
+    };
+
+    const existing = await ctx.db
+      .query("gamePlayLogs")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+
+    let id: string;
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+      id = existing._id;
+    } else {
+      id = await ctx.db.insert("gamePlayLogs", payload);
+    }
+    return { id };
+  },
+});
+
+export const getGamePlayLog = query({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.union(gamePlayLogDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("gamePlayLogs")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .first();
+    if (!row) return null;
+    return {
+      fixtureId: row.fixtureId,
+      seasonId: row.seasonId,
+      logJson: row.logJson,
+      engineVersion: row.engineVersion,
+      createdAt: row.createdAt,
+      createdBy: row.createdBy,
+    };
+  },
+});
+
 export const deletePlayerGameStats = internalMutation({
   args: { fixtureId: v.id("fixtures"), playerId: v.id("players") },
   returns: v.boolean(),

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockSchedulesStandingsV1,
+  mockAuth,
+  mockGetLeague,
+  mockGetLeagueOrgId,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockCanManageRoster,
+  mockGetFixture,
+  mockRecordGameResult,
+  mockUpsertGamePlayLog,
+  mockSimulateAndPersistFixture,
+} = vi.hoisted(() => ({
+  mockSchedulesStandingsV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetLeague: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockCanManageRoster: vi.fn(),
+  mockGetFixture: vi.fn(),
+  mockRecordGameResult: vi.fn(),
+  mockUpsertGamePlayLog: vi.fn(),
+  mockSimulateAndPersistFixture: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({
+  schedulesStandingsV1: mockSchedulesStandingsV1,
+}));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  getFixture: mockGetFixture,
+  recordGameResult: mockRecordGameResult,
+  upsertGamePlayLog: mockUpsertGamePlayLog,
+  getLeague: mockGetLeague,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  listFixturesBySeason: vi.fn(),
+  getSeason: vi.fn(),
+  generatePlayoffBracket: vi.fn(),
+  getPlayoffBracket: vi.fn(),
+  createFixture: vi.fn(),
+  deleteFixture: vi.fn(),
+  generateSeasonSchedule: vi.fn(),
+}));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/permissions", () => ({
+  canManageRoster: mockCanManageRoster,
+}));
+vi.mock("@/lib/analytics", () => ({
+  trackFixtureCreated: vi.fn(),
+  trackResultRecorded: vi.fn(),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/simulate-fixture", () => ({
+  simulateAndPersistFixture: mockSimulateAndPersistFixture,
+}));
+
+import {
+  recordGameResultAction,
+  simulateGameAction,
+} from "../actions";
+
+const LEAGUE = "league_1";
+const FIX = "fixture_abc";
+const USER = "user_1";
+
+const FIXTURE = {
+  id: FIX,
+  seasonId: "season_1",
+  homeTeamId: "team_home",
+  awayTeamId: "team_away",
+  homeTeamName: "Home",
+  awayTeamName: "Away",
+  scheduledAt: null,
+  week: 1,
+  venue: null,
+  status: "scheduled" as const,
+  stage: "regular",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  createdBy: USER,
+};
+
+function authorize() {
+  mockSchedulesStandingsV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: USER });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
+  mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue("org:admin");
+  mockCanManageRoster.mockReturnValue(true);
+  mockGetFixture.mockResolvedValue(FIXTURE);
+}
+
+describe("simulateGameAction (PBP Slice B)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("delegates to simulateAndPersistFixture and returns the score", async () => {
+    mockSimulateAndPersistFixture.mockResolvedValue({
+      homeScore: 28,
+      awayScore: 21,
+      usedScoreFallback: false,
+    });
+
+    const res = await simulateGameAction({ leagueId: LEAGUE, fixtureId: FIX });
+
+    expect(res).toEqual({ ok: true, homeScore: 28, awayScore: 21 });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledWith({
+      fixture: FIXTURE,
+      orgContext: { visibleLeagueIds: [LEAGUE] },
+      actorUserId: USER,
+      decisive: false,
+      profileCache: expect.any(Map),
+    });
+  });
+});
+
+describe("recordGameResultAction (manual path)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("does not write a play log", async () => {
+    mockRecordGameResult.mockResolvedValue({ id: "gr_1" });
+
+    const res = await recordGameResultAction({
+      leagueId: LEAGUE,
+      fixtureId: FIX,
+      homeScore: 14,
+      awayScore: 10,
+    });
+
+    expect(res).toEqual({ ok: true });
+    expect(mockRecordGameResult).toHaveBeenCalledWith({
+      fixtureId: FIX,
+      homeScore: 14,
+      awayScore: 10,
+      actorUserId: USER,
+    });
+    expect(mockUpsertGamePlayLog).not.toHaveBeenCalled();
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -12,8 +12,6 @@ import {
   getFixture,
   getSeason,
   listFixturesBySeason,
-  getTeamAttributeSnapshots,
-  getTeamMaddenOveralls,
   generatePlayoffBracket,
   getPlayoffBracket,
   recordGameResult,
@@ -22,7 +20,8 @@ import type { PlayoffMatchupDto } from "@/lib/data-api";
 import type { OrgContext } from "@/lib/org-context";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
-import { simulateScore, seedFromString } from "@/lib/simulate-game";
+import { type TeamSimProfileCache } from "@/lib/build-team-sim-profile";
+import { simulateAndPersistFixture } from "@/lib/simulate-fixture";
 import {
   trackFixtureCreated,
   trackResultRecorded,
@@ -217,51 +216,11 @@ export async function deleteFixtureAction(
 }
 
 /*
- * Game simulation (WSM-000183) — fill plausible, ratings-weighted scores for
- * unplayed games. A team's strength is the mean of its roster's SPRT/Madden
- * `weightedOverall` (50 = unrated/neutral). Sims are deterministic per fixture
- * and recorded as normal results (never overwrite a real/final game), so
- * standings + playoff advancement flow exactly as hand-entered results do.
+ * Game simulation (WSM-000183) — play-by-play engine produces scores, a full
+ * game log, and per-player stat lines. Sims are deterministic per fixture and
+ * recorded as normal results (never overwrite a real/final game), so standings
+ * + playoff advancement flow exactly as hand-entered results do.
  */
-
-const NEUTRAL_STRENGTH = 50;
-
-function mean(values: number[]): number {
-  if (values.length === 0) return NEUTRAL_STRENGTH;
-  return values.reduce((a, b) => a + b, 0) / values.length;
-}
-
-/** Aggregate team strength for a season, cached per team across a batch sim. */
-async function teamStrength(
-  teamId: string,
-  orgContext: OrgContext,
-  cache: Map<string, number>,
-): Promise<number> {
-  const cached = cache.get(teamId);
-  if (cached !== undefined) return cached;
-
-  let strength = NEUTRAL_STRENGTH;
-  const snaps = await getTeamAttributeSnapshots(teamId, orgContext).catch(
-    () => null,
-  );
-  const sprt = snaps
-    ? [...snaps.values()]
-        .map((s) => s.weightedOverall)
-        .filter((n): n is number => n != null)
-    : [];
-  if (sprt.length > 0) {
-    strength = mean(sprt);
-  } else {
-    // Fall back to Madden overalls when no SPRT snapshot exists this season.
-    const madden = await getTeamMaddenOveralls(teamId, orgContext).catch(
-      () => null,
-    );
-    if (madden && madden.size > 0) strength = mean([...madden.values()]);
-  }
-
-  cache.set(teamId, strength);
-  return strength;
-}
 
 export async function simulateGameAction(input: {
   leagueId: string;
@@ -281,25 +240,14 @@ export async function simulateGameAction(input: {
   if (fixture.status === "cancelled") return { ok: false, error: "cancelled" };
 
   const orgContext = await resolveOrgContext(userId);
-  const cache = new Map<string, number>();
-  const [homeStrength, awayStrength] = await Promise.all([
-    teamStrength(fixture.homeTeamId, orgContext, cache),
-    teamStrength(fixture.awayTeamId, orgContext, cache),
-  ]);
-
-  const { homeScore, awayScore } = simulateScore({
-    homeStrength,
-    awayStrength,
-    seed: seedFromString(input.fixtureId),
-    decisive: fixture.stage === "playoff",
-  });
 
   try {
-    await recordGameResult({
-      fixtureId: input.fixtureId,
-      homeScore,
-      awayScore,
+    const { homeScore, awayScore } = await simulateAndPersistFixture({
+      fixture,
+      orgContext,
       actorUserId: userId,
+      decisive: fixture.stage === "playoff",
+      profileCache: new Map(),
     });
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
@@ -317,7 +265,7 @@ async function simulateUnplayedRegularSeason(
   seasonId: string,
   userId: string,
   orgContext: OrgContext,
-  cache: Map<string, number>,
+  profileCache: TeamSimProfileCache,
 ): Promise<number> {
   const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
   // Regular-season, unplayed games only — never overwrite real results, and
@@ -327,20 +275,12 @@ async function simulateUnplayedRegularSeason(
   );
   let simulated = 0;
   for (const fixture of unplayed) {
-    const [homeStrength, awayStrength] = await Promise.all([
-      teamStrength(fixture.homeTeamId, orgContext, cache),
-      teamStrength(fixture.awayTeamId, orgContext, cache),
-    ]);
-    const { homeScore, awayScore } = simulateScore({
-      homeStrength,
-      awayStrength,
-      seed: seedFromString(fixture.id),
-    });
-    await recordGameResult({
-      fixtureId: fixture.id,
-      homeScore,
-      awayScore,
+    await simulateAndPersistFixture({
+      fixture,
+      orgContext,
       actorUserId: userId,
+      profileCache,
+      bulkStats: true,
     });
     simulated += 1;
   }
@@ -401,13 +341,13 @@ export async function simulateSeasonThroughChampionAction(input: {
   if (!userId) return { ok: false, error: "unauthorized" };
 
   const orgContext = await resolveOrgContext(userId);
-  const cache = new Map<string, number>();
+  const profileCache: TeamSimProfileCache = new Map();
   try {
     const regularSimulated = await simulateUnplayedRegularSeason(
       input.seasonId,
       userId,
       orgContext,
-      cache,
+      profileCache,
     );
 
     const season = await getSeason(input.seasonId, orgContext).catch(() => null);
@@ -439,21 +379,13 @@ export async function simulateSeasonThroughChampionAction(input: {
       );
       if (pending.length === 0) break;
       for (const fixture of pending) {
-        const [homeStrength, awayStrength] = await Promise.all([
-          teamStrength(fixture.homeTeamId, orgContext, cache),
-          teamStrength(fixture.awayTeamId, orgContext, cache),
-        ]);
-        const { homeScore, awayScore } = simulateScore({
-          homeStrength,
-          awayStrength,
-          seed: seedFromString(fixture.id),
-          decisive: true,
-        });
-        await recordGameResult({
-          fixtureId: fixture.id,
-          homeScore,
-          awayScore,
+        await simulateAndPersistFixture({
+          fixture,
+          orgContext,
           actorUserId: userId,
+          decisive: true,
+          profileCache,
+          bulkStats: true,
         });
         playoffGames += 1;
       }

--- a/apps/web/src/lib/__tests__/simulate-fixture.test.ts
+++ b/apps/web/src/lib/__tests__/simulate-fixture.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { seedFromString } from "@/lib/simulate-game";
+import { deriveStatLines, simulateGameLog } from "@/lib/pbp";
+import type { TeamSimProfile } from "@/lib/pbp";
+
+const {
+  mockRecordGameResult,
+  mockUpsertGamePlayLog,
+  mockUpsertPlayerGameStats,
+  mockBulkUpsertPlayerGameStats,
+  mockBuildTeamSimProfile,
+} = vi.hoisted(() => ({
+  mockRecordGameResult: vi.fn(),
+  mockUpsertGamePlayLog: vi.fn(),
+  mockUpsertPlayerGameStats: vi.fn(),
+  mockBulkUpsertPlayerGameStats: vi.fn(),
+  mockBuildTeamSimProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/data-api", () => ({
+  recordGameResult: mockRecordGameResult,
+  upsertGamePlayLog: mockUpsertGamePlayLog,
+  upsertPlayerGameStats: mockUpsertPlayerGameStats,
+  bulkUpsertPlayerGameStats: mockBulkUpsertPlayerGameStats,
+}));
+vi.mock("@/lib/build-team-sim-profile", () => ({
+  buildTeamSimProfile: mockBuildTeamSimProfile,
+}));
+
+import { simulateAndPersistFixture } from "../simulate-fixture";
+import type { OrgContext } from "@/lib/org-context";
+
+const FIX = "fixture_abc";
+const SEASON = "season_1";
+const USER = "user_1";
+const LEAGUE = "league_1";
+
+const ORG_CONTEXT: OrgContext = {
+  userId: USER,
+  orgIds: ["org_1"],
+  visibleLeagueIds: [LEAGUE],
+  subscribedLeagueIds: [LEAGUE],
+  subscriptionTeamScopes: {},
+};
+
+const FIXTURE = {
+  id: FIX,
+  seasonId: SEASON,
+  homeTeamId: "team_home",
+  awayTeamId: "team_away",
+  homeTeamName: "Home",
+  awayTeamName: "Away",
+  scheduledAt: null,
+  week: 1,
+  venue: null,
+  status: "scheduled" as const,
+  stage: "regular",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  createdBy: USER,
+};
+
+function sampleTeam(teamId: string, playerIds: string[]): TeamSimProfile {
+  return {
+    teamId,
+    strength: 72,
+    players: playerIds.map((id, i) => ({
+      playerId: id,
+      position: i === 0 ? "QB" : "WR",
+      overall: 70 + i,
+      positionSlot: i === 0 ? "QB" : "WR",
+      depthRank: i + 1,
+    })),
+  };
+}
+
+describe("simulateAndPersistFixture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists log, bulk stat lines, and a matching score", async () => {
+    const home = sampleTeam("team_home", ["p_home_qb", "p_home_wr"]);
+    const away = sampleTeam("team_away", ["p_away_qb", "p_away_wr"]);
+    mockBuildTeamSimProfile.mockImplementation(async (teamId: string) =>
+      teamId === "team_home" ? home : away,
+    );
+    mockUpsertGamePlayLog.mockResolvedValue({ id: "log_1" });
+    mockBulkUpsertPlayerGameStats.mockResolvedValue({ upserted: 4 });
+    mockRecordGameResult.mockResolvedValue({ id: "gr_1" });
+
+    const log = simulateGameLog({
+      home,
+      away,
+      seed: seedFromString(FIX),
+      decisive: false,
+    });
+
+    const res = await simulateAndPersistFixture({
+      fixture: FIXTURE,
+      orgContext: ORG_CONTEXT,
+      actorUserId: USER,
+      profileCache: new Map(),
+      bulkStats: true,
+    });
+
+    expect(res.usedScoreFallback).toBe(false);
+    expect(res.homeScore).toBe(log.homeScore);
+    expect(res.awayScore).toBe(log.awayScore);
+    expect(mockUpsertGamePlayLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fixtureId: FIX,
+        seasonId: SEASON,
+        actorUserId: USER,
+      }),
+    );
+    expect(mockRecordGameResult).toHaveBeenCalledWith({
+      fixtureId: FIX,
+      homeScore: log.homeScore,
+      awayScore: log.awayScore,
+      actorUserId: USER,
+    });
+    const lines = deriveStatLines(log).filter((l) =>
+      ["p_home_qb", "p_home_wr", "p_away_qb", "p_away_wr"].includes(l.playerId),
+    );
+    expect(mockBulkUpsertPlayerGameStats).toHaveBeenCalledWith({
+      fixtureId: FIX,
+      seasonId: SEASON,
+      actorUserId: USER,
+      lines: expect.arrayContaining(
+        lines.map((l) => ({
+          playerId: l.playerId,
+          teamId: l.teamId,
+          statsJson: JSON.stringify(l.statLine),
+        })),
+      ),
+    });
+  });
+
+  it("is deterministic for the same fixture seed", async () => {
+    const home = sampleTeam("team_home", ["p1", "p2", "p3"]);
+    const away = sampleTeam("team_away", ["p4", "p5", "p6"]);
+    mockBuildTeamSimProfile.mockImplementation(async (teamId: string) =>
+      teamId === "team_home" ? home : away,
+    );
+    mockUpsertGamePlayLog.mockResolvedValue({ id: "log_1" });
+    mockRecordGameResult.mockResolvedValue({ id: "gr_1" });
+
+    const calls: string[] = [];
+    mockUpsertPlayerGameStats.mockImplementation(async (input) => {
+      calls.push(JSON.stringify(input.stats));
+      return { id: "pgs_1" };
+    });
+
+    await simulateAndPersistFixture({
+      fixture: FIXTURE,
+      orgContext: ORG_CONTEXT,
+      actorUserId: USER,
+      profileCache: new Map(),
+    });
+    const first = [...calls].sort();
+
+    calls.length = 0;
+    await simulateAndPersistFixture({
+      fixture: FIXTURE,
+      orgContext: ORG_CONTEXT,
+      actorUserId: USER,
+      profileCache: new Map(),
+    });
+    const second = [...calls].sort();
+
+    expect(first).toEqual(second);
+    expect(first.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to score-only when a team has an empty roster", async () => {
+    mockBuildTeamSimProfile.mockImplementation(async (teamId: string) =>
+      teamId === "team_home"
+        ? sampleTeam("team_home", ["p1"])
+        : { teamId: "team_away", strength: 60, players: [] },
+    );
+    mockRecordGameResult.mockResolvedValue({ id: "gr_1" });
+
+    const res = await simulateAndPersistFixture({
+      fixture: FIXTURE,
+      orgContext: ORG_CONTEXT,
+      actorUserId: USER,
+      profileCache: new Map(),
+    });
+
+    expect(res.usedScoreFallback).toBe(true);
+    expect(mockUpsertGamePlayLog).not.toHaveBeenCalled();
+    expect(mockUpsertPlayerGameStats).not.toHaveBeenCalled();
+    expect(mockBulkUpsertPlayerGameStats).not.toHaveBeenCalled();
+    expect(mockRecordGameResult).toHaveBeenCalledWith(
+      expect.objectContaining({ fixtureId: FIX }),
+    );
+  });
+});

--- a/apps/web/src/lib/build-team-sim-profile.ts
+++ b/apps/web/src/lib/build-team-sim-profile.ts
@@ -1,0 +1,107 @@
+import type { PlayerDto } from "@sports-management/shared-types";
+import {
+  getDepthChartByTeamSeason,
+  getPlayersByTeam,
+  getRosterBySeasonTeam,
+  getTeamAttributeSnapshots,
+  getTeamMaddenOveralls,
+} from "@/lib/data-api";
+import type { OrgContext } from "@/lib/org-context";
+import type { PlayerSimProfile, TeamSimProfile } from "@/lib/pbp";
+
+const NEUTRAL_OVERALL = 50;
+
+function mean(values: number[]): number {
+  if (values.length === 0) return NEUTRAL_OVERALL;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function teamStrengthFromMaps(
+  snaps: Map<string, { weightedOverall: number | null }>,
+  madden: Map<string, number>,
+): number {
+  const sprt = [...snaps.values()]
+    .map((s) => s.weightedOverall)
+    .filter((n): n is number => n != null);
+  if (sprt.length > 0) return mean(sprt);
+  if (madden.size > 0) return mean([...madden.values()]);
+  return NEUTRAL_OVERALL;
+}
+
+function resolvePlayerOverall(
+  playerId: string,
+  snaps: Map<string, { weightedOverall: number | null }>,
+  madden: Map<string, number>,
+): number {
+  const snap = snaps.get(playerId);
+  if (snap?.weightedOverall != null) return snap.weightedOverall;
+  const mad = madden.get(playerId);
+  if (mad != null) return mad;
+  return NEUTRAL_OVERALL;
+}
+
+export type TeamSimProfileCache = Map<string, TeamSimProfile>;
+
+export function teamSimProfileCacheKey(teamId: string, seasonId: string): string {
+  return `${teamId}:${seasonId}`;
+}
+
+/**
+ * Build a `TeamSimProfile` for the PBP engine from roster + ratings + depth.
+ * Cached per (teamId, seasonId) for batch season sims.
+ */
+export async function buildTeamSimProfile(
+  teamId: string,
+  seasonId: string,
+  orgContext: OrgContext,
+  cache: TeamSimProfileCache,
+): Promise<TeamSimProfile> {
+  const key = teamSimProfileCacheKey(teamId, seasonId);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const [players, snaps, madden, roster, depthChart] = await Promise.all([
+    getPlayersByTeam(teamId, orgContext).catch(() => [] as PlayerDto[]),
+    getTeamAttributeSnapshots(teamId, orgContext).catch(
+      () => new Map<string, { weightedOverall: number | null; attributes: Record<string, number> }>(),
+    ),
+    getTeamMaddenOveralls(teamId, orgContext).catch(() => new Map<string, number>()),
+    getRosterBySeasonTeam(seasonId, teamId).catch(() => []),
+    getDepthChartByTeamSeason(teamId, seasonId).catch(() => []),
+  ]);
+
+  const depthByPlayer = new Map<string, { positionSlot?: string; depthRank?: number }>();
+  for (const row of roster) {
+    depthByPlayer.set(row.playerId, {
+      positionSlot: row.positionSlot,
+      depthRank: row.depthRank,
+    });
+  }
+  for (const row of depthChart) {
+    if (!depthByPlayer.has(row.playerId)) {
+      depthByPlayer.set(row.playerId, {
+        positionSlot: row.positionSlot,
+        depthRank: row.sortOrder,
+      });
+    }
+  }
+
+  const simPlayers: PlayerSimProfile[] = players.map((p) => {
+    const depth = depthByPlayer.get(p.id);
+    return {
+      playerId: p.id,
+      position: p.position,
+      overall: resolvePlayerOverall(p.id, snaps, madden),
+      positionSlot: depth?.positionSlot,
+      depthRank: depth?.depthRank,
+    };
+  });
+
+  const profile: TeamSimProfile = {
+    teamId,
+    strength: teamStrengthFromMaps(snaps, madden),
+    players: simPlayers,
+  };
+  cache.set(key, profile);
+  return profile;
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -691,6 +691,29 @@ const refs = {
     },
     { id: string }
   >("sports:upsertPlayerGameStats"),
+  bulkUpsertPlayerGameStats: mutationRef<
+    {
+      fixtureId: string;
+      seasonId: string;
+      actorUserId: string;
+      lines: Array<{
+        playerId: string;
+        teamId: string;
+        statsJson: string;
+      }>;
+    },
+    { upserted: number }
+  >("sports:bulkUpsertPlayerGameStats"),
+  upsertGamePlayLog: mutationRef<
+    {
+      fixtureId: string;
+      seasonId: string;
+      logJson: string;
+      engineVersion: string;
+      actorUserId: string;
+    },
+    { id: string }
+  >("sports:upsertGamePlayLog"),
   deletePlayerGameStats: mutationRef<
     { fixtureId: string; playerId: string },
     boolean
@@ -699,6 +722,10 @@ const refs = {
     { fixtureId: string },
     PlayerGameStatsRow[]
   >("sports:getPlayerGameStatsByFixture"),
+  getGamePlayLog: queryRef<
+    { fixtureId: string },
+    GamePlayLogDto | null
+  >("sports:getGamePlayLog"),
   getPlayerSeasonTotals: queryRef<
     { playerId: string; seasonId: string },
     { statsJson: string; gameCount: number }
@@ -2075,6 +2102,53 @@ export async function upsertPlayerGameStats(
     statsJson: JSON.stringify(input.stats),
     actorUserId: input.actorUserId,
   });
+}
+
+export interface BulkUpsertPlayerGameStatsInput {
+  fixtureId: string;
+  seasonId: string;
+  actorUserId: string;
+  lines: Array<{
+    playerId: string;
+    teamId: string;
+    statsJson: string;
+  }>;
+}
+
+export async function bulkUpsertPlayerGameStats(
+  input: BulkUpsertPlayerGameStatsInput,
+): Promise<{ upserted: number }> {
+  return mutateConvex(refs.bulkUpsertPlayerGameStats, input);
+}
+
+export interface UpsertGamePlayLogInput {
+  fixtureId: string;
+  seasonId: string;
+  logJson: string;
+  engineVersion: string;
+  actorUserId: string;
+}
+
+export async function upsertGamePlayLog(
+  input: UpsertGamePlayLogInput,
+): Promise<{ id: string }> {
+  return mutateConvex(refs.upsertGamePlayLog, input);
+}
+
+/** Stored play-by-play log for a simulated fixture (Slice C reads this). */
+export interface GamePlayLogDto {
+  fixtureId: string;
+  seasonId: string;
+  logJson: string;
+  engineVersion: string;
+  createdAt: string;
+  createdBy: string;
+}
+
+export async function getGamePlayLog(
+  fixtureId: string,
+): Promise<GamePlayLogDto | null> {
+  return queryConvex(refs.getGamePlayLog, { fixtureId });
 }
 
 export async function deletePlayerGameStats(

--- a/apps/web/src/lib/pbp/index.ts
+++ b/apps/web/src/lib/pbp/index.ts
@@ -12,6 +12,9 @@ export type {
   TeamSimProfile,
 } from "./types";
 
+/** Bump when play model / serialization changes (stored on each gamePlayLogs row). */
+export const PBP_ENGINE_VERSION = "1.0.0";
+
 export { simulateGameLog } from "./engine";
 export {
   deriveStatLines,

--- a/apps/web/src/lib/simulate-fixture.ts
+++ b/apps/web/src/lib/simulate-fixture.ts
@@ -1,0 +1,134 @@
+import type { FixtureDto } from "@sports-management/shared-types";
+import {
+  bulkUpsertPlayerGameStats,
+  recordGameResult,
+  upsertGamePlayLog,
+  upsertPlayerGameStats,
+} from "@/lib/data-api";
+import {
+  buildTeamSimProfile,
+  type TeamSimProfileCache,
+} from "@/lib/build-team-sim-profile";
+import type { OrgContext } from "@/lib/org-context";
+import {
+  deriveStatLines,
+  PBP_ENGINE_VERSION,
+  simulateGameLog,
+} from "@/lib/pbp";
+import { seedFromString, simulateScore } from "@/lib/simulate-game";
+
+export interface SimulateFixtureInput {
+  fixture: FixtureDto;
+  orgContext: OrgContext;
+  actorUserId: string;
+  decisive?: boolean;
+  profileCache: TeamSimProfileCache;
+  /** When true, stat lines are written in one bulk mutation (season sims). */
+  bulkStats?: boolean;
+}
+
+export interface SimulateFixtureResult {
+  homeScore: number;
+  awayScore: number;
+  /** True when either team had no roster players — score-only fallback. */
+  usedScoreFallback: boolean;
+}
+
+function knownPlayerIds(
+  homePlayers: { playerId: string }[],
+  awayPlayers: { playerId: string }[],
+): Set<string> {
+  return new Set([
+    ...homePlayers.map((p) => p.playerId),
+    ...awayPlayers.map((p) => p.playerId),
+  ]);
+}
+
+/**
+ * Run PBP sim (or score fallback), persist the log + stat lines, and record
+ * the final score. Playoff bracket advancement stays in recordGameResult.
+ */
+export async function simulateAndPersistFixture(
+  input: SimulateFixtureInput,
+): Promise<SimulateFixtureResult> {
+  const { fixture, orgContext, actorUserId, profileCache } = input;
+  const decisive = input.decisive ?? fixture.stage === "playoff";
+  const seed = seedFromString(fixture.id);
+
+  const [home, away] = await Promise.all([
+    buildTeamSimProfile(fixture.homeTeamId, fixture.seasonId, orgContext, profileCache),
+    buildTeamSimProfile(fixture.awayTeamId, fixture.seasonId, orgContext, profileCache),
+  ]);
+
+  const rosterEmpty = home.players.length === 0 || away.players.length === 0;
+
+  if (rosterEmpty) {
+    const { homeScore, awayScore } = simulateScore({
+      homeStrength: home.strength,
+      awayStrength: away.strength,
+      seed,
+      decisive,
+    });
+    await recordGameResult({
+      fixtureId: fixture.id,
+      homeScore,
+      awayScore,
+      actorUserId,
+    });
+    return { homeScore, awayScore, usedScoreFallback: true };
+  }
+
+  const log = simulateGameLog({ home, away, seed, decisive });
+  const homeScore = log.homeScore;
+  const awayScore = log.awayScore;
+
+  await upsertGamePlayLog({
+    fixtureId: fixture.id,
+    seasonId: fixture.seasonId,
+    logJson: JSON.stringify(log),
+    engineVersion: PBP_ENGINE_VERSION,
+    actorUserId,
+  });
+
+  const rosterIds = knownPlayerIds(home.players, away.players);
+  const statLines = deriveStatLines(log).filter((line) =>
+    rosterIds.has(line.playerId),
+  );
+
+  if (statLines.length > 0) {
+    if (input.bulkStats) {
+      await bulkUpsertPlayerGameStats({
+        fixtureId: fixture.id,
+        seasonId: fixture.seasonId,
+        actorUserId,
+        lines: statLines.map((line) => ({
+          playerId: line.playerId,
+          teamId: line.teamId,
+          statsJson: JSON.stringify(line.statLine),
+        })),
+      });
+    } else {
+      await Promise.all(
+        statLines.map((line) =>
+          upsertPlayerGameStats({
+            fixtureId: fixture.id,
+            seasonId: fixture.seasonId,
+            playerId: line.playerId,
+            teamId: line.teamId,
+            stats: line.statLine,
+            actorUserId,
+          }),
+        ),
+      );
+    }
+  }
+
+  await recordGameResult({
+    fixtureId: fixture.id,
+    homeScore,
+    awayScore,
+    actorUserId,
+  });
+
+  return { homeScore, awayScore, usedScoreFallback: false };
+}


### PR DESCRIPTION
## Summary

Slice B of the play-by-play architecture (design doc merged in #462). Every simulated game now produces a full play-by-play log and real player stat lines.

- **`gamePlayLogs` table** (`by_fixtureId`, upsert-by-fixture, `engineVersion` for future migrations) written via internal `upsertGamePlayLog`; `getGamePlayLog` read query added now so the Gamecast view (Slice C) has its data source.
- **`simulate-fixture.ts`** centralizes the sim flow: builds `TeamSimProfile`s (SPRT `weightedOverall` → Madden fallback → neutral 50; depth order from depth chart/roster assignments, per-team caching for season sims), runs `simulateGameLog` with the existing per-fixture seed + playoff `decisive` flag, persists the log, records the log's final score through the **unchanged** `recordGameResult` path (fixture status + bracket advancement untouched), and upserts derived stat lines via internal `bulkUpsertPlayerGameStats`.
- **All four sim paths** (single game, season, unplayed regular season, sim-to-champion) now generate player stats consumed **unchanged** by `computeSeasonSprt` and stat leaders.
- **Edge cases:** empty-roster fixtures fall back to score-only `simulateScore` (no plays/stats, no crash); manual "Record result" writes no synthetic plays.
- `writeMutationsAreInternal` guard extended — all new writes are internal (WSM-000096 model).

## Verification

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 110 files / 844 tests (determinism, score↔log consistency, empty-roster fallback, manual-path isolation)

## Deploy note

Adds Convex functions — requires a manual `convex deploy` to prod from merged main (will also pick up `updatePlayerAttributes` from #461).

🤖 Generated with [Claude Code](https://claude.com/claude-code)