### PR TITLE
feat(web): season completion flow feeding dynasty rollover (WSM-000217)

### DIFF
--- a/apps/web/convex/__tests__/completeSeason.test.ts
+++ b/apps/web/convex/__tests__/completeSeason.test.ts
@@ -1,0 +1,217 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/*
+ * Season completion lifecycle (WSM-000217): completeSeason requires a decided
+ * champion (or force), and a completed season is read-only for game data.
+ */
+
+interface Seeded {
+  leagueId: Id<"leagues">;
+  seasonId: Id<"seasons">;
+  teamIds: [Id<"teams">, Id<"teams">];
+  fixtureId: Id<"fixtures">;
+}
+
+async function seedSeason(
+  t: ReturnType<typeof convexTest>,
+  opts: { champion?: boolean } = {},
+): Promise<Seeded> {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const team = (name: string) =>
+      ctx.db.insert("teams", {
+        name,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Loc",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+    const teamA = await team("Alphas");
+    const teamB = await team("Betas");
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: "2026-09-01",
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const fixtureId = await ctx.db.insert("fixtures", {
+      seasonId,
+      homeTeamId: teamA,
+      awayTeamId: teamB,
+      scheduledAt: null,
+      week: 1,
+      venue: null,
+      status: "scheduled",
+      createdAt: "2026-01-01",
+      createdBy: "actor",
+    });
+
+    if (opts.champion) {
+      const bracketId = await ctx.db.insert("playoffBrackets", {
+        seasonId,
+        leagueId,
+        size: 2,
+        rounds: 1,
+        createdAt: "2026-01-01",
+        createdBy: "actor",
+      });
+      await ctx.db.insert("playoffMatchups", {
+        bracketId,
+        seasonId,
+        round: 1,
+        slot: 0,
+        homeSeed: 1,
+        awaySeed: 2,
+        homeTeamId: teamA,
+        awayTeamId: teamB,
+        nextMatchupId: null,
+        nextSlot: null,
+        winnerTeamId: teamA,
+        fixtureId: null,
+      });
+    }
+
+    return { leagueId, seasonId, teamIds: [teamA, teamB], fixtureId };
+  });
+}
+
+async function seasonStatus(
+  t: ReturnType<typeof convexTest>,
+  seasonId: Id<"seasons">,
+): Promise<string | undefined> {
+  return t.run(async (ctx) => (await ctx.db.get(seasonId))?.status);
+}
+
+describe("completeSeason", () => {
+  it("completes a season whose bracket has a champion", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedSeason(t, { champion: true });
+
+    await t.mutation(internal.sports.completeSeason, { seasonId });
+
+    expect(await seasonStatus(t, seasonId)).toBe("completed");
+  });
+
+  it("rejects without a champion", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedSeason(t);
+
+    await expect(
+      t.mutation(internal.sports.completeSeason, { seasonId }),
+    ).rejects.toThrow("no_champion");
+    expect(await seasonStatus(t, seasonId)).toBe("active");
+  });
+
+  it("force overrides the champion requirement", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedSeason(t);
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+
+    expect(await seasonStatus(t, seasonId)).toBe("completed");
+  });
+
+  it("is idempotent on an already-completed season", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedSeason(t);
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+    await t.mutation(internal.sports.completeSeason, { seasonId });
+
+    expect(await seasonStatus(t, seasonId)).toBe("completed");
+  });
+});
+
+describe("completed seasons are read-only for game data", () => {
+  async function completedSeason(t: ReturnType<typeof convexTest>) {
+    const seeded = await seedSeason(t);
+    await t.mutation(internal.sports.completeSeason, {
+      seasonId: seeded.seasonId,
+      force: true,
+    });
+    return seeded;
+  }
+
+  it("recordGameResult rejects (blocks manual results and every sim path)", async () => {
+    const t = convexTest(schema, modules);
+    const { fixtureId } = await completedSeason(t);
+
+    await expect(
+      t.mutation(internal.sports.recordGameResult, {
+        fixtureId,
+        homeScore: 21,
+        awayScore: 14,
+        actorUserId: "actor",
+      }),
+    ).rejects.toThrow("season_completed");
+  });
+
+  it("createFixture rejects", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, teamIds } = await completedSeason(t);
+
+    await expect(
+      t.mutation(internal.sports.createFixture, {
+        seasonId,
+        homeTeamId: teamIds[0],
+        awayTeamId: teamIds[1],
+        scheduledAt: null,
+        week: 2,
+        venue: null,
+        actorUserId: "actor",
+      }),
+    ).rejects.toThrow("season_completed");
+  });
+
+  it("generateSeasonSchedule rejects", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await completedSeason(t);
+
+    await expect(
+      t.mutation(internal.sports.generateSeasonSchedule, {
+        seasonId,
+        actorUserId: "actor",
+      }),
+    ).rejects.toThrow("season_completed");
+  });
+
+  it("generatePlayoffBracket rejects", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await completedSeason(t);
+
+    await expect(
+      t.mutation(internal.sports.generatePlayoffBracket, {
+        seasonId,
+        size: 2,
+        actorUserId: "actor",
+      }),
+    ).rejects.toThrow("season_completed");
+  });
+
+  it("setActiveSeason reactivates a completed season (escape hatch)", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await completedSeason(t);
+
+    await t.mutation(internal.sports.setActiveSeason, { seasonId });
+
+    expect(await seasonStatus(t, seasonId)).toBe("active");
+  });
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -1956,6 +1956,45 @@ export const setActiveSeason = internalMutationGeneric({
 });
 
 /**
+ * Mark a season completed (WSM-000217). Requires the playoff bracket to have a
+ * decided champion unless `force` is passed (admin override for seasons without
+ * playoffs or abandoned mid-way). Completed seasons are read-only for game
+ * data: createFixture / generateSeasonSchedule / recordGameResult /
+ * generatePlayoffBracket all reject with "season_completed" (which also blocks
+ * every simulation path, since sims persist through recordGameResult).
+ * Reactivating via setActiveSeason is the escape hatch.
+ */
+export const completeSeason = internalMutationGeneric({
+  args: { seasonId: v.id("seasons"), force: v.optional(v.boolean()) },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.status === "completed") return null;
+
+    if (!args.force) {
+      const bracket = await ctx.db
+        .query("playoffBrackets")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+        .first();
+      const matchups = bracket
+        ? await ctx.db
+            .query("playoffMatchups")
+            .withIndex("by_bracketId", (q) => q.eq("bracketId", bracket._id))
+            .collect()
+        : [];
+      const champion = bracket
+        ? championFromMatchups(matchups, bracket.format ?? "single")
+        : null;
+      if (!champion) throw new Error("no_champion");
+    }
+
+    await ctx.db.patch(args.seasonId, { status: "completed" });
+    return null;
+  },
+});
+
+/**
  * Delete a season and cascade its season-scoped rows (WSM-000126, WSM-000209):
  * fixtures and per-fixture game data, depth chart, playoff bracket rows, player
  * attributes, and roster assignments. rosterAuditLog is intentionally retained
@@ -3779,6 +3818,7 @@ export const createFixture = internalMutationGeneric({
 
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
+    if (season.status === "completed") throw new Error("season_completed");
 
     const home = await ctx.db.get(args.homeTeamId);
     const away = await ctx.db.get(args.awayTeamId);
@@ -3949,6 +3989,7 @@ export const generateSeasonSchedule = internalMutationGeneric({
   handler: async (ctx, args) => {
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
+    if (season.status === "completed") throw new Error("season_completed");
 
     const teams = await ctx.db
       .query("teams")
@@ -4323,6 +4364,11 @@ export const recordGameResult = internalMutationGeneric({
   handler: async (ctx, args) => {
     const fixture = await ctx.db.get(args.fixtureId);
     if (!fixture) throw new Error("fixture_not_found");
+
+    // Completed seasons are read-only (WSM-000217). This single gate also
+    // blocks all simulation paths, which persist via recordGameResult.
+    const season = await ctx.db.get(fixture.seasonId);
+    if (season?.status === "completed") throw new Error("season_completed");
 
     const recordedAt = new Date().toISOString();
     const payload = {
@@ -5973,6 +6019,7 @@ export const generatePlayoffBracket = internalMutationGeneric({
     }
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
+    if (season.status === "completed") throw new Error("season_completed");
     const format =
       (args.format ?? season.playoffFormat) === "double" ? "double" : "single";
     // Honor the season's configured qualification rule (overridable per call).

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -6,6 +6,7 @@ import {
   upsertSeason,
   updateSeason as updateSeasonMutation,
   setActiveSeason as setActiveSeasonMutation,
+  completeSeason as completeSeasonMutation,
   deleteSeason as deleteSeasonMutation,
   copySeasonRosters,
   getSeasonLeagueId,
@@ -113,6 +114,35 @@ export async function activateSeasonAction(seasonId: string): Promise<Result> {
   await setActiveSeasonMutation(seasonId);
   revalidatePath("/dashboard/seasons");
   return { ok: true };
+}
+
+/*
+ * Season completion (WSM-000217). Refuses unless the playoff bracket has a
+ * champion; the UI surfaces "no_champion" as a force-confirm so admins can
+ * close out playoff-less or abandoned seasons deliberately.
+ */
+export async function completeSeasonAction(input: {
+  seasonId: string;
+  force?: boolean;
+}): Promise<Result> {
+  const leagueId = await getSeasonLeagueId(input.seasonId);
+  const gate = await requireLeagueAdmin(leagueId);
+  if (!gate.ok) return gate;
+
+  try {
+    await completeSeasonMutation({
+      seasonId: input.seasonId,
+      force: input.force,
+    });
+    revalidatePath("/dashboard/seasons");
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("no_champion")) {
+      return { ok: false, error: "no_champion" };
+    }
+    return { ok: false, error: message };
+  }
 }
 
 export async function deleteSeasonAction(seasonId: string): Promise<Result> {

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -24,11 +24,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "sonner";
-import { Plus, Trash2, Pencil, CheckCircle2, Users } from "lucide-react";
+import { Plus, Trash2, Pencil, CheckCircle2, Users, Trophy } from "lucide-react";
 import {
   createSeasonAction,
   updateSeasonAction,
   activateSeasonAction,
+  completeSeasonAction,
   deleteSeasonAction,
   copyRostersAction,
 } from "./actions";
@@ -384,6 +385,45 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
     }
   }
 
+  async function complete() {
+    if (
+      !window.confirm(
+        `Mark "${season.name}" as completed? Schedule generation, result recording, and simulations will be locked for it.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    let res = await completeSeasonAction({ seasonId: season.id });
+    if (!res.ok && res.error === "no_champion") {
+      const force = window.confirm(
+        "No playoff champion has been decided for this season. Complete it anyway?",
+      );
+      if (force) {
+        res = await completeSeasonAction({ seasonId: season.id, force: true });
+      } else {
+        setBusy(false);
+        return;
+      }
+    }
+    setBusy(false);
+    if (res.ok) {
+      toast.success(`${season.name} completed.`, {
+        description: "Run the dynasty rollover from the league page next.",
+        action: {
+          label: "League page",
+          onClick: () =>
+            router.push(`/dashboard/leagues/${season.leagueId}`),
+        },
+      });
+      router.refresh();
+    } else {
+      toast.error(
+        res.error === "not_admin" ? "Only league admins can do that." : res.error,
+      );
+    }
+  }
+
   async function save() {
     const trimmed = name.trim();
     if (!trimmed) return;
@@ -483,6 +523,18 @@ export function SeasonRowActions({ season }: { season: SeasonDto }) {
         >
           <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
           Make active
+        </Button>
+      )}
+      {isActive && (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={complete}
+          aria-label={`Complete ${season.name}`}
+        >
+          <Trophy className="mr-1 h-3.5 w-3.5" />
+          Complete
         </Button>
       )}
       <CopyRostersButton season={season} />

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -339,6 +339,9 @@ const refs = {
   setActiveSeason: mutationRef<{ seasonId: string }, null>(
     "sports:setActiveSeason",
   ),
+  completeSeason: mutationRef<{ seasonId: string; force?: boolean }, null>(
+    "sports:completeSeason",
+  ),
   deleteSeason: mutationRef<{ seasonId: string }, null>("sports:deleteSeason"),
   setLeagueInviteToken: mutationRef<
     { leagueId: string; token: string | null },
@@ -1376,6 +1379,13 @@ export async function updateSeason(input: {
   const dto = await mutateConvex(refs.updateSeason, input);
   if (!dto) throw new Error("Season not found");
   return dto;
+}
+
+export async function completeSeason(input: {
+  seasonId: string;
+  force?: boolean;
+}): Promise<null> {
+  return mutateConvex(refs.completeSeason, input);
 }
 
 export async function setActiveSeason(seasonId: string): Promise<null> {


### PR DESCRIPTION
## Summary
Seasons now have an explicit end. A new `completeSeason` Convex mutation sets `status: "completed"`, refusing unless the playoff bracket has a decided champion — or `force: true`, which the UI surfaces as a second confirm ("No playoff champion has been decided… Complete it anyway?") for playoff-less or abandoned seasons.

Completed seasons are read-only for game data, gated once at the mutation layer: `createFixture`, `generateSeasonSchedule`, `recordGameResult`, and `generatePlayoffBracket` all throw `season_completed`. Since every simulation path persists through `recordGameResult`, sims are blocked by the same single gate. `setActiveSeason` still reactivates a completed season as the escape hatch (it already demoted prior actives to "completed", so the status value predates this PR).

Active season rows on `/dashboard/seasons` get a **Complete** action (trophy icon, admin-gated like its neighbors); the success toast links to the league page where the dynasty rollover panel lives.

## Related Issue
Closes #481

## Testing
- 9 new convex-test cases: champion happy path, no-champion rejection, force override, idempotency, all four read-only gates, and the reactivation escape hatch
- 939/939 unit tests, type-check and ESLint clean

Made with [Cursor](https://cursor.com)