### PR TITLE
fix(web): gamecast auto-sim page scroll-jump (WSM-000226)

### DIFF
--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -439,12 +439,14 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
     await expect(page.getByText(/^Play 0\//)).toBeVisible();
 
     const startCounter = await readPlayCounter(page);
+    const y0 = await page.evaluate(() => window.scrollY);
     await page.getByRole("button", { name: "Play" }).click();
     await expect
       .poll(async () => (await readPlayCounter(page)).index, {
         timeout: 30_000,
       })
-      .toBeGreaterThan(startCounter.index);
+      .toBeGreaterThan(startCounter.index + 2);
+    expect(await page.evaluate(() => window.scrollY)).toBe(y0);
 
     await page.getByRole("button", { name: "Pause" }).click();
     const pausedIndex = (await readPlayCounter(page)).index;

--- a/apps/web/src/components/gamecast/PlayList.tsx
+++ b/apps/web/src/components/gamecast/PlayList.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/gamecast";
 import type { PbpPlay } from "@/lib/pbp";
 import { cn } from "@/lib/utils";
+import { computePlayListScrollTop } from "./play-list-scroll";
 
 export interface PlayListProps {
   groups: DrivePlayGroup[];
@@ -39,14 +40,35 @@ export default function PlayList({
   animate,
   onPlaySelect,
 }: PlayListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const currentRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
-    currentRef.current?.scrollIntoView({
-      behavior: animate ? "smooth" : "auto",
-      block: "nearest",
-    });
-  }, [playIndex, animate]);
+    if (mode !== "sim") return;
+
+    const container = containerRef.current;
+    const row = currentRef.current;
+    if (!container || !row) return;
+
+    const rowTop =
+      row.getBoundingClientRect().top -
+      container.getBoundingClientRect().top +
+      container.scrollTop;
+    const targetTop = computePlayListScrollTop(
+      container.scrollTop,
+      container.clientHeight,
+      rowTop,
+      row.offsetHeight,
+    );
+
+    if (targetTop === null) return;
+
+    if (animate) {
+      container.scrollTo({ top: targetTop, behavior: "smooth" });
+    } else {
+      container.scrollTop = targetTop;
+    }
+  }, [playIndex, animate, mode]);
 
   if (groups.length === 0) {
     return (
@@ -62,7 +84,7 @@ export default function PlayList({
   }));
 
   return (
-    <div className="max-h-[28rem] overflow-y-auto">
+    <div ref={containerRef} className="max-h-[28rem] overflow-y-auto">
       {displayGroups.map((group) => {
         const team =
           group.teamId === homeTeamId ? homeTeam : awayTeam;

--- a/apps/web/src/components/gamecast/__tests__/play-list-scroll.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/play-list-scroll.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { computePlayListScrollTop } from "@/components/gamecast/play-list-scroll";
+
+describe("computePlayListScrollTop", () => {
+  const clientHeight = 100;
+
+  it("returns null when the row intersects the visible band", () => {
+    expect(computePlayListScrollTop(50, clientHeight, 60, 20)).toBeNull();
+    expect(computePlayListScrollTop(0, clientHeight, 0, 20)).toBeNull();
+    expect(computePlayListScrollTop(80, clientHeight, 90, 20)).toBeNull();
+  });
+
+  it("scrolls up when the row is entirely above the viewport", () => {
+    expect(computePlayListScrollTop(100, clientHeight, 10, 20)).toBe(10);
+  });
+
+  it("scrolls down when the row is entirely below the viewport", () => {
+    expect(computePlayListScrollTop(0, clientHeight, 150, 20)).toBe(70);
+  });
+});

--- a/apps/web/src/components/gamecast/play-list-scroll.ts
+++ b/apps/web/src/components/gamecast/play-list-scroll.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns a target scrollTop when the row is outside the container viewport,
+ * or null when the row already intersects the visible band (no nudge).
+ */
+export function computePlayListScrollTop(
+  scrollTop: number,
+  clientHeight: number,
+  rowTop: number,
+  rowHeight: number,
+): number | null {
+  const visibleBottom = scrollTop + clientHeight;
+  const rowBottom = rowTop + rowHeight;
+
+  if (rowTop < visibleBottom && rowBottom > scrollTop) {
+    return null;
+  }
+
+  if (rowBottom <= scrollTop) {
+    return rowTop;
+  }
+
+  return rowBottom - clientHeight;
+}


### PR DESCRIPTION
Fixes #503

## Root cause
`PlayList.tsx` ran `scrollIntoView({block:"nearest"})` on every `playIndex` change — it escalates to the nearest scrollable ancestor (the document), so the window jumped every auto-sim tick.

## Fix
- Container-local scroll math only: `containerRef` + pure `computePlayListScrollTop` (returns null while the current row intersects the container's visible band → no-op)
- Sim mode only — review mode never fights the user's scroll
- `prefers-reduced-motion` behavior preserved (smooth vs instant)
- Window/document scroll never touched

## Verification
- `type-check`, `lint`, `test:unit` green — 983 tests (+3 helper units)
- E2E: auto-sim scenario now captures `window.scrollY` before Play, advances several plays, asserts it unchanged (no sleeps) — executes in this PR's CI Playwright gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK