### PR TITLE
feat(web): dynasty panel on league view + FR/SO/JR/SR class labels (D2)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -7,7 +7,17 @@ import {
   getLeagueClaimable,
   getSeasons,
   listFixturesBySeason,
+  getPlayoffBracket,
+  getPlayers,
+  getTeamsByLeague,
 } from "@/lib/data-api";
+import { summarizeClassDistribution } from "@/lib/class-year";
+import {
+  dynastySeasonState,
+  evaluateStartNextSeason,
+  seasonDecidedContext,
+} from "@/lib/dynasty-panel";
+import { DynastyPanel } from "@/components/dynasty/DynastyPanel";
 import { isSeasonStarted } from "@/lib/season-started";
 import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -55,14 +65,63 @@ export default async function LeagueDetailPage({
   const canGenerateRosters = isAdmin && (await syntheticRostersV1());
 
   const seasons = await getSeasons([id]).catch(() => []);
-  const activeSeason =
-    seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  const activeSeason = seasons.find((s) => s.status === "active") ?? null;
+  const upcomingSeason = seasons.find((s) => s.status === "upcoming") ?? null;
+  const [fixtures, bracket, leaguePlayers, teams] = await Promise.all([
+    activeSeason
+      ? listFixturesBySeason(activeSeason.id).catch(() => [])
+      : Promise.resolve([]),
+    activeSeason
+      ? getPlayoffBracket(activeSeason.id).catch(() => null)
+      : Promise.resolve(null),
+    isAdmin && league.orgId
+      ? getPlayers([id]).catch(() => [])
+      : Promise.resolve([]),
+    isAdmin && league.orgId
+      ? getTeamsByLeague(id, orgContext).catch(() => [])
+      : Promise.resolve([]),
+  ]);
+  const decidedCtx = activeSeason
+    ? seasonDecidedContext(fixtures, bracket)
+    : {
+        seasonDecided: false,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      };
   const seasonStarted = activeSeason
-    ? isSeasonStarted(
-        activeSeason,
-        await listFixturesBySeason(activeSeason.id).catch(() => []),
-      )
+    ? isSeasonStarted(activeSeason, fixtures)
     : false;
+  const teamNameById = new Map(teams.map((t) => [t.id, t.name]));
+  const graduatedPlayers =
+    isAdmin && league.orgId
+      ? leaguePlayers
+          .filter((p) => p.status === "graduated")
+          .map((p) => ({
+            id: p.id,
+            name: p.name,
+            position: p.position,
+            teamName: teamNameById.get(p.teamId) ?? null,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+      : [];
+  const dynastySeasonStateLine = dynastySeasonState({
+    activeSeason: activeSeason
+      ? { name: activeSeason.name }
+      : null,
+    upcomingSeason: upcomingSeason
+      ? { name: upcomingSeason.name }
+      : null,
+    seasonDecided: decidedCtx.seasonDecided,
+  });
+  const startNextSeasonGate = evaluateStartNextSeason({
+    activeSeason: activeSeason
+      ? { id: activeSeason.id, name: activeSeason.name }
+      : null,
+    upcomingSeason: upcomingSeason
+      ? { id: upcomingSeason.id, name: upcomingSeason.name }
+      : null,
+    ...decidedCtx,
+  });
 
   return (
     <div>
@@ -121,6 +180,22 @@ export default async function LeagueDetailPage({
                 </div>
                 <AddTeamForm leagueId={id} />
               </div>
+              {isAdmin && league.orgId && (
+                <DynastyPanel
+                  leagueId={id}
+                  seasonState={dynastySeasonStateLine}
+                  gate={startNextSeasonGate}
+                  classDistribution={summarizeClassDistribution(leaguePlayers)}
+                  graduatedPlayers={graduatedPlayers}
+                  upcomingSeason={
+                    upcomingSeason
+                      ? { id: upcomingSeason.id, name: upcomingSeason.name }
+                      : null
+                  }
+                  unplayedGames={decidedCtx.unplayedGames}
+                  playoffsUndecided={decidedCtx.playoffsUndecided}
+                />
+              )}
               {canGenerateRosters && (
                 <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
                   <div className="min-w-0">

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
 import { derivePositionGroup } from "@/lib/position-group";
+import { gradeToClassYear } from "@/lib/class-year";
 import { orderedMaddenAttributes } from "@/lib/madden/attributes";
 import { playerAttributesV1, statKeepingV1 } from "@/lib/flags";
 import { SeasonStatsCard } from "@/components/stats/SeasonStatsCard";
@@ -65,6 +66,7 @@ export default async function PlayerProfilePage({
 
   const team = await getTeam(player.teamId, orgContext).catch(() => null);
   const positionGroup = derivePositionGroup(player.position);
+  const classYear = gradeToClassYear(player.grade);
   const age = player.dateOfBirth ? ageFrom(player.dateOfBirth) : null;
   const attributesEnabled = await playerAttributesV1();
 
@@ -182,6 +184,8 @@ export default async function PlayerProfilePage({
                 {positionGroup && positionGroup !== player.position
                   ? ` · ${positionGroup}`
                   : ""}
+                {classYear ? ` · ${classYear}` : ""}
+                {age != null ? ` · Age ${age}` : ""}
                 {player.jerseyNumber != null ? ` · #${player.jerseyNumber}` : ""}
                 {team ? ` · ${team.name}` : ""}
               </p>

--- a/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/team-management.tsx
@@ -12,6 +12,7 @@ import { RosterStatusIndicator } from "@/components/roster/RosterStatusIndicator
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { orderByDepth } from "@/lib/roster/depth-order";
 import { abbreviateName } from "@/lib/position-group";
+import { gradeToClassYear } from "@/lib/class-year";
 import {
   lookupAttribute,
   presentHeadlineKeys,
@@ -153,6 +154,13 @@ export default function TeamManagement({
         ),
       },
       { key: "position", header: "Pos", sortable: true },
+      {
+        key: "classYear",
+        header: "Class",
+        sortable: true,
+        accessor: (p: RosterRow) => gradeToClassYear(p.grade),
+        render: (p) => gradeToClassYear(p.grade) ?? "\u2014",
+      },
       {
         key: "jerseyNumber",
         header: "#",

--- a/apps/web/src/components/dynasty/DynastyPanel.tsx
+++ b/apps/web/src/components/dynasty/DynastyPanel.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { CalendarClock, GraduationCap, Users } from "lucide-react";
+import { startNextSeasonAction } from "@/app/dashboard/_actions/dynasty";
+import {
+  evaluateStartNextSeason,
+  formatRolloverSuccessSummary,
+  startNextSeasonErrorMessage,
+  type DynastySeasonState,
+} from "@/lib/dynasty-panel";
+import type { ClassDistribution } from "@/lib/class-year";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export interface GraduatedPlayerRow {
+  id: string;
+  name: string;
+  position: string;
+  teamName: string | null;
+}
+
+export interface DynastyPanelProps {
+  leagueId: string;
+  seasonState: DynastySeasonState;
+  gate: ReturnType<typeof evaluateStartNextSeason>;
+  classDistribution: ClassDistribution;
+  graduatedPlayers: GraduatedPlayerRow[];
+  upcomingSeason: { id: string; name: string } | null;
+  unplayedGames: number;
+  playoffsUndecided: boolean;
+}
+
+const STATUS_BADGE_VARIANT: Record<
+  DynastySeasonState["status"],
+  "default" | "secondary" | "outline" | "success"
+> = {
+  no_season: "secondary",
+  in_progress: "default",
+  decided: "success",
+  offseason_upcoming: "outline",
+};
+
+export function DynastyPanel({
+  leagueId,
+  seasonState,
+  gate,
+  classDistribution,
+  graduatedPlayers,
+  upcomingSeason,
+  unplayedGames,
+  playoffsUndecided,
+}: DynastyPanelProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [lastSuccess, setLastSuccess] = useState<string | null>(null);
+
+  function runStartNextSeason() {
+    if (!gate.canStart) return;
+    if (
+      !window.confirm(
+        "Start the next season? Seniors will graduate, other players advance a grade, and freshmen will be generated.",
+      )
+    ) {
+      return;
+    }
+
+    start(async () => {
+      const res = await startNextSeasonAction({ leagueId });
+      if (!res.ok) {
+        toast.error(
+          startNextSeasonErrorMessage(res.error, {
+            unplayedGames,
+            playoffsUndecided,
+            upcomingSeason,
+          }),
+        );
+        return;
+      }
+      const summary = formatRolloverSuccessSummary({
+        graduated: res.graduated,
+        advanced: res.advanced,
+        freshmen: res.freshmen,
+        progressed: res.progressed,
+      });
+      setLastSuccess(summary);
+      toast.success("Next season started.");
+      router.refresh();
+    });
+  }
+
+  const activeTotal =
+    classDistribution.FR +
+    classDistribution.SO +
+    classDistribution.JR +
+    classDistribution.SR +
+    classDistribution.unknown;
+
+  return (
+    <div className="space-y-4 border-t border-border pt-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="inline-flex items-center gap-1.5 text-label-14 text-foreground">
+            <CalendarClock className="h-4 w-4 shrink-0 text-primary" />
+            Dynasty
+          </p>
+          <p className="mt-1 text-caption-12 text-text-muted">
+            Season continuity — graduate seniors, advance classes, and recruit
+            freshmen.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-foreground">
+            {seasonState.seasonName ?? "—"}
+          </span>
+          <Badge variant={STATUS_BADGE_VARIANT[seasonState.status]}>
+            {seasonState.statusLabel}
+          </Badge>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            size="sm"
+            disabled={pending || !gate.canStart}
+            onClick={runStartNextSeason}
+            title={gate.message ?? "Start the next season (offseason rollover)"}
+          >
+            {pending ? "Starting…" : "Start next season"}
+          </Button>
+          {!gate.canStart && gate.message && (
+            <p className="text-caption-12 text-text-muted">{gate.message}</p>
+          )}
+        </div>
+
+        {gate.errorCode === "next_season_exists" && upcomingSeason && (
+          <p className="mt-2 text-caption-12">
+            <Link
+              href={`/dashboard/seasons/${upcomingSeason.id}`}
+              className="text-primary hover:underline"
+            >
+              View {upcomingSeason.name} →
+            </Link>
+          </p>
+        )}
+
+        {lastSuccess && (
+          <p className="mt-3 rounded-sm border border-border bg-muted/50 px-3 py-2 text-caption-12 text-foreground">
+            {lastSuccess}
+          </p>
+        )}
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+          <Users className="h-4 w-4 shrink-0 text-primary" />
+          Class distribution
+          <span className="font-normal text-muted-foreground">
+            ({activeTotal} active)
+          </span>
+        </p>
+        <dl className="mt-3 grid grid-cols-4 gap-3 text-center sm:grid-cols-5">
+          {(["FR", "SO", "JR", "SR"] as const).map((label) => (
+            <div key={label}>
+              <dt className="text-xs font-medium text-muted-foreground">
+                {label}
+              </dt>
+              <dd className="mt-0.5 font-mono text-lg font-semibold text-foreground">
+                {classDistribution[label]}
+              </dd>
+            </div>
+          ))}
+          {classDistribution.unknown > 0 && (
+            <div>
+              <dt className="text-xs font-medium text-muted-foreground">—</dt>
+              <dd className="mt-0.5 font-mono text-lg font-semibold text-muted-foreground">
+                {classDistribution.unknown}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {graduatedPlayers.length > 0 && (
+        <Accordion type="single" collapsible className="rounded-md border border-border bg-card px-4">
+          <AccordionItem value="graduated" className="border-none">
+            <AccordionTrigger className="hover:no-underline">
+              <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+                <GraduationCap className="h-4 w-4 shrink-0 text-primary" />
+                Graduated players ({graduatedPlayers.length})
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <ul className="space-y-1.5 text-sm">
+                {graduatedPlayers.map((player) => (
+                  <li key={player.id}>
+                    <Link
+                      href={`/dashboard/players/${player.id}`}
+                      className="text-primary hover:underline"
+                    >
+                      {player.name}
+                    </Link>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · {player.position}
+                      {player.teamName ? ` · ${player.teamName}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/class-year.test.ts
+++ b/apps/web/src/lib/__tests__/class-year.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  gradeToClassYear,
+  summarizeClassDistribution,
+  EMPTY_CLASS_DISTRIBUTION,
+} from "../class-year";
+
+describe("gradeToClassYear", () => {
+  it("maps grades 9–12 to FR/SO/JR/SR", () => {
+    expect(gradeToClassYear(9)).toBe("FR");
+    expect(gradeToClassYear(10)).toBe("SO");
+    expect(gradeToClassYear(11)).toBe("JR");
+    expect(gradeToClassYear(12)).toBe("SR");
+  });
+
+  it("returns null for undefined, null, and out-of-range grades", () => {
+    expect(gradeToClassYear(undefined)).toBeNull();
+    expect(gradeToClassYear(null)).toBeNull();
+    expect(gradeToClassYear(8)).toBeNull();
+    expect(gradeToClassYear(13)).toBeNull();
+    expect(gradeToClassYear(NaN)).toBeNull();
+  });
+});
+
+describe("summarizeClassDistribution", () => {
+  it("counts active players by class and skips graduated", () => {
+    const dist = summarizeClassDistribution([
+      { grade: 9, status: "Active" },
+      { grade: 9, status: "Active" },
+      { grade: 10, status: "Active" },
+      { grade: 12, status: "graduated" },
+      { grade: null, status: "Active" },
+    ]);
+    expect(dist).toEqual({
+      FR: 2,
+      SO: 1,
+      JR: 0,
+      SR: 0,
+      unknown: 1,
+    });
+  });
+
+  it("returns zeros when given no players", () => {
+    expect(summarizeClassDistribution([])).toEqual(EMPTY_CLASS_DISTRIBUTION);
+  });
+});

--- a/apps/web/src/lib/__tests__/dynasty-panel.test.ts
+++ b/apps/web/src/lib/__tests__/dynasty-panel.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  dynastySeasonState,
+  evaluateStartNextSeason,
+  formatRolloverSuccessSummary,
+  seasonDecidedContext,
+  startNextSeasonErrorMessage,
+} from "../dynasty-panel";
+import type { FixtureDto } from "@sports-management/shared-types";
+
+const finalFixture = (id: string): FixtureDto => ({
+  id,
+  seasonId: "s1",
+  homeTeamId: "h",
+  awayTeamId: "a",
+  homeTeamName: "H",
+  awayTeamName: "A",
+  scheduledAt: null,
+  week: 1,
+  venue: null,
+  status: "final",
+  stage: "regular",
+  createdAt: "",
+  createdBy: "",
+});
+
+describe("dynastySeasonState", () => {
+  it("labels in-progress, decided, and offseason states", () => {
+    expect(
+      dynastySeasonState({
+        activeSeason: { name: "2026" },
+        upcomingSeason: null,
+        seasonDecided: false,
+      }),
+    ).toMatchObject({ status: "in_progress", statusLabel: "In progress" });
+
+    expect(
+      dynastySeasonState({
+        activeSeason: { name: "2026" },
+        upcomingSeason: null,
+        seasonDecided: true,
+      }),
+    ).toMatchObject({ status: "decided", statusLabel: "Decided" });
+
+    expect(
+      dynastySeasonState({
+        activeSeason: { name: "2026" },
+        upcomingSeason: { name: "2027" },
+        seasonDecided: true,
+      }),
+    ).toMatchObject({
+      status: "offseason_upcoming",
+      statusLabel: "Offseason · upcoming 2027",
+    });
+  });
+});
+
+describe("seasonDecidedContext", () => {
+  it("reports unplayed regular-season games", () => {
+    const ctx = seasonDecidedContext(
+      [finalFixture("f1"), { ...finalFixture("f2"), status: "scheduled" }],
+      null,
+    );
+    expect(ctx.seasonDecided).toBe(false);
+    expect(ctx.unplayedGames).toBe(1);
+    expect(ctx.playoffsUndecided).toBe(false);
+  });
+
+  it("flags undecided playoffs when a bracket exists", () => {
+    const ctx = seasonDecidedContext([], {
+      bracketId: "b1",
+      size: 4,
+      rounds: 2,
+      format: "single",
+      matchups: [{ id: "m1" } as never],
+      champion: null,
+    });
+    expect(ctx.playoffsUndecided).toBe(true);
+  });
+});
+
+describe("startNextSeasonErrorMessage", () => {
+  it("maps season_not_decided to unplayed games or playoffs", () => {
+    expect(
+      startNextSeasonErrorMessage("season_not_decided", { unplayedGames: 3 }),
+    ).toBe("3 games unplayed.");
+    expect(
+      startNextSeasonErrorMessage("season_not_decided", {
+        playoffsUndecided: true,
+      }),
+    ).toBe("Playoffs undecided.");
+  });
+
+  it("mentions the upcoming season when it already exists", () => {
+    expect(
+      startNextSeasonErrorMessage("next_season_exists", {
+        upcomingSeason: { id: "s2", name: "2027" },
+      }),
+    ).toContain("2027");
+  });
+});
+
+describe("evaluateStartNextSeason", () => {
+  const active = { id: "s1", name: "2026" };
+
+  it("blocks when preconditions fail", () => {
+    expect(
+      evaluateStartNextSeason({
+        activeSeason: null,
+        upcomingSeason: null,
+        seasonDecided: false,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      }).errorCode,
+    ).toBe("no_season");
+
+    expect(
+      evaluateStartNextSeason({
+        activeSeason: active,
+        upcomingSeason: { id: "s2", name: "2027" },
+        seasonDecided: true,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      }).errorCode,
+    ).toBe("next_season_exists");
+
+    expect(
+      evaluateStartNextSeason({
+        activeSeason: active,
+        upcomingSeason: null,
+        seasonDecided: false,
+        unplayedGames: 2,
+        playoffsUndecided: false,
+      }),
+    ).toMatchObject({
+      canStart: false,
+      message: "2 games unplayed.",
+    });
+  });
+
+  it("allows start when the active season is decided and no upcoming season", () => {
+    expect(
+      evaluateStartNextSeason({
+        activeSeason: active,
+        upcomingSeason: null,
+        seasonDecided: true,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      }),
+    ).toEqual({ canStart: true, errorCode: null, message: null });
+  });
+});
+
+describe("formatRolloverSuccessSummary", () => {
+  it("joins rollover counts into a readable summary", () => {
+    expect(
+      formatRolloverSuccessSummary({
+        graduated: 12,
+        advanced: 36,
+        freshmen: 24,
+        progressed: 36,
+      }),
+    ).toContain("12 graduated");
+    expect(
+      formatRolloverSuccessSummary({
+        graduated: 1,
+        advanced: 1,
+        freshmen: 1,
+      }),
+    ).toBe("1 graduated · 1 advanced · 1 freshman generated");
+  });
+});

--- a/apps/web/src/lib/class-year.ts
+++ b/apps/web/src/lib/class-year.ts
@@ -1,0 +1,49 @@
+/**
+ * High-school class year labels derived from grade (9–12 ↔ FR/SO/JR/SR).
+ */
+export type ClassYear = "FR" | "SO" | "JR" | "SR";
+
+const GRADE_TO_CLASS: Record<number, ClassYear> = {
+  9: "FR",
+  10: "SO",
+  11: "JR",
+  12: "SR",
+};
+
+/** Map grade 9–12 to FR/SO/JR/SR; null/undefined/out-of-range → null. */
+export function gradeToClassYear(
+  grade: number | null | undefined,
+): ClassYear | null {
+  if (grade == null || !Number.isFinite(grade)) return null;
+  return GRADE_TO_CLASS[grade] ?? null;
+}
+
+export interface ClassDistribution {
+  FR: number;
+  SO: number;
+  JR: number;
+  SR: number;
+  unknown: number;
+}
+
+export const EMPTY_CLASS_DISTRIBUTION: ClassDistribution = {
+  FR: 0,
+  SO: 0,
+  JR: 0,
+  SR: 0,
+  unknown: 0,
+};
+
+/** Count active (non-graduated) players by class year across a league roster. */
+export function summarizeClassDistribution(
+  players: ReadonlyArray<{ grade: number | null; status: string }>,
+): ClassDistribution {
+  const counts = { ...EMPTY_CLASS_DISTRIBUTION };
+  for (const player of players) {
+    if (player.status === "graduated") continue;
+    const label = gradeToClassYear(player.grade);
+    if (label) counts[label] += 1;
+    else counts.unknown += 1;
+  }
+  return counts;
+}

--- a/apps/web/src/lib/dynasty-panel.ts
+++ b/apps/web/src/lib/dynasty-panel.ts
@@ -1,0 +1,168 @@
+/**
+ * Dynasty panel presentation helpers — season state and rollover preconditions.
+ */
+import { isSeasonDecided } from "@/lib/dynasty";
+import { regularSeasonProgress } from "@/lib/playoffs";
+import type { FixtureDto } from "@sports-management/shared-types";
+import type { PlayoffBracketDto } from "@/lib/data-api";
+
+export type DynastySeasonDisplayStatus =
+  | "no_season"
+  | "in_progress"
+  | "decided"
+  | "offseason_upcoming";
+
+export interface DynastySeasonState {
+  seasonName: string | null;
+  status: DynastySeasonDisplayStatus;
+  statusLabel: string;
+}
+
+export interface StartNextSeasonGate {
+  canStart: boolean;
+  errorCode: string | null;
+  message: string | null;
+}
+
+export interface SeasonDecidedContext {
+  seasonDecided: boolean;
+  unplayedGames: number;
+  playoffsUndecided: boolean;
+}
+
+/** Derive decided-state context for rollover gating and user messaging. */
+export function seasonDecidedContext(
+  fixtures: FixtureDto[],
+  bracket: PlayoffBracketDto | null,
+): SeasonDecidedContext {
+  const hasBracket = Boolean(bracket && bracket.matchups.length > 0);
+  const seasonDecided = isSeasonDecided(fixtures, bracket);
+  const progress = regularSeasonProgress(fixtures);
+  const unplayedGames = Math.max(0, progress.total - progress.final);
+  return {
+    seasonDecided,
+    unplayedGames,
+    playoffsUndecided: hasBracket && !seasonDecided,
+  };
+}
+
+/** Human-readable season line for the dynasty panel header. */
+export function dynastySeasonState(input: {
+  activeSeason: { name: string } | null;
+  upcomingSeason: { name: string } | null;
+  seasonDecided: boolean;
+}): DynastySeasonState {
+  if (!input.activeSeason) {
+    return {
+      seasonName: null,
+      status: "no_season",
+      statusLabel: "No active season",
+    };
+  }
+  if (input.upcomingSeason) {
+    return {
+      seasonName: input.activeSeason.name,
+      status: "offseason_upcoming",
+      statusLabel: `Offseason · upcoming ${input.upcomingSeason.name}`,
+    };
+  }
+  if (input.seasonDecided) {
+    return {
+      seasonName: input.activeSeason.name,
+      status: "decided",
+      statusLabel: "Decided",
+    };
+  }
+  return {
+    seasonName: input.activeSeason.name,
+    status: "in_progress",
+    statusLabel: "In progress",
+  };
+}
+
+/** Map rollover error codes to user-facing precondition text. */
+export function startNextSeasonErrorMessage(
+  errorCode: string,
+  context: {
+    unplayedGames?: number;
+    playoffsUndecided?: boolean;
+    upcomingSeason?: { id: string; name: string } | null;
+  } = {},
+): string {
+  switch (errorCode) {
+    case "no_season":
+      return "Create an active season before starting the next year.";
+    case "not_authorized":
+      return "You don't have permission to start the next season.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "next_season_exists":
+      return context.upcomingSeason
+        ? `An upcoming season already exists (${context.upcomingSeason.name}).`
+        : "An upcoming season already exists.";
+    case "season_not_decided":
+      if (context.playoffsUndecided) return "Playoffs undecided.";
+      if (context.unplayedGames != null && context.unplayedGames > 0) {
+        const n = context.unplayedGames;
+        return `${n} game${n === 1 ? "" : "s"} unplayed.`;
+      }
+      return "The current season is not decided yet.";
+    default:
+      return errorCode;
+  }
+}
+
+/** Evaluate whether the Start next season CTA should be enabled. */
+export function evaluateStartNextSeason(input: {
+  activeSeason: { id: string; name: string } | null;
+  upcomingSeason: { id: string; name: string } | null;
+  seasonDecided: boolean;
+  unplayedGames: number;
+  playoffsUndecided: boolean;
+}): StartNextSeasonGate {
+  if (!input.activeSeason) {
+    return {
+      canStart: false,
+      errorCode: "no_season",
+      message: startNextSeasonErrorMessage("no_season"),
+    };
+  }
+  if (input.upcomingSeason) {
+    return {
+      canStart: false,
+      errorCode: "next_season_exists",
+      message: startNextSeasonErrorMessage("next_season_exists", {
+        upcomingSeason: input.upcomingSeason,
+      }),
+    };
+  }
+  if (!input.seasonDecided) {
+    return {
+      canStart: false,
+      errorCode: "season_not_decided",
+      message: startNextSeasonErrorMessage("season_not_decided", {
+        unplayedGames: input.unplayedGames,
+        playoffsUndecided: input.playoffsUndecided,
+      }),
+    };
+  }
+  return { canStart: true, errorCode: null, message: null };
+}
+
+/** Format a successful rollover summary from action counts. */
+export function formatRolloverSuccessSummary(counts: {
+  graduated: number;
+  advanced: number;
+  freshmen: number;
+  progressed?: number;
+}): string {
+  const parts = [
+    `${counts.graduated} graduated`,
+    `${counts.advanced} advanced`,
+    `${counts.freshmen} freshman${counts.freshmen === 1 ? "" : "en"} generated`,
+  ];
+  if (counts.progressed != null && counts.progressed > 0) {
+    parts.push(`${counts.progressed} attribute snapshot${counts.progressed === 1 ? "" : "s"} written`);
+  }
+  return parts.join(" · ");
+}


### PR DESCRIPTION
## Summary

Slice D2 completes dynasty mode (#467 backend): the League-view surface for running a multi-season program — the "generations from the League view" item from the 2026-07-03 prod review.

- **Dynasty panel** (admin-only, league detail page): current season state; **Start next season** CTA wired to `startNextSeasonAction` with per-precondition messaging ("N games unplayed", "playoffs undecided", "next season already exists"); success summary after rollover; **FR/SO/JR/SR class distribution** across active players; compact graduated-players list.
- **Class labels**: shared `gradeToClassYear` helper (9–12 → FR/SO/JR/SR, safe on missing/out-of-range grades) on the player detail header and team roster table.
- Panel state logic is a pure helper with unit tests; no Convex writes; token-only styling.

## Verification

- `pnpm --filter @sports-management/web type-check` ✅ · `lint` ✅
- `test:unit` ✅ 121 files / 907 tests (class-year mapping, precondition-message mapping, panel states)
- Hex audit clean; league-page edits localized

## Note

With this merge the full dynasty loop is live in code: season → sim → playoffs → champion → **Start next season** → graduation/progression/freshmen → repeat. Prod additionally needs the pending `convex deploy` (D1 functions) to execute rollovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)