### PR TITLE
feat(web): S3 gamecast transport controls + auto-advance hook (WSM-000222)

### DIFF
--- a/apps/web/src/components/gamecast/GamecastTransport.tsx
+++ b/apps/web/src/components/gamecast/GamecastTransport.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import type { PbpPlay } from "@/lib/pbp";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  ChevronsRight,
+  Pause,
+  Play,
+  RotateCcw,
+  SkipBack,
+  SkipForward,
+} from "lucide-react";
+import {
+  GAMECAST_SPEEDS,
+  handleModeChange,
+  handlePlayPauseClick,
+  isBackTransportDisabled,
+  isForwardTransportDisabled,
+  transportIndexHandlers,
+  type GamecastMode,
+} from "./gamecast-transport-logic";
+import { useAutoAdvance, type GamecastSpeed } from "./useAutoAdvance";
+
+function subscribeReducedMotion(cb: () => void): () => void {
+  const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mq.addEventListener("change", cb);
+  return () => mq.removeEventListener("change", cb);
+}
+
+function getReducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export type { GamecastMode, GamecastSpeed };
+
+export interface GamecastTransportProps {
+  plays: PbpPlay[];
+  playIndex: number;
+  totalPlays: number;
+  mode: GamecastMode;
+  playing: boolean;
+  speed: GamecastSpeed;
+  onPlayIndexChange: (next: number) => void;
+  onModeChange: (mode: GamecastMode) => void;
+  onPlayingChange: (playing: boolean) => void;
+  onSpeedChange: (speed: GamecastSpeed) => void;
+}
+
+function SegmentedControl<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+  formatOption = (option) => String(option),
+}: {
+  label: string;
+  options: readonly T[];
+  value: T;
+  onChange: (next: T) => void;
+  formatOption?: (option: T) => string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="inline-flex gap-1 rounded-control bg-surface-2 p-1"
+    >
+      {options.map((option) => {
+        const isActive = option === value;
+        return (
+          <button
+            key={String(option)}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(option)}
+            className={cn(
+              "rounded-control px-3 py-1.5 text-label-14 font-medium transition-colors",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-text-muted hover:bg-surface-3 hover:text-text",
+            )}
+          >
+            {formatOption(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function GamecastTransport({
+  plays,
+  playIndex,
+  totalPlays,
+  mode,
+  playing,
+  speed,
+  onPlayIndexChange,
+  onModeChange,
+  onPlayingChange,
+  onSpeedChange,
+}: GamecastTransportProps) {
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotion,
+    () => false,
+  );
+
+  const backDisabled = isBackTransportDisabled(playIndex);
+  const forwardDisabled = isForwardTransportDisabled(playIndex, totalPlays);
+  const isComplete = playIndex >= totalPlays;
+  const handlers = transportIndexHandlers(plays, totalPlays);
+
+  useAutoAdvance({
+    playing,
+    speed,
+    playIndex,
+    totalPlays,
+    onPlayIndexChange,
+  });
+
+  const pause = () => onPlayingChange(false);
+
+  const stepTo = (next: number) => {
+    pause();
+    onPlayIndexChange(next);
+  };
+
+  const progressPct =
+    totalPlays > 0 ? Math.round((playIndex / totalPlays) * 100) : 0;
+
+  return (
+    <div className="space-y-3 rounded-card border border-border bg-surface-2 p-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <SegmentedControl<GamecastMode>
+          label="Gamecast mode"
+          options={["sim", "review"] as const}
+          value={mode}
+          onChange={(next) =>
+            handleModeChange(next, onModeChange, onPlayingChange)
+          }
+          formatOption={(option) =>
+            option === "sim" ? "Sim" : "Review"
+          }
+        />
+
+        <div
+          className="flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label="Playback transport"
+        >
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Restart"
+            disabled={backDisabled}
+            onClick={() => stepTo(handlers.restart())}
+          >
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Previous half"
+            disabled={backDisabled}
+            onClick={() => stepTo(handlers.prevHalf(playIndex))}
+          >
+            <span className="font-mono text-xs font-bold">½</span>
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Previous quarter"
+            disabled={backDisabled}
+            onClick={() => stepTo(handlers.prevQuarter(playIndex))}
+          >
+            <span className="font-mono text-xs font-bold">Q</span>
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Previous play"
+            disabled={backDisabled}
+            onClick={() => stepTo(handlers.prevPlay(playIndex))}
+          >
+            <SkipBack className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="default"
+            className="h-11 w-11"
+            aria-label={playing ? "Pause" : "Play"}
+            onClick={() =>
+              handlePlayPauseClick(
+                playIndex,
+                totalPlays,
+                playing,
+                onPlayIndexChange,
+                onPlayingChange,
+              )
+            }
+          >
+            {playing ? (
+              <Pause className="h-5 w-5" />
+            ) : (
+              <Play className="h-5 w-5" />
+            )}
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Next play"
+            disabled={forwardDisabled}
+            onClick={() => stepTo(handlers.nextPlay(playIndex))}
+          >
+            <SkipForward className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Next quarter"
+            disabled={forwardDisabled}
+            onClick={() => stepTo(handlers.nextQuarter(playIndex))}
+          >
+            <span className="font-mono text-xs font-bold">Q</span>
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Next half"
+            disabled={forwardDisabled}
+            onClick={() => stepTo(handlers.nextHalf(playIndex))}
+          >
+            <span className="font-mono text-xs font-bold">½</span>
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Entire game"
+            disabled={forwardDisabled}
+            onClick={() => stepTo(handlers.entireGame())}
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <SegmentedControl<GamecastSpeed>
+          label="Simulation speed"
+          options={GAMECAST_SPEEDS}
+          value={speed}
+          onChange={onSpeedChange}
+          formatOption={(option) => `${option}×`}
+        />
+      </div>
+
+      <div className="space-y-2">
+        {mode === "review" ? (
+          <input
+            type="range"
+            min={0}
+            max={totalPlays}
+            step={1}
+            value={playIndex}
+            aria-label="Scrub play index"
+            className="gc-scrub h-1.5 w-full cursor-pointer appearance-none rounded-full bg-surface-3 accent-text"
+            onChange={(event) => {
+              pause();
+              onPlayIndexChange(Number(event.target.value));
+            }}
+          />
+        ) : (
+          <div
+            className="h-1.5 w-full overflow-hidden rounded-full bg-surface-3"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={totalPlays}
+            aria-valuenow={playIndex}
+            aria-label="Simulation progress"
+          >
+            <div
+              className={cn(
+                "h-full rounded-full",
+                !reducedMotion && "transition-[width] duration-150 ease-out",
+                isComplete ? "bg-accent" : "bg-text",
+              )}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        )}
+
+        <p className="font-mono text-caption-12 text-text-muted">
+          Play {playIndex}/{totalPlays}
+          {mode === "sim" && playing ? " · Simulating" : null}
+          {mode === "sim" && isComplete ? " · Complete" : null}
+          {mode === "review" ? " · Drag to scrub" : null}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/__tests__/gamecast-transport-logic.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/gamecast-transport-logic.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleModeChange,
+  handlePlayPauseClick,
+  isBackTransportDisabled,
+  isForwardTransportDisabled,
+} from "@/components/gamecast/gamecast-transport-logic";
+
+describe("gamecast transport bounds", () => {
+  it("disables back-side controls at playIndex 0", () => {
+    expect(isBackTransportDisabled(0)).toBe(true);
+    expect(isBackTransportDisabled(1)).toBe(false);
+  });
+
+  it("disables forward-side controls at final index", () => {
+    expect(isForwardTransportDisabled(10, 10)).toBe(true);
+    expect(isForwardTransportDisabled(9, 10)).toBe(false);
+  });
+});
+
+describe("handlePlayPauseClick", () => {
+  it("restarts from 0 and plays when pressed at final", () => {
+    const onPlayIndexChange = vi.fn();
+    const onPlayingChange = vi.fn();
+
+    handlePlayPauseClick(10, 10, false, onPlayIndexChange, onPlayingChange);
+
+    expect(onPlayIndexChange).toHaveBeenCalledWith(0);
+    expect(onPlayingChange).toHaveBeenCalledWith(true);
+  });
+
+  it("toggles playing when not at final", () => {
+    const onPlayIndexChange = vi.fn();
+    const onPlayingChange = vi.fn();
+
+    handlePlayPauseClick(3, 10, false, onPlayIndexChange, onPlayingChange);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+    expect(onPlayingChange).toHaveBeenCalledWith(true);
+
+    onPlayingChange.mockClear();
+    handlePlayPauseClick(3, 10, true, onPlayIndexChange, onPlayingChange);
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("handleModeChange", () => {
+  it("pauses before switching mode", () => {
+    const onModeChange = vi.fn();
+    const onPlayingChange = vi.fn();
+
+    handleModeChange("review", onModeChange, onPlayingChange);
+
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+    expect(onModeChange).toHaveBeenCalledWith("review");
+  });
+});

--- a/apps/web/src/components/gamecast/__tests__/useAutoAdvance.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/useAutoAdvance.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  AUTO_ADVANCE_MS,
+  getAutoAdvanceIntervalMs,
+  scheduleAutoAdvance,
+} from "@/components/gamecast/useAutoAdvance";
+
+describe("getAutoAdvanceIntervalMs", () => {
+  it("returns 950/speed ms", () => {
+    expect(getAutoAdvanceIntervalMs(1)).toBe(AUTO_ADVANCE_MS);
+    expect(getAutoAdvanceIntervalMs(2)).toBe(475);
+    expect(getAutoAdvanceIntervalMs(0.5)).toBe(1900);
+    expect(getAutoAdvanceIntervalMs(4)).toBe(237.5);
+  });
+});
+
+describe("scheduleAutoAdvance", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("advances one play every 950/speed ms while playing", () => {
+    let playIndex = 0;
+    const onPlayIndexChange = vi.fn((next: number) => {
+      playIndex = next;
+    });
+
+    scheduleAutoAdvance({
+      playing: true,
+      speed: 1,
+      getPlayIndex: () => playIndex,
+      totalPlays: 5,
+      onPlayIndexChange,
+    });
+
+    vi.advanceTimersByTime(949);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onPlayIndexChange).toHaveBeenCalledWith(1);
+
+    vi.advanceTimersByTime(950);
+    expect(onPlayIndexChange).toHaveBeenCalledWith(2);
+  });
+
+  it("re-paces when speed changes after dispose and reschedule", () => {
+    let playIndex = 0;
+    const onPlayIndexChange = vi.fn((next: number) => {
+      playIndex = next;
+    });
+
+    const disposeSlow = scheduleAutoAdvance({
+      playing: true,
+      speed: 1,
+      getPlayIndex: () => playIndex,
+      totalPlays: 5,
+      onPlayIndexChange,
+    });
+
+    vi.advanceTimersByTime(950);
+    expect(onPlayIndexChange).toHaveBeenCalledTimes(1);
+
+    disposeSlow();
+    onPlayIndexChange.mockClear();
+
+    scheduleAutoAdvance({
+      playing: true,
+      speed: 2,
+      getPlayIndex: () => playIndex,
+      totalPlays: 5,
+      onPlayIndexChange,
+    });
+
+    vi.advanceTimersByTime(474);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onPlayIndexChange).toHaveBeenCalledWith(2);
+  });
+
+  it("stops advancing at final play", () => {
+    let playIndex = 4;
+    const onPlayIndexChange = vi.fn((next: number) => {
+      playIndex = next;
+    });
+    const onComplete = vi.fn();
+
+    scheduleAutoAdvance({
+      playing: true,
+      speed: 1,
+      getPlayIndex: () => playIndex,
+      totalPlays: 5,
+      onPlayIndexChange,
+      onComplete,
+    });
+
+    vi.advanceTimersByTime(950);
+    expect(onPlayIndexChange).toHaveBeenCalledTimes(1);
+    expect(onPlayIndexChange).toHaveBeenCalledWith(5);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    onPlayIndexChange.mockClear();
+    vi.advanceTimersByTime(3000);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+  });
+
+  it("does not schedule when not playing", () => {
+    const onPlayIndexChange = vi.fn();
+
+    scheduleAutoAdvance({
+      playing: false,
+      speed: 1,
+      getPlayIndex: () => 0,
+      totalPlays: 5,
+      onPlayIndexChange,
+    });
+
+    vi.advanceTimersByTime(5000);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+  });
+
+  it("cleans up on dispose", () => {
+    const onPlayIndexChange = vi.fn();
+
+    const dispose = scheduleAutoAdvance({
+      playing: true,
+      speed: 1,
+      getPlayIndex: () => 0,
+      totalPlays: 5,
+      onPlayIndexChange,
+    });
+
+    dispose();
+    vi.advanceTimersByTime(5000);
+    expect(onPlayIndexChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/gamecast/gamecast-transport-logic.ts
+++ b/apps/web/src/components/gamecast/gamecast-transport-logic.ts
@@ -1,0 +1,67 @@
+import type { PbpPlay } from "@/lib/pbp";
+import {
+  entireGameIndex,
+  nextHalfIndex,
+  nextPlayIndex,
+  nextQuarterIndex,
+  prevHalfIndex,
+  prevPlayIndex,
+  prevQuarterIndex,
+  restartIndex,
+} from "@/lib/gamecast";
+import type { GamecastSpeed } from "./useAutoAdvance";
+
+export type GamecastMode = "sim" | "review";
+
+export const GAMECAST_SPEEDS: GamecastSpeed[] = [0.5, 1, 2, 4];
+
+export function isBackTransportDisabled(playIndex: number): boolean {
+  return playIndex <= 0;
+}
+
+export function isForwardTransportDisabled(
+  playIndex: number,
+  totalPlays: number,
+): boolean {
+  return playIndex >= totalPlays;
+}
+
+export function handlePlayPauseClick(
+  playIndex: number,
+  totalPlays: number,
+  playing: boolean,
+  onPlayIndexChange: (next: number) => void,
+  onPlayingChange: (playing: boolean) => void,
+): void {
+  if (playIndex >= totalPlays) {
+    onPlayIndexChange(restartIndex());
+    onPlayingChange(true);
+    return;
+  }
+  onPlayingChange(!playing);
+}
+
+export function handleModeChange(
+  mode: GamecastMode,
+  onModeChange: (mode: GamecastMode) => void,
+  onPlayingChange: (playing: boolean) => void,
+): void {
+  onPlayingChange(false);
+  onModeChange(mode);
+}
+
+export function transportIndexHandlers(
+  plays: PbpPlay[],
+  totalPlays: number,
+) {
+  return {
+    restart: () => restartIndex(),
+    prevHalf: (i: number) => prevHalfIndex(plays, i),
+    prevQuarter: (i: number) => prevQuarterIndex(plays, i),
+    prevPlay: (i: number) => prevPlayIndex(i),
+    nextPlay: (i: number) => nextPlayIndex(i, totalPlays),
+    nextQuarter: (i: number) => nextQuarterIndex(plays, i),
+    nextHalf: (i: number) => nextHalfIndex(plays, i),
+    entireGame: () => entireGameIndex(totalPlays),
+  };
+}

--- a/apps/web/src/components/gamecast/useAutoAdvance.ts
+++ b/apps/web/src/components/gamecast/useAutoAdvance.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export type GamecastSpeed = 0.5 | 1 | 2 | 4;
+
+export const AUTO_ADVANCE_MS = 950;
+
+export function getAutoAdvanceIntervalMs(speed: GamecastSpeed): number {
+  return AUTO_ADVANCE_MS / speed;
+}
+
+export interface UseAutoAdvanceOptions {
+  playing: boolean;
+  speed: GamecastSpeed;
+  playIndex: number;
+  totalPlays: number;
+  onPlayIndexChange: (next: number) => void;
+  onComplete?: () => void;
+}
+
+/** Schedules one-play ticks while `playing`; testable without React. */
+export function scheduleAutoAdvance({
+  playing,
+  speed,
+  getPlayIndex,
+  totalPlays,
+  onPlayIndexChange,
+  onComplete,
+}: {
+  playing: boolean;
+  speed: GamecastSpeed;
+  getPlayIndex: () => number;
+  totalPlays: number;
+  onPlayIndexChange: (next: number) => void;
+  onComplete?: () => void;
+}): () => void {
+  if (!playing) {
+    return () => {};
+  }
+
+  const intervalMs = getAutoAdvanceIntervalMs(speed);
+  const id = setInterval(() => {
+    const current = getPlayIndex();
+    if (current >= totalPlays) {
+      return;
+    }
+    const next = current + 1;
+    onPlayIndexChange(next);
+    if (next >= totalPlays) {
+      onComplete?.();
+    }
+  }, intervalMs);
+
+  return () => clearInterval(id);
+}
+
+export function useAutoAdvance({
+  playing,
+  speed,
+  playIndex,
+  totalPlays,
+  onPlayIndexChange,
+  onComplete,
+}: UseAutoAdvanceOptions): void {
+  const playIndexRef = useRef(playIndex);
+  const onPlayIndexChangeRef = useRef(onPlayIndexChange);
+  const onCompleteRef = useRef(onComplete);
+
+  useEffect(() => {
+    playIndexRef.current = playIndex;
+  }, [playIndex]);
+
+  useEffect(() => {
+    onPlayIndexChangeRef.current = onPlayIndexChange;
+  }, [onPlayIndexChange]);
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    return scheduleAutoAdvance({
+      playing,
+      speed,
+      getPlayIndex: () => playIndexRef.current,
+      totalPlays,
+      onPlayIndexChange: (next) => onPlayIndexChangeRef.current(next),
+      onComplete: onCompleteRef.current
+        ? () => onCompleteRef.current?.()
+        : undefined,
+    });
+  }, [playing, speed, totalPlays]);
+}


### PR DESCRIPTION
Part of Epic #490 (WSM-000219) — Gamecast redesign. **S3 of 6, lands inert**: built as a NEW `GamecastTransport` component; `GamecastControls.tsx` has an empty diff and nothing imports the new files, so the live gamecast is bit-for-bit unchanged. Depends on S1 (#497) + S2 (#498), both merged.

Fixes #493

## What
- **`GamecastTransport.tsx`** — fully **controlled** component (zero internal game state): props `plays`, `playIndex`, `totalPlays`, `mode`, `playing`, `speed`; callbacks `onPlayIndexChange` / `onModeChange` / `onPlayingChange` / `onSpeedChange`. Sim|Review mode toggle, transport row (Restart · prev half/quarter/play · play-pause primary · next play/quarter/half · Entire game) mapped to the S1 lib functions with bound-aware disabling, 0.5×/1×/2×/4× speed segmented control, Review scrubber vs Sim progress bar, "Play {i}/{total}" caption, `prefers-reduced-motion` respected. Icons lucide-react only; 13 aria-labels.
- **`useAutoAdvance.ts`** — exported hook: one play per `950/speed` ms while playing, re-paces cleanly on speed change, stops at final (optional `onComplete`; parent owns `playing`), clears on unmount.
- **`gamecast-transport-logic.ts`** — pure helpers (bound disabling, play-at-final restart, mode-switch pause).

This is the state contract S4 (go-live story) composes against — controls can't force a rework of the view.

## Verification (run independently after the worker)
- `type-check`, `lint`, `test:unit` green — **131 files / 967 tests** (+11 new, incl. fake-timer interval math: tick pacing, re-pace on speed change, stop-at-final, dispose cleanup)
- Controlled purity: no `useState`/`useReducer` in the component
- Inertness: `git diff GamecastControls.tsx` empty; no importers outside `components/gamecast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK