### PR TITLE
feat(web): S2 gamecast redesign leaf panels (WSM-000221)

### DIFF
--- a/apps/web/src/components/gamecast/BoxScore.tsx
+++ b/apps/web/src/components/gamecast/BoxScore.tsx
@@ -1,0 +1,65 @@
+import type { BoxScoreAtPosition } from "@/lib/gamecast";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export interface BoxScoreTeam {
+  abbr: string;
+}
+
+export interface BoxScoreProps {
+  data: BoxScoreAtPosition;
+  homeTeam: BoxScoreTeam;
+  awayTeam: BoxScoreTeam;
+}
+
+type StatKey = "total" | "pass" | "rush" | "first" | "to" | "plays";
+
+const ROWS: ReadonlyArray<{ label: string; key: StatKey }> = [
+  { label: "Total yards", key: "total" },
+  { label: "Passing", key: "pass" },
+  { label: "Rushing", key: "rush" },
+  { label: "First downs", key: "first" },
+  { label: "Turnovers", key: "to" },
+  { label: "Off. plays", key: "plays" },
+];
+
+export default function BoxScore({
+  data,
+  homeTeam,
+  awayTeam,
+}: BoxScoreProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead className="text-text-muted">Team stats</TableHead>
+          <TableHead className="text-right font-mono text-caption-12 font-bold text-foreground">
+            {homeTeam.abbr}
+          </TableHead>
+          <TableHead className="text-right font-mono text-caption-12 font-bold text-foreground">
+            {awayTeam.abbr}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {ROWS.map((row) => (
+          <TableRow key={row.key} className="hover:bg-transparent">
+            <TableCell className="text-text-muted">{row.label}</TableCell>
+            <TableCell className="text-right font-mono text-caption-12 font-bold tabular-nums">
+              {data.home[row.key]}
+            </TableCell>
+            <TableCell className="text-right font-mono text-caption-12 font-bold tabular-nums">
+              {data.away[row.key]}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/src/components/gamecast/FieldPosition.tsx
+++ b/apps/web/src/components/gamecast/FieldPosition.tsx
@@ -1,0 +1,244 @@
+export interface FieldPositionTeam {
+  name: string;
+  abbr: string;
+  color: string;
+}
+
+export interface FieldPositionProps {
+  homeTeam: FieldPositionTeam;
+  awayTeam: FieldPositionTeam;
+  ballChartYard: number;
+  firstDownChartYard: number | null;
+  losChartYard: number;
+  possession: "home" | "away" | null;
+  showLegend?: boolean;
+}
+
+const VIEW_WIDTH = 480;
+const VIEW_HEIGHT = 200;
+const END_ZONE_WIDTH = 60;
+const TURF_WIDTH = 360;
+
+const LOS_COLOR = "#4a9be0";
+const FIRST_DOWN_COLOR = "#e0b64a";
+const BALL_COLOR = "#c47b3a";
+
+function chartToX(chartYard: number): number {
+  return END_ZONE_WIDTH + chartYard * 3;
+}
+
+export default function FieldPosition({
+  homeTeam,
+  awayTeam,
+  ballChartYard,
+  firstDownChartYard,
+  losChartYard,
+  possession,
+  showLegend = true,
+}: FieldPositionProps) {
+  const driveDir = possession === "home" ? 1 : possession === "away" ? -1 : 0;
+  const possessionColor =
+    possession === "home"
+      ? homeTeam.color
+      : possession === "away"
+        ? awayTeam.color
+        : undefined;
+  const ballX = chartToX(ballChartYard);
+
+  return (
+    <div>
+      <svg
+        viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="block w-full rounded-card border border-border"
+        role="img"
+        aria-label="Field position"
+      >
+        <rect
+          x={0}
+          y={0}
+          width={END_ZONE_WIDTH}
+          height={VIEW_HEIGHT}
+          fill={homeTeam.color}
+          opacity={0.9}
+        />
+        <rect
+          x={END_ZONE_WIDTH + TURF_WIDTH}
+          y={0}
+          width={END_ZONE_WIDTH}
+          height={VIEW_HEIGHT}
+          fill={awayTeam.color}
+          opacity={0.9}
+        />
+        <text
+          x={30}
+          y={100}
+          fill="#fff"
+          fontSize={15}
+          fontWeight={800}
+          fontFamily="var(--font-mono)"
+          textAnchor="middle"
+          transform="rotate(-90 30 100)"
+          opacity={0.92}
+        >
+          {homeTeam.abbr}
+        </text>
+        <text
+          x={450}
+          y={100}
+          fill="#fff"
+          fontSize={15}
+          fontWeight={800}
+          fontFamily="var(--font-mono)"
+          textAnchor="middle"
+          transform="rotate(90 450 100)"
+          opacity={0.92}
+        >
+          {awayTeam.abbr}
+        </text>
+
+        <rect
+          x={END_ZONE_WIDTH}
+          y={0}
+          width={TURF_WIDTH}
+          height={VIEW_HEIGHT}
+          className="fill-surface-2"
+        />
+
+        {Array.from({ length: 11 }, (_, i) => i * 10).map((chartYard) => (
+          <line
+            key={`yard-${chartYard}`}
+            x1={chartToX(chartYard)}
+            y1={0}
+            x2={chartToX(chartYard)}
+            y2={VIEW_HEIGHT}
+            className={
+              chartYard === 50 ? "stroke-border-strong" : "stroke-border"
+            }
+            strokeWidth={chartYard === 50 ? 1.4 : 1}
+          />
+        ))}
+
+        {Array.from({ length: 19 }, (_, i) => (i + 1) * 5).map((chartYard) => (
+          <g key={`hash-${chartYard}`}>
+            <line
+              x1={chartToX(chartYard)}
+              y1={62}
+              x2={chartToX(chartYard)}
+              y2={70}
+              className="stroke-border-strong"
+              strokeWidth={1}
+            />
+            <line
+              x1={chartToX(chartYard)}
+              y1={130}
+              x2={chartToX(chartYard)}
+              y2={138}
+              className="stroke-border-strong"
+              strokeWidth={1}
+            />
+          </g>
+        ))}
+
+        {Array.from({ length: 9 }, (_, i) => (i + 1) * 10).map((chartYard) => {
+          const label = chartYard <= 50 ? chartYard : 100 - chartYard;
+          return (
+            <text
+              key={`num-${chartYard}`}
+              x={chartToX(chartYard)}
+              y={108}
+              className="fill-text-subtle"
+              fontSize={13}
+              fontWeight={700}
+              fontFamily="var(--font-mono)"
+              textAnchor="middle"
+            >
+              {label}
+            </text>
+          );
+        })}
+
+        {firstDownChartYard != null ? (
+          <line
+            x1={chartToX(firstDownChartYard)}
+            y1={0}
+            x2={chartToX(firstDownChartYard)}
+            y2={VIEW_HEIGHT}
+            stroke={FIRST_DOWN_COLOR}
+            strokeWidth={2.4}
+          />
+        ) : null}
+
+        <line
+          x1={chartToX(losChartYard)}
+          y1={0}
+          x2={chartToX(losChartYard)}
+          y2={VIEW_HEIGHT}
+          stroke={LOS_COLOR}
+          strokeWidth={2.4}
+        />
+
+        <circle
+          cx={ballX}
+          cy={100}
+          r={11}
+          className="fill-bg"
+          opacity={0.55}
+        />
+        <ellipse
+          cx={ballX}
+          cy={100}
+          rx={8}
+          ry={5}
+          fill={BALL_COLOR}
+          stroke="#fff"
+          strokeWidth={1.4}
+        />
+
+        {driveDir !== 0 && possessionColor ? (
+          <g>
+            <line
+              x1={ballX + driveDir * 15}
+              y1={100}
+              x2={ballX + driveDir * 22}
+              y2={100}
+              stroke={possessionColor}
+              strokeWidth={3}
+              strokeLinecap="round"
+            />
+            <path
+              d={`M${ballX + driveDir * 22} 100 l${-driveDir * 6} -5 v10 z`}
+              fill={possessionColor}
+            />
+          </g>
+        ) : null}
+      </svg>
+
+      {showLegend ? (
+        <div className="mt-2 flex flex-wrap gap-4 text-caption-12 text-text-subtle">
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block h-[3px] w-3.5 rounded-sm"
+              style={{ backgroundColor: LOS_COLOR }}
+            />
+            Line of scrimmage
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block h-[3px] w-3.5 rounded-sm"
+              style={{ backgroundColor: FIRST_DOWN_COLOR }}
+            />
+            First down
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block size-2 rounded-full"
+              style={{ backgroundColor: BALL_COLOR }}
+            />
+            Ball
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/ScoringSummary.tsx
+++ b/apps/web/src/components/gamecast/ScoringSummary.tsx
@@ -1,0 +1,91 @@
+import type { ScoringSummaryEntry } from "@/lib/gamecast";
+import { formatGameClock, formatQuarterLabel } from "@/lib/gamecast";
+import { Badge } from "@/components/ui/badge";
+
+export interface ScoringSummaryTeam {
+  id: string;
+  abbr: string;
+  color: string;
+}
+
+export interface ScoringSummaryProps {
+  entries: ScoringSummaryEntry[];
+  homeTeam: ScoringSummaryTeam;
+  awayTeam: ScoringSummaryTeam;
+}
+
+function kindBadgeLabel(kind: ScoringSummaryEntry["kind"]): string {
+  return kind === "touchdown" ? "TD" : "FG";
+}
+
+function kindLabel(kind: ScoringSummaryEntry["kind"]): string {
+  return kind === "touchdown" ? "Touchdown" : "Field goal";
+}
+
+export default function ScoringSummary({
+  entries,
+  homeTeam,
+  awayTeam,
+}: ScoringSummaryProps) {
+  const sorted = [...entries].reverse();
+
+  if (sorted.length === 0) {
+    return (
+      <p className="py-6 text-center text-caption-12 text-text-subtle">
+        No scoring yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border">
+      {sorted.map((entry, index) => {
+        const team =
+          entry.team === homeTeam.id
+            ? homeTeam
+            : entry.team === awayTeam.id
+              ? awayTeam
+              : null;
+        const timeLabel = `${formatQuarterLabel(entry.quarter)} ${formatGameClock(entry.clockSeconds)}`;
+
+        return (
+          <li
+            key={`${entry.quarter}-${entry.clockSeconds}-${entry.kind}-${index}`}
+            className="flex items-center gap-3 py-2.5"
+          >
+            <span className="w-[52px] shrink-0 font-mono text-caption-12 text-text-subtle">
+              {timeLabel}
+            </span>
+            <Badge variant="outline" className="shrink-0 px-1.5 py-0 font-mono text-[10px]">
+              {kindBadgeLabel(entry.kind)}
+            </Badge>
+            {team ? (
+              <span
+                className="inline-flex items-center gap-1.5 font-mono text-caption-12 font-bold"
+                style={{ color: team.color }}
+              >
+                <span
+                  className="inline-block size-3 shrink-0 rounded-sm"
+                  style={{ backgroundColor: team.color }}
+                  aria-hidden
+                />
+                {team.abbr}
+              </span>
+            ) : (
+              <span className="font-mono text-caption-12 text-text-muted">—</span>
+            )}
+            <span className="min-w-0 flex-1 truncate text-label-14 text-text-muted">
+              {kindLabel(entry.kind)}
+            </span>
+            <span className="shrink-0 font-mono text-caption-12 text-text-muted">
+              +{entry.points}
+            </span>
+            <span className="shrink-0 font-mono text-label-14 font-bold tabular-nums text-foreground">
+              {entry.homeScore}–{entry.awayScore}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/gamecast/WinProbability.tsx
+++ b/apps/web/src/components/gamecast/WinProbability.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export interface WinProbabilityTeam {
+  abbr: string;
+  color: string;
+}
+
+export interface WinProbabilityProps {
+  series: number[];
+  currentIndex: number;
+  mode: "sim" | "review";
+  homeTeam: WinProbabilityTeam;
+  awayTeam: WinProbabilityTeam;
+}
+
+function teamSoftFill(color: string): string {
+  return `${color}2e`;
+}
+
+export default function WinProbability({
+  series,
+  currentIndex,
+  mode,
+  homeTeam,
+  awayTeam,
+}: WinProbabilityProps) {
+  const total = Math.max(series.length - 1, 1);
+  const endIndex =
+    mode === "sim"
+      ? Math.min(currentIndex, series.length - 1)
+      : series.length - 1;
+  const visibleSeries = series.slice(0, endIndex + 1);
+  const currentWinPct =
+    series[Math.min(currentIndex, series.length - 1)] ?? 50;
+
+  const points = visibleSeries.map((winPct, i) => [
+    (i / total) * 100,
+    100 - winPct,
+  ] as const);
+
+  const linePath = points
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(" ");
+
+  const areaPath =
+    points.length > 0
+      ? `${linePath} L${points[points.length - 1][0].toFixed(2)} 50 L0 50 Z`
+      : "";
+
+  const showMarker = currentIndex > 0 && series.length > 0;
+  const markerX = (currentIndex / total) * 100;
+  const markerY = 100 - (series[currentIndex] ?? currentWinPct);
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2">
+        <p className="font-mono text-caption-12 font-bold uppercase tracking-wide text-text-muted">
+          Illustrative model
+        </p>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              type="button"
+              className="inline-flex text-text-subtle transition-colors hover:text-text-muted"
+              aria-label="About win probability model"
+            >
+              <Info className="size-3.5" aria-hidden />
+            </TooltipTrigger>
+            <TooltipContent sideOffset={4}>
+              Estimated from score and time remaining — not a forecast
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <TeamChip abbr={homeTeam.abbr} color={homeTeam.color} />
+        <span className="font-mono text-[20px] font-extrabold leading-none tabular-nums text-foreground">
+          {currentWinPct}%
+        </span>
+        <TeamChip abbr={awayTeam.abbr} color={awayTeam.color} align="right" />
+      </div>
+
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="block h-[120px] w-full rounded-card border border-border bg-surface-2"
+        role="img"
+        aria-label="Win probability chart"
+      >
+        <rect x={0} y={0} width={100} height={50} fill={teamSoftFill(homeTeam.color)} />
+        <rect x={0} y={50} width={100} height={50} fill={teamSoftFill(awayTeam.color)} />
+        <line
+          x1={0}
+          y1={50}
+          x2={100}
+          y2={50}
+          className="stroke-border-strong"
+          strokeWidth={0.5}
+          strokeDasharray="2 2"
+        />
+        {areaPath ? (
+          <path d={areaPath} fill={homeTeam.color} opacity={0.14} />
+        ) : null}
+        {linePath ? (
+          <path
+            d={linePath}
+            fill="none"
+            stroke={homeTeam.color}
+            strokeWidth={1.4}
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : null}
+        {showMarker ? (
+          <>
+            <line
+              x1={markerX}
+              y1={0}
+              x2={markerX}
+              y2={100}
+              className="stroke-text-muted"
+              strokeWidth={0.5}
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx={markerX}
+              cy={markerY}
+              r={2.4}
+              className="fill-foreground stroke-bg"
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+          </>
+        ) : null}
+      </svg>
+
+      <div className="mt-1.5 flex justify-between font-mono text-[10px] leading-none text-text-subtle">
+        <span>Kickoff</span>
+        <span>Q2</span>
+        <span>Half</span>
+        <span>Q4</span>
+        <span>Final</span>
+      </div>
+    </div>
+  );
+}
+
+function TeamChip({
+  abbr,
+  color,
+  align = "left",
+}: {
+  abbr: string;
+  color: string;
+  align?: "left" | "right";
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 font-mono text-caption-12 font-bold ${
+        align === "right" ? "flex-row-reverse" : ""
+      }`}
+      style={{ color }}
+    >
+      <span
+        className="inline-block size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      {abbr}
+    </span>
+  );
+}

--- a/apps/web/src/lib/gamecast/__tests__/team-display.test.ts
+++ b/apps/web/src/lib/gamecast/__tests__/team-display.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { deriveTeamDisplay } from "@/lib/gamecast/team-display";
+
+describe("deriveTeamDisplay", () => {
+  it("derives a three-letter uppercase abbreviation from the team name", () => {
+    expect(deriveTeamDisplay("Wheeler").abbr).toBe("WHE");
+    expect(deriveTeamDisplay("Hillgrove High").abbr).toBe("HIL");
+  });
+
+  it("uses the primary color when it is a valid hex value", () => {
+    expect(deriveTeamDisplay("Wheeler", "#3d6fe6").color).toBe("#3d6fe6");
+  });
+
+  it("falls back to the neutral token when color is missing or invalid", () => {
+    expect(deriveTeamDisplay("Wheeler").color).toBe("var(--text-subtle)");
+    expect(deriveTeamDisplay("Wheeler", "blue").color).toBe("var(--text-subtle)");
+    expect(deriveTeamDisplay("Wheeler", "#abc").color).toBe("var(--text-subtle)");
+    expect(deriveTeamDisplay("Wheeler", null).color).toBe("var(--text-subtle)");
+  });
+
+  it("uses TM when the name is empty", () => {
+    expect(deriveTeamDisplay("").abbr).toBe("TM");
+    expect(deriveTeamDisplay("   ").abbr).toBe("TM");
+  });
+});

--- a/apps/web/src/lib/gamecast/index.ts
+++ b/apps/web/src/lib/gamecast/index.ts
@@ -47,3 +47,4 @@ export {
   type ScoringSummaryEntry,
   type ScoringPlayKind,
 } from "./scoring-summary";
+export { deriveTeamDisplay, type TeamDisplay } from "./team-display";

--- a/apps/web/src/lib/gamecast/team-display.ts
+++ b/apps/web/src/lib/gamecast/team-display.ts
@@ -1,0 +1,19 @@
+export interface TeamDisplay {
+  abbr: string;
+  color: string;
+}
+
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+export function deriveTeamDisplay(
+  name: string,
+  primaryColor?: string | null,
+): TeamDisplay {
+  const trimmed = name.trim();
+  const abbr = (trimmed.slice(0, 3) || "TM").toUpperCase();
+  const color =
+    primaryColor && HEX_COLOR_RE.test(primaryColor)
+      ? primaryColor
+      : "var(--text-subtle)";
+  return { abbr, color };
+}


### PR DESCRIPTION
Part of Epic #490 (WSM-000219) — Gamecast redesign. **S2 of 6, lands inert**: nothing imports these components; the live gamecast is untouched. Depends on S1 (#497, merged).

Fixes #492

## What
Four pure presentational components in `apps/web/src/components/gamecast/` (props in, JSX out — no fetching, timers, navigation, or storage):
- **`FieldPosition`** — SVG field (viewBox 0 0 480 200), team-color end zones (home left), yard lines/hashes/numbers, first-down line (gold `#e0b64a`), LOS (blue `#4a9be0`), ball (brown `#c47b3a`) with possession arrow, suppressible legend
- **`WinProbability`** — area/line chart over `winProbabilitySeries`; Sim clips to `currentIndex`, Review shows full curve + marker; team chips + current home-win %; **"Illustrative model" eyebrow + tooltip** ("estimated from score and time remaining — not a forecast")
- **`BoxScore`** — shadcn Table over `boxScoreAtPosition` (6 stat rows, right-aligned tabular-nums)
- **`ScoringSummary`** — newest-first TD/FG list with quarter/clock, kind badge, team dot + abbr, running score; "No scoring yet." empty state

Plus `deriveTeamDisplay(name, primaryColor?)` in `lib/gamecast` (abbr = first 3 letters uppercased; color falls back to a neutral token), unit-tested.

## Verification (run independently after the worker)
- `type-check`, `lint`, `test:unit` green — **129 files / 956 tests passed**
- Inertness grep: no file outside `components/gamecast` + `lib/gamecast` references the new components
- Purity grep: no hooks/effects/fetch/localStorage/design-system imports in the panels
- Hex discipline: only the named content colors (+ `#fff` for text/stroke painted on team-color fills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK