### PR TITLE
fix(web): link season rows to the league schedule (WSM-000211)

### DIFF
--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getSeasons, getLeagues } from "@/lib/data-api";
@@ -72,9 +73,12 @@ export default async function SeasonsPage() {
                           className="flex flex-wrap items-center justify-between gap-3 px-3 py-2"
                         >
                           <div className="flex min-w-0 flex-wrap items-center gap-3">
-                            <span className="font-medium text-foreground">
+                            <Link
+                              href={`/dashboard/leagues/${season.leagueId}/schedule`}
+                              className="font-medium text-foreground hover:underline"
+                            >
                               {season.name}
-                            </span>
+                            </Link>
                             <StatusBadge status={season.status} />
                             <span className="text-xs text-muted-foreground">
                               {formatDate(season.startDate)} &ndash;{" "}


### PR DESCRIPTION
## Summary
Season rows on `/dashboard/seasons` were not clickable — only the action buttons were interactive. The season name now links to `/dashboard/leagues/[leagueId]/schedule`, which renders that league's season schedule. `StatusBadge`, the date range, and `SeasonRowActions` stay outside the anchor so row actions behave exactly as before.

## Related Issue
Closes #472

## Changes
- `apps/web/src/app/dashboard/seasons/page.tsx`: import `Link`; wrap the season name in a link with hover underline.

## Testing
- `pnpm run type-check` clean
- `eslint` clean on the file
- 753/753 unit tests pass

Made with [Cursor](https://cursor.com)