### PR TITLE
test(web): fix gamecast e2e selectors that were silently red (WSM-000230)

### DIFF
--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -440,7 +440,7 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
 
     const startCounter = await readPlayCounter(page);
     const y0 = await page.evaluate(() => window.scrollY);
-    await page.getByRole("button", { name: "Play" }).click();
+    await page.getByRole("button", { name: "Play", exact: true }).click();
     await expect
       .poll(async () => (await readPlayCounter(page)).index, {
         timeout: 30_000,
@@ -462,7 +462,7 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
       .getByRole("group", { name: "Simulation speed" })
       .getByRole("button", { name: "4×" })
       .click();
-    await page.getByRole("button", { name: "Play" }).click();
+    await page.getByRole("button", { name: "Play", exact: true }).click();
 
     const { total } = await readPlayCounter(page);
     await expect
@@ -491,19 +491,24 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
     );
 
     await page.getByTestId("gamecast-layout-operator").click();
-    await expect(page.getByTestId("gamecast-operator-header")).toBeVisible();
+    const operatorHeader = page.getByTestId("gamecast-operator-header");
+    await expect(operatorHeader).toBeVisible();
     await expect(page.getByTestId("gamecast-operator-clock-chip")).toContainText(
       "Final",
     );
-    await expect(page.getByTestId("gamecast-score-home")).toContainText(
-      String(ctx.expectedHome),
-    );
+    // The operator layout renders the score inline in its mono header rather
+    // than the broadcast scoreboard's gamecast-score-home/away testids.
+    await expect(operatorHeader).toContainText(String(ctx.expectedHome));
+    await expect(operatorHeader).toContainText(String(ctx.expectedAway));
 
     await page.reload();
+    // The operator layout content is the deterministic post-hydration signal
+    // that the persisted choice was restored; wait for it before asserting the
+    // switcher button's aria state (which otherwise races client hydration).
+    await expect(page.getByTestId("gamecast-operator-header")).toBeVisible();
     await expect(
       page.getByTestId("gamecast-layout-operator"),
     ).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByTestId("gamecast-operator-header")).toBeVisible();
 
     await page.getByTestId("gamecast-layout-broadcast").click();
     await expect(


### PR DESCRIPTION
## Why
While dogfooding the gamecast locally I discovered **two gamecast Playwright scenarios have been failing since #502** — they merged anyway because `main` has **no required status checks**, so squash-auto-merge landed each PR the moment it was mergeable, regardless of the Playwright job (which was `FAILURE` on #502 and #509). Unit/type/lint/build were always genuinely green; the e2e layer was not.

Both are **test-selector bugs, not product regressions** — I verified the underlying features work by driving the real UI locally:

1. **auto-sim** — `getByRole('button', { name: 'Play' })` matched **3 buttons** ("Play", "Next play", "Previous play"; Playwright name matching is substring) → strict-mode violation before the click. A counter probe confirmed auto-advance works (0→1→2→3… at ~950ms/play at 1×). Fix: `exact: true`.
2. **layout switcher** — asserted `gamecast-score-home` in the **Operator** layout, which renders the score inline in its mono `gamecast-operator-header` (not the broadcast scoreboard testids). Fix: assert the operator header's score text.

## Verification (run locally against the seeded stack — not inferred from merge)
- `gamecast.spec.ts` — **12/12 pass**
- `dynasty.spec.ts` — **6/6 pass** (confirms the #507/#508 rollover + graduated-players surfacing genuinely work)

## Follow-up (recommended, needs repo admin)
Enable branch protection on `main` requiring the **Playwright (apps/web)** check before merge, so red e2e can't land silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK