### PR TITLE
feat(web): Gamecast drive-chart view with granular sim replay (Slice C)

### DIFF
--- a/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
+++ b/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { schedulesStandingsV1 } from "@/lib/flags";
+import {
+  getFixture,
+  getGamePlayLog,
+  getLeague,
+  getSeasonLeagueId,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { PBP_ENGINE_VERSION } from "@/lib/pbp";
+import { parseGamePlayLog } from "@/lib/gamecast/parse-log";
+import GamecastView from "@/components/gamecast/GamecastView";
+import GamecastEmptyState from "@/components/gamecast/GamecastEmptyState";
+
+export default async function GamecastPage({
+  params,
+}: {
+  params: Promise<{ fixtureId: string }>;
+}) {
+  const enabled = await schedulesStandingsV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { fixtureId } = await params;
+  const fixture = await getFixture(fixtureId);
+  if (!fixture) notFound();
+
+  const leagueId = await getSeasonLeagueId(fixture.seasonId);
+  if (!leagueId) notFound();
+
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  const row = await getGamePlayLog(fixtureId);
+  const log = row ? parseGamePlayLog(row.logJson) : null;
+
+  let body: ReactNode;
+  if (!row) {
+    body = <GamecastEmptyState leagueId={leagueId} reason="no_log" />;
+  } else if (!log) {
+    body = <GamecastEmptyState leagueId={leagueId} reason="parse_error" />;
+  } else {
+    body = (
+      <GamecastView
+        log={log}
+        homeTeamName={fixture.homeTeamName}
+        awayTeamName={fixture.awayTeamName}
+        engineVersionMismatch={row.engineVersion !== PBP_ENGINE_VERSION}
+        storedEngineVersion={row.engineVersion}
+        currentEngineVersion={PBP_ENGINE_VERSION}
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <Link
+        href={`/dashboard/leagues/${leagueId}/schedule`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Schedule
+      </Link>
+
+      <header className="mb-6">
+        <h2 className="text-2xl font-bold text-foreground">Gamecast</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {fixture.homeTeamName} vs {fixture.awayTeamName}
+          {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
+        </p>
+      </header>
+
+      {body}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { ClipboardList, Radio } from "lucide-react";
+import { ClipboardList, Radio, Tv } from "lucide-react";
 import {
   schedulesStandingsV1,
   liveStreamingV1,
@@ -16,6 +16,7 @@ import {
   getSeasons,
   getResultByFixture,
   getStreamByFixture,
+  getGamePlayLog,
   getTeamsByLeague,
   listFixturesBySeason,
   type PublicGameStream,
@@ -102,7 +103,9 @@ export default async function LeagueSchedulePage({
     fixtures.map(async (f) => {
       const result =
         f.status === "final" ? await getResultByFixture(f.id) : null;
-      return { fixture: f, result };
+      const hasPlayLog =
+        f.status === "final" ? (await getGamePlayLog(f.id)) !== null : false;
+      return { fixture: f, result, hasPlayLog };
     }),
   );
 
@@ -266,7 +269,7 @@ export default async function LeagueSchedulePage({
                       </tr>
                     </thead>
                     <tbody>
-                      {rows.map(({ fixture, result }) => (
+                      {rows.map(({ fixture, result, hasPlayLog }) => (
                         <tr key={fixture.id} className="border-b border-border">
                           <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
                             {formatFixtureWhen(fixture.scheduledAt)}
@@ -375,6 +378,17 @@ export default async function LeagueSchedulePage({
                                       className="text-primary hover:underline"
                                     >
                                       Away
+                                    </Link>
+                                  </span>
+                                ) : null}
+                                {fixture.status === "final" && hasPlayLog ? (
+                                  <span className="flex items-center gap-1 text-xs">
+                                    <Tv className="h-3.5 w-3.5 text-muted-foreground" />
+                                    <Link
+                                      href={`/dashboard/games/${fixture.id}/gamecast`}
+                                      className="text-primary hover:underline"
+                                    >
+                                      Gamecast
                                     </Link>
                                   </span>
                                 ) : null}

--- a/apps/web/src/components/gamecast/DriveChart.tsx
+++ b/apps/web/src/components/gamecast/DriveChart.tsx
@@ -1,0 +1,136 @@
+import type { DriveChartSegment, DriveResultToken } from "@/lib/gamecast";
+import { driveResultLabel, driveResultToken } from "@/lib/gamecast";
+
+const TOKEN_FILL: Record<DriveResultToken, string> = {
+  accent: "fill-accent",
+  primary: "fill-primary",
+  muted: "fill-surface-3",
+  danger: "fill-danger",
+  subtle: "fill-border-strong",
+};
+
+interface DriveChartProps {
+  segments: DriveChartSegment[];
+  homeLabel: string;
+  awayLabel: string;
+  animate: boolean;
+}
+
+const ROW_HEIGHT = 14;
+const FIELD_HEIGHT = 48;
+const PAD_X = 4;
+
+export default function DriveChart({
+  segments,
+  homeLabel,
+  awayLabel,
+  animate,
+}: DriveChartProps) {
+  const revealed = segments.filter((s) => s.isRevealed);
+  const chartHeight = Math.max(revealed.length, 1) * ROW_HEIGHT + FIELD_HEIGHT + 24;
+  const width = 100 + PAD_X * 2;
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[320px]">
+        <div className="mb-2 flex justify-between font-mono text-caption-12 text-text-subtle">
+          <span>{homeLabel}</span>
+          <span>{awayLabel}</span>
+        </div>
+        <svg
+          viewBox={`0 0 ${width} ${chartHeight}`}
+          className="w-full text-border"
+          role="img"
+          aria-label="Drive chart"
+        >
+          <Field width={width} y={0} />
+          {revealed.map((seg, i) => (
+            <DriveBar
+              key={seg.driveId}
+              segment={seg}
+              y={FIELD_HEIGHT + 8 + i * ROW_HEIGHT}
+              width={width}
+              animate={animate}
+            />
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function Field({ width, y }: { width: number; y: number }) {
+  const x0 = PAD_X;
+  const w = 100;
+  return (
+    <g transform={`translate(0, ${y})`}>
+      <rect
+        x={x0}
+        y={0}
+        width={w}
+        height={FIELD_HEIGHT}
+        rx={2}
+        className="fill-surface-2 stroke-border"
+        strokeWidth={0.5}
+      />
+      <line
+        x1={x0 + w / 2}
+        y1={0}
+        x2={x0 + w / 2}
+        y2={FIELD_HEIGHT}
+        className="stroke-border"
+        strokeWidth={0.5}
+        strokeDasharray="2 2"
+      />
+      {[0, 25, 50, 75, 100].map((tick) => (
+        <line
+          key={tick}
+          x1={x0 + tick}
+          y1={FIELD_HEIGHT - 4}
+          x2={x0 + tick}
+          y2={FIELD_HEIGHT}
+          className="stroke-border-strong"
+          strokeWidth={0.5}
+        />
+      ))}
+    </g>
+  );
+}
+
+function DriveBar({
+  segment,
+  y,
+  width,
+  animate,
+}: {
+  segment: DriveChartSegment;
+  y: number;
+  width: number;
+  animate: boolean;
+}) {
+  const x0 = PAD_X;
+  const start = x0 + Math.min(segment.startChart, segment.endChart);
+  const barW = Math.max(Math.abs(segment.endChart - segment.startChart), 1.5);
+  const token: DriveResultToken = segment.isCurrent
+    ? "accent"
+    : driveResultToken(segment.endReason);
+  const fill = TOKEN_FILL[token];
+  const transition = animate ? "transition-all duration-300 ease-out" : undefined;
+
+  return (
+    <g transform={`translate(0, ${y})`} className={transition}>
+      <rect
+        x={start}
+        y={2}
+        width={barW}
+        height={8}
+        rx={2}
+        className={`${fill} ${segment.isCurrent ? "opacity-100" : "opacity-80"}`}
+      >
+        <title>
+          Drive {segment.driveId}: {driveResultLabel(segment.endReason)}
+        </title>
+      </rect>
+    </g>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastControls.tsx
+++ b/apps/web/src/components/gamecast/GamecastControls.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@/components/ui/button";
+
+interface GamecastControlsProps {
+  playIndex: number;
+  totalPlays: number;
+  onNextPlay: () => void;
+  onNextQuarter: () => void;
+  onNextHalf: () => void;
+  onEntireGame: () => void;
+  onRestart: () => void;
+}
+
+export default function GamecastControls({
+  playIndex,
+  totalPlays,
+  onNextPlay,
+  onNextQuarter,
+  onNextHalf,
+  onEntireGame,
+  onRestart,
+}: GamecastControlsProps) {
+  const atEnd = playIndex >= totalPlays;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        type="button"
+        size="sm"
+        onClick={onNextPlay}
+        disabled={atEnd}
+      >
+        Next play
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={onNextQuarter}
+        disabled={atEnd}
+      >
+        Next quarter
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        onClick={onNextHalf}
+        disabled={atEnd}
+      >
+        Next half
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={onEntireGame}
+        disabled={atEnd}
+      >
+        Entire game
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        onClick={onRestart}
+        disabled={playIndex === 0}
+      >
+        Restart
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastEmptyState.tsx
+++ b/apps/web/src/components/gamecast/GamecastEmptyState.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export interface GamecastEmptyStateProps {
+  leagueId: string;
+  reason: "no_log" | "parse_error";
+}
+
+export function gamecastEmptyMessage(reason: GamecastEmptyStateProps["reason"]): string {
+  if (reason === "parse_error") {
+    return "This game has a play log that could not be read. Try re-simulating the fixture.";
+  }
+  return "Gamecast is available for simulated games with a stored play-by-play log. Record a result via simulation or open a game that was simmed from the schedule.";
+}
+
+export default function GamecastEmptyState({
+  leagueId,
+  reason,
+}: GamecastEmptyStateProps) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
+        <p className="text-sm text-muted-foreground">{gamecastEmptyMessage(reason)}</p>
+        <Button asChild size="sm" variant="outline">
+          <Link href={`/dashboard/leagues/${leagueId}/schedule`}>
+            Back to schedule
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastScoreboard.tsx
+++ b/apps/web/src/components/gamecast/GamecastScoreboard.tsx
@@ -1,0 +1,64 @@
+import { formatGameClock, formatQuarterLabel } from "@/lib/gamecast";
+
+export interface GamecastScoreboardProps {
+  homeTeamName: string;
+  awayTeamName: string;
+  homeScore: number;
+  awayScore: number;
+  quarter: number | null;
+  clockSeconds: number | null;
+  isComplete: boolean;
+}
+
+export default function GamecastScoreboard({
+  homeTeamName,
+  awayTeamName,
+  homeScore,
+  awayScore,
+  quarter,
+  clockSeconds,
+  isComplete,
+}: GamecastScoreboardProps) {
+  const periodLabel =
+    quarter === null
+      ? "Pre-game"
+      : isComplete
+        ? "Final"
+        : formatQuarterLabel(quarter);
+  const clockLabel =
+    clockSeconds !== null && !isComplete
+      ? formatGameClock(clockSeconds)
+      : null;
+
+  return (
+    <div className="rounded-card border border-border bg-surface p-4">
+      <div className="flex items-center justify-around gap-4 text-center">
+        <TeamCol name={homeTeamName} score={homeScore} />
+        <div className="shrink-0 text-center">
+          <div className="font-mono text-caption-12 uppercase tracking-widest text-text-muted">
+            {periodLabel}
+          </div>
+          {clockLabel ? (
+            <div className="mt-1 font-mono text-stat-30 tabular-nums text-foreground">
+              {clockLabel}
+            </div>
+          ) : isComplete ? (
+            <div className="mt-1 text-label-14 font-medium text-accent">Final</div>
+          ) : null}
+        </div>
+        <TeamCol name={awayTeamName} score={awayScore} />
+      </div>
+    </div>
+  );
+}
+
+function TeamCol({ name, score }: { name: string; score: number }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-label-14 text-text-muted">{name}</div>
+      <div className="font-mono text-stat-30 font-bold tabular-nums text-foreground">
+        {score}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastView.tsx
+++ b/apps/web/src/components/gamecast/GamecastView.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo, useState, useSyncExternalStore } from "react";
+import { allPlays, type PbpGameLog } from "@/lib/pbp";
+import {
+  buildDriveChartSegments,
+  clockAtPosition,
+  entireGameIndex,
+  groupPlaysByDrive,
+  nextHalfIndex,
+  nextPlayIndex,
+  nextQuarterIndex,
+  restartIndex,
+  revealedPlays,
+  scoreAtPosition,
+} from "@/lib/gamecast";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import GamecastScoreboard from "./GamecastScoreboard";
+import DriveChart from "./DriveChart";
+import PlayList from "./PlayList";
+import GamecastControls from "./GamecastControls";
+
+function subscribeReducedMotion(cb: () => void): () => void {
+  const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mq.addEventListener("change", cb);
+  return () => mq.removeEventListener("change", cb);
+}
+
+function getReducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export interface GamecastViewProps {
+  log: PbpGameLog;
+  homeTeamName: string;
+  awayTeamName: string;
+  engineVersionMismatch: boolean;
+  storedEngineVersion: string;
+  currentEngineVersion: string;
+}
+
+export default function GamecastView({
+  log,
+  homeTeamName,
+  awayTeamName,
+  engineVersionMismatch,
+  storedEngineVersion,
+  currentEngineVersion,
+}: GamecastViewProps) {
+  const plays = useMemo(() => allPlays(log), [log]);
+  const [playIndex, setPlayIndex] = useState(0);
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotion,
+    () => false,
+  );
+
+  const score = scoreAtPosition(log, plays, playIndex);
+  const clock = clockAtPosition(plays, playIndex);
+  const isComplete = playIndex >= plays.length;
+  const segments = buildDriveChartSegments(log, plays, playIndex);
+  const groups = groupPlaysByDrive(log, revealedPlays(plays, playIndex));
+
+  return (
+    <div className="space-y-4">
+      {engineVersionMismatch ? (
+        <p className="rounded-card border border-border bg-surface-2 px-4 py-2 text-caption-12 text-text-muted">
+          Play log engine version ({storedEngineVersion}) differs from the
+          current engine ({currentEngineVersion}). Showing best-effort replay.
+        </p>
+      ) : null}
+
+      <GamecastScoreboard
+        homeTeamName={homeTeamName}
+        awayTeamName={awayTeamName}
+        homeScore={score.home}
+        awayScore={score.away}
+        quarter={clock?.quarter ?? null}
+        clockSeconds={clock?.clockSeconds ?? null}
+        isComplete={isComplete}
+      />
+
+      <GamecastControls
+        playIndex={playIndex}
+        totalPlays={plays.length}
+        onNextPlay={() => setPlayIndex((i) => nextPlayIndex(i, plays.length))}
+        onNextQuarter={() =>
+          setPlayIndex((i) => nextQuarterIndex(plays, i))
+        }
+        onNextHalf={() => setPlayIndex((i) => nextHalfIndex(plays, i))}
+        onEntireGame={() => setPlayIndex(entireGameIndex(plays.length))}
+        onRestart={() => setPlayIndex(restartIndex())}
+      />
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-heading-18">Drive chart</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto pb-4">
+          <DriveChart
+            segments={segments}
+            homeLabel={homeTeamName}
+            awayLabel={awayTeamName}
+            animate={!reducedMotion}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-heading-18">Play-by-play</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <PlayList
+            groups={groups}
+            homeTeamId={log.homeTeamId}
+            homeTeamName={homeTeamName}
+            awayTeamName={awayTeamName}
+            animate={!reducedMotion}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/PlayList.tsx
+++ b/apps/web/src/components/gamecast/PlayList.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import type { DrivePlayGroup } from "@/lib/gamecast";
+import { describePlay, driveResultLabel, formatDownAndDistance } from "@/lib/gamecast";
+
+interface PlayListProps {
+  groups: DrivePlayGroup[];
+  homeTeamId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  animate: boolean;
+}
+
+export default function PlayList({
+  groups,
+  homeTeamId,
+  homeTeamName,
+  awayTeamName,
+  animate,
+}: PlayListProps) {
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({
+      behavior: animate ? "smooth" : "auto",
+      block: "nearest",
+    });
+  }, [groups, animate]);
+
+  if (groups.length === 0) {
+    return (
+      <p className="p-4 text-center text-sm text-muted-foreground">
+        Press Next play to start the gamecast.
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-h-96 overflow-y-auto">
+      {groups.map((group) => {
+        const teamName =
+          group.teamId === homeTeamId ? homeTeamName : awayTeamName;
+        return (
+          <section key={group.driveId} className="border-b border-border">
+            <header className="sticky top-0 z-10 bg-surface-2 px-4 py-2">
+              <div className="flex items-center justify-between gap-2 text-caption-12">
+                <span className="font-medium text-foreground">
+                  {teamName} drive
+                </span>
+                <span className="font-mono text-text-muted">
+                  {driveResultLabel(group.endReason)}
+                </span>
+              </div>
+            </header>
+            <ul>
+              {group.plays.map((play) => (
+                <li
+                  key={play.playId}
+                  className={`border-t border-border px-4 py-2 ${
+                    animate ? "transition-colors duration-200" : ""
+                  }`}
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="shrink-0 font-mono text-caption-12 text-text-muted">
+                      {formatDownAndDistance(play)}
+                    </span>
+                    <span className="shrink-0 font-mono text-caption-12 tabular-nums text-text-subtle">
+                      {play.yardsGained > 0 ? `+${play.yardsGained}` : play.yardsGained}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-body-15 text-foreground">
+                    {describePlay(play)}
+                    {play.isScoring ? (
+                      <span className="ml-2 font-medium text-accent">
+                        +{play.pointsScored}
+                      </span>
+                    ) : null}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/__tests__/GamecastEmptyState.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/GamecastEmptyState.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from "react";
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import GamecastEmptyState, {
+  gamecastEmptyMessage,
+} from "@/components/gamecast/GamecastEmptyState";
+
+describe("GamecastEmptyState", () => {
+  it("renders the no-log message and schedule link", () => {
+    const html = renderToStaticMarkup(
+      createElement(GamecastEmptyState, {
+        leagueId: "league-1",
+        reason: "no_log",
+      }),
+    );
+    expect(html).toContain(gamecastEmptyMessage("no_log"));
+    expect(html).toContain("/dashboard/leagues/league-1/schedule");
+    expect(html).toContain("Back to schedule");
+  });
+
+  it("renders parse-error copy", () => {
+    const html = renderToStaticMarkup(
+      createElement(GamecastEmptyState, {
+        leagueId: "league-2",
+        reason: "parse_error",
+      }),
+    );
+    expect(html).toContain(gamecastEmptyMessage("parse_error"));
+  });
+});

--- a/apps/web/src/lib/gamecast/__tests__/drives.test.ts
+++ b/apps/web/src/lib/gamecast/__tests__/drives.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog, allPlays } from "@/lib/pbp";
+import type { PbpGameInput, TeamSimProfile, PlayerSimProfile } from "@/lib/pbp";
+import {
+  buildDriveChartSegments,
+  groupPlaysByDrive,
+  offenseToChartYard,
+  driveResultToken,
+  driveResultLabel,
+  revealedPlays,
+} from "@/lib/gamecast";
+import { nextPlayIndex } from "../reveal";
+
+function makePlayer(
+  teamId: string,
+  position: string,
+  overall: number,
+  depthRank: number,
+): PlayerSimProfile {
+  return {
+    playerId: `${teamId}-${position}-${depthRank}`,
+    position,
+    overall,
+    depthRank,
+    positionSlot: position,
+  };
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 1],
+    ["RB", 2],
+    ["WR", 3],
+    ["TE", 1],
+    ["DE", 2],
+    ["LB", 2],
+    ["CB", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      players.push(makePlayer(teamId, pos, strength, i));
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+function defaultInput(seed: number): PbpGameInput {
+  return {
+    home: buildTeam("home", 68),
+    away: buildTeam("away", 62),
+    seed,
+    decisive: false,
+  };
+}
+
+describe("gamecast drive selectors", () => {
+  const log = simulateGameLog(defaultInput(4242));
+  const plays = allPlays(log);
+
+  it("maps offense yard lines onto a home-left chart", () => {
+    expect(offenseToChartYard(25, log.homeTeamId, log.homeTeamId)).toBe(25);
+    expect(offenseToChartYard(25, log.awayTeamId, log.homeTeamId)).toBe(75);
+  });
+
+  it("builds chart segments for every drive", () => {
+    const segments = buildDriveChartSegments(log, plays, 0);
+    expect(segments).toHaveLength(log.drives.length);
+    expect(segments.every((s) => s.startChart >= 0 && s.startChart <= 100)).toBe(
+      true,
+    );
+  });
+
+  it("marks the current drive from the reveal index", () => {
+    const mid = Math.floor(plays.length / 2);
+    const segments = buildDriveChartSegments(log, plays, mid);
+    const current = segments.filter((s) => s.isCurrent);
+    expect(current).toHaveLength(1);
+    expect(current[0].driveId).toBe(plays[mid - 1].driveId);
+  });
+
+  it("groups revealed plays by drive in order", () => {
+    const idx = nextPlayIndex(nextPlayIndex(0, plays.length), plays.length);
+    const groups = groupPlaysByDrive(
+      log,
+      revealedPlays(plays, idx),
+    );
+    expect(groups.length).toBeGreaterThan(0);
+    expect(groups[0].plays.length).toBeGreaterThan(0);
+    for (const g of groups) {
+      expect(g.plays.every((p) => p.driveId === g.driveId)).toBe(true);
+    }
+  });
+
+  it("maps drive end reasons to semantic tokens and labels", () => {
+    expect(driveResultToken("touchdown")).toBe("accent");
+    expect(driveResultToken("turnover")).toBe("danger");
+    expect(driveResultLabel("punt")).toBe("Punt");
+  });
+});

--- a/apps/web/src/lib/gamecast/__tests__/reveal.test.ts
+++ b/apps/web/src/lib/gamecast/__tests__/reveal.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog, allPlays } from "@/lib/pbp";
+import type { PbpGameInput, TeamSimProfile, PlayerSimProfile } from "@/lib/pbp";
+import {
+  scoreAtPosition,
+  clockAtPosition,
+  nextPlayIndex,
+  nextQuarterIndex,
+  nextHalfIndex,
+  entireGameIndex,
+  restartIndex,
+  revealedPlays,
+  formatGameClock,
+  formatQuarterLabel,
+} from "../reveal";
+
+function makePlayer(
+  teamId: string,
+  position: string,
+  overall: number,
+  depthRank: number,
+): PlayerSimProfile {
+  return {
+    playerId: `${teamId}-${position}-${depthRank}`,
+    position,
+    overall,
+    depthRank,
+    positionSlot: position,
+  };
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 1],
+    ["RB", 2],
+    ["WR", 3],
+    ["TE", 1],
+    ["DE", 2],
+    ["LB", 2],
+    ["CB", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      players.push(makePlayer(teamId, pos, strength, i));
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+function defaultInput(seed: number): PbpGameInput {
+  return {
+    home: buildTeam("home", 68),
+    away: buildTeam("away", 62),
+    seed,
+    decisive: false,
+  };
+}
+
+describe("gamecast reveal stepping", () => {
+  const log = simulateGameLog(defaultInput(9001));
+  const plays = allPlays(log);
+
+  it("starts at zero plays revealed", () => {
+    expect(restartIndex()).toBe(0);
+    expect(revealedPlays(plays, 0)).toEqual([]);
+    expect(clockAtPosition(plays, 0)).toBeNull();
+    expect(scoreAtPosition(log, plays, 0)).toEqual({ home: 0, away: 0 });
+  });
+
+  it("next play advances one at a time through the full log", () => {
+    let idx = 0;
+    for (let step = 0; step < plays.length; step++) {
+      idx = nextPlayIndex(idx, plays.length);
+      expect(idx).toBe(step + 1);
+    }
+    expect(nextPlayIndex(idx, plays.length)).toBe(plays.length);
+  });
+
+  it("score at position matches scoring plays through the reveal index", () => {
+    for (let i = 1; i <= plays.length; i += Math.max(1, Math.floor(plays.length / 12))) {
+      const expected = scoreAtPosition(log, plays, plays.length);
+      const at = scoreAtPosition(log, plays, i);
+      let home = 0;
+      let away = 0;
+      for (let j = 0; j < i; j++) {
+        const p = plays[j];
+        if (!p.isScoring) continue;
+        if (p.offenseTeamId === log.homeTeamId) home += p.pointsScored;
+        else away += p.pointsScored;
+      }
+      expect(at).toEqual({ home, away });
+      if (i === plays.length) expect(at).toEqual(expected);
+    }
+  });
+
+  it("next quarter jumps to quarter boundaries", () => {
+    const q1End = nextQuarterIndex(plays, 0);
+    expect(q1End).toBeGreaterThan(0);
+    expect(plays[q1End - 1].quarter).toBe(1);
+    if (q1End < plays.length) expect(plays[q1End].quarter).toBeGreaterThan(1);
+
+    const q2End = nextQuarterIndex(plays, q1End);
+    expect(q2End).toBeGreaterThanOrEqual(q1End);
+  });
+
+  it("next half jumps to half boundaries", () => {
+    const half1End = nextHalfIndex(plays, 0);
+    expect(half1End).toBeGreaterThan(0);
+    expect(plays[half1End - 1].quarter).toBeLessThanOrEqual(2);
+
+    const half2End = nextHalfIndex(plays, half1End);
+    expect(half2End).toBeGreaterThanOrEqual(half1End);
+    if (half2End < plays.length) {
+      expect(plays[half2End - 1].quarter).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("entire game reveals all plays", () => {
+    expect(entireGameIndex(plays.length)).toBe(plays.length);
+    expect(revealedPlays(plays, plays.length)).toHaveLength(plays.length);
+  });
+
+  it("formats clock and quarter labels", () => {
+    expect(formatGameClock(125)).toBe("2:05");
+    expect(formatGameClock(7)).toBe("0:07");
+    expect(formatQuarterLabel(3)).toBe("Q3");
+    expect(formatQuarterLabel(5)).toBe("OT1");
+  });
+});

--- a/apps/web/src/lib/gamecast/drives.ts
+++ b/apps/web/src/lib/gamecast/drives.ts
@@ -1,0 +1,190 @@
+import type {
+  PbpDrive,
+  PbpDriveEndReason,
+  PbpGameLog,
+  PbpPlay,
+} from "@/lib/pbp";
+
+export interface DriveChartSegment {
+  driveId: number;
+  teamId: string;
+  startChart: number;
+  endChart: number;
+  endReason: PbpDriveEndReason;
+  isCurrent: boolean;
+  isRevealed: boolean;
+}
+
+export interface DrivePlayGroup {
+  driveId: number;
+  teamId: string;
+  endReason: PbpDriveEndReason;
+  plays: PbpPlay[];
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/** Map an offense-perspective yard line onto a home-left broadcast field (0–100). */
+export function offenseToChartYard(
+  yardLine: number,
+  offenseTeamId: string,
+  homeTeamId: string,
+): number {
+  if (offenseTeamId === homeTeamId) return clamp(yardLine, 0, 100);
+  return clamp(100 - yardLine, 0, 100);
+}
+
+function playIndexOf(plays: PbpPlay[], playId: number): number {
+  return plays.findIndex((p) => p.playId === playId);
+}
+
+function driveRevealedEndField(
+  drive: PbpDrive,
+  plays: PbpPlay[],
+  playIndex: number,
+): number {
+  let end = drive.startFieldPosition;
+  for (const play of drive.plays) {
+    const idx = playIndexOf(plays, play.playId);
+    if (idx < 0 || idx >= playIndex) break;
+    end = clamp(play.fieldPosition + play.yardsGained, 0, 100);
+  }
+  return end;
+}
+
+function driveFullyRevealed(
+  drive: PbpDrive,
+  plays: PbpPlay[],
+  playIndex: number,
+): boolean {
+  const last = drive.plays[drive.plays.length - 1];
+  if (!last) return false;
+  const idx = playIndexOf(plays, last.playId);
+  return idx >= 0 && idx < playIndex;
+}
+
+export function currentDriveId(
+  plays: PbpPlay[],
+  playIndex: number,
+  fallbackDriveId: number | null,
+): number | null {
+  if (playIndex <= 0) return fallbackDriveId;
+  return plays[Math.min(playIndex, plays.length) - 1]?.driveId ?? fallbackDriveId;
+}
+
+export function buildDriveChartSegments(
+  log: PbpGameLog,
+  plays: PbpPlay[],
+  playIndex: number,
+): DriveChartSegment[] {
+  const activeDriveId = currentDriveId(
+    plays,
+    playIndex,
+    log.drives[0]?.driveId ?? null,
+  );
+
+  return log.drives.map((drive) => {
+    const startChart = offenseToChartYard(
+      drive.startFieldPosition,
+      drive.teamId,
+      log.homeTeamId,
+    );
+    const offenseEnd = driveRevealedEndField(drive, plays, playIndex);
+    const endChart = offenseToChartYard(
+      offenseEnd,
+      drive.teamId,
+      log.homeTeamId,
+    );
+    const isRevealed =
+      playIndex > 0 &&
+      (driveFullyRevealed(drive, plays, playIndex) ||
+        drive.plays.some((p) => {
+          const idx = playIndexOf(plays, p.playId);
+          return idx >= 0 && idx < playIndex;
+        }));
+
+    return {
+      driveId: drive.driveId,
+      teamId: drive.teamId,
+      startChart,
+      endChart,
+      endReason: drive.endReason,
+      isCurrent: drive.driveId === activeDriveId,
+      isRevealed,
+    };
+  });
+}
+
+export function groupPlaysByDrive(
+  log: PbpGameLog,
+  revealed: PbpPlay[],
+): DrivePlayGroup[] {
+  const byDrive = new Map<number, PbpPlay[]>();
+  for (const play of revealed) {
+    const arr = byDrive.get(play.driveId) ?? [];
+    arr.push(play);
+    byDrive.set(play.driveId, arr);
+  }
+
+  return log.drives
+    .filter((d) => byDrive.has(d.driveId))
+    .map((d) => ({
+      driveId: d.driveId,
+      teamId: d.teamId,
+      endReason: d.endReason,
+      plays: byDrive.get(d.driveId) ?? [],
+    }));
+}
+
+export type DriveResultToken =
+  | "accent"
+  | "primary"
+  | "muted"
+  | "danger"
+  | "subtle";
+
+export function driveResultToken(
+  reason: PbpDriveEndReason,
+): DriveResultToken {
+  switch (reason) {
+    case "touchdown":
+      return "accent";
+    case "field_goal":
+      return "primary";
+    case "turnover":
+    case "downs":
+    case "missed_field_goal":
+      return "danger";
+    case "end_of_half":
+    case "end_of_game":
+      return "subtle";
+    case "punt":
+    default:
+      return "muted";
+  }
+}
+
+export function driveResultLabel(reason: PbpDriveEndReason): string {
+  switch (reason) {
+    case "touchdown":
+      return "Touchdown";
+    case "field_goal":
+      return "Field goal";
+    case "punt":
+      return "Punt";
+    case "turnover":
+      return "Turnover";
+    case "downs":
+      return "Turnover on downs";
+    case "end_of_half":
+      return "End of half";
+    case "end_of_game":
+      return "End of game";
+    case "missed_field_goal":
+      return "Missed FG";
+    default:
+      return reason;
+  }
+}

--- a/apps/web/src/lib/gamecast/index.ts
+++ b/apps/web/src/lib/gamecast/index.ts
@@ -1,0 +1,28 @@
+export { parseGamePlayLog } from "./parse-log";
+export {
+  scoreAtPosition,
+  clockAtPosition,
+  nextPlayIndex,
+  nextQuarterIndex,
+  nextHalfIndex,
+  entireGameIndex,
+  restartIndex,
+  revealedPlays,
+  formatGameClock,
+  formatQuarterLabel,
+  type PlayRevealIndex,
+  type ScoreAtPosition,
+  type GameClockAtPosition,
+} from "./reveal";
+export {
+  buildDriveChartSegments,
+  groupPlaysByDrive,
+  driveResultToken,
+  driveResultLabel,
+  offenseToChartYard,
+  currentDriveId,
+  type DriveChartSegment,
+  type DrivePlayGroup,
+  type DriveResultToken,
+} from "./drives";
+export { formatDownAndDistance, describePlay } from "./play-text";

--- a/apps/web/src/lib/gamecast/parse-log.ts
+++ b/apps/web/src/lib/gamecast/parse-log.ts
@@ -1,0 +1,19 @@
+import type { PbpGameLog } from "@/lib/pbp";
+
+/** Parse persisted log JSON into a {@link PbpGameLog}, or null when invalid. */
+export function parseGamePlayLog(logJson: string): PbpGameLog | null {
+  try {
+    const parsed = JSON.parse(logJson) as PbpGameLog;
+    if (
+      !parsed ||
+      typeof parsed.homeTeamId !== "string" ||
+      typeof parsed.awayTeamId !== "string" ||
+      !Array.isArray(parsed.drives)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/gamecast/play-text.ts
+++ b/apps/web/src/lib/gamecast/play-text.ts
@@ -1,0 +1,59 @@
+import type { PbpPlay } from "@/lib/pbp";
+
+function ordinalDown(down: number): string {
+  if (down === 1) return "1st";
+  if (down === 2) return "2nd";
+  if (down === 3) return "3rd";
+  return `${down}th`;
+}
+
+function yardsLabel(yards: number): string {
+  if (yards === 0) return "no gain";
+  if (yards > 0) return `${yards} yd gain`;
+  return `${Math.abs(yards)} yd loss`;
+}
+
+export function formatDownAndDistance(play: PbpPlay): string {
+  if (play.playType === "kickoff") return "Kickoff";
+  if (play.playType === "extra_point" || play.playType === "extra_point_miss") {
+    return "Extra point";
+  }
+  if (play.playType === "field_goal" || play.playType === "field_goal_miss") {
+    return "Field goal";
+  }
+  if (play.playType === "punt") return "Punt";
+  if (play.playType === "kneel") return "Kneel";
+  return `${ordinalDown(play.down)} & ${play.distance}`;
+}
+
+export function describePlay(play: PbpPlay): string {
+  const yards = yardsLabel(play.yardsGained);
+  switch (play.playType) {
+    case "kickoff":
+      return `Kickoff, ${yards}`;
+    case "rush":
+      return `Rush, ${yards}`;
+    case "pass_complete":
+      return `Pass complete, ${yards}`;
+    case "pass_incomplete":
+      return "Pass incomplete";
+    case "sack":
+      return `Sacked, ${yards}`;
+    case "interception":
+      return `Intercepted${play.yardsGained ? `, ${yards}` : ""}`;
+    case "punt":
+      return `Punt, ${yards}`;
+    case "field_goal":
+      return play.isScoring ? "Field goal GOOD" : `Field goal, ${yards}`;
+    case "field_goal_miss":
+      return "Field goal NO GOOD";
+    case "extra_point":
+      return play.isScoring ? "Extra point GOOD" : "Extra point NO GOOD";
+    case "extra_point_miss":
+      return "Extra point NO GOOD";
+    case "kneel":
+      return `Kneel, ${yards}`;
+    default:
+      return yards;
+  }
+}

--- a/apps/web/src/lib/gamecast/reveal.ts
+++ b/apps/web/src/lib/gamecast/reveal.ts
@@ -1,0 +1,121 @@
+import type { PbpGameLog, PbpPlay } from "@/lib/pbp";
+
+export interface ScoreAtPosition {
+  home: number;
+  away: number;
+}
+
+export interface GameClockAtPosition {
+  quarter: number;
+  clockSeconds: number;
+}
+
+/** Number of revealed plays (0 = pre-kickoff, length = full game). */
+export type PlayRevealIndex = number;
+
+export function formatGameClock(clockSeconds: number): string {
+  const m = Math.floor(clockSeconds / 60);
+  const s = clockSeconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function formatQuarterLabel(quarter: number): string {
+  if (quarter <= 4) return `Q${quarter}`;
+  return `OT${quarter - 4}`;
+}
+
+export function scoreAtPosition(
+  log: PbpGameLog,
+  plays: PbpPlay[],
+  playIndex: PlayRevealIndex,
+): ScoreAtPosition {
+  let home = 0;
+  let away = 0;
+  const end = Math.min(playIndex, plays.length);
+  for (let i = 0; i < end; i++) {
+    const play = plays[i];
+    if (!play.isScoring) continue;
+    if (play.offenseTeamId === log.homeTeamId) home += play.pointsScored;
+    else if (play.offenseTeamId === log.awayTeamId) away += play.pointsScored;
+  }
+  return { home, away };
+}
+
+export function clockAtPosition(
+  plays: PbpPlay[],
+  playIndex: PlayRevealIndex,
+): GameClockAtPosition | null {
+  if (playIndex <= 0 || plays.length === 0) return null;
+  const play = plays[Math.min(playIndex, plays.length) - 1];
+  return { quarter: play.quarter, clockSeconds: play.clockSeconds };
+}
+
+export function nextPlayIndex(
+  current: PlayRevealIndex,
+  totalPlays: number,
+): PlayRevealIndex {
+  return Math.min(current + 1, totalPlays);
+}
+
+export function nextQuarterIndex(
+  plays: PbpPlay[],
+  current: PlayRevealIndex,
+): PlayRevealIndex {
+  if (plays.length === 0) return 0;
+
+  let targetQuarter: number;
+  if (current === 0) {
+    targetQuarter = plays[0].quarter;
+  } else {
+    const revealedQuarter = plays[current - 1].quarter;
+    const hasMoreInQuarter =
+      current < plays.length && plays[current].quarter === revealedQuarter;
+    targetQuarter = hasMoreInQuarter ? revealedQuarter : revealedQuarter + 1;
+  }
+
+  let i = 0;
+  while (i < plays.length && plays[i].quarter <= targetQuarter) i++;
+  return i;
+}
+
+export function nextHalfIndex(
+  plays: PbpPlay[],
+  current: PlayRevealIndex,
+): PlayRevealIndex {
+  if (plays.length === 0) return 0;
+
+  let targetMaxQuarter: number;
+  if (current === 0) {
+    targetMaxQuarter = 2;
+  } else {
+    const q = plays[current - 1].quarter;
+    if (q <= 2) {
+      const hasMoreInFirstHalf =
+        current < plays.length && plays[current].quarter <= 2;
+      targetMaxQuarter = hasMoreInFirstHalf ? 2 : 4;
+    } else if (q <= 4) {
+      targetMaxQuarter = 4;
+    } else {
+      return plays.length;
+    }
+  }
+
+  let i = 0;
+  while (i < plays.length && plays[i].quarter <= targetMaxQuarter) i++;
+  return i;
+}
+
+export function entireGameIndex(totalPlays: number): PlayRevealIndex {
+  return totalPlays;
+}
+
+export function restartIndex(): PlayRevealIndex {
+  return 0;
+}
+
+export function revealedPlays(
+  plays: PbpPlay[],
+  playIndex: PlayRevealIndex,
+): PbpPlay[] {
+  return plays.slice(0, Math.min(playIndex, plays.length));
+}


### PR DESCRIPTION
## Summary

Slice C completes the play-by-play arc (#462 engine, #463 wiring): an ESPN-Gamecast-style replay view for simulated games.

- **Route**: `/dashboard/games/[fixtureId]/gamecast`, server-rendered with org context, loading the persisted log via `getGamePlayLog`.
- **Drive chart**: SVG field with one bar per drive (start→end, direction, result-coded via semantic tokens — TD/FG/punt/turnover/downs), current drive highlighted.
- **Play list**: grouped by drive, down-and-distance + generated play descriptions, auto-scroll to latest revealed play.
- **Granular replay**: Next play / Next quarter / Next half / Entire game / Restart — pure client-side progressive reveal over the loaded log; the scoreboard (score, quarter, clock) derives as-of-position. `prefers-reduced-motion` respected.
- **Entry point**: "Gamecast" link on schedule rows for simulated final fixtures; friendly empty state for manual/unsimulated games.
- **Read-only**: no Convex writes, no schema changes — renders Slice B data.

## Verification

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 113 files / 858 tests (reveal boundaries, score-as-of-position, drive grouping, empty state)
- No hardcoded hex (token audit clean); no e2e selector impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)