### PR TITLE
feat(web): gamecast player leaders + per-play contributors (WSM-000228)

### DIFF
--- a/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
+++ b/apps/web/src/app/dashboard/games/[fixtureId]/gamecast/page.tsx
@@ -11,6 +11,7 @@ import {
   getSeasons,
   listFixturesBySeason,
   getPlayoffBracket,
+  getPlayersByTeam,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { PBP_ENGINE_VERSION } from "@/lib/pbp";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/dynasty-panel";
 import GamecastView from "@/components/gamecast/GamecastView";
 import GamecastEmptyState from "@/components/gamecast/GamecastEmptyState";
+import type { GamecastPlayerNameMap } from "@/lib/gamecast";
 import { getTeam } from "@/lib/data-api";
 
 export default async function GamecastPage({
@@ -75,10 +77,16 @@ export default async function GamecastPage({
   } else if (!log) {
     body = <GamecastEmptyState leagueId={leagueId} reason="parse_error" />;
   } else {
-    const [homeTeam, awayTeam] = await Promise.all([
+    const [homeTeam, awayTeam, homePlayers, awayPlayers] = await Promise.all([
       getTeam(fixture.homeTeamId, orgContext).catch(() => null),
       getTeam(fixture.awayTeamId, orgContext).catch(() => null),
+      getPlayersByTeam(fixture.homeTeamId, orgContext).catch(() => []),
+      getPlayersByTeam(fixture.awayTeamId, orgContext).catch(() => []),
     ]);
+    const playerNameMap: GamecastPlayerNameMap = {};
+    for (const p of [...homePlayers, ...awayPlayers]) {
+      playerNameMap[p.id] = { name: p.name, position: p.position };
+    }
     const weekLabel =
       fixture.week !== null ? `Week ${fixture.week}` : null;
     body = (
@@ -93,6 +101,7 @@ export default async function GamecastPage({
         storedEngineVersion={row.engineVersion}
         currentEngineVersion={PBP_ENGINE_VERSION}
         dynastyCta={dynastyCta}
+        playerNameMap={playerNameMap}
       />
     );
   }

--- a/apps/web/src/components/gamecast/GamecastView.tsx
+++ b/apps/web/src/components/gamecast/GamecastView.tsx
@@ -9,12 +9,15 @@ import {
   deriveTeamDisplay,
   formatDownAndDistance,
   groupPlaysByDrive,
+  leadersByCategory,
   offenseToChartYard,
+  playerStatsAtPosition,
   revealedPlays,
   scoreAtPosition,
   scoringSummaryAtPosition,
   winProbabilitySeries,
 } from "@/lib/gamecast";
+import type { GamecastPlayerNameMap } from "@/lib/gamecast";
 import { Badge } from "@/components/ui/badge";
 import GamecastScoreboard from "./GamecastScoreboard";
 import DriveChart from "./DriveChart";
@@ -23,6 +26,7 @@ import FieldPosition from "./FieldPosition";
 import WinProbability from "./WinProbability";
 import BoxScore from "./BoxScore";
 import ScoringSummary from "./ScoringSummary";
+import PlayerLeaders from "./PlayerLeaders";
 import GamecastTransport from "./GamecastTransport";
 import GamecastLayoutSwitcher from "./GamecastLayoutSwitcher";
 import { GamecastPanel, GamecastPlayByPlayCard } from "./GamecastPanel";
@@ -98,6 +102,7 @@ export interface GamecastViewProps {
   storedEngineVersion: string;
   currentEngineVersion: string;
   dynastyCta?: GamecastDynastyCta | null;
+  playerNameMap?: GamecastPlayerNameMap;
 }
 
 export default function GamecastView({
@@ -111,6 +116,7 @@ export default function GamecastView({
   storedEngineVersion,
   currentEngineVersion,
   dynastyCta = null,
+  playerNameMap = {},
 }: GamecastViewProps) {
   const plays = useMemo(() => allPlays(log), [log]);
   const totalPlays = plays.length;
@@ -160,6 +166,15 @@ export default function GamecastView({
   const isPreGame = playIndex === 0;
   const boxScore = boxScoreAtPosition(log, plays, playIndex);
   const scoringSummary = scoringSummaryAtPosition(log, plays, playIndex);
+  const playerStatLines = useMemo(
+    () => playerStatsAtPosition(log, plays, playIndex),
+    [log, plays, playIndex],
+  );
+  const playerLeaderGroups = useMemo(
+    () =>
+      leadersByCategory(playerStatLines, log.homeTeamId, log.awayTeamId),
+    [playerStatLines, log.homeTeamId, log.awayTeamId],
+  );
 
   const currentPlay =
     playIndex > 0 && playIndex <= plays.length
@@ -357,6 +372,17 @@ export default function GamecastView({
     />
   );
 
+  const playerLeadersNode = (
+    <GamecastPanel title="Player leaders">
+      <PlayerLeaders
+        groups={playerLeaderGroups}
+        playerNameMap={playerNameMap}
+        homeTeam={{ abbr: homeDisplay.abbr, color: homeDisplay.color }}
+        awayTeam={{ abbr: awayDisplay.abbr, color: awayDisplay.color }}
+      />
+    </GamecastPanel>
+  );
+
   const playByPlayNode = (
     <GamecastPlayByPlayCard>
       <PlayList
@@ -369,6 +395,7 @@ export default function GamecastView({
         mode={mode}
         animate={!reducedMotion}
         onPlaySelect={pauseAndJump}
+        playerNameMap={playerNameMap}
       />
     </GamecastPlayByPlayCard>
   );
@@ -418,6 +445,7 @@ export default function GamecastView({
         <div className="[&_svg]:h-[90px]">{winProbabilityNode}</div>
       ),
       boxScore: <GamecastPanel title="Team stats">{boxScoreNode}</GamecastPanel>,
+      playerLeaders: playerLeadersNode,
       scoringSummary: (
         <GamecastPanel title="Scoring summary">{scoringSummaryNode}</GamecastPanel>
       ),

--- a/apps/web/src/components/gamecast/PlayList.tsx
+++ b/apps/web/src/components/gamecast/PlayList.tsx
@@ -9,6 +9,8 @@ import {
   formatGameClock,
   formatQuarterLabel,
 } from "@/lib/gamecast";
+import { formatPlayContributors } from "@/lib/gamecast/play-contributors";
+import type { GamecastPlayerNameMap } from "@/lib/gamecast/player-names";
 import type { PbpPlay } from "@/lib/pbp";
 import { cn } from "@/lib/utils";
 import { computePlayListScrollTop } from "./play-list-scroll";
@@ -23,6 +25,7 @@ export interface PlayListProps {
   mode: "sim" | "review";
   animate: boolean;
   onPlaySelect: (playIndex: number) => void;
+  playerNameMap?: GamecastPlayerNameMap;
 }
 
 function playFlatIndex(allPlaysFlat: PbpPlay[], playId: number): number {
@@ -39,6 +42,7 @@ export default function PlayList({
   mode,
   animate,
   onPlaySelect,
+  playerNameMap = {},
 }: PlayListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const currentRef = useRef<HTMLLIElement>(null);
@@ -115,6 +119,7 @@ export default function PlayList({
                 const isCurrent = targetIndex === playIndex;
                 const isFuture = flatIdx >= playIndex;
                 const dimmed = mode === "review" && isFuture;
+                const contributors = formatPlayContributors(play, playerNameMap);
 
                 return (
                   <li
@@ -158,6 +163,11 @@ export default function PlayList({
                           </span>
                         ) : null}
                       </p>
+                      {contributors ? (
+                        <p className="mt-0.5 truncate text-caption-12 text-text-subtle">
+                          {contributors}
+                        </p>
+                      ) : null}
                     </button>
                   </li>
                 );

--- a/apps/web/src/components/gamecast/PlayerLeaders.tsx
+++ b/apps/web/src/components/gamecast/PlayerLeaders.tsx
@@ -1,0 +1,100 @@
+import type { StatGroupLeaders } from "@/lib/gamecast";
+import {
+  resolvePlayerLabel,
+  type GamecastPlayerNameMap,
+} from "@/lib/gamecast/player-names";
+
+export interface PlayerLeadersTeam {
+  abbr: string;
+  color: string;
+}
+
+export interface PlayerLeadersProps {
+  groups: StatGroupLeaders[];
+  playerNameMap: GamecastPlayerNameMap;
+  homeTeam: PlayerLeadersTeam;
+  awayTeam: PlayerLeadersTeam;
+}
+
+function leaderName(
+  playerId: string,
+  map: GamecastPlayerNameMap,
+): string {
+  return resolvePlayerLabel(playerId, map) ?? `#${playerId.slice(-4)}`;
+}
+
+function LeaderRow({
+  leader,
+  team,
+  map,
+}: {
+  leader: NonNullable<StatGroupLeaders["home"]>;
+  team: PlayerLeadersTeam;
+  map: GamecastPlayerNameMap;
+}) {
+  return (
+    <div className="flex items-start gap-2 py-1">
+      <span
+        className="mt-1 inline-block size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: team.color }}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-mono text-caption-12 font-bold" style={{ color: team.color }}>
+          {team.abbr} · {leaderName(leader.playerId, map)}
+        </p>
+        <p className="font-mono text-[11px] tabular-nums text-text-muted">
+          {leader.compactLine}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function PlayerLeaders({
+  groups,
+  playerNameMap,
+  homeTeam,
+  awayTeam,
+}: PlayerLeadersProps) {
+  if (groups.length === 0) {
+    return (
+      <p className="py-4 text-center text-caption-12 text-text-subtle">
+        No player stats yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-h-64 overflow-y-auto">
+      <p className="mb-3 text-caption-12 text-text-subtle">
+        Stats reflect the revealed game state.
+      </p>
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <section key={group.group}>
+            <h4 className="mb-1 font-mono text-[10px] font-bold uppercase tracking-wide text-text-subtle">
+              {group.label}
+            </h4>
+            <div className="divide-y divide-border rounded-md border border-border bg-surface-2/50 px-2">
+              {group.home ? (
+                <LeaderRow
+                  leader={group.home}
+                  team={homeTeam}
+                  map={playerNameMap}
+                />
+              ) : null}
+              {group.away ? (
+                <LeaderRow
+                  leader={group.away}
+                  team={awayTeam}
+                  map={playerNameMap}
+                />
+              ) : null}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/__tests__/GamecastView.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/GamecastView.test.ts
@@ -114,6 +114,7 @@ describe("GamecastView", () => {
     expect(html).toContain("Win probability");
     expect(html).toContain("Scoring summary");
     expect(html).toContain("Team stats");
+    expect(html).toContain("Player leaders");
     expect(html).toContain("Play-by-play");
     expect(html).toContain('data-testid="gamecast-layout-switcher"');
     expect(html).not.toContain("Press Next play to start the gamecast.");
@@ -162,6 +163,7 @@ describe("GamecastView", () => {
       boxScore: createElement("div", {
         "data-testid": "gamecast-score-away",
       }),
+      playerLeaders: null,
       scoringSummary: null,
       playByPlay: null,
       operatorHeader: createElement("div", {

--- a/apps/web/src/components/gamecast/__tests__/PlayList-contributors.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/PlayList-contributors.test.ts
@@ -1,0 +1,111 @@
+import { createElement } from "react";
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { simulateGameLog, allPlays } from "@/lib/pbp";
+import type { PbpGameInput, PlayerSimProfile, TeamSimProfile } from "@/lib/pbp";
+import { groupPlaysByDrive } from "@/lib/gamecast";
+import PlayList from "@/components/gamecast/PlayList";
+
+function makePlayer(
+  teamId: string,
+  position: string,
+  overall: number,
+  depthRank: number,
+): PlayerSimProfile {
+  return {
+    playerId: `${teamId}-${position}-${depthRank}`,
+    position,
+    overall,
+    depthRank,
+    positionSlot: position,
+  };
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 1],
+    ["RB", 2],
+    ["WR", 3],
+    ["TE", 1],
+    ["DE", 2],
+    ["LB", 2],
+    ["CB", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      players.push(makePlayer(teamId, pos, strength, i));
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+const log = simulateGameLog({
+  home: buildTeam("home", 68),
+  away: buildTeam("away", 62),
+  seed: 4242,
+  decisive: false,
+} satisfies PbpGameInput);
+const plays = allPlays(log);
+const homeTeam = { name: "Home", abbr: "HOM", color: "#111" };
+const awayTeam = { name: "Away", abbr: "AWY", color: "#222" };
+
+describe("PlayList contributor line", () => {
+  it("renders contributor text inside the play row button", () => {
+    const passPlay = plays.find((p) => p.playType === "pass_complete");
+    expect(passPlay).toBeDefined();
+    const passer = passPlay!.participants.find((p) => p.role === "passer");
+    expect(passer).toBeDefined();
+
+    const map: Record<string, { name: string; position: string }> = {
+      [passer!.playerId]: { name: "Test Passer", position: "QB" },
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(PlayList, {
+        groups: groupPlaysByDrive(log, [passPlay!]),
+        allPlaysFlat: plays,
+        homeTeamId: log.homeTeamId,
+        homeTeam,
+        awayTeam,
+        playIndex: plays.length,
+        mode: "review",
+        animate: false,
+        onPlaySelect: () => {},
+        playerNameMap: map,
+      }),
+    );
+
+    expect(html).toContain("<button");
+    expect(html).toContain("T. Passer");
+    expect(html.indexOf("T. Passer")).toBeGreaterThan(html.indexOf("<button"));
+  });
+
+  it("uses role fallback when name map is empty", () => {
+    const passPlay = plays.find((p) => p.playType === "pass_complete");
+    expect(passPlay).toBeDefined();
+
+    const html = renderToStaticMarkup(
+      createElement(PlayList, {
+        groups: groupPlaysByDrive(log, [passPlay!]),
+        allPlaysFlat: plays,
+        homeTeamId: log.homeTeamId,
+        homeTeam,
+        awayTeam,
+        playIndex: plays.length,
+        mode: "review",
+        animate: false,
+        onPlaySelect: () => {},
+        playerNameMap: {},
+      }),
+    );
+
+    expect(html).toContain("QB QB-1");
+  });
+});

--- a/apps/web/src/components/gamecast/__tests__/PlayerLeaders.test.ts
+++ b/apps/web/src/components/gamecast/__tests__/PlayerLeaders.test.ts
@@ -1,0 +1,105 @@
+import { createElement } from "react";
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import PlayerLeaders from "@/components/gamecast/PlayerLeaders";
+import type { StatGroupLeaders } from "@/lib/gamecast";
+
+const homeTeam = { abbr: "WHE", color: "#3d6fe6" };
+const awayTeam = { abbr: "HIL", color: "#d1503a" };
+
+const sampleGroups: StatGroupLeaders[] = [
+  {
+    group: "passing",
+    label: "Passing",
+    home: {
+      playerId: "home-qb-1",
+      teamId: "home",
+      statLine: {
+        passing: { comp: 12, att: 18, yards: 164, td: 2, int: 0, sacked: 1 },
+      },
+      compactLine: "12/18, 164 yds, 2 TD",
+      primaryValue: 164,
+    },
+    away: {
+      playerId: "away-qb-1",
+      teamId: "away",
+      statLine: {
+        passing: { comp: 9, att: 14, yards: 98, td: 1, int: 1, sacked: 0 },
+      },
+      compactLine: "9/14, 98 yds, 1 TD, 1 INT",
+      primaryValue: 98,
+    },
+  },
+  {
+    group: "rushing",
+    label: "Rushing",
+    home: {
+      playerId: "home-rb-1",
+      teamId: "home",
+      statLine: { rushing: { carries: 14, yards: 72, td: 1, long: 22 } },
+      compactLine: "14 car, 72 yds, 1 TD",
+      primaryValue: 72,
+    },
+    away: null,
+  },
+];
+
+describe("PlayerLeaders", () => {
+  it("renders groups with activity and player names", () => {
+    const html = renderToStaticMarkup(
+      createElement(PlayerLeaders, {
+        groups: sampleGroups,
+        playerNameMap: {
+          "home-qb-1": { name: "Jaylen Smith", position: "QB" },
+          "away-qb-1": { name: "Tyler Brown", position: "QB" },
+          "home-rb-1": { name: "Marcus Lee", position: "RB" },
+        },
+        homeTeam,
+        awayTeam,
+      }),
+    );
+    expect(html).toContain("Passing");
+    expect(html).toContain("Rushing");
+    expect(html).toContain("J. Smith");
+    expect(html).toContain("T. Brown");
+    expect(html).toContain("M. Lee");
+    expect(html).toContain("12/18, 164 yds, 2 TD");
+    expect(html).toContain("Stats reflect the revealed game state");
+  });
+
+  it("omits empty state message when groups exist", () => {
+    const html = renderToStaticMarkup(
+      createElement(PlayerLeaders, {
+        groups: sampleGroups,
+        playerNameMap: {},
+        homeTeam,
+        awayTeam,
+      }),
+    );
+    expect(html).not.toContain("No player stats yet");
+  });
+
+  it("shows empty state when no groups", () => {
+    const html = renderToStaticMarkup(
+      createElement(PlayerLeaders, {
+        groups: [],
+        playerNameMap: {},
+        homeTeam,
+        awayTeam,
+      }),
+    );
+    expect(html).toContain("No player stats yet");
+  });
+
+  it("uses fallback label when player missing from map", () => {
+    const html = renderToStaticMarkup(
+      createElement(PlayerLeaders, {
+        groups: [sampleGroups[0]],
+        playerNameMap: {},
+        homeTeam,
+        awayTeam,
+      }),
+    );
+    expect(html).toContain("#qb-1");
+  });
+});

--- a/apps/web/src/components/gamecast/layouts/BroadcastLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/BroadcastLayout.tsx
@@ -55,6 +55,7 @@ export default function BroadcastLayout({
             <div className={MOBILE_ORDER.winProb}>{panels.winProbability}</div>
             <div className={MOBILE_ORDER.stats}>{panels.scoringSummary}</div>
             <div className={MOBILE_ORDER.stats}>{panels.boxScore}</div>
+            <div className={MOBILE_ORDER.stats}>{panels.playerLeaders}</div>
           </div>
         </div>
 

--- a/apps/web/src/components/gamecast/layouts/FieldFirstLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/FieldFirstLayout.tsx
@@ -56,6 +56,9 @@ export default function FieldFirstLayout({ panels }: { panels: GamecastPanelSlot
           {panels.boxScore}
         </div>
         <div className={`hidden max-[900px]:block ${MOBILE_ORDER.stats}`}>
+          {panels.playerLeaders}
+        </div>
+        <div className={`hidden max-[900px]:block ${MOBILE_ORDER.stats}`}>
           {panels.scoringSummary}
         </div>
       </div>

--- a/apps/web/src/components/gamecast/layouts/GamecastPanelSlots.ts
+++ b/apps/web/src/components/gamecast/layouts/GamecastPanelSlots.ts
@@ -14,6 +14,7 @@ export interface GamecastPanelSlots {
   winProbabilityCompact: ReactNode;
   boxScore: ReactNode;
   scoringSummary: ReactNode;
+  playerLeaders: ReactNode;
   playByPlay: ReactNode;
   operatorHeader: ReactNode;
 }

--- a/apps/web/src/components/gamecast/layouts/OperatorLayout.tsx
+++ b/apps/web/src/components/gamecast/layouts/OperatorLayout.tsx
@@ -55,6 +55,7 @@ export default function OperatorLayout({ panels }: { panels: GamecastPanelSlots 
 
         <aside className={`space-y-[18px] bg-surface max-[900px]:contents ${MOBILE_ORDER.stats}`}>
           {panels.boxScore}
+          {panels.playerLeaders}
           {panels.scoringSummary}
         </aside>
       </div>

--- a/apps/web/src/lib/gamecast/__tests__/player-stats.test.ts
+++ b/apps/web/src/lib/gamecast/__tests__/player-stats.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveStatLines,
+  simulateGameLog,
+  allPlays,
+  type PbpGameInput,
+  type PlayerSimProfile,
+  type TeamSimProfile,
+} from "@/lib/pbp";
+import {
+  leadersByCategory,
+  normalizeStatLines,
+  playerStatsAtPosition,
+} from "@/lib/gamecast";
+
+function makePlayer(
+  teamId: string,
+  position: string,
+  overall: number,
+  depthRank: number,
+): PlayerSimProfile {
+  return {
+    playerId: `${teamId}-${position}-${depthRank}`,
+    position,
+    overall,
+    depthRank,
+    positionSlot: position,
+  };
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 1],
+    ["RB", 2],
+    ["WR", 3],
+    ["TE", 1],
+    ["DE", 2],
+    ["LB", 2],
+    ["CB", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      players.push(makePlayer(teamId, pos, strength, i));
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+function defaultInput(seed: number): PbpGameInput {
+  return {
+    home: buildTeam("home", 68),
+    away: buildTeam("away", 62),
+    seed,
+    decisive: false,
+  };
+}
+
+describe("gamecast player stats", () => {
+  const log = simulateGameLog(defaultInput(5150));
+  const plays = allPlays(log);
+
+  it("accumulates only revealed plays", () => {
+    const idx = Math.floor(plays.length / 3);
+    const partial = playerStatsAtPosition(log, plays, idx);
+    const full = playerStatsAtPosition(log, plays, plays.length);
+    expect(partial.length).toBeLessThanOrEqual(full.length);
+    expect(partial.length).toBeGreaterThan(0);
+  });
+
+  it("matches deriveStatLines at full game (order-insensitive)", () => {
+    const atEnd = normalizeStatLines(
+      playerStatsAtPosition(log, plays, plays.length),
+    );
+    const derived = normalizeStatLines(deriveStatLines(log));
+    expect(atEnd).toEqual(derived);
+  });
+
+  it("returns empty lines at kickoff", () => {
+    expect(playerStatsAtPosition(log, plays, 0)).toEqual([]);
+  });
+
+  it("leadersByCategory omits groups with no activity at kickoff", () => {
+    const leaders = leadersByCategory([], log.homeTeamId, log.awayTeamId);
+    expect(leaders).toEqual([]);
+  });
+
+  it("leadersByCategory returns per-team leaders for active groups", () => {
+    const lines = playerStatsAtPosition(log, plays, plays.length);
+    const leaders = leadersByCategory(lines, log.homeTeamId, log.awayTeamId);
+    expect(leaders.length).toBeGreaterThan(0);
+
+    for (const group of leaders) {
+      if (group.home) {
+        expect(group.home.teamId).toBe(log.homeTeamId);
+        expect(group.home.compactLine.length).toBeGreaterThan(0);
+      }
+      if (group.away) {
+        expect(group.away.teamId).toBe(log.awayTeamId);
+        expect(group.away.compactLine.length).toBeGreaterThan(0);
+      }
+    }
+
+    const passing = leaders.find((g) => g.group === "passing");
+    expect(passing).toBeDefined();
+    expect(passing!.home?.primaryValue).toBeGreaterThanOrEqual(0);
+  });
+
+  it("breaks ties by playerId for passing yards", () => {
+    const homeId = log.homeTeamId;
+    const tiedLines = [
+      {
+        playerId: "z-player",
+        teamId: homeId,
+        statLine: { passing: { comp: 5, att: 8, yards: 100, td: 0, int: 0, sacked: 0 } },
+      },
+      {
+        playerId: "a-player",
+        teamId: homeId,
+        statLine: { passing: { comp: 5, att: 8, yards: 100, td: 0, int: 0, sacked: 0 } },
+      },
+    ];
+    const leaders = leadersByCategory(tiedLines, homeId, "away");
+    const passing = leaders.find((g) => g.group === "passing");
+    expect(passing?.home?.playerId).toBe("a-player");
+  });
+});

--- a/apps/web/src/lib/gamecast/index.ts
+++ b/apps/web/src/lib/gamecast/index.ts
@@ -48,3 +48,18 @@ export {
   type ScoringPlayKind,
 } from "./scoring-summary";
 export { deriveTeamDisplay, type TeamDisplay } from "./team-display";
+export {
+  playerStatsAtPosition,
+  leadersByCategory,
+  normalizeStatLines,
+  type StatGroupLeaders,
+  type TeamStatLeader,
+} from "./player-stats";
+export {
+  formatShortPlayerName,
+  resolvePlayerLabel,
+  rolePositionFallback,
+  type GamecastPlayerInfo,
+  type GamecastPlayerNameMap,
+} from "./player-names";
+export { formatPlayContributors } from "./play-contributors";

--- a/apps/web/src/lib/gamecast/play-contributors.ts
+++ b/apps/web/src/lib/gamecast/play-contributors.ts
@@ -1,0 +1,105 @@
+import type { PbpParticipantRole, PbpPlay } from "@/lib/pbp";
+import {
+  resolvePlayerLabel,
+  type GamecastPlayerNameMap,
+} from "./player-names";
+
+function participantLabel(
+  play: PbpPlay,
+  map: GamecastPlayerNameMap,
+  role: PbpParticipantRole,
+): string | null {
+  const p = play.participants.find((x) => x.role === role);
+  if (!p) return null;
+  return resolvePlayerLabel(p.playerId, map, role);
+}
+
+function tacklerLabels(play: PbpPlay, map: GamecastPlayerNameMap): string[] {
+  const labels: string[] = [];
+  for (const role of ["tackler_solo", "tackler_ast"] as const) {
+    for (const p of play.participants.filter((x) => x.role === role)) {
+      const name = resolvePlayerLabel(p.playerId, map, role);
+      if (name) labels.push(name);
+    }
+  }
+  return labels;
+}
+
+/** Terse contributor line for play-by-play rows. */
+export function formatPlayContributors(
+  play: PbpPlay,
+  map: GamecastPlayerNameMap,
+): string | null {
+  const parts: string[] = [];
+
+  switch (play.playType) {
+    case "pass_complete":
+    case "pass_incomplete": {
+      const passer = participantLabel(play, map, "passer");
+      const receiver = participantLabel(play, map, "receiver");
+      if (passer && receiver) {
+        parts.push(`${passer} → ${receiver}`);
+      } else if (passer) {
+        parts.push(passer);
+      } else if (receiver) {
+        parts.push(receiver);
+      }
+      break;
+    }
+    case "interception": {
+      const passer = participantLabel(play, map, "passer");
+      const interceptor = participantLabel(play, map, "interceptor");
+      if (passer && interceptor) {
+        parts.push(`${passer} · int: ${interceptor}`);
+      } else if (passer) {
+        parts.push(passer);
+      } else if (interceptor) {
+        parts.push(`int: ${interceptor}`);
+      }
+      break;
+    }
+    case "sack": {
+      const passer = participantLabel(play, map, "passer");
+      const sacker = participantLabel(play, map, "sacker");
+      if (passer && sacker) {
+        parts.push(`${passer} · sack: ${sacker}`);
+      } else if (passer) {
+        parts.push(passer);
+      } else if (sacker) {
+        parts.push(sacker);
+      }
+      break;
+    }
+    case "rush":
+    case "kneel": {
+      const rusher = participantLabel(play, map, "rusher");
+      if (rusher) parts.push(rusher);
+      break;
+    }
+    case "kickoff":
+    case "punt":
+    case "field_goal":
+    case "field_goal_miss":
+    case "extra_point":
+    case "extra_point_miss": {
+      const kicker = participantLabel(play, map, "kicker");
+      if (kicker) parts.push(kicker);
+      const returner = participantLabel(play, map, "returner");
+      if (returner) parts.push(`ret: ${returner}`);
+      break;
+    }
+    default:
+      break;
+  }
+
+  const tacklers = tacklerLabels(play, map);
+  if (tacklers.length > 0) {
+    parts.push(`tkl: ${tacklers.join(", ")}`);
+  }
+
+  const fumbler = participantLabel(play, map, "fumbler");
+  if (fumbler) parts.push(`fum: ${fumbler}`);
+
+  if (parts.length === 0) return null;
+  return parts.join(" · ");
+}

--- a/apps/web/src/lib/gamecast/player-names.ts
+++ b/apps/web/src/lib/gamecast/player-names.ts
@@ -1,0 +1,53 @@
+import type { PbpParticipantRole } from "@/lib/pbp";
+
+export interface GamecastPlayerInfo {
+  name: string;
+  position: string;
+}
+
+export type GamecastPlayerNameMap = Record<string, GamecastPlayerInfo>;
+
+const ROLE_POSITION_FALLBACK: Partial<Record<PbpParticipantRole, string>> = {
+  passer: "QB",
+  rusher: "RB",
+  receiver: "WR",
+  kicker: "K",
+  returner: "KR",
+  sacker: "DL",
+  tackler_solo: "LB",
+  tackler_ast: "LB",
+  interceptor: "DB",
+  pass_defender: "DB",
+  fumbler: "RB",
+  recoverer: "DL",
+};
+
+export function formatShortPlayerName(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/);
+  if (parts.length === 0) return fullName;
+  if (parts.length === 1) return parts[0];
+  const initial = parts[0].charAt(0).toUpperCase();
+  return `${initial}. ${parts[parts.length - 1]}`;
+}
+
+export function rolePositionFallback(
+  role: PbpParticipantRole | undefined,
+): string | null {
+  if (!role) return null;
+  return ROLE_POSITION_FALLBACK[role] ?? null;
+}
+
+/** Resolve a display label; returns null when the role should be omitted. */
+export function resolvePlayerLabel(
+  playerId: string,
+  map: GamecastPlayerNameMap,
+  role?: PbpParticipantRole,
+): string | null {
+  const entry = map[playerId];
+  if (entry?.name) return formatShortPlayerName(entry.name);
+
+  const position = entry?.position || rolePositionFallback(role);
+  if (position) return `${position} ${playerId.slice(-4)}`;
+
+  return null;
+}

--- a/apps/web/src/lib/gamecast/player-stats.ts
+++ b/apps/web/src/lib/gamecast/player-stats.ts
@@ -1,0 +1,238 @@
+import type { PlayerGameStatLine } from "@sports-management/shared-types";
+import type { PbpGameLog, PbpPlay } from "@/lib/pbp";
+import {
+  applyPlay,
+  pruneLine,
+  type DerivedPlayerStatLine,
+  type MutableLine,
+} from "@/lib/pbp/derive-stats";
+import type { PlayRevealIndex } from "./reveal";
+
+export type { DerivedPlayerStatLine };
+
+export interface TeamStatLeader {
+  playerId: string;
+  teamId: string;
+  statLine: PlayerGameStatLine;
+  compactLine: string;
+  primaryValue: number;
+}
+
+export interface StatGroupLeaders {
+  group: keyof PlayerGameStatLine;
+  label: string;
+  home: TeamStatLeader | null;
+  away: TeamStatLeader | null;
+}
+
+type StatGroupKey = keyof PlayerGameStatLine;
+
+interface GroupConfig {
+  key: StatGroupKey;
+  label: string;
+  primaryValue: (line: DerivedPlayerStatLine) => number;
+  formatCompact: (stats: PlayerGameStatLine) => string;
+}
+
+function hasGroupActivity(
+  line: DerivedPlayerStatLine,
+  key: StatGroupKey,
+): boolean {
+  const group = line.statLine[key];
+  if (!group) return false;
+  return Object.values(group).some((v) => v !== 0);
+}
+
+function pickTeamLeader(
+  lines: DerivedPlayerStatLine[],
+  teamId: string,
+  config: GroupConfig,
+): TeamStatLeader | null {
+  const candidates = lines
+    .filter((l) => l.teamId === teamId && hasGroupActivity(l, config.key))
+    .sort((a, b) => {
+      const diff = config.primaryValue(b) - config.primaryValue(a);
+      if (diff !== 0) return diff;
+      return a.playerId.localeCompare(b.playerId);
+    });
+
+  const top = candidates[0];
+  if (!top) return null;
+
+  return {
+    playerId: top.playerId,
+    teamId: top.teamId,
+    statLine: top.statLine,
+    compactLine: config.formatCompact(top.statLine),
+    primaryValue: config.primaryValue(top),
+  };
+}
+
+const GROUP_CONFIGS: GroupConfig[] = [
+  {
+    key: "passing",
+    label: "Passing",
+    primaryValue: (l) => l.statLine.passing?.yards ?? 0,
+    formatCompact: (s) => {
+      const p = s.passing!;
+      const parts = [`${p.comp}/${p.att}`, `${p.yards} yds`];
+      if (p.td) parts.push(`${p.td} TD`);
+      if (p.int) parts.push(`${p.int} INT`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "rushing",
+    label: "Rushing",
+    primaryValue: (l) => l.statLine.rushing?.yards ?? 0,
+    formatCompact: (s) => {
+      const r = s.rushing!;
+      const parts = [`${r.carries} car`, `${r.yards} yds`];
+      if (r.td) parts.push(`${r.td} TD`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "receiving",
+    label: "Receiving",
+    primaryValue: (l) => l.statLine.receiving?.yards ?? 0,
+    formatCompact: (s) => {
+      const r = s.receiving!;
+      const parts = [`${r.rec} rec`, `${r.yards} yds`];
+      if (r.td) parts.push(`${r.td} TD`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "defense",
+    label: "Defense",
+    primaryValue: (l) => {
+      const d = l.statLine.defense;
+      if (!d) return 0;
+      return (d.tacklesSolo ?? 0) + (d.tacklesAst ?? 0);
+    },
+    formatCompact: (s) => {
+      const d = s.defense!;
+      const tkls = (d.tacklesSolo ?? 0) + (d.tacklesAst ?? 0);
+      const parts = [`${tkls} tkl`];
+      if (d.sacks) parts.push(`${d.sacks} sack`);
+      if (d.int) parts.push(`${d.int} INT`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "kicking",
+    label: "Kicking",
+    primaryValue: (l) => {
+      const k = l.statLine.kicking;
+      if (!k) return 0;
+      return (k.fgMade ?? 0) * 3 + (k.xpMade ?? 0);
+    },
+    formatCompact: (s) => {
+      const k = s.kicking!;
+      const parts: string[] = [];
+      if (k.fgAtt) parts.push(`${k.fgMade}/${k.fgAtt} FG`);
+      if (k.xpAtt) parts.push(`${k.xpMade}/${k.xpAtt} XP`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "punting",
+    label: "Punting",
+    primaryValue: (l) => {
+      const p = l.statLine.punting;
+      if (!p || (p.punts ?? 0) === 0) return 0;
+      return (p.yards ?? 0) / (p.punts ?? 1);
+    },
+    formatCompact: (s) => {
+      const p = s.punting!;
+      const punts = p.punts ?? 0;
+      const yards = p.yards ?? 0;
+      const avg = punts > 0 ? (yards / punts).toFixed(1) : "0.0";
+      return `${punts} punts, ${avg} avg`;
+    },
+  },
+  {
+    key: "returns",
+    label: "Returns",
+    primaryValue: (l) => {
+      const r = l.statLine.returns;
+      if (!r) return 0;
+      return (r.krYards ?? 0) + (r.prYards ?? 0);
+    },
+    formatCompact: (s) => {
+      const r = s.returns!;
+      const count = (r.krCount ?? 0) + (r.prCount ?? 0);
+      const yards = (r.krYards ?? 0) + (r.prYards ?? 0);
+      const parts = [`${count} ret`, `${yards} yds`];
+      const td = (r.krTd ?? 0) + (r.prTd ?? 0);
+      if (td) parts.push(`${td} TD`);
+      return parts.join(", ");
+    },
+  },
+  {
+    key: "ballSecurity",
+    label: "Ball security",
+    primaryValue: (l) => l.statLine.ballSecurity?.fumbles ?? 0,
+    formatCompact: (s) => {
+      const b = s.ballSecurity!;
+      const parts: string[] = [];
+      if (b.fumbles) parts.push(`${b.fumbles} FUM`);
+      if (b.fumblesLost) parts.push(`${b.fumblesLost} lost`);
+      return parts.join(", ");
+    },
+  },
+];
+
+export function playerStatsAtPosition(
+  log: PbpGameLog,
+  plays: PbpPlay[],
+  playIndex: PlayRevealIndex,
+): DerivedPlayerStatLine[] {
+  const map = new Map<string, MutableLine>();
+  const teamByPlayer = new Map<string, string>();
+  const end = Math.min(playIndex, plays.length);
+
+  for (let i = 0; i < end; i++) {
+    const play = plays[i];
+    for (const p of play.participants) {
+      teamByPlayer.set(p.playerId, p.teamId);
+    }
+    applyPlay(map, play);
+  }
+
+  return [...map.entries()].map(([playerId, line]) => ({
+    playerId,
+    teamId: teamByPlayer.get(playerId) ?? log.homeTeamId,
+    statLine: pruneLine(line),
+  }));
+}
+
+export function leadersByCategory(
+  lines: DerivedPlayerStatLine[],
+  homeTeamId: string,
+  awayTeamId: string,
+): StatGroupLeaders[] {
+  const result: StatGroupLeaders[] = [];
+
+  for (const config of GROUP_CONFIGS) {
+    const home = pickTeamLeader(lines, homeTeamId, config);
+    const away = pickTeamLeader(lines, awayTeamId, config);
+    if (!home && !away) continue;
+    result.push({
+      group: config.key,
+      label: config.label,
+      home,
+      away,
+    });
+  }
+
+  return result;
+}
+
+/** Normalize stat lines for order-insensitive comparison in tests. */
+export function normalizeStatLines(
+  lines: DerivedPlayerStatLine[],
+): DerivedPlayerStatLine[] {
+  return [...lines].sort((a, b) => a.playerId.localeCompare(b.playerId));
+}

--- a/apps/web/src/lib/pbp/derive-stats.ts
+++ b/apps/web/src/lib/pbp/derive-stats.ts
@@ -7,7 +7,7 @@ export interface DerivedPlayerStatLine {
   statLine: PlayerGameStatLine;
 }
 
-type MutableLine = {
+export type MutableLine = {
   passing: Required<NonNullable<PlayerGameStatLine["passing"]>>;
   rushing: Required<NonNullable<PlayerGameStatLine["rushing"]>>;
   receiving: Required<NonNullable<PlayerGameStatLine["receiving"]>>;
@@ -18,7 +18,7 @@ type MutableLine = {
   ballSecurity: Required<NonNullable<PlayerGameStatLine["ballSecurity"]>>;
 };
 
-function emptyLine(): MutableLine {
+export function emptyLine(): MutableLine {
   return {
     passing: { comp: 0, att: 0, yards: 0, td: 0, int: 0, sacked: 0 },
     rushing: { carries: 0, yards: 0, td: 0, long: 0 },
@@ -76,7 +76,7 @@ function isNegativePlay(play: PbpPlay): boolean {
   return play.yardsGained < 0 && (play.playType === "rush" || play.playType === "sack");
 }
 
-function applyPlay(
+export function applyPlay(
   map: Map<string, MutableLine>,
   play: PbpPlay,
 ): void {
@@ -244,7 +244,7 @@ function creditFumble(map: Map<string, MutableLine>, play: PbpPlay): void {
   }
 }
 
-function pruneLine(line: MutableLine): PlayerGameStatLine {
+export function pruneLine(line: MutableLine): PlayerGameStatLine {
   const out: PlayerGameStatLine = {};
   const groups: (keyof MutableLine)[] = [
     "passing",


### PR DESCRIPTION
Fixes #505

## What
Surfaces the per-player data the sim already stores (`play.participants` + `derive-stats.ts`) in Gamecast:

- **Shared crediting core**: `derive-stats.ts` internals (`applyPlay`/`emptyLine`/`pruneLine`/`MutableLine`) exported — diff is export-keywords only, `deriveStatLines` byte-identical, existing tests unchanged
- **`playerStatsAtPosition(log, plays, playIndex)`** in `lib/gamecast` — revealed plays only, reusing the shared core; invariant test: at full reveal it deep-equals `deriveStatLines` (order-insensitive). Plus `leadersByCategory` selectors
- **`PlayerLeaders` panel** — full stat sheet (locked decision): all 8 groups as sections, top player per team per group with compact stat lines, empty groups omitted, scroll-contained. Broadcast + Operator right rail under Box score; mobile stack after stats. Field-first desktop intentionally omits it (spec reserves that rail for win prob + play-by-play)
- **PlayList contributor lines** — terse (passer → receiver · tacklers, kickers) inside the existing row button (e2e row structure untouched), from a server-built `playerId → {name, position}` map (`getPlayersByTeam` both teams) with position+short-id fallback

## Verification
- `type-check`, `lint`, `test:unit` (**1000 tests**, 138 files), prod `build` — all green
- Invariant + leader-selection + render tests added; `playwright test --list` clean (132 e2e enumerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK