### PR TITLE
feat(web): season switcher on schedule/standings/stats/playoffs (WSM-000214)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -16,11 +16,15 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import PlayoffBracket from "@/components/playoffs/PlayoffBracket";
 import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
+import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
+import { resolveViewedSeason } from "@/lib/season-view";
 
 export default async function LeaguePlayoffsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ season?: string }>;
 }) {
   const enabled = await playoffsV1();
   if (!enabled) notFound();
@@ -37,9 +41,9 @@ export default async function LeaguePlayoffsPage({
   const role = orgId ? await resolveOrgRole(orgId, userId) : null;
   const isAdmin = canManageRoster(role);
 
+  const { season: seasonParam } = await searchParams;
   const allSeasons = await getSeasons([leagueId]);
-  const activeSeason =
-    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
 
   const fixtures = activeSeason
     ? await listFixturesBySeason(activeSeason.id)
@@ -75,6 +79,16 @@ export default async function LeaguePlayoffsPage({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">
+          {activeSeason ? (
+            <SeasonSwitcher
+              seasons={allSeasons.map((s) => ({
+                id: s.id,
+                name: s.name,
+                status: s.status,
+              }))}
+              currentSeasonId={activeSeason.id}
+            />
+          ) : null}
           <Link
             href={`/dashboard/leagues/${leagueId}/schedule`}
             className="text-sm text-primary hover:underline"

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -40,13 +40,17 @@ import {
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
+import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
+import { resolveViewedSeason } from "@/lib/season-view";
 
 type StreamStatus = "idle" | "active" | "ended";
 
 export default async function LeagueSchedulePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ season?: string }>;
 }) {
   const enabled = await schedulesStandingsV1();
   if (!enabled) notFound();
@@ -83,10 +87,10 @@ export default async function LeagueSchedulePage({
   // detail page; the server actions re-check flag + role.
   const canGenerateRosters = canManageOrgSettings(role) && (await syntheticRostersV1());
 
-  // Pick the active season — fall back to whichever exists if none flagged active.
+  // Season being VIEWED (WSM-000214): `?season=` wins, else active, else first.
+  const { season: seasonParam } = await searchParams;
   const allSeasons = await getSeasons([leagueId]);
-  const activeSeason =
-    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
 
   const teams = await getTeamsByLeague(leagueId, orgContext);
 
@@ -153,6 +157,16 @@ export default async function LeagueSchedulePage({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {activeSeason ? (
+            <SeasonSwitcher
+              seasons={allSeasons.map((s) => ({
+                id: s.id,
+                name: s.name,
+                status: s.status,
+              }))}
+              currentSeasonId={activeSeason.id}
+            />
+          ) : null}
           <Link
             href={`/dashboard/leagues/${leagueId}/standings`}
             className="text-sm text-primary hover:underline"

--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -12,12 +12,16 @@ import {
 import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import StandingsTable from "@/components/schedule/StandingsTable";
+import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
+import { resolveViewedSeason } from "@/lib/season-view";
 import { trackStandingsView } from "@/lib/analytics";
 
 export default async function LeagueStandingsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ season?: string }>;
 }) {
   const enabled = await schedulesStandingsV1();
   if (!enabled) notFound();
@@ -32,9 +36,9 @@ export default async function LeagueStandingsPage({
   const league = await getLeague(leagueId, orgContext).catch(() => null);
   if (!league) notFound();
 
+  const { season: seasonParam } = await searchParams;
   const allSeasons = await getSeasons([leagueId]);
-  const activeSeason =
-    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
 
   if (!activeSeason) {
     return (
@@ -88,7 +92,15 @@ export default async function LeagueStandingsPage({
             Standings · {activeSeason.name}
           </p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex items-center gap-3">
+          <SeasonSwitcher
+            seasons={allSeasons.map((s) => ({
+              id: s.id,
+              name: s.name,
+              status: s.status,
+            }))}
+            currentSeasonId={activeSeason.id}
+          />
           <Link
             href={`/dashboard/leagues/${leagueId}/schedule`}
             className="text-sm text-primary hover:underline"

--- a/apps/web/src/app/dashboard/leagues/[id]/stats/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/stats/page.tsx
@@ -6,11 +6,15 @@ import { getLeague, getSeasons, getSeasonStatLeaders } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/card";
 import { StatLeadersBoard } from "@/components/stats/StatLeadersBoard";
+import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
+import { resolveViewedSeason } from "@/lib/season-view";
 
 export default async function LeagueStatLeadersPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ season?: string }>;
 }) {
   // Same dark-flag gate as the rest of stat-keeping (WSM-000112).
   const enabled = await statKeepingV1();
@@ -24,9 +28,9 @@ export default async function LeagueStatLeadersPage({
   const league = await getLeague(leagueId, orgContext).catch(() => null);
   if (!league) notFound();
 
+  const { season: seasonParam } = await searchParams;
   const allSeasons = await getSeasons([leagueId]);
-  const activeSeason =
-    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
 
   return (
     <div>
@@ -44,7 +48,17 @@ export default async function LeagueStatLeadersPage({
             Stat leaders{activeSeason ? ` · ${activeSeason.name}` : ""}
           </p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex items-center gap-3">
+          {activeSeason ? (
+            <SeasonSwitcher
+              seasons={allSeasons.map((s) => ({
+                id: s.id,
+                name: s.name,
+                status: s.status,
+              }))}
+              currentSeasonId={activeSeason.id}
+            />
+          ) : null}
           <Link
             href={`/dashboard/leagues/${leagueId}/standings`}
             className="text-sm text-primary hover:underline"

--- a/apps/web/src/components/schedule/SeasonSwitcher.tsx
+++ b/apps/web/src/components/schedule/SeasonSwitcher.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+
+/*
+ * Season selector for league-scoped pages (WSM-000214). Navigates to
+ * `?season=<id>` on the current path; the server component resolves it via
+ * resolveViewedSeason. Hidden when there's nothing to switch between.
+ */
+export default function SeasonSwitcher({
+  seasons,
+  currentSeasonId,
+}: {
+  seasons: Array<{ id: string; name: string; status: string }>;
+  currentSeasonId: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (seasons.length < 2) return null;
+
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      Season
+      <select
+        className="rounded-md border border-input bg-background px-2 py-1 text-sm text-foreground"
+        value={currentSeasonId}
+        aria-label="Switch season"
+        onChange={(e) => {
+          router.push(`${pathname}?season=${encodeURIComponent(e.target.value)}`);
+        }}
+      >
+        {seasons.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+            {s.status === "active" ? " (active)" : ""}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/web/src/lib/__tests__/season-view.test.ts
+++ b/apps/web/src/lib/__tests__/season-view.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { SeasonDto } from "@sports-management/shared-types";
+import { resolveViewedSeason } from "../season-view";
+
+function season(id: string, status: string): SeasonDto {
+  return {
+    id,
+    name: `Season ${id}`,
+    leagueId: "league1",
+    status,
+    startDate: null,
+    endDate: null,
+    rosterLocked: false,
+    playoffTeams: null,
+    playoffFormat: null,
+    divisionWinnersQualify: false,
+  };
+}
+
+const finished = season("s1", "upcoming");
+const active = season("s2", "active");
+const older = season("s3", "upcoming");
+
+describe("resolveViewedSeason", () => {
+  it("returns the requested season when the id belongs to the league", () => {
+    expect(resolveViewedSeason([finished, active, older], "s3")).toBe(older);
+  });
+
+  it("falls back to the active season for an unknown id", () => {
+    expect(resolveViewedSeason([finished, active], "nope")).toBe(active);
+  });
+
+  it("falls back to the active season with no param", () => {
+    expect(resolveViewedSeason([finished, active], undefined)).toBe(active);
+  });
+
+  it("falls back to the first season when none is active", () => {
+    expect(resolveViewedSeason([finished, older], undefined)).toBe(finished);
+  });
+
+  it("returns null for a league with no seasons", () => {
+    expect(resolveViewedSeason([], "s1")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/season-view.ts
+++ b/apps/web/src/lib/season-view.ts
@@ -1,0 +1,21 @@
+import type { SeasonDto } from "@sports-management/shared-types";
+
+/*
+ * Viewed-season resolution for league-scoped pages (WSM-000214).
+ *
+ * Schedule / standings / stats / playoffs historically hard-wired the ACTIVE
+ * season, which made finished seasons unreachable the moment a new one was
+ * activated. These pages now accept `?season=<id>`: a valid id belonging to
+ * the league wins; anything else falls back to the old behavior
+ * (active season, else the first one).
+ */
+export function resolveViewedSeason(
+  seasons: SeasonDto[],
+  seasonParam: string | undefined,
+): SeasonDto | null {
+  if (seasonParam) {
+    const requested = seasons.find((s) => s.id === seasonParam);
+    if (requested) return requested;
+  }
+  return seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+}


### PR DESCRIPTION
## Summary
Finished seasons stay viewable: the schedule, standings, stat-leaders, and playoffs pages now accept `?season=<id>` and show a season selector when a league has more than one season. Previously all four hard-wired `find(s => s.status === "active") ?? seasons[0]`, so activating a new season made the old one's schedule/standings/bracket unreachable.

## Related Issue
Closes #478

## Changes
- `apps/web/src/lib/season-view.ts`: `resolveViewedSeason(seasons, seasonParam)` — requested season wins when it belongs to the league; falls back to the previous behavior (active, else first). 5 unit tests.
- `apps/web/src/components/schedule/SeasonSwitcher.tsx`: client select that navigates to `?season=<id>` on the current path; hidden with fewer than 2 seasons.
- The four league pages: accept `searchParams`, resolve the viewed season through the helper, render the switcher in the header. Admin controls (generate schedule, fixtures, sim) operate on the viewed season, which they already took as `seasonId`.

## Testing
- 914/914 unit tests pass (5 new)
- `pnpm run type-check` clean, ESLint clean on all touched files

Made with [Cursor](https://cursor.com)