### PR TITLE
feat(web): advance-to-playoffs step + enhanced bracket view

### DIFF
--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -5999,7 +5999,53 @@ const playoffMatchupDtoValidator = v.object({
   bracketType: v.union(v.string(), v.null()),
   // First-round bye marker (team auto-advanced, no game).
   isBye: v.boolean(),
+  hasPlayLog: v.boolean(),
 });
+
+const playoffChampionDtoValidator = v.object({
+  teamId: v.string(),
+  teamName: v.union(v.string(), v.null()),
+});
+
+function championFromMatchups(
+  matchups: Array<{
+    round: number;
+    bracketType?: string | null;
+    winnerTeamId?: string | null;
+    homeTeamId?: string | null;
+    awayTeamId?: string | null;
+    homeTeamName?: string | null;
+    awayTeamName?: string | null;
+  }>,
+  format: string,
+): { teamId: string; teamName: string | null } | null {
+  if (format === "double") {
+    const grandFinal = matchups.find((m) => m.bracketType === "grandFinal");
+    if (!grandFinal?.winnerTeamId) return null;
+    return {
+      teamId: grandFinal.winnerTeamId,
+      teamName:
+        grandFinal.winnerTeamId === grandFinal.homeTeamId
+          ? (grandFinal.homeTeamName ?? null)
+          : (grandFinal.awayTeamName ?? null),
+    };
+  }
+  const final = matchups.reduce<(typeof matchups)[number] | null>(
+    (best, m) =>
+      (m.bracketType ?? "winners") === "winners" && m.round > (best?.round ?? -1)
+        ? m
+        : best,
+    null,
+  );
+  if (!final?.winnerTeamId) return null;
+  return {
+    teamId: final.winnerTeamId,
+    teamName:
+      final.winnerTeamId === final.homeTeamId
+        ? (final.homeTeamName ?? null)
+        : (final.awayTeamName ?? null),
+  };
+}
 
 /** Bracket tree DTO for the UI (WSM-000165). Null when no bracket exists. */
 export const getPlayoffBracket = queryGeneric({
@@ -6011,6 +6057,7 @@ export const getPlayoffBracket = queryGeneric({
       rounds: v.number(),
       format: v.string(), // "single" | "double"
       matchups: v.array(playoffMatchupDtoValidator),
+      champion: v.union(playoffChampionDtoValidator, v.null()),
     }),
     v.null(),
   ),
@@ -6035,6 +6082,7 @@ export const getPlayoffBracket = queryGeneric({
           let status: string | null = null;
           let homeScore: number | null = null;
           let awayScore: number | null = null;
+          let hasPlayLog = false;
           if (m.fixtureId) {
             const fx = await ctx.db.get(m.fixtureId);
             status = fx?.status ?? null;
@@ -6047,6 +6095,13 @@ export const getPlayoffBracket = queryGeneric({
                 .first();
               homeScore = res?.homeScore ?? null;
               awayScore = res?.awayScore ?? null;
+              const log = await ctx.db
+                .query("gamePlayLogs")
+                .withIndex("by_fixtureId", (q) =>
+                  q.eq("fixtureId", m.fixtureId!),
+                )
+                .first();
+              hasPlayLog = log != null;
             }
           }
           // A first-round bye: a single present team with no opponent/game.
@@ -6069,16 +6124,19 @@ export const getPlayoffBracket = queryGeneric({
             awayScore,
             bracketType: m.bracketType ?? null,
             isBye,
+            hasPlayLog,
           };
         }),
     );
 
+    const format = bracket.format ?? "single";
     return {
       bracketId: bracket._id,
       size: bracket.size,
       rounds: bracket.rounds,
-      format: bracket.format ?? "single",
+      format,
       matchups: dtos,
+      champion: championFromMatchups(dtos, format),
     };
   },
 });

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPlayoffsV1,
+  mockAuth,
+  mockGetLeague,
+  mockGetLeagueOrgId,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockCanManageRoster,
+  mockGeneratePlayoffBracket,
+  mockGetSeasons,
+  mockGetPlayoffBracket,
+  mockListFixturesBySeason,
+} = vi.hoisted(() => ({
+  mockPlayoffsV1: vi.fn(),
+  mockAuth: vi.fn(),
+  mockGetLeague: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockCanManageRoster: vi.fn(),
+  mockGeneratePlayoffBracket: vi.fn(),
+  mockGetSeasons: vi.fn(),
+  mockGetPlayoffBracket: vi.fn(),
+  mockListFixturesBySeason: vi.fn(),
+}));
+
+vi.mock("@/lib/flags", () => ({ playoffsV1: mockPlayoffsV1 }));
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/data-api", () => ({
+  generatePlayoffBracket: mockGeneratePlayoffBracket,
+  getLeague: mockGetLeague,
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getSeasons: mockGetSeasons,
+  getPlayoffBracket: mockGetPlayoffBracket,
+  listFixturesBySeason: mockListFixturesBySeason,
+}));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/permissions", () => ({ canManageRoster: mockCanManageRoster }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { advanceToPlayoffsAction } from "../actions";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+
+const ACTIVE_SEASON = {
+  id: SEASON,
+  name: "2026",
+  leagueId: LEAGUE,
+  status: "active",
+  playoffTeams: 8,
+  playoffFormat: "single",
+  divisionWinnersQualify: false,
+};
+
+function authorize() {
+  mockPlayoffsV1.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({ userId: "user_1" });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
+  mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue("org:admin");
+  mockCanManageRoster.mockReturnValue(true);
+  mockGetSeasons.mockResolvedValue([ACTIVE_SEASON]);
+  mockGetPlayoffBracket.mockResolvedValue(null);
+}
+
+describe("advanceToPlayoffsAction", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects when the regular season is incomplete", async () => {
+    authorize();
+    mockListFixturesBySeason.mockResolvedValue([
+      { stage: "regular", status: "final" },
+      { stage: "regular", status: "scheduled" },
+    ]);
+
+    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+
+    expect(res).toEqual({ ok: false, error: "regular_season_incomplete" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects double-advance when a bracket already exists", async () => {
+    authorize();
+    mockListFixturesBySeason.mockResolvedValue([
+      { stage: "regular", status: "final" },
+    ]);
+    mockGetPlayoffBracket.mockResolvedValue({
+      bracketId: "b1",
+      size: 8,
+      rounds: 3,
+      format: "single",
+      matchups: [],
+      champion: null,
+    });
+
+    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+
+    expect(res).toEqual({ ok: false, error: "already_advanced" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no season exists", async () => {
+    authorize();
+    mockGetSeasons.mockResolvedValue([]);
+
+    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+
+    expect(res).toEqual({ ok: false, error: "no_season" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("generates a bracket when preconditions pass", async () => {
+    authorize();
+    mockListFixturesBySeason.mockResolvedValue([
+      { stage: "regular", status: "final" },
+      { stage: "regular", status: "final" },
+      { stage: "playoff", status: "scheduled" },
+    ]);
+    mockGeneratePlayoffBracket.mockResolvedValue({
+      bracketId: "b1",
+      size: 8,
+      rounds: 3,
+      matchups: 7,
+    });
+
+    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+
+    expect(res).toEqual({
+      ok: true,
+      bracketId: "b1",
+      size: 8,
+      rounds: 3,
+      matchups: 7,
+    });
+    expect(mockGeneratePlayoffBracket).toHaveBeenCalledWith({
+      seasonId: SEASON,
+      size: 8,
+      actorUserId: "user_1",
+      divisionWinnersQualify: false,
+      format: "single",
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -3,7 +3,14 @@
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 import { playoffsV1 } from "@/lib/flags";
-import { generatePlayoffBracket, getLeague, getLeagueOrgId } from "@/lib/data-api";
+import {
+  generatePlayoffBracket,
+  getLeague,
+  getLeagueOrgId,
+  getPlayoffBracket,
+  getSeasons,
+  listFixturesBySeason,
+} from "@/lib/data-api";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
 
@@ -89,6 +96,67 @@ export async function generatePlayoffsAction(input: {
     if (message.includes("bracket_has_results")) {
       return { ok: false, needsConfirm: true };
     }
+    return { ok: false, error: friendlyError(message) };
+  }
+}
+
+function revalidatePlayoffPaths(leagueId: string) {
+  revalidatePath(`/dashboard/leagues/${leagueId}/playoffs`);
+  revalidatePath(`/dashboard/leagues/${leagueId}/schedule`);
+  revalidatePath(`/dashboard/leagues/${leagueId}/standings`);
+}
+
+/*
+ * Advance an active season to playoffs once every regular-season game is final
+ * (WSM-bracket-view). Seeds and first-round fixtures come from the season's
+ * configured playoff settings via the existing generatePlayoffBracket path.
+ */
+export async function advanceToPlayoffsAction(input: {
+  leagueId: string;
+}): Promise<
+  | { ok: true; bracketId: string; size: number; rounds: number; matchups: number }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizePlayoffAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const allSeasons = await getSeasons([input.leagueId]);
+  const activeSeason =
+    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  if (!activeSeason) return { ok: false, error: "no_season" };
+
+  const existing = await getPlayoffBracket(activeSeason.id).catch(() => null);
+  if (existing) return { ok: false, error: "already_advanced" };
+
+  const fixtures = await listFixturesBySeason(activeSeason.id).catch(() => []);
+  const regular = fixtures.filter((f) => f.stage !== "playoff");
+  const regularComplete =
+    regular.length === 0 ||
+    regular.every((f) => f.status === "final" || f.status === "cancelled");
+  if (!regularComplete) {
+    return { ok: false, error: "regular_season_incomplete" };
+  }
+
+  const size = activeSeason.playoffTeams ?? 0;
+  if (!size || size < 2) {
+    return { ok: false, error: "no_playoffs_configured" };
+  }
+
+  try {
+    const res = await generatePlayoffBracket({
+      seasonId: activeSeason.id,
+      size,
+      actorUserId: userId,
+      divisionWinnersQualify: activeSeason.divisionWinnersQualify,
+      format: activeSeason.playoffFormat ?? undefined,
+    });
+    revalidatePlayoffPaths(input.leagueId);
+    return { ok: true, ...res };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     return { ok: false, error: friendlyError(message) };
   }
 }

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -7,13 +7,15 @@ import {
   getLeagueOrgId,
   getSeasons,
   getPlayoffBracket,
+  listFixturesBySeason,
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
+import { playoffPagePhase, regularSeasonProgress } from "@/lib/playoffs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import PlayoffBracket from "@/components/playoffs/PlayoffBracket";
-import GeneratePlayoffsButton from "@/components/playoffs/GeneratePlayoffsButton";
+import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
 
 export default async function LeaguePlayoffsPage({
   params,
@@ -31,7 +33,6 @@ export default async function LeaguePlayoffsPage({
   const league = await getLeague(leagueId, orgContext).catch(() => null);
   if (!league) notFound();
 
-  // Manager gate (admins + coaches), consistent with the schedule page.
   const orgId = await getLeagueOrgId(leagueId);
   const role = orgId ? await resolveOrgRole(orgId, userId) : null;
   const isAdmin = canManageRoster(role);
@@ -40,8 +41,21 @@ export default async function LeaguePlayoffsPage({
   const activeSeason =
     allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
 
+  const fixtures = activeSeason
+    ? await listFixturesBySeason(activeSeason.id)
+    : [];
+  const progress = regularSeasonProgress(fixtures);
+
   const bracket = activeSeason
     ? await getPlayoffBracket(activeSeason.id)
+    : null;
+
+  const phase = activeSeason
+    ? playoffPagePhase({
+        playoffTeams: activeSeason.playoffTeams,
+        bracketExists: bracket !== null,
+        regularComplete: progress.complete,
+      })
     : null;
 
   return (
@@ -60,23 +74,19 @@ export default async function LeaguePlayoffsPage({
             Playoffs {activeSeason ? `· ${activeSeason.name}` : ""}
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-3">
           <Link
             href={`/dashboard/leagues/${leagueId}/schedule`}
             className="text-sm text-primary hover:underline"
           >
             &larr; Schedule
           </Link>
-          {isAdmin && activeSeason ? (
-            <GeneratePlayoffsButton
-              leagueId={leagueId}
-              seasonId={activeSeason.id}
-              seasonName={activeSeason.name}
-              hasBracket={bracket !== null}
-              defaultSize={activeSeason.playoffTeams}
-              defaultFormat={activeSeason.playoffFormat}
-            />
-          ) : null}
+          <Link
+            href={`/dashboard/leagues/${leagueId}/standings`}
+            className="text-sm text-primary hover:underline"
+          >
+            Standings &rarr;
+          </Link>
         </div>
       </header>
 
@@ -92,17 +102,43 @@ export default async function LeaguePlayoffsPage({
             </Button>
           </CardContent>
         </Card>
-      ) : !bracket ? (
+      ) : phase === "no_playoffs_config" ? (
         <Card>
           <CardContent className="p-6 text-center text-muted-foreground">
-            No bracket yet for {activeSeason.name}.
-            {isAdmin
-              ? " Pick a size and generate one — seeds come from the current standings."
-              : ""}
+            {activeSeason.name} is not configured for playoffs. Set a playoff team
+            count on the season to enable the bracket.
+          </CardContent>
+        </Card>
+      ) : phase === "bracket_live" && bracket ? (
+        <PlayoffBracket bracket={bracket} />
+      ) : phase === "ready" ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Regular season complete ({progress.final} of {progress.total} games
+              final). Ready to seed the bracket from current standings.
+            </p>
+            {isAdmin ? (
+              <AdvanceToPlayoffsButton leagueId={leagueId} />
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Waiting for a league manager to advance to playoffs.
+              </p>
+            )}
           </CardContent>
         </Card>
       ) : (
-        <PlayoffBracket bracket={bracket} />
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Regular season in progress — {progress.final} of {progress.total}{" "}
+              games final.
+            </p>
+            {isAdmin ? (
+              <AdvanceToPlayoffsButton leagueId={leagueId} disabled />
+            ) : null}
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { schedulesStandingsV1 } from "@/lib/flags";
+import { schedulesStandingsV1, playoffsV1 } from "@/lib/flags";
 import {
   computeStandings,
   computeDivisionStandings,
@@ -21,6 +21,8 @@ export default async function LeagueStandingsPage({
 }) {
   const enabled = await schedulesStandingsV1();
   if (!enabled) notFound();
+
+  const playoffsEnabled = await playoffsV1();
 
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
@@ -93,6 +95,14 @@ export default async function LeagueStandingsPage({
           >
             Schedule &rarr;
           </Link>
+          {playoffsEnabled ? (
+            <Link
+              href={`/dashboard/leagues/${leagueId}/playoffs`}
+              className="text-sm text-primary hover:underline"
+            >
+              Playoffs &rarr;
+            </Link>
+          ) : null}
         </div>
       </header>
 

--- a/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { advanceToPlayoffsAction } from "@/app/dashboard/leagues/[id]/playoffs/actions";
+
+export interface AdvanceToPlayoffsButtonProps {
+  leagueId: string;
+  disabled?: boolean;
+}
+
+export default function AdvanceToPlayoffsButton({
+  leagueId,
+  disabled = false,
+}: AdvanceToPlayoffsButtonProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  function onClick() {
+    if (
+      !window.confirm(
+        "Advance to playoffs? A bracket will be seeded from the current standings and first-round games will be scheduled.",
+      )
+    ) {
+      return;
+    }
+
+    startTransition(async () => {
+      const res = await advanceToPlayoffsAction({ leagueId });
+      if (res.ok) {
+        toast.success(
+          `Playoffs started — ${res.matchups} matchups across ${res.rounds} rounds.`,
+        );
+        router.refresh();
+        return;
+      }
+
+      const message =
+        res.error === "regular_season_incomplete"
+          ? "Finish every regular-season game before advancing."
+          : res.error === "already_advanced"
+            ? "Playoffs have already started for this season."
+            : res.error === "no_season"
+              ? "No active season found."
+              : res.error === "no_playoffs_configured"
+                ? "This season is not configured for playoffs."
+                : res.error;
+      toast.error(message);
+    });
+  }
+
+  return (
+    <Button
+      size="sm"
+      disabled={disabled || pending}
+      onClick={onClick}
+      className="gap-1.5"
+    >
+      <Trophy className="h-4 w-4" />
+      {pending ? "Advancing…" : "Advance to playoffs"}
+    </Button>
+  );
+}

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -1,14 +1,44 @@
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { PlayoffBracketDto, PlayoffMatchupDto } from "@/lib/data-api";
 import { bracketSections, winnerSide } from "@/lib/playoffs";
 
+function TeamName({
+  teamId,
+  name,
+  won,
+  dim,
+}: {
+  teamId: string | null;
+  name: string | null;
+  won: boolean;
+  dim: boolean;
+}) {
+  const label = name ?? "TBD";
+  const className = cn(
+    "truncate hover:underline",
+    won && "font-semibold text-foreground",
+    dim && !won && "text-muted-foreground",
+  );
+  if (teamId) {
+    return (
+      <Link href={`/dashboard/teams/${teamId}`} className={className}>
+        {label}
+      </Link>
+    );
+  }
+  return <span className={className}>{label}</span>;
+}
+
 function Side({
+  teamId,
   seed,
   name,
   score,
   won,
   dim,
 }: {
+  teamId: string | null;
   seed: number | null;
   name: string | null;
   score: number | null;
@@ -19,8 +49,7 @@ function Side({
     <div
       className={cn(
         "flex items-center justify-between gap-2 px-2 py-1 text-sm",
-        won && "font-semibold text-foreground",
-        dim && !won && "text-muted-foreground",
+        won && "bg-muted/50",
       )}
     >
       <span className="flex min-w-0 items-center gap-1.5">
@@ -29,7 +58,7 @@ function Side({
             {seed}
           </span>
         ) : null}
-        <span className="truncate">{name ?? "TBD"}</span>
+        <TeamName teamId={teamId} name={name} won={won} dim={dim} />
       </span>
       <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
         {score ?? ""}
@@ -41,27 +70,30 @@ function Side({
 function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
   const side = winnerSide(m);
   const decided = side !== null;
-  // A first-round bye: a single present team auto-advances with no opponent.
-  if (m.isBye) {
-    return (
-      <div className="overflow-hidden rounded-md border border-dashed border-border bg-card">
-        <Side
-          seed={m.homeSeed}
-          name={m.homeTeamName}
-          score={null}
-          won={true}
-          dim={false}
-        />
-        <div className="border-t border-border" />
-        <div className="px-2 py-1 text-xs italic text-muted-foreground">
-          Bye — advances
-        </div>
+  const gamecastHref =
+    m.fixtureId && m.status === "final" && m.hasPlayLog
+      ? `/dashboard/games/${m.fixtureId}/gamecast`
+      : null;
+
+  const card = m.isBye ? (
+    <div className="overflow-hidden rounded-md border border-dashed border-border bg-card">
+      <Side
+        teamId={m.homeTeamId}
+        seed={m.homeSeed}
+        name={m.homeTeamName}
+        score={null}
+        won={true}
+        dim={false}
+      />
+      <div className="border-t border-border" />
+      <div className="px-2 py-1 text-xs italic text-muted-foreground">
+        Bye — advances
       </div>
-    );
-  }
-  return (
+    </div>
+  ) : (
     <div className="overflow-hidden rounded-md border border-border bg-card">
       <Side
+        teamId={m.homeTeamId}
         seed={m.homeSeed}
         name={m.homeTeamName}
         score={m.homeScore}
@@ -70,6 +102,7 @@ function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
       />
       <div className="border-t border-border" />
       <Side
+        teamId={m.awayTeamId}
         seed={m.awaySeed}
         name={m.awayTeamName}
         score={m.awayScore}
@@ -78,6 +111,20 @@ function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
       />
     </div>
   );
+
+  if (gamecastHref) {
+    return (
+      <Link
+        href={gamecastHref}
+        className="block rounded-md transition-colors hover:ring-2 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        title="View gamecast"
+      >
+        {card}
+      </Link>
+    );
+  }
+
+  return card;
 }
 
 /**
@@ -97,36 +144,59 @@ export default function PlayoffBracket({
     bracket.rounds,
     bracket.format,
   );
+
   return (
-    <div className="flex flex-col gap-8">
-      {sections.map((section) => (
-        <section key={section.type}>
-          {section.title ? (
-            <h3 className="mb-3 text-sm font-semibold text-foreground">
-              {section.title}
-            </h3>
-          ) : null}
-          <div className="overflow-x-auto">
-            <div className="flex min-w-max gap-6 pb-2">
-              {section.rounds.map((r) => (
-                <div
-                  key={`${section.type}-${r.round}`}
-                  className="flex w-56 shrink-0 flex-col"
-                >
-                  <h4 className="mb-3 font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
-                    {r.label}
-                  </h4>
-                  <div className="flex flex-1 flex-col justify-around gap-4">
-                    {r.matchups.map((m) => (
-                      <MatchupCard key={m.id} m={m} />
-                    ))}
+    <div className="flex flex-col gap-6">
+      {bracket.champion ? (
+        <div className="rounded-lg border border-primary/30 bg-primary/10 px-4 py-3">
+          <p className="font-mono text-caption-12 uppercase tracking-wide text-primary">
+            Champion
+          </p>
+          <p className="mt-1 text-lg font-semibold text-foreground">
+            {bracket.champion.teamId ? (
+              <Link
+                href={`/dashboard/teams/${bracket.champion.teamId}`}
+                className="hover:underline"
+              >
+                {bracket.champion.teamName ?? "Champion"}
+              </Link>
+            ) : (
+              (bracket.champion.teamName ?? "Champion")
+            )}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-8">
+        {sections.map((section) => (
+          <section key={section.type}>
+            {section.title ? (
+              <h3 className="mb-3 text-sm font-semibold text-foreground">
+                {section.title}
+              </h3>
+            ) : null}
+            <div className="overflow-x-auto">
+              <div className="flex min-w-max gap-6 pb-2">
+                {section.rounds.map((r) => (
+                  <div
+                    key={`${section.type}-${r.round}`}
+                    className="flex w-56 shrink-0 flex-col"
+                  >
+                    <h4 className="mb-3 font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
+                      {r.label}
+                    </h4>
+                    <div className="flex flex-1 flex-col justify-around gap-4">
+                      {r.matchups.map((m) => (
+                        <MatchupCard key={m.id} m={m} />
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </div>
-        </section>
-      ))}
+          </section>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/playoffs.test.ts
+++ b/apps/web/src/lib/__tests__/playoffs.test.ts
@@ -4,6 +4,9 @@ import {
   groupMatchupsByRound,
   winnerSide,
   bracketSections,
+  deriveChampion,
+  regularSeasonProgress,
+  playoffPagePhase,
 } from "../playoffs";
 import type { PlayoffMatchupDto } from "@/lib/data-api";
 
@@ -25,6 +28,7 @@ function m(partial: Partial<PlayoffMatchupDto>): PlayoffMatchupDto {
     awayScore: null,
     bracketType: null,
     isBye: false,
+    hasPlayLog: false,
     ...partial,
   };
 }
@@ -115,5 +119,105 @@ describe("bracketSections (WSM-flex-brackets)", () => {
     const matchups = [m({ id: "w0", round: 1, slot: 0, bracketType: "winners" })];
     const sections = bracketSections(matchups, 1, "double");
     expect(sections.map((s) => s.type)).toEqual(["winners"]);
+  });
+});
+
+describe("deriveChampion", () => {
+  it("returns the winner of the highest winners-bracket round in single elim", () => {
+    const matchups = [
+      m({ id: "s0", round: 1, slot: 0, homeTeamId: "t1", homeTeamName: "A" }),
+      m({
+        id: "f",
+        round: 2,
+        slot: 0,
+        homeTeamId: "t1",
+        homeTeamName: "A",
+        awayTeamId: "t2",
+        awayTeamName: "B",
+        winnerTeamId: "t2",
+      }),
+    ];
+    expect(deriveChampion(matchups, "single")).toEqual({
+      teamId: "t2",
+      teamName: "B",
+    });
+  });
+
+  it("returns null until the final has a winner", () => {
+    const matchups = [
+      m({ id: "f", round: 2, slot: 0, homeTeamId: "t1", awayTeamId: "t2" }),
+    ];
+    expect(deriveChampion(matchups, "single")).toBeNull();
+  });
+
+  it("uses the grand final in double elim", () => {
+    const matchups = [
+      m({ id: "wf", round: 2, bracketType: "winners", winnerTeamId: "t1" }),
+      m({
+        id: "gf",
+        round: 1,
+        bracketType: "grandFinal",
+        homeTeamId: "t1",
+        homeTeamName: "A",
+        awayTeamId: "t2",
+        awayTeamName: "B",
+        winnerTeamId: "t1",
+      }),
+    ];
+    expect(deriveChampion(matchups, "double")).toEqual({
+      teamId: "t1",
+      teamName: "A",
+    });
+  });
+});
+
+describe("regularSeasonProgress", () => {
+  it("counts only non-playoff fixtures", () => {
+    const progress = regularSeasonProgress([
+      { stage: "regular", status: "final" },
+      { stage: "regular", status: "scheduled" },
+      { stage: "playoff", status: "final" },
+    ]);
+    expect(progress).toEqual({ total: 2, final: 1, complete: false });
+  });
+
+  it("marks complete when every regular game is final", () => {
+    const progress = regularSeasonProgress([
+      { stage: "regular", status: "final" },
+      { stage: "regular", status: "cancelled" },
+    ]);
+    expect(progress.complete).toBe(true);
+  });
+});
+
+describe("playoffPagePhase", () => {
+  it("returns bracket_live when a bracket exists", () => {
+    expect(
+      playoffPagePhase({
+        playoffTeams: 8,
+        bracketExists: true,
+        regularComplete: false,
+      }),
+    ).toBe("bracket_live");
+  });
+
+  it("returns ready when the regular season is complete and no bracket", () => {
+    expect(
+      playoffPagePhase({
+        playoffTeams: 8,
+        bracketExists: false,
+        regularComplete: true,
+      }),
+    ).toBe("ready");
+  });
+
+  it("returns in_progress when games remain", () => {
+    expect(
+      playoffPagePhase({
+        playoffTeams: 8,
+        bracketExists: false,
+        regularComplete: false,
+      }),
+    ).toBe("in_progress");
   });
 });

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -87,6 +87,13 @@ export interface PlayoffMatchupDto {
   bracketType: string | null;
   /** First-round bye: the present team auto-advanced with no game. */
   isBye: boolean;
+  /** True when a simulated play-by-play log exists for the linked fixture. */
+  hasPlayLog: boolean;
+}
+
+export interface PlayoffChampionDto {
+  teamId: string;
+  teamName: string | null;
 }
 
 export interface PlayoffBracketDto {
@@ -96,6 +103,7 @@ export interface PlayoffBracketDto {
   /** "single" | "double". */
   format: string;
   matchups: PlayoffMatchupDto[];
+  champion: PlayoffChampionDto | null;
 }
 
 /** Season stat-leaders (WSM-000186). */

--- a/apps/web/src/lib/playoffs.ts
+++ b/apps/web/src/lib/playoffs.ts
@@ -131,3 +131,80 @@ export function bracketSections(
 
   return sections;
 }
+
+export interface ChampionInfo {
+  teamId: string;
+  teamName: string | null;
+}
+
+/** Derive the season champion from bracket matchups (null until the final is decided). */
+export function deriveChampion(
+  matchups: PlayoffMatchupDto[],
+  format: string,
+): ChampionInfo | null {
+  if (format === "double") {
+    const grandFinal = matchups.find((m) => m.bracketType === "grandFinal");
+    if (!grandFinal?.winnerTeamId) return null;
+    return {
+      teamId: grandFinal.winnerTeamId,
+      teamName:
+        grandFinal.winnerTeamId === grandFinal.homeTeamId
+          ? grandFinal.homeTeamName
+          : grandFinal.awayTeamName,
+    };
+  }
+  const final = matchups.reduce<PlayoffMatchupDto | null>(
+    (best, m) =>
+      (m.bracketType ?? "winners") === "winners" && m.round > (best?.round ?? -1)
+        ? m
+        : best,
+    null,
+  );
+  if (!final?.winnerTeamId) return null;
+  return {
+    teamId: final.winnerTeamId,
+    teamName:
+      final.winnerTeamId === final.homeTeamId
+        ? final.homeTeamName
+        : final.awayTeamName,
+  };
+}
+
+export interface RegularSeasonProgress {
+  total: number;
+  final: number;
+  complete: boolean;
+}
+
+/** Count regular-season fixture completion (playoff games excluded). */
+export function regularSeasonProgress(
+  fixtures: Array<{ stage: string; status: string }>,
+): RegularSeasonProgress {
+  const regular = fixtures.filter((f) => f.stage !== "playoff");
+  const total = regular.length;
+  const finalCount = regular.filter(
+    (f) => f.status === "final" || f.status === "cancelled",
+  ).length;
+  return {
+    total,
+    final: finalCount,
+    complete: total === 0 || finalCount === total,
+  };
+}
+
+export type PlayoffPagePhase =
+  | "no_playoffs_config"
+  | "in_progress"
+  | "ready"
+  | "bracket_live";
+
+export function playoffPagePhase(input: {
+  playoffTeams: number | null | undefined;
+  bracketExists: boolean;
+  regularComplete: boolean;
+}): PlayoffPagePhase {
+  if (!input.playoffTeams || input.playoffTeams < 2) return "no_playoffs_config";
+  if (input.bracketExists) return "bracket_live";
+  if (input.regularComplete) return "ready";
+  return "in_progress";
+}


### PR DESCRIPTION
## Summary

Closes the last non-dynasty item from the 2026-07-03 prod review: an explicit **Advance to playoffs** step and a full bracket view. This completes the single-season loop end-to-end: schedule → sim (any scope, #465) → Gamecast (#464) → advance → bracket → champion.

- **`advanceToPlayoffsAction`** — role-gated; rejects with `no_season` / `already_advanced` / `regular_season_incomplete` (every non-playoff fixture must be final); on success wraps the **existing** bracket-generation path. Zero new Convex mutations.
- **Playoffs page** — three states: regular season in progress (X of Y games final, disabled CTA) → ready (Advance CTA) → live bracket. Builds on the existing playoffs page/components rather than duplicating them.
- **Bracket view** — rounds as columns with seeds, team-page links, scores, winner carry-through, champion highlight; simulated playoff finals deep-link to their Gamecast; wide brackets scroll horizontally in their own container.
- **Entry point** from standings; token-only styling (no hardcoded colors).

## Verification

- `pnpm --filter @sports-management/web type-check` ✅
- `pnpm --filter @sports-management/web lint` ✅
- `pnpm --filter @sports-management/web test:unit` ✅ 114 files / 874 tests (advance gating ×4, bracket shaping)
- No schema changes, no new Convex functions — **no deploy needed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)