### PR TITLE
feat(web): distinct sim scopes — week, regular season, playoffs, champion

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -12,6 +12,8 @@ const {
   mockRecordGameResult,
   mockUpsertGamePlayLog,
   mockSimulateAndPersistFixture,
+  mockListFixturesBySeason,
+  mockGetPlayoffBracket,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -24,6 +26,8 @@ const {
   mockRecordGameResult: vi.fn(),
   mockUpsertGamePlayLog: vi.fn(),
   mockSimulateAndPersistFixture: vi.fn(),
+  mockListFixturesBySeason: vi.fn(),
+  mockGetPlayoffBracket: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
@@ -36,10 +40,10 @@ vi.mock("@/lib/data-api", () => ({
   upsertGamePlayLog: mockUpsertGamePlayLog,
   getLeague: mockGetLeague,
   getLeagueOrgId: mockGetLeagueOrgId,
-  listFixturesBySeason: vi.fn(),
+  listFixturesBySeason: mockListFixturesBySeason,
   getSeason: vi.fn(),
   generatePlayoffBracket: vi.fn(),
-  getPlayoffBracket: vi.fn(),
+  getPlayoffBracket: mockGetPlayoffBracket,
   createFixture: vi.fn(),
   deleteFixture: vi.fn(),
   generateSeasonSchedule: vi.fn(),
@@ -63,27 +67,40 @@ vi.mock("@/lib/simulate-fixture", () => ({
 import {
   recordGameResultAction,
   simulateGameAction,
+  simulatePlayoffsAction,
+  simulateRegularSeasonAction,
+  simulateWeekAction,
 } from "../actions";
 
 const LEAGUE = "league_1";
+const SEASON = "season_1";
 const FIX = "fixture_abc";
 const USER = "user_1";
 
-const FIXTURE = {
-  id: FIX,
-  seasonId: "season_1",
-  homeTeamId: "team_home",
-  awayTeamId: "team_away",
-  homeTeamName: "Home",
-  awayTeamName: "Away",
-  scheduledAt: null,
-  week: 1,
-  venue: null,
-  status: "scheduled" as const,
-  stage: "regular",
-  createdAt: "2026-01-01T00:00:00.000Z",
-  createdBy: USER,
-};
+function fixture(
+  overrides: Partial<{
+    id: string;
+    week: number | null;
+    stage: "regular" | "playoff";
+    status: "scheduled" | "final";
+  }> = {},
+) {
+  return {
+    id: overrides.id ?? FIX,
+    seasonId: SEASON,
+    homeTeamId: "team_home",
+    awayTeamId: "team_away",
+    homeTeamName: "Home",
+    awayTeamName: "Away",
+    scheduledAt: null,
+    week: overrides.week ?? 1,
+    venue: null,
+    status: overrides.status ?? ("scheduled" as const),
+    stage: overrides.stage ?? ("regular" as const),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    createdBy: USER,
+  };
+}
 
 function authorize() {
   mockSchedulesStandingsV1.mockResolvedValue(true);
@@ -93,7 +110,12 @@ function authorize() {
   mockGetLeagueOrgId.mockResolvedValue("org_1");
   mockResolveOrgRole.mockResolvedValue("org:admin");
   mockCanManageRoster.mockReturnValue(true);
-  mockGetFixture.mockResolvedValue(FIXTURE);
+  mockGetFixture.mockResolvedValue(fixture());
+  mockSimulateAndPersistFixture.mockResolvedValue({
+    homeScore: 21,
+    awayScore: 14,
+    usedScoreFallback: false,
+  });
 }
 
 describe("simulateGameAction (PBP Slice B)", () => {
@@ -113,11 +135,134 @@ describe("simulateGameAction (PBP Slice B)", () => {
 
     expect(res).toEqual({ ok: true, homeScore: 28, awayScore: 21 });
     expect(mockSimulateAndPersistFixture).toHaveBeenCalledWith({
-      fixture: FIXTURE,
+      fixture: fixture(),
       orgContext: { visibleLeagueIds: [LEAGUE] },
       actorUserId: USER,
       decisive: false,
       profileCache: expect.any(Map),
+    });
+  });
+});
+
+describe("simulateWeekAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("sims only unplayed fixtures in the requested week", async () => {
+    const week1A = fixture({ id: "w1a", week: 1 });
+    const week1B = fixture({ id: "w1b", week: 1 });
+    const week2 = fixture({ id: "w2", week: 2 });
+    const week1Final = fixture({ id: "w1f", week: 1, status: "final" });
+    mockListFixturesBySeason.mockResolvedValue([
+      week1A,
+      week1B,
+      week2,
+      week1Final,
+    ]);
+
+    const res = await simulateWeekAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      week: 1,
+    });
+
+    expect(res).toEqual({ ok: true, simulated: 2 });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledTimes(2);
+    const calledIds = mockSimulateAndPersistFixture.mock.calls.map(
+      ([arg]) => arg.fixture.id,
+    );
+    expect(calledIds).toEqual(["w1a", "w1b"]);
+    expect(mockSimulateAndPersistFixture.mock.calls[0][0]).toMatchObject({
+      bulkStats: true,
+      profileCache: expect.any(Map),
+    });
+  });
+});
+
+describe("simulateRegularSeasonAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("skips playoff fixtures", async () => {
+    const regular = fixture({ id: "reg", stage: "regular" });
+    const playoff = fixture({ id: "po", stage: "playoff", week: null });
+    mockListFixturesBySeason.mockResolvedValue([regular, playoff]);
+
+    const res = await simulateRegularSeasonAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: true, simulated: 1 });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledTimes(1);
+    expect(mockSimulateAndPersistFixture.mock.calls[0][0].fixture.id).toBe(
+      "reg",
+    );
+  });
+});
+
+describe("simulatePlayoffsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("returns no_playoffs when the bracket is missing", async () => {
+    mockGetPlayoffBracket.mockResolvedValue(null);
+
+    const res = await simulatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "no_playoffs" });
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
+  });
+
+  it("sims playoff fixtures decisively when a bracket exists", async () => {
+    const playoff = fixture({ id: "po1", stage: "playoff", week: null });
+    mockGetPlayoffBracket
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        matchups: [{ round: 1, homeTeamId: "team_home" }],
+      })
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        matchups: [
+          {
+            round: 2,
+            homeTeamId: "team_home",
+            homeTeamName: "Home",
+            awayTeamName: "Away",
+            winnerTeamId: "team_home",
+          },
+        ],
+      });
+    mockListFixturesBySeason
+      .mockResolvedValueOnce([playoff])
+      .mockResolvedValueOnce([]);
+
+    const res = await simulatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({
+      ok: true,
+      playoffGames: 1,
+      champion: "Home",
+    });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledWith({
+      fixture: playoff,
+      orgContext: { visibleLeagueIds: [LEAGUE] },
+      actorUserId: USER,
+      decisive: true,
+      profileCache: expect.any(Map),
+      bulkStats: true,
     });
   });
 });

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -259,8 +259,18 @@ export async function simulateGameAction(input: {
   }
 }
 
-/** Sim every unplayed regular-season fixture; returns how many were played.
- *  Shared by simulateSeasonAction and the through-to-champion flow. */
+const MAX_PLAYOFF_ROUNDS = 8;
+
+function revalidateSchedulePaths(leagueId: string, includePlayoffs = false) {
+  revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+  revalidatePath(`/dashboard/leagues/${leagueId}/standings`);
+  revalidatePath(`/leagues/${leagueId}/standings`);
+  if (includePlayoffs) {
+    revalidatePath(`/dashboard/leagues/${leagueId}/playoffs`);
+  }
+}
+
+/** Sim every unplayed regular-season fixture; returns how many were played. */
 async function simulateUnplayedRegularSeason(
   seasonId: string,
   userId: string,
@@ -287,7 +297,88 @@ async function simulateUnplayedRegularSeason(
   return simulated;
 }
 
-export async function simulateSeasonAction(input: {
+/** Sim playoff fixtures round by round until the bracket is decided. */
+async function simulateUnplayedPlayoffs(
+  seasonId: string,
+  userId: string,
+  orgContext: OrgContext,
+  profileCache: TeamSimProfileCache,
+): Promise<number> {
+  let playoffGames = 0;
+  for (let round = 0; round < MAX_PLAYOFF_ROUNDS; round++) {
+    const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
+    const pending = fixtures.filter(
+      (f) => f.stage === "playoff" && f.status === "scheduled",
+    );
+    if (pending.length === 0) break;
+    for (const fixture of pending) {
+      await simulateAndPersistFixture({
+        fixture,
+        orgContext,
+        actorUserId: userId,
+        decisive: true,
+        profileCache,
+        bulkStats: true,
+      });
+      playoffGames += 1;
+    }
+  }
+  return playoffGames;
+}
+
+function championFromBracket(
+  bracket: { matchups: PlayoffMatchupDto[] } | null,
+): string | null {
+  if (!bracket) return null;
+  const final = bracket.matchups.reduce<PlayoffMatchupDto | null>(
+    (best, m) => (m.round > (best?.round ?? -1) ? m : best),
+    null,
+  );
+  if (!final?.winnerTeamId) return null;
+  return final.winnerTeamId === final.homeTeamId
+    ? final.homeTeamName
+    : final.awayTeamName;
+}
+
+export async function simulateWeekAction(input: {
+  leagueId: string;
+  seasonId: string;
+  week: number;
+}): Promise<{ ok: true; simulated: number } | { ok: false; error: string }> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const profileCache: TeamSimProfileCache = new Map();
+  try {
+    const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
+    const unplayed = fixtures.filter(
+      (f) => f.status === "scheduled" && f.week === input.week,
+    );
+    let simulated = 0;
+    for (const fixture of unplayed) {
+      await simulateAndPersistFixture({
+        fixture,
+        orgContext,
+        actorUserId: userId,
+        decisive: fixture.stage === "playoff",
+        profileCache,
+        bulkStats: true,
+      });
+      simulated += 1;
+    }
+    revalidateSchedulePaths(input.leagueId);
+    return { ok: true, simulated };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export async function simulateRegularSeasonAction(input: {
   leagueId: string;
   seasonId: string;
 }): Promise<{ ok: true; simulated: number } | { ok: false; error: string }> {
@@ -305,10 +396,55 @@ export async function simulateSeasonAction(input: {
       orgContext,
       new Map(),
     );
-    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
-    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
-    revalidatePath(`/leagues/${input.leagueId}/standings`);
+    revalidateSchedulePaths(input.leagueId);
     return { ok: true, simulated };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/** Legacy label — same scope as {@link simulateRegularSeasonAction}. */
+export async function simulateSeasonAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<{ ok: true; simulated: number } | { ok: false; error: string }> {
+  return simulateRegularSeasonAction(input);
+}
+
+export async function simulatePlayoffsAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<
+  | { ok: true; playoffGames: number; champion: string | null }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const bracket = await getPlayoffBracket(input.seasonId).catch(() => null);
+  if (!bracket || bracket.matchups.length === 0) {
+    return { ok: false, error: "no_playoffs" };
+  }
+
+  const orgContext = await resolveOrgContext(userId);
+  const profileCache: TeamSimProfileCache = new Map();
+  try {
+    const playoffGames = await simulateUnplayedPlayoffs(
+      input.seasonId,
+      userId,
+      orgContext,
+      profileCache,
+    );
+    const updatedBracket = await getPlayoffBracket(input.seasonId).catch(
+      () => null,
+    );
+    const champion = championFromBracket(updatedBracket);
+    revalidateSchedulePaths(input.leagueId, true);
+    return { ok: true, playoffGames, champion };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: message };
@@ -354,9 +490,7 @@ export async function simulateSeasonThroughChampionAction(input: {
     const size = season?.playoffTeams ?? 0;
     if (!season || !size) {
       // No playoffs configured — regular season is the whole story.
-      revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
-      revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
-      revalidatePath(`/leagues/${input.leagueId}/standings`);
+      revalidateSchedulePaths(input.leagueId);
       return { ok: true, regularSimulated, playoffGames: 0, champion: null };
     }
 
@@ -369,48 +503,17 @@ export async function simulateSeasonThroughChampionAction(input: {
       divisionWinnersQualify: season.divisionWinnersQualify,
     });
 
-    // Sim round by round — each result advances the bracket and spawns the next
-    // round's fixtures once both feeders are decided.
-    let playoffGames = 0;
-    for (let round = 0; round < 8; round++) {
-      const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
-      const pending = fixtures.filter(
-        (f) => f.stage === "playoff" && f.status === "scheduled",
-      );
-      if (pending.length === 0) break;
-      for (const fixture of pending) {
-        await simulateAndPersistFixture({
-          fixture,
-          orgContext,
-          actorUserId: userId,
-          decisive: true,
-          profileCache,
-          bulkStats: true,
-        });
-        playoffGames += 1;
-      }
-    }
+    const playoffGames = await simulateUnplayedPlayoffs(
+      input.seasonId,
+      userId,
+      orgContext,
+      profileCache,
+    );
 
-    // Champion = the final (highest-round) matchup's winner.
     const bracket = await getPlayoffBracket(input.seasonId).catch(() => null);
-    let champion: string | null = null;
-    if (bracket) {
-      const final = bracket.matchups.reduce<PlayoffMatchupDto | null>(
-        (best, m) => (m.round > (best?.round ?? -1) ? m : best),
-        null,
-      );
-      if (final?.winnerTeamId) {
-        champion =
-          final.winnerTeamId === final.homeTeamId
-            ? final.homeTeamName
-            : final.awayTeamName;
-      }
-    }
+    const champion = championFromBracket(bracket);
 
-    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
-    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
-    revalidatePath(`/leagues/${input.leagueId}/standings`);
-    revalidatePath(`/dashboard/leagues/${input.leagueId}/playoffs`);
+    revalidateSchedulePaths(input.leagueId, true);
     return { ok: true, regularSimulated, playoffGames, champion };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -34,8 +34,8 @@ import GoLiveControl from "@/components/schedule/GoLiveControl";
 import ClipsControl from "@/components/schedule/ClipsControl";
 import {
   SimulateGameButton,
-  SimulateSeasonButton,
-  SimulateChampionButton,
+  SimulateScopeMenu,
+  SimulateWeekButton,
 } from "@/components/schedule/SimulateControls";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { StatusBadge } from "@/components/status-badge";
@@ -183,16 +183,10 @@ export default async function LeagueSchedulePage({
             />
           ) : null}
           {isAdmin && activeSeason && fixtures.length > 0 ? (
-            <>
-              <SimulateSeasonButton
-                leagueId={leagueId}
-                seasonId={activeSeason.id}
-              />
-              <SimulateChampionButton
-                leagueId={leagueId}
-                seasonId={activeSeason.id}
-              />
-            </>
+            <SimulateScopeMenu
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+            />
           ) : null}
           {canGenerateRosters ? (
             <>
@@ -234,12 +228,25 @@ export default async function LeagueSchedulePage({
         <div className="space-y-6">
           {weekKeys.map((week) => {
             const rows = buckets.get(week)!;
+            const weekHasUnplayed = rows.some(
+              ({ fixture }) => fixture.status === "scheduled",
+            );
             return (
               <Card key={week ?? "unscheduled"}>
-                <CardHeader>
+                <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
                   <CardTitle>
                     {week === null ? "Unscheduled" : `Week ${week}`}
                   </CardTitle>
+                  {isAdmin &&
+                  activeSeason &&
+                  week !== null &&
+                  weekHasUnplayed ? (
+                    <SimulateWeekButton
+                      leagueId={leagueId}
+                      seasonId={activeSeason.id}
+                      week={week}
+                    />
+                  ) : null}
                 </CardHeader>
                 <CardContent className="p-0">
                   <div className="overflow-x-auto">

--- a/apps/web/src/components/schedule/SimulateControls.tsx
+++ b/apps/web/src/components/schedule/SimulateControls.tsx
@@ -3,20 +3,30 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Dices, Wand2, Trophy } from "lucide-react";
+import { CalendarDays, ChevronDown, Dices, Trophy, Wand2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   simulateGameAction,
+  simulatePlayoffsAction,
+  simulateRegularSeasonAction,
   simulateSeasonAction,
   simulateSeasonThroughChampionAction,
+  simulateWeekAction,
 } from "@/app/dashboard/leagues/[id]/schedule/actions";
 
 /*
  * Simulation controls (WSM-000183) — fill plausible, ratings-weighted scores.
- * Per-game "Sim" sits next to Record result; "Simulate season" fills every
- * unplayed regular-season game at once. Both record normal results, so
- * standings update exactly as hand-entered scores do. Manager/admin only
- * (parent gates rendering).
+ * Per-game "Sim" sits next to Record result; scoped batch sims (week, regular
+ * season, playoffs, to champion) record normal results so standings update
+ * exactly as hand-entered scores do. Manager/admin only (parent gates rendering).
  */
 
 export function SimulateGameButton({
@@ -63,6 +73,182 @@ export function SimulateGameButton({
   );
 }
 
+export function SimulateWeekButton({
+  leagueId,
+  seasonId,
+  week,
+}: {
+  leagueId: string;
+  seasonId: string;
+  week: number;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function run() {
+    if (
+      !window.confirm(
+        `Simulate every unplayed game in Week ${week}? Already-recorded games are left untouched.`,
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulateWeekAction({ leagueId, seasonId, week });
+      if (res.ok) {
+        toast.success(
+          res.simulated === 0
+            ? `No unplayed games in Week ${week}.`
+            : `Simulated ${res.simulated} game${res.simulated === 1 ? "" : "s"} in Week ${week}.`,
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={run}
+      title={`Fill every unplayed game in Week ${week}`}
+    >
+      <CalendarDays className="mr-1 h-4 w-4" />
+      {pending ? "Simulating…" : "Sim week"}
+    </Button>
+  );
+}
+
+/** Header dropdown grouping season-wide simulation scopes. */
+export function SimulateScopeMenu({
+  leagueId,
+  seasonId,
+}: {
+  leagueId: string;
+  seasonId: string;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  function runRegularSeason() {
+    if (
+      !window.confirm(
+        "Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched.",
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulateRegularSeasonAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.simulated === 0
+            ? "No unplayed regular-season games to simulate."
+            : `Simulated ${res.simulated} regular-season game${res.simulated === 1 ? "" : "s"}.`,
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  function runPlayoffs() {
+    if (
+      !window.confirm(
+        "Simulate every unplayed playoff game round by round? Already-recorded games are left untouched.",
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulatePlayoffsAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.champion
+            ? `${res.champion} wins — simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
+            : res.playoffGames > 0
+              ? `Simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
+              : "No unplayed playoff games to simulate.",
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  function runToChampion() {
+    if (
+      !window.confirm(
+        "Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept.",
+      )
+    ) {
+      return;
+    }
+    start(async () => {
+      const res = await simulateSeasonThroughChampionAction({ leagueId, seasonId });
+      if (res.ok) {
+        const parts = [
+          res.regularSimulated > 0
+            ? `${res.regularSimulated} regular-season game${res.regularSimulated === 1 ? "" : "s"}`
+            : null,
+          res.playoffGames > 0
+            ? `${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
+            : null,
+        ].filter(Boolean);
+        toast.success(
+          res.champion
+            ? `${res.champion} wins — simulated ${parts.join(" + ")}`
+            : parts.length > 0
+              ? `Simulated ${parts.join(" + ")}`
+              : "Nothing left to simulate",
+        );
+        router.refresh();
+      } else {
+        toast.error(simError(res.error));
+      }
+    });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pending}
+          title="Season simulation scopes"
+        >
+          <Wand2 className="mr-1 h-4 w-4" />
+          {pending ? "Simulating…" : "Simulate"}
+          <ChevronDown className="ml-1 h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Simulation scope</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled={pending} onSelect={runRegularSeason}>
+          Sim regular season
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={pending} onSelect={runPlayoffs}>
+          Sim playoffs
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={pending} onSelect={runToChampion}>
+          <Trophy className="h-4 w-4" />
+          Sim to champion
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Legacy control — same scope as Sim regular season (kept for callers / e2e). */
 export function SimulateSeasonButton({
   leagueId,
   seasonId,
@@ -183,6 +369,8 @@ function simError(error: string): string {
       return "That game is cancelled.";
     case "fixture_not_found":
       return "Game not found.";
+    case "no_playoffs":
+      return "No playoff bracket yet. Generate a bracket on the Playoffs page first.";
     default:
       if (error.includes("not_enough_teams")) {
         return "Not enough teams for the configured playoff bracket. Lower the playoff team count in season settings.";


### PR DESCRIPTION
## Summary

Implements the sim-scopes item from the 2026-07-03 prod review: sim an entire **week**, the **regular season**, the **playoffs**, or straight **to champion** — as distinct, labeled scopes. All scopes route through the play-by-play `simulate-fixture` flow (#463), so every simmed game produces a stored play log (Gamecast-ready, #464) and real player stat lines.

- **`simulateWeekAction`** — per-week "Sim week" button in each schedule week header; sims only that week's unplayed fixtures; hidden without sim permissions or when the week is complete.
- **`simulateRegularSeasonAction`** — regular-season-only scope exposed as a proper control (skips playoff-stage fixtures).
- **`simulatePlayoffsAction`** — playoff fixtures only, round by round through existing bracket advancement (`decisive: true`); returns `no_playoffs` when no bracket exists.
- **`SimulateControls`** consolidated into a four-scope group: Sim week (contextual) / Sim regular season / Sim playoffs / Sim to champion.
- Per-team profile caching shared across batch sims; empty-roster fallback inherited from the shared flow.
- No schema changes, no new public mutations, `recordGameResult`/bracket logic untouched — **no Convex deploy needed**.

## Verification (rebased on #464)

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 113 files / 862 tests (scope isolation: week-only, playoffs-only, regular-season-skips-playoffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)