### PR TITLE
feat(web): clickable scores open a read-only game box score (WSM-000212)

### DIFF
--- a/apps/web/src/app/dashboard/games/[fixtureId]/boxscore/page.tsx
+++ b/apps/web/src/app/dashboard/games/[fixtureId]/boxscore/page.tsx
@@ -1,0 +1,192 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ClipboardList } from "lucide-react";
+import { statKeepingV1 } from "@/lib/flags";
+import {
+  getFixture,
+  getLeague,
+  getPlayerGameStatsByFixture,
+  getPlayersByTeam,
+  getResultByFixture,
+  getSeasonLeagueId,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import {
+  buildBoxScoreTables,
+  type BoxScoreGroupTable,
+  type BoxScorePlayerInfo,
+} from "@/lib/box-score";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatusBadge } from "@/components/status-badge";
+
+/*
+ * Read-only game box score (WSM-000212). Linked from the schedule's score cell.
+ * Unlike /dashboard/teams/[id]/games/[gameId]/stats (the coach-gated ENTRY
+ * form), this renders both teams' entered stat lines for anyone who can see
+ * the league — same guard chain as the gamecast page: stat-keeping flag,
+ * auth, then league visibility through getLeague + orgContext.
+ */
+
+function TeamBoxScore({
+  teamName,
+  tables,
+}: {
+  teamName: string;
+  tables: BoxScoreGroupTable[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{teamName}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {tables.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No player stats entered for {teamName}.
+          </p>
+        ) : (
+          tables.map((table) => (
+            <div key={table.key}>
+              <h4 className="mb-2 text-sm font-semibold text-foreground">
+                {table.label}
+              </h4>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="py-1.5 pr-4 font-mono text-xs uppercase">
+                        Player
+                      </th>
+                      {table.fields.map((f) => (
+                        <th
+                          key={f.key}
+                          className="py-1.5 pr-3 text-right font-mono text-xs uppercase"
+                        >
+                          {f.label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {table.rows.map((row) => (
+                      <tr
+                        key={row.playerId}
+                        className="border-b border-border last:border-0"
+                      >
+                        <td className="py-1.5 pr-4 text-foreground">
+                          {row.jerseyNumber !== null && (
+                            <span className="mr-2 font-mono text-xs text-muted-foreground">
+                              #{row.jerseyNumber}
+                            </span>
+                          )}
+                          {row.playerName}
+                        </td>
+                        {row.values.map((v, i) => (
+                          <td
+                            key={table.fields[i].key}
+                            className="py-1.5 pr-3 text-right font-mono tabular-nums text-foreground"
+                          >
+                            {v ?? "—"}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function BoxScorePage({
+  params,
+}: {
+  params: Promise<{ fixtureId: string }>;
+}) {
+  const enabled = await statKeepingV1();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { fixtureId } = await params;
+  const fixture = await getFixture(fixtureId);
+  if (!fixture) notFound();
+
+  const leagueId = await getSeasonLeagueId(fixture.seasonId);
+  if (!leagueId) notFound();
+
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+
+  const [result, allStats, homePlayers, awayPlayers] = await Promise.all([
+    getResultByFixture(fixtureId),
+    getPlayerGameStatsByFixture(fixtureId),
+    getPlayersByTeam(fixture.homeTeamId, orgContext).catch(() => []),
+    getPlayersByTeam(fixture.awayTeamId, orgContext).catch(() => []),
+  ]);
+
+  const playersById = new Map<string, BoxScorePlayerInfo>();
+  for (const p of [...homePlayers, ...awayPlayers]) {
+    playersById.set(p.id, { name: p.name, jerseyNumber: p.jerseyNumber });
+  }
+
+  const homeTables = buildBoxScoreTables(
+    allStats.filter((s) => s.teamId === fixture.homeTeamId),
+    playersById,
+  );
+  const awayTables = buildBoxScoreTables(
+    allStats.filter((s) => s.teamId === fixture.awayTeamId),
+    playersById,
+  );
+  const hasAnyStats = homeTables.length > 0 || awayTables.length > 0;
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <Link
+        href={`/dashboard/leagues/${leagueId}/schedule`}
+        className="mb-4 inline-block text-sm text-primary hover:underline"
+      >
+        &larr; Back to Schedule
+      </Link>
+
+      <header className="mb-6">
+        <h2 className="text-2xl font-bold text-foreground">Box score</h2>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            {fixture.homeTeamName} vs {fixture.awayTeamName}
+            {fixture.week !== null ? ` · Week ${fixture.week}` : ""}
+          </span>
+          <StatusBadge status={fixture.status} />
+        </div>
+        {result && (
+          <p className="mt-3 font-mono text-3xl tabular-nums text-foreground">
+            {result.homeScore} – {result.awayScore}
+          </p>
+        )}
+      </header>
+
+      {!hasAnyStats ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+            <ClipboardList className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No player stats have been entered for this game yet.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          <TeamBoxScore teamName={fixture.homeTeamName} tables={homeTables} />
+          <TeamBoxScore teamName={fixture.awayTeamName} tables={awayTables} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -288,9 +288,21 @@ export default async function LeagueSchedulePage({
                             {fixture.awayTeamName}
                           </td>
                           <td className="px-4 py-2 text-right font-mono text-foreground">
-                            {result
-                              ? `${result.homeScore} – ${result.awayScore}`
-                              : "—"}
+                            {result ? (
+                              statsEnabled ? (
+                                <Link
+                                  href={`/dashboard/games/${fixture.id}/boxscore`}
+                                  className="hover:underline"
+                                  title="View box score"
+                                >
+                                  {result.homeScore} – {result.awayScore}
+                                </Link>
+                              ) : (
+                                `${result.homeScore} – ${result.awayScore}`
+                              )
+                            ) : (
+                              "—"
+                            )}
                           </td>
                           <td className="px-4 py-2">
                             <StatusBadge status={fixture.status} />

--- a/apps/web/src/lib/__tests__/box-score.test.ts
+++ b/apps/web/src/lib/__tests__/box-score.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { PlayerGameStatsDto } from "@sports-management/shared-types";
+import { buildBoxScoreTables, type BoxScorePlayerInfo } from "../box-score";
+
+function statLine(
+  playerId: string,
+  stats: PlayerGameStatsDto["stats"],
+): PlayerGameStatsDto {
+  return {
+    id: `stat-${playerId}`,
+    fixtureId: "fx1",
+    playerId,
+    teamId: "team1",
+    seasonId: "season1",
+    stats,
+    enteredBy: "user1",
+    updatedAt: "2026-07-05T00:00:00Z",
+  };
+}
+
+const players = new Map<string, BoxScorePlayerInfo>([
+  ["p1", { name: "Alpha QB", jerseyNumber: 7 }],
+  ["p2", { name: "Bravo RB", jerseyNumber: 22 }],
+  ["p3", { name: "Charlie WR", jerseyNumber: 81 }],
+]);
+
+describe("buildBoxScoreTables", () => {
+  it("builds one table per stat group present, in STAT_GROUPS order", () => {
+    const tables = buildBoxScoreTables(
+      [
+        statLine("p1", { passing: { comp: 18, att: 25, yards: 240, td: 2 } }),
+        statLine("p2", { rushing: { carries: 14, yards: 88, td: 1 } }),
+      ],
+      players,
+    );
+    expect(tables.map((t) => t.key)).toEqual(["passing", "rushing"]);
+    expect(tables[0].label).toBe("Passing");
+    expect(tables[0].fields.map((f) => f.label)).toContain("Yds");
+  });
+
+  it("omits groups with no entered lines", () => {
+    const tables = buildBoxScoreTables(
+      [statLine("p1", { passing: { yards: 100 } })],
+      players,
+    );
+    expect(tables.find((t) => t.key === "defense")).toBeUndefined();
+  });
+
+  it("maps field values in field order with null for missing fields", () => {
+    const tables = buildBoxScoreTables(
+      [statLine("p1", { passing: { comp: 10, yards: 150 } })],
+      players,
+    );
+    const passing = tables[0];
+    const compIdx = passing.fields.findIndex((f) => f.key === "comp");
+    const attIdx = passing.fields.findIndex((f) => f.key === "att");
+    const yardsIdx = passing.fields.findIndex((f) => f.key === "yards");
+    expect(passing.rows[0].values[compIdx]).toBe(10);
+    expect(passing.rows[0].values[attIdx]).toBeNull();
+    expect(passing.rows[0].values[yardsIdx]).toBe(150);
+  });
+
+  it("sorts rows by the group's first field descending", () => {
+    const tables = buildBoxScoreTables(
+      [
+        statLine("p2", { rushing: { carries: 5, yards: 30 } }),
+        statLine("p1", { rushing: { carries: 15, yards: 90 } }),
+      ],
+      players,
+    );
+    const rushing = tables.find((t) => t.key === "rushing")!;
+    expect(rushing.rows.map((r) => r.playerId)).toEqual(["p1", "p2"]);
+  });
+
+  it("resolves player name and jersey, tolerating unknown players", () => {
+    const tables = buildBoxScoreTables(
+      [
+        statLine("p3", { receiving: { rec: 6, yards: 72 } }),
+        statLine("ghost", { receiving: { rec: 2, yards: 12 } }),
+      ],
+      players,
+    );
+    const receiving = tables.find((t) => t.key === "receiving")!;
+    expect(receiving.rows[0]).toMatchObject({
+      playerName: "Charlie WR",
+      jerseyNumber: 81,
+    });
+    expect(receiving.rows[1]).toMatchObject({
+      playerName: "Unknown player",
+      jerseyNumber: null,
+    });
+  });
+
+  it("skips lines whose group object has no numeric values", () => {
+    const tables = buildBoxScoreTables(
+      [statLine("p1", { passing: {} })],
+      players,
+    );
+    expect(tables).toEqual([]);
+  });
+
+  it("returns empty for no stat lines", () => {
+    expect(buildBoxScoreTables([], players)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/box-score.ts
+++ b/apps/web/src/lib/box-score.ts
@@ -1,0 +1,76 @@
+import type {
+  PlayerGameStatLine,
+  PlayerGameStatsDto,
+} from "@sports-management/shared-types";
+import { STAT_GROUPS, type StatFieldDef } from "./stat-groups";
+
+/*
+ * Read-only box-score tables (WSM-000212). Turns one team's entered stat lines
+ * for a game into per-category tables using the same group/field definitions
+ * the entry form uses (stat-groups.ts), so labels and column order match what
+ * the stat-keeper saw.
+ */
+
+export interface BoxScorePlayerInfo {
+  name: string;
+  jerseyNumber: number | null;
+}
+
+export interface BoxScoreRow {
+  playerId: string;
+  playerName: string;
+  jerseyNumber: number | null;
+  /** One value per field in the group's field order; null = not entered. */
+  values: Array<number | null>;
+}
+
+export interface BoxScoreGroupTable {
+  key: keyof PlayerGameStatLine;
+  label: string;
+  fields: StatFieldDef[];
+  rows: BoxScoreRow[];
+}
+
+/**
+ * Build per-category tables for ONE team from that team's stat lines. Groups
+ * with no entered lines are omitted; rows sort by the group's first field
+ * descending (e.g. Comp for passing, Car for rushing) so the busiest player
+ * leads the table.
+ */
+export function buildBoxScoreTables(
+  stats: PlayerGameStatsDto[],
+  playersById: Map<string, BoxScorePlayerInfo>,
+): BoxScoreGroupTable[] {
+  const tables: BoxScoreGroupTable[] = [];
+
+  for (const group of STAT_GROUPS) {
+    const rows: BoxScoreRow[] = [];
+    for (const line of stats) {
+      const groupStats = line.stats[group.key] as
+        | Record<string, number | undefined>
+        | undefined;
+      if (!groupStats) continue;
+      const values = group.fields.map((f) => groupStats[f.key] ?? null);
+      if (values.every((v) => v === null)) continue;
+
+      const info = playersById.get(line.playerId);
+      rows.push({
+        playerId: line.playerId,
+        playerName: info?.name ?? "Unknown player",
+        jerseyNumber: info?.jerseyNumber ?? null,
+        values,
+      });
+    }
+    if (rows.length === 0) continue;
+
+    rows.sort((a, b) => (b.values[0] ?? 0) - (a.values[0] ?? 0));
+    tables.push({
+      key: group.key,
+      label: group.label,
+      fields: group.fields,
+      rows,
+    });
+  }
+
+  return tables;
+}


### PR DESCRIPTION
## Summary
Clicking a recorded score on the league schedule now opens a read-only box score for that game at `/dashboard/games/[fixtureId]/boxscore`, showing both teams' player stat lines grouped by category (Passing, Rushing, Defense, …) with the same labels/column order as the stats entry form.

Previously the only "box score" surface was the coach-gated **entry** form (`canManageTeam` 404s viewers), split per team and only reachable from the admin Actions column.

## Related Issue
Closes #475

## Changes
- `apps/web/src/lib/box-score.ts`: pure helper building per-team, per-group tables from `PlayerGameStatsDto[]` + a player map (sorted by the group's lead stat; missing fields render as "—").
- `apps/web/src/lib/__tests__/box-score.test.ts`: 7 unit tests (group ordering/omission, field mapping, sorting, unknown players, empty inputs).
- `apps/web/src/app/dashboard/games/[fixtureId]/boxscore/page.tsx`: new read-only page; guard chain mirrors gamecast (statKeepingV1 → auth → league visibility via `getLeague` + orgContext). Empty state when a game has a result but no stat lines.
- `apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx`: score cell links to the box score when a result exists and stat-keeping is enabled (plain text otherwise).

## Testing
- 916/916 unit tests pass (7 new)
- `pnpm run type-check` clean
- ESLint clean on all touched files

Made with [Cursor](https://cursor.com)