### PR TITLE
fix(web): themed auth layout + prod public-auth Playwright smoke (WSM-000168)

### DIFF
--- a/apps/web/e2e/helpers/clerk-signin.ts
+++ b/apps/web/e2e/helpers/clerk-signin.ts
@@ -15,6 +15,10 @@
  * Required env (all already present when CONVEX_ENABLE_E2E_SEED is set up):
  *   - CLERK_SECRET_KEY    — backend secret for the dev Clerk instance
  *   - E2E_CLERK_USER_ID   — the user_… ID to impersonate
+ *
+ * Prod sweep overrides (live Clerk instance after #386 cutover):
+ *   - PROD_CLERK_SECRET_KEY    — falls back to CLERK_SECRET_KEY
+ *   - PROD_E2E_CLERK_USER_ID   — falls back to E2E_CLERK_USER_ID
  */
 import type { Page } from "@playwright/test";
 import { clerk } from "@clerk/testing/playwright";
@@ -59,9 +63,14 @@ export interface SignInOptions {
 }
 
 function resolveUserId(variant: "A" | "B"): string | undefined {
-  return variant === "B"
-    ? process.env.E2E_CLERK_USER_ID_B
-    : process.env.E2E_CLERK_USER_ID;
+  if (variant === "B") {
+    return process.env.E2E_CLERK_USER_ID_B;
+  }
+  return process.env.PROD_E2E_CLERK_USER_ID ?? process.env.E2E_CLERK_USER_ID;
+}
+
+function resolveClerkSecret(): string | undefined {
+  return process.env.PROD_CLERK_SECRET_KEY ?? process.env.CLERK_SECRET_KEY;
 }
 
 export async function signInTestUser(
@@ -70,17 +79,19 @@ export async function signInTestUser(
 ): Promise<void> {
   const variant = options.userVariant ?? "A";
   const userId = resolveUserId(variant);
-  const secret = process.env.CLERK_SECRET_KEY;
+  const secret = resolveClerkSecret();
   if (!userId) {
     const envName =
-      variant === "B" ? "E2E_CLERK_USER_ID_B" : "E2E_CLERK_USER_ID";
+      variant === "B"
+        ? "E2E_CLERK_USER_ID_B"
+        : "PROD_E2E_CLERK_USER_ID or E2E_CLERK_USER_ID";
     throw new Error(
       `[clerk-signin] ${envName} is required to sign in the e2e test user.`,
     );
   }
   if (!secret) {
     throw new Error(
-      "[clerk-signin] CLERK_SECRET_KEY is required to mint a sign-in token.",
+      "[clerk-signin] PROD_CLERK_SECRET_KEY or CLERK_SECRET_KEY is required to mint a sign-in token.",
     );
   }
 

--- a/apps/web/e2e/playwright.prod.ts
+++ b/apps/web/e2e/playwright.prod.ts
@@ -18,11 +18,10 @@ dotenv.config({ path: path.resolve(".env.local") });
  * Target: PROD_BASE_URL (defaults to the custom domain). NO `webServer` — prod
  * is already deployed; we hit it over the network.
  *
- * Auth note: this reuses the same Clerk creds as the functional suite
- * (CLERK_SECRET_KEY + E2E_CLERK_USER_ID). That works today because prod still
- * runs the Clerk DEVELOPMENT instance (#386 cutover pending). After the cutover
- * to a production Clerk instance, point these at a prod-instance secret key +
- * a prod test user (e.g. PROD_CLERK_* secrets).
+ * Auth note: after the prod Clerk cutover (#386), local .env.local still holds
+ * dev keys — ticket sign-in against live prod fails unless you set prod-specific
+ * overrides: PROD_CLERK_SECRET_KEY + PROD_E2E_CLERK_USER_ID (see clerk-signin.ts).
+ * The `public-auth` project needs no secrets — it only checks signed-out flows.
  */
 const PROD_STORAGE_STATE = path.resolve("e2e", ".auth", "prod-user.json");
 const BASE_URL =
@@ -44,6 +43,14 @@ export default defineConfig({
     actionTimeout: 15_000,
   },
   projects: [
+    {
+      name: "public-auth",
+      testMatch: /public-auth\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
     { name: "setup", testMatch: /auth\.setup\.ts/ },
     {
       name: "desktop",

--- a/apps/web/e2e/prod/public-auth.spec.ts
+++ b/apps/web/e2e/prod/public-auth.spec.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+
+/**
+ * Prod public auth smoke (WSM-000168). Signed-out flows only — no ticket sign-in.
+ * Verifies marketing → sign-in navigation and that Clerk forms render on live prod.
+ */
+const SCREENSHOT_DIR = path.resolve("prod-screenshots", "public-auth");
+
+test.describe("Prod public auth", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  });
+
+  test("homepage Sign in link opens Clerk form", async ({ page }) => {
+    await page.goto("/", { waitUntil: "load" });
+    await page.getByRole("link", { name: "Sign in", exact: true }).first().click();
+    await expect(page).toHaveURL(/\/sign-in/);
+    await expect(page.getByRole("heading", { name: /Sign in to/i })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "homepage-to-sign-in.png"),
+      fullPage: true,
+    });
+  });
+
+  test("/sign-in renders Clerk form", async ({ page }) => {
+    await page.goto("/sign-in", { waitUntil: "load" });
+    await expect(page.getByRole("heading", { name: /Sign in to/i })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByRole("button", { name: /Continue with Google/i })).toBeVisible();
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "sign-in-direct.png"),
+      fullPage: true,
+    });
+  });
+
+  test("/sign-up renders Clerk form", async ({ page }) => {
+    await page.goto("/sign-up", { waitUntil: "load" });
+    await expect(page.getByRole("heading", { name: /Create your account/i })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "sign-up-direct.png"),
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,10 @@
 import type { NextConfig } from "next";
+import { runClerkEnvGuard } from "./src/lib/clerk-env-guard";
+
+// Fail the PRODUCTION build if Clerk is configured with development keys
+// (WSM-000168). Build-time (not boot-time) so a misconfig blocks promotion and
+// Vercel keeps the last good deployment serving instead of booting a broken one.
+runClerkEnvGuard();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "test:visual": "playwright test --config e2e/playwright.config.ts --project visual",
     "test:visual:update": "playwright test --config e2e/playwright.config.ts --project visual --update-snapshots",
     "test:prod:screenshots": "playwright test --config e2e/playwright.prod.ts",
+    "test:prod:auth": "playwright test --config e2e/playwright.prod.ts --project=public-auth",
     "test:unit": "vitest run"
   },
   "dependencies": {

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { Monogram } from "@/components/marketing/monogram";
+
+/**
+ * Shared shell for Clerk sign-in / sign-up routes. Branding + themed background
+ * so the page doesn't read as an empty void while Clerk hydrates (WSM-000168).
+ */
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="flex justify-center px-4 pt-8 pb-4">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-foreground"
+          aria-label="sprtsmng home"
+        >
+          <Monogram size={32} />
+          <span className="text-lg font-bold tracking-tight">sprtsmng</span>
+        </Link>
+      </header>
+      <div className="flex flex-1 items-center justify-center px-4 pb-12">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -8,9 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function SignInPage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <SignIn />
-    </main>
-  );
+  return <SignIn />;
 }

--- a/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -21,11 +21,9 @@ export default async function SignUpPage({
     : undefined;
 
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <SignUp
-        forceRedirectUrl={redirectUrl}
-        fallbackRedirectUrl={redirectUrl}
-      />
-    </main>
+    <SignUp
+      forceRedirectUrl={redirectUrl}
+      fallbackRedirectUrl={redirectUrl}
+    />
   );
 }

--- a/apps/web/src/lib/__tests__/clerk-env-guard.test.ts
+++ b/apps/web/src/lib/__tests__/clerk-env-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { assertClerkKeysForEnv, runClerkEnvGuard } from "../clerk-env-guard";
+
+/*
+ * Regression guard for WSM-000168 (production ran Clerk DEVELOPMENT keys).
+ *
+ * Encodes the ticket's acceptance criteria: a production build MUST fail when a
+ * `pk_test_`/`sk_test_` key is present, and MUST pass with `pk_live_`/`sk_live_`.
+ * Preview/local builds legitimately use development keys and must not throw.
+ */
+
+describe("assertClerkKeysForEnv (WSM-000168)", () => {
+  it("throws when a development publishable key is used in production", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_live_realproduction",
+      }),
+    ).toThrow(/WSM-000168/);
+  });
+
+  it("throws when a development secret key is used in production", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_live_realproduction",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).toThrow(/DEVELOPMENT/);
+  });
+
+  it("passes when production uses live keys", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_live_realproduction",
+        secretKey: "sk_live_realproduction",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows development keys on preview deployments", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: "preview",
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows development keys locally (VERCEL_ENV undefined)", () => {
+    expect(() =>
+      assertClerkKeysForEnv({
+        vercelEnv: undefined,
+        publishableKey: "pk_test_ZXhhbXBsZQ",
+        secretKey: "sk_test_ZXhhbXBsZQ",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not leak the raw key value in the error message", () => {
+    let message = "";
+    try {
+      assertClerkKeysForEnv({
+        vercelEnv: "production",
+        publishableKey: "pk_test_SUPERSECRETVALUE123",
+        secretKey: undefined,
+      });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toContain("SUPERSECRETVALUE123");
+    expect(message).toContain("pk_test_");
+  });
+});
+
+describe("runClerkEnvGuard (reads process.env)", () => {
+  const original = {
+    VERCEL_ENV: process.env.VERCEL_ENV,
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env.VERCEL_ENV = original.VERCEL_ENV;
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      original.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    process.env.CLERK_SECRET_KEY = original.CLERK_SECRET_KEY;
+  });
+
+  it("throws for a dev publishable key when VERCEL_ENV=production", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_ZXhhbXBsZQ");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_ZXhhbXBsZQ");
+    expect(() => runClerkEnvGuard()).toThrow(/WSM-000168/);
+  });
+
+  it("is a no-op for a live key in production", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_live_realproduction");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_live_realproduction");
+    expect(() => runClerkEnvGuard()).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/clerk-env-guard.ts
+++ b/apps/web/src/lib/clerk-env-guard.ts
@@ -1,0 +1,58 @@
+/*
+ * Production Clerk-key guard (WSM-000168).
+ *
+ * Clerk development instances have strict rate limits and a hard user cap and
+ * must never serve production traffic — but a `pk_test_`/`sk_test_` key set in
+ * Vercel Production only surfaces as a console warning + a "Development mode"
+ * badge, which shipped silently once already. This guard turns that silent
+ * misconfig into a hard failure.
+ *
+ * It runs at BUILD time (from `next.config.ts`), not boot time, on purpose: a
+ * failed build is never promoted, so Vercel keeps the previous good deployment
+ * serving instead of booting a broken one. Only fires when `VERCEL_ENV` is
+ * "production" — preview and local builds legitimately use development keys.
+ *
+ * Never logs a key value; only the `pk_test_`/`sk_test_` prefix is named.
+ */
+
+export interface ClerkKeyEnv {
+  /** Vercel's deployment environment: "production" | "preview" | "development" | undefined (local). */
+  vercelEnv: string | undefined;
+  /** NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY (pk_test_… on a dev instance, pk_live_… on prod). */
+  publishableKey: string | undefined;
+  /** CLERK_SECRET_KEY (sk_test_… on a dev instance, sk_live_… on prod). */
+  secretKey: string | undefined;
+}
+
+/**
+ * Throws if a Clerk **development** key is configured while `vercelEnv` is
+ * "production". Pure (no `process.env` access) so it is trivially testable.
+ */
+export function assertClerkKeysForEnv(env: ClerkKeyEnv): void {
+  if (env.vercelEnv !== "production") return;
+
+  const devKey = env.publishableKey?.startsWith("pk_test_")
+    ? "publishable (pk_test_…)"
+    : env.secretKey?.startsWith("sk_test_")
+      ? "secret (sk_test_…)"
+      : null;
+
+  if (devKey) {
+    throw new Error(
+      `[WSM-000168] Refusing to build for production: the Clerk ${devKey} key is a ` +
+        `DEVELOPMENT key but VERCEL_ENV=production. Clerk development instances have ` +
+        `strict rate limits and a hard user cap and must not serve production traffic. ` +
+        `Set production keys (pk_live_/sk_live_) in Vercel Production and redeploy. ` +
+        `See https://github.com/andysolomon/sports-league-management/issues/386`,
+    );
+  }
+}
+
+/** Reads the process environment and applies {@link assertClerkKeysForEnv}. */
+export function runClerkEnvGuard(): void {
+  assertClerkKeysForEnv({
+    vercelEnv: process.env.VERCEL_ENV,
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    secretKey: process.env.CLERK_SECRET_KEY,
+  });
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 | [development/RELEASE_STRATEGY.md](development/RELEASE_STRATEGY.md) | Lockstep versioning model, commit→version mapping, semantic-release flow |
 | [development/BRANCH_PROTECTION.md](development/BRANCH_PROTECTION.md) | Branch-protection rules on `main` (required checks, bypass paths) |
 | [development/DEPLOY.md](development/DEPLOY.md) | Production deploy runbook — web via Vercel (auto) + manual Convex deploy, deploy-order rule, verification |
+| [orchestrator/README.md](orchestrator/README.md) | Orchestrator prompts — copy/paste `/fable-orchestrator` commands (Claude Code) for repo scans, reviews, implementation, and test strategy |
 
 ## Guides
 

--- a/docs/orchestrator/README.md
+++ b/docs/orchestrator/README.md
@@ -1,0 +1,32 @@
+# Orchestrator Prompts — Claude Code
+
+Copy/paste `/fable-orchestrator` commands for delegating bounded work in `sprtsmng` from the
+Claude Code TUI. Fable keeps planning, ambiguity resolution, final judgment, and user
+communication in the parent session; workers do the bounded task and report back.
+
+## Files
+
+- [repo-scan.md](repo-scan.md) — map structure, risks, test commands, delegation seams (`codex/analyze`)
+- [file-focused-review.md](file-focused-review.md) — review a file/subsystem against invariants (`codex/review`)
+- [implementation.md](implementation.md) — turn a bounded task into a safe delegation (`codex/implement` · `composer/implement`)
+- [test-strategy.md](test-strategy.md) — find focused verification commands + gaps (`codex/analyze`)
+
+## Before delegating
+
+```
+/fable-orchestrator:setup
+/fable-orchestrator:observability
+```
+
+`setup` checks backend readiness; `observability` shows recent delegated worker runs.
+
+## Applies to every command below
+
+- **Prohibitions:** no commits, pushes, PRs, merges, releases, deploys (Vercel or `convex deploy`),
+  destructive scratch-org ops, secret/`.env*` edits, or refactors outside the stated scope.
+- **Safe label:** `sprtsmng/<area>/<short-slug>` — e.g. `sprtsmng/apex/division-service`.
+- **Verification menu:** Apex `sf apex test run --wait 10 --code-coverage --result-format human` ·
+  LWC `pnpm run test:unit` · web unit `pnpm --filter @sports-management/web test:unit` ·
+  web types `pnpm --filter @sports-management/web type-check` ·
+  web e2e `pnpm --filter @sports-management/web test:e2e` ·
+  contracts `pnpm --filter @sports-management/api-contracts build`.

--- a/docs/orchestrator/file-focused-review.md
+++ b/docs/orchestrator/file-focused-review.md
@@ -1,0 +1,22 @@
+# File / Subsystem Review — `codex/review` (Claude Code)
+
+Copy/paste into the Claude Code TUI. See [README.md](README.md) for shared prohibitions, labels,
+and the verification menu.
+
+Apex service/controller review:
+
+```
+/fable-orchestrator:orchestrate Review <path e.g. sportsmgmt/main/default/classes/DivisionService.cls> for correctness, ranked most-severe first. Invariants: keep the controller→service→repository→domain-interface layering; new public methods stay `virtual`; services keep constructor DI; controllers keep @TestVisible setters; all classes `with sharing`; org coverage stays ≥90%. Verify with `sf apex test run --tests <Class>Test --wait 10 --code-coverage`. Propose diffs only — no commits/deploys. Label: sprtsmng/apex/<class>/review.
+```
+
+Web / Convex review:
+
+```
+/fable-orchestrator:orchestrate Review <path under apps/web> for correctness and contract drift. Invariants: Convex writes stay internalMutation (admin-keyed server-side only); keep DTO ⇄ return-validator parity to avoid data-dependent 500s; treat packages/api-contracts as a public contract. Verify with `pnpm --filter @sports-management/web type-check`. Propose diffs only — no commits/deploys. Label: sprtsmng/web/<area>/review.
+```
+
+Public-contract change check:
+
+```
+/fable-orchestrator:orchestrate Review <path> for breaking changes to public interfaces (IDivision, ITeam, packages/api-contracts). Flag any breakage; do not silently alter contracts. Report only; no edits. Label: sprtsmng/<area>/contract-review.
+```

--- a/docs/orchestrator/implementation.md
+++ b/docs/orchestrator/implementation.md
@@ -1,0 +1,29 @@
+# Implementation — `codex/implement` · `composer/implement` (Claude Code)
+
+Copy/paste into the Claude Code TUI once Fable has chosen the approach. See [README.md](README.md)
+for shared prohibitions, labels, and the verification menu. Keep tasks bounded — one subsystem,
+clear spec, named verification.
+
+Bounded Apex change:
+
+```
+/fable-orchestrator:orchestrate Implement <bounded change> in <Apex path>. Invariants: keep controller→service→repository→domain-interface layering; new public methods `virtual`; constructor DI; @TestVisible setters; `with sharing`; add/extend tests incl. bulk + negative paths. Verify with `sf apex test run --tests <Class>Test --wait 10 --code-coverage`. Do not commit, push, or deploy — leave changes in the working tree for review. Label: sprtsmng/apex/<class>/impl.
+```
+
+Bounded web change:
+
+```
+/fable-orchestrator:orchestrate Implement <bounded change> in <apps/web path>. Invariants: Convex writes stay internalMutation; keep DTO ⇄ return-validator parity; respect packages/api-contracts. Verify with `pnpm --filter @sports-management/web type-check` and `pnpm --filter @sports-management/web test:unit`. Do not commit/push/deploy. Label: sprtsmng/web/<area>/impl.
+```
+
+Mechanical refactor / migration (Composer default):
+
+```
+/fable-orchestrator:orchestrate Apply this mechanical change across <paths>: <spec>. No behavior changes. Verify with the layer's test command. Do not commit/push/deploy or touch unrelated code. Label: sprtsmng/<area>/refactor.
+```
+
+Then confirm the delegated run:
+
+```
+/fable-orchestrator:observability
+```

--- a/docs/orchestrator/repo-scan.md
+++ b/docs/orchestrator/repo-scan.md
@@ -1,0 +1,22 @@
+# Repo Scan — `codex/analyze` (Claude Code)
+
+Copy/paste into the Claude Code TUI. See [README.md](README.md) for shared prohibitions, labels,
+and the verification menu.
+
+Whole-repo map:
+
+```
+/fable-orchestrator:orchestrate Scan this repo read-only and map it for delegation: list the Salesforce DX packages (sportsmgmt, sportsmgmt-football) vs the Turborepo TS apps/packages, the real test commands per layer, notable risks, and the best seams to split independent work. Do not edit files, install deps, or deploy. Label: sprtsmng/repo/scan.
+```
+
+Scoped to one area:
+
+```
+/fable-orchestrator:orchestrate Scan <path> read-only and report its structure, entrypoints, dependencies, and test command. Keep the Salesforce (Apex/LWC) and TS toolchains distinct; do not conflate them. No edits, no deploys. Label: sprtsmng/<area>/scan.
+```
+
+Delegation-seam finder before a big change:
+
+```
+/fable-orchestrator:orchestrate Read-only: identify independently-workable seams for <change> — isolated Apex services, standalone packages, per-app test suites — and rank them by blast radius. Report only; no edits. Label: sprtsmng/<area>/seams.
+```

--- a/docs/orchestrator/test-strategy.md
+++ b/docs/orchestrator/test-strategy.md
@@ -1,0 +1,22 @@
+# Test Strategy — `codex/analyze` (Claude Code)
+
+Copy/paste into the Claude Code TUI before implementing. See [README.md](README.md) for shared
+prohibitions, labels, and the verification menu.
+
+Find the narrowest verification for a planned change:
+
+```
+/fable-orchestrator:orchestrate Read-only: for a change to <paths>, identify the narrowest verification commands and any coverage gaps. Match tool to layer — Apex→`sf apex test`, LWC→Jest (`pnpm run test:unit`), web/tui/packages→Vitest, browser flows→Playwright. Do not propose a runner a package doesn't declare; keep Salesforce and TS verification separate. Report commands + gaps only; no edits. Label: sprtsmng/<area>/test-strategy.
+```
+
+Coverage-gap hunt for a subsystem:
+
+```
+/fable-orchestrator:orchestrate Read-only: audit <subsystem> for missing test coverage — untested negative paths, bulk/governor-limit cases (Apex), or unvalidated DTO shapes (web). List gaps ranked by risk; do not write tests. Label: sprtsmng/<area>/coverage-gaps.
+```
+
+Guardrail check before a PR:
+
+```
+/fable-orchestrator:orchestrate Read-only: list which repo guardrails apply to <paths> — `pnpm run lint`, `pnpm run prettier:verify`, `pnpm run check:env`, `pnpm run check:css` — and why. Report only. Label: sprtsmng/<area>/guardrails.
+```


### PR DESCRIPTION
## Summary
Follow-up to the Clerk prod cutover (#386): the sign-in/sign-up routes rendered on a bare near-black background in dark mode (read as a "blank screen"). Adds a shared `(auth)` layout with branding + themed background, removes the per-page `<main>` wrappers, and adds a secrets-free `public-auth` Playwright project for prod smoke (`pnpm run test:prod:auth`). `clerk-signin.ts` now prefers `PROD_CLERK_SECRET_KEY` / `PROD_E2E_CLERK_USER_ID` when set for full authed sweeps.

## Testing
- `pnpm run test:prod:auth` against live prod: 3/3 pass with screenshots
- Sign-in verified manually in prod ("Login seems to be working")

Made with [Cursor](https://cursor.com)