### PR TITLE
feat(web): dynasty advance-to-next-season CTA on gamecast + season hub (WSM-000227)

### DIFF
--- a/apps/web/e2e/tests/dynasty.spec.ts
+++ b/apps/web/e2e/tests/dynasty.spec.ts
@@ -113,11 +113,11 @@ test.describe("Dynasty panel (dynasty rollover)", () => {
     await page.goto("/dashboard/seasons");
     await expect(page.getByText(/E2E Season \d{4}/)).toBeVisible();
 
-    // NOTE: the DynastyPanel "Graduated players (N)" accordion assertion was
-    // removed pending WSM investigation — the accordion did not render on the
-    // league page after a first rollover in CI, which may indicate graduated
-    // players are not surfacing on the panel (or the seeded roster lacked
-    // seniors). Class advancement below is the deterministic progression check.
+    await page.goto(`/dashboard/leagues/${leagueId}`);
+    await expect(
+      page.getByRole("button", { name: /Graduated players \(\d+\)/ }),
+    ).toBeVisible();
+
     if (jrPlayerId) {
       await page.goto(`/dashboard/players/${jrPlayerId}`);
       await expect(page.getByText(/ · SR/)).toBeVisible();

--- a/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
+++ b/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
@@ -8,10 +8,17 @@ import {
   getGamePlayLog,
   getLeague,
   getSeasonLeagueId,
+  getSeasons,
+  listFixturesBySeason,
+  getPlayoffBracket,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { PBP_ENGINE_VERSION } from "@/lib/pbp";
 import { parseGamePlayLog } from "@/lib/gamecast/parse-log";
+import {
+  seasonDecidedContext,
+  shouldShowDynastyCta,
+} from "@/lib/dynasty-panel";
 import GamecastView from "@/components/gamecast/GamecastView";
 import GamecastEmptyState from "@/components/gamecast/GamecastEmptyState";
 import { getTeam } from "@/lib/data-api";
@@ -37,6 +44,27 @@ export default async function GamecastPage({
   const orgContext = await resolveOrgContext(userId);
   const league = await getLeague(leagueId, orgContext).catch(() => null);
   if (!league) notFound();
+
+  const seasons = await getSeasons([leagueId]).catch(() => []);
+  const activeSeason = seasons.find((s) => s.status === "active") ?? null;
+  const upcomingSeason = seasons.find((s) => s.status === "upcoming") ?? null;
+  const [seasonFixtures, bracket] = await Promise.all([
+    activeSeason
+      ? listFixturesBySeason(activeSeason.id).catch(() => [])
+      : Promise.resolve([]),
+    activeSeason
+      ? getPlayoffBracket(activeSeason.id).catch(() => null)
+      : Promise.resolve(null),
+  ]);
+  const decidedCtx = activeSeason
+    ? seasonDecidedContext(seasonFixtures, bracket)
+    : { seasonDecided: false };
+  const showDynastyCta = shouldShowDynastyCta({
+    gameFinal: fixture.status === "final",
+    seasonDecided: decidedCtx.seasonDecided,
+    upcomingSeasonExists: Boolean(upcomingSeason),
+  });
+  const dynastyCta = showDynastyCta ? { leagueId } : null;
 
   const row = await getGamePlayLog(fixtureId);
   const log = row ? parseGamePlayLog(row.logJson) : null;
@@ -64,6 +92,7 @@ export default async function GamecastPage({
         engineVersionMismatch={row.engineVersion !== PBP_ENGINE_VERSION}
         storedEngineVersion={row.engineVersion}
         currentEngineVersion={PBP_ENGINE_VERSION}
+        dynastyCta={dynastyCta}
       />
     );
   }

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -11,10 +11,20 @@ import {
   computeStandings,
   getLeague,
   getPlayoffBracket,
+  getPlayers,
   getSeason,
+  getSeasons,
+  getTeamsByLeague,
   listFixturesBySeason,
 } from "@/lib/data-api";
-import { resolveOrgContext } from "@/lib/org-context";
+import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
+import { summarizeClassDistribution } from "@/lib/class-year";
+import {
+  dynastySeasonState,
+  evaluateStartNextSeason,
+  seasonDecidedContext,
+} from "@/lib/dynasty-panel";
+import { DynastyPanel } from "@/components/dynasty/DynastyPanel";
 import { regularSeasonProgress } from "@/lib/playoffs";
 import { formatDate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -43,7 +53,21 @@ export default async function SeasonHubPage({
   const league = await getLeague(season.leagueId, orgContext).catch(() => null);
   if (!league) notFound();
 
-  const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled] =
+  let isAdmin = false;
+  if (league.orgId) {
+    try {
+      await requireOrgAdmin(league.orgId, userId);
+      isAdmin = true;
+    } catch {
+      // Not admin — read-only view
+    }
+  }
+
+  const seasons = await getSeasons([league.id]).catch(() => []);
+  const activeSeason = seasons.find((s) => s.status === "active") ?? null;
+  const upcomingSeason = seasons.find((s) => s.status === "upcoming") ?? null;
+
+  const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
     await Promise.all([
       listFixturesBySeason(season.id),
       computeStandings(season.id),
@@ -51,7 +75,54 @@ export default async function SeasonHubPage({
       schedulesStandingsV1(),
       playoffsV1(),
       statKeepingV1(),
+      activeSeason
+        ? listFixturesBySeason(activeSeason.id).catch(() => [])
+        : Promise.resolve([]),
+      activeSeason
+        ? getPlayoffBracket(activeSeason.id).catch(() => null)
+        : Promise.resolve(null),
+      isAdmin && league.orgId
+        ? getPlayers([league.id]).catch(() => [])
+        : Promise.resolve([]),
+      isAdmin && league.orgId
+        ? getTeamsByLeague(league.id, orgContext).catch(() => [])
+        : Promise.resolve([]),
     ]);
+
+  const decidedCtx = activeSeason
+    ? seasonDecidedContext(dynastyFixtures, dynastyBracket)
+    : {
+        seasonDecided: false,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      };
+  const teamNameById = new Map(teams.map((t) => [t.id, t.name]));
+  const graduatedPlayers =
+    isAdmin && league.orgId
+      ? leaguePlayers
+          .filter((p) => p.status === "graduated")
+          .map((p) => ({
+            id: p.id,
+            name: p.name,
+            position: p.position,
+            teamName: teamNameById.get(p.teamId) ?? null,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+      : [];
+  const dynastySeasonStateLine = dynastySeasonState({
+    activeSeason: activeSeason ? { name: activeSeason.name } : null,
+    upcomingSeason: upcomingSeason ? { name: upcomingSeason.name } : null,
+    seasonDecided: decidedCtx.seasonDecided,
+  });
+  const startNextSeasonGate = evaluateStartNextSeason({
+    activeSeason: activeSeason
+      ? { id: activeSeason.id, name: activeSeason.name }
+      : null,
+    upcomingSeason: upcomingSeason
+      ? { id: upcomingSeason.id, name: upcomingSeason.name }
+      : null,
+    ...decidedCtx,
+  });
 
   const progress = regularSeasonProgress(fixtures);
   const playoffFixtures = fixtures.filter((f) => f.stage === "playoff");
@@ -244,6 +315,27 @@ export default async function SeasonHubPage({
           </CardContent>
         </Card>
       </div>
+
+      {isAdmin && league.orgId && (
+        <Card className="mt-6">
+          <CardContent className="pt-6">
+            <DynastyPanel
+              leagueId={league.id}
+              seasonState={dynastySeasonStateLine}
+              gate={startNextSeasonGate}
+              classDistribution={summarizeClassDistribution(leaguePlayers)}
+              graduatedPlayers={graduatedPlayers}
+              upcomingSeason={
+                upcomingSeason
+                  ? { id: upcomingSeason.id, name: upcomingSeason.name }
+                  : null
+              }
+              unplayedGames={decidedCtx.unplayedGames}
+              playoffsUndecided={decidedCtx.playoffsUndecided}
+            />
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/dynasty/DynastyPanel.tsx
+++ b/apps/web/src/components/dynasty/DynastyPanel.tsx
@@ -106,7 +106,7 @@ export function DynastyPanel({
     classDistribution.unknown;
 
   return (
-    <div className="space-y-4 border-t border-border pt-4">
+    <div id="dynasty-panel" className="space-y-4 border-t border-border pt-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="inline-flex items-center gap-1.5 text-label-14 text-foreground">

--- a/apps/web/src/components/gamecast/GamecastDynastyBanner.tsx
+++ b/apps/web/src/components/gamecast/GamecastDynastyBanner.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export interface GamecastDynastyBannerProps {
+  leagueId: string;
+}
+
+export default function GamecastDynastyBanner({
+  leagueId,
+}: GamecastDynastyBannerProps) {
+  return (
+    <div
+      className="border-b border-border bg-card px-5 py-4"
+      data-testid="gamecast-dynasty-banner"
+    >
+      <p className="text-sm font-medium text-foreground">Season decided</p>
+      <p className="mt-1 text-caption-12 text-text-muted">
+        Advance to the next season from the league dynasty panel.
+      </p>
+      <Button asChild size="sm" className="mt-3">
+        <Link href={`/dashboard/leagues/${leagueId}#dynasty-panel`}>
+          Go to dynasty panel
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastView.tsx
+++ b/apps/web/src/components/gamecast/GamecastView.tsx
@@ -40,6 +40,11 @@ import OperatorHeader from "./layouts/OperatorHeader";
 import type { GamecastPanelSlots } from "./layouts/GamecastPanelSlots";
 import type { GamecastMode } from "./gamecast-transport-logic";
 import type { GamecastSpeed } from "./useAutoAdvance";
+import GamecastDynastyBanner from "./GamecastDynastyBanner";
+
+export interface GamecastDynastyCta {
+  leagueId: string;
+}
 
 function subscribeReducedMotion(cb: () => void): () => void {
   const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -92,6 +97,7 @@ export interface GamecastViewProps {
   engineVersionMismatch: boolean;
   storedEngineVersion: string;
   currentEngineVersion: string;
+  dynastyCta?: GamecastDynastyCta | null;
 }
 
 export default function GamecastView({
@@ -104,6 +110,7 @@ export default function GamecastView({
   engineVersionMismatch,
   storedEngineVersion,
   currentEngineVersion,
+  dynastyCta = null,
 }: GamecastViewProps) {
   const plays = useMemo(() => allPlays(log), [log]);
   const totalPlays = plays.length;
@@ -366,8 +373,13 @@ export default function GamecastView({
     </GamecastPlayByPlayCard>
   );
 
+  const postScoreboardBanner = dynastyCta ? (
+    <GamecastDynastyBanner leagueId={dynastyCta.leagueId} />
+  ) : null;
+
   const panels: GamecastPanelSlots = {
       scoreboard: <GamecastScoreboard {...scoreboardProps} />,
+      postScoreboardBanner,
       transport,
       situationStrip,
       fieldPosition: (

--- a/apps/web/src/components/gamecast/__tests__/GamecastView.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/GamecastView.test.ts
@@ -117,6 +117,27 @@ describe("GamecastView", () => {
     expect(html).toContain("Play-by-play");
     expect(html).toContain('data-testid="gamecast-layout-switcher"');
     expect(html).not.toContain("Press Next play to start the gamecast.");
+    expect(html).not.toContain('data-testid="gamecast-dynasty-banner"');
+  });
+
+  it("renders the dynasty deep-link banner when dynastyCta is set", () => {
+    const html = renderToStaticMarkup(
+      createElement(GamecastView, {
+        ...baseProps,
+        dynastyCta: { leagueId: "league-abc" },
+      }),
+    );
+    expect(html).toContain('data-testid="gamecast-dynasty-banner"');
+    expect(html).toContain("Season decided");
+    expect(html).toContain("Go to dynasty panel");
+    expect(html).toContain("/dashboard/leagues/league-abc#dynasty-panel");
+  });
+
+  it("omits the dynasty banner when dynastyCta is null", () => {
+    const html = renderToStaticMarkup(
+      createElement(GamecastView, { ...baseProps, dynastyCta: null }),
+    );
+    expect(html).not.toContain('data-testid="gamecast-dynasty-banner"');
   });
 
   it("renders score testids in each layout arrangement", () => {
@@ -128,6 +149,7 @@ describe("GamecastView", () => {
       scoreboard: createElement("div", {
         "data-testid": "gamecast-score-home",
       }),
+      postScoreboardBanner: null,
       transport: null,
       situationStrip: null,
       fieldPosition: null,

--- a/apps/web/src/components/gamecast/layouts/BroadcastLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/BroadcastLayout.tsx
@@ -24,6 +24,7 @@ export default function BroadcastLayout({
   return (
     <>
       {panels.scoreboard}
+      {panels.postScoreboardBanner}
 
       <div className={MOBILE_STACK}>
         <div

--- a/apps/web/src/components/gamecast/layouts/FieldFirstLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/FieldFirstLayout.tsx
@@ -21,6 +21,7 @@ export default function FieldFirstLayout({ panels }: { panels: GamecastPanelSlot
       <div className="flex min-h-0 flex-col gap-[18px] max-[900px]:contents">
         <div className="shrink-0 [&_[data-testid=gamecast-scoreboard]]:px-4 [&_[data-testid=gamecast-scoreboard]]:py-3 max-[900px]:order-none">
           {panels.scoreboard}
+          {panels.postScoreboardBanner}
         </div>
 
         <div className={`flex min-h-0 flex-1 flex-col gap-3 max-[900px]:contents ${MOBILE_ORDER.field}`}>

--- a/apps/web/src/components/gamecast/layouts/GamecastPanelSlots.ts
+++ b/apps/web/src/components/gamecast/layouts/GamecastPanelSlots.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 export interface GamecastPanelSlots {
   scoreboard: ReactNode;
+  postScoreboardBanner: ReactNode | null;
   transport: ReactNode;
   situationStrip: ReactNode;
   fieldPosition: ReactNode;

--- a/apps/web/src/components/gamecast/layouts/OperatorLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/OperatorLayout.tsx
@@ -26,6 +26,7 @@ export default function OperatorLayout({ panels }: { panels: GamecastPanelSlots 
       <div className="border-b border-border bg-surface px-5 py-3 max-[900px]:hidden">
         {panels.operatorHeader}
       </div>
+      {panels.postScoreboardBanner}
 
       <div className="grid grid-cols-1 gap-[18px] p-5 lg:grid-cols-[250px_1fr_300px] max-[900px]:contents max-[900px]:p-0">
         <aside className="space-y-4 bg-surface max-[900px]:contents">

--- a/apps/web/src/lib/__tests__/dynasty-panel.test.ts
+++ b/apps/web/src/lib/__tests__/dynasty-panel.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateStartNextSeason,
   formatRolloverSuccessSummary,
   seasonDecidedContext,
+  shouldShowDynastyCta,
   startNextSeasonErrorMessage,
 } from "../dynasty-panel";
 import type { FixtureDto } from "@sports-management/shared-types";
@@ -168,5 +169,41 @@ describe("formatRolloverSuccessSummary", () => {
         freshmen: 1,
       }),
     ).toBe("1 graduated · 1 advanced · 1 freshman generated");
+  });
+});
+
+describe("shouldShowDynastyCta", () => {
+  it("shows only when the game is final, season decided, and no upcoming season", () => {
+    expect(
+      shouldShowDynastyCta({
+        gameFinal: true,
+        seasonDecided: true,
+        upcomingSeasonExists: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldShowDynastyCta({
+        gameFinal: false,
+        seasonDecided: true,
+        upcomingSeasonExists: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowDynastyCta({
+        gameFinal: true,
+        seasonDecided: false,
+        upcomingSeasonExists: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowDynastyCta({
+        gameFinal: true,
+        seasonDecided: true,
+        upcomingSeasonExists: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/dynasty-panel.ts
+++ b/apps/web/src/lib/dynasty-panel.ts
@@ -149,6 +149,19 @@ export function evaluateStartNextSeason(input: {
   return { canStart: true, errorCode: null, message: null };
 }
 
+/** Whether gamecast should deep-link to the league dynasty panel. */
+export function shouldShowDynastyCta(input: {
+  gameFinal: boolean;
+  seasonDecided: boolean;
+  upcomingSeasonExists: boolean;
+}): boolean {
+  return (
+    input.gameFinal &&
+    input.seasonDecided &&
+    !input.upcomingSeasonExists
+  );
+}
+
 /** Format a successful rollover summary from action counts. */
 export function formatRolloverSuccessSummary(counts: {
   graduated: number;


### PR DESCRIPTION
Fixes #504. Builds on the #489 rollover fix (#507, merged).

## What
- **Gamecast post-game banner** (`GamecastDynastyBanner`): shown when the game is Final **and** the season is decided **and** no upcoming season exists (rollover not yet run) — computed **server-side** in the gamecast page via the existing `seasonDecidedContext`; zero forked gating. Deep-links to `/dashboard/leagues/[id]#dynasty-panel`. Rendered via a new `postScoreboardBanner` layout slot so it appears identically in Broadcast / Field-first / Operator.
- **Season hub**: `DynastyPanel` now mounts on `/dashboard/seasons/[id]` with the same wiring and gate/error states (`no_season`, `season_not_decided`, `next_season_exists`) as the league page.
- **E2E**: restores the "Graduated players (N)" assertion removed in #488 — the #507 backend fix is what makes it pass — and corrects it to assert on the league page where the panel renders. (A gamecast banner e2e was deliberately skipped: the seeded fixture sims one game, not a decided season — noted for a follow-up fixture.)

## Verification
- `type-check`, `lint`, `test:unit` (**988 tests**, incl. new `shouldShowDynastyCta` units + banner render/omit), prod `build` — all green
- This PR's CI Playwright run is the first end-to-end execution of the restored graduated-players assertion against the merged rollover fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK