### PR TITLE
feat(web): offseason free-agency backend (WSM-000231)

### DIFF
--- a/apps/web/convex/__tests__/offseasonFreeAgency.test.ts
+++ b/apps/web/convex/__tests__/offseasonFreeAgency.test.ts
@@ -1,0 +1,255 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { targetRosterSize } from "../lib/offseason";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_test_actor";
+
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "FA League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "Team A",
+      leagueId,
+      divisionId: null,
+      city: "A",
+      stadium: "A",
+      foundedYear: null,
+      location: "A",
+      logoUrl: null,
+      rosterLimit: null,
+    });
+    const teamB = await ctx.db.insert("teams", {
+      name: "Team B",
+      leagueId,
+      divisionId: null,
+      city: "B",
+      stadium: "B",
+      foundedYear: null,
+      location: "B",
+      logoUrl: null,
+      rosterLimit: null,
+    });
+    const activeSeason = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const upcomingSeason = await ctx.db.insert("seasons", {
+      name: "2027",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "upcoming",
+      rosterLocked: false,
+    });
+    const player = await ctx.db.insert("players", {
+      name: "Release Me",
+      leagueId,
+      teamId: teamA,
+      position: "WR",
+      positionGroup: null,
+      jerseyNumber: 11,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+      grade: 11,
+    });
+    const rostered = await ctx.db.insert("players", {
+      name: "Stay Active",
+      leagueId,
+      teamId: teamA,
+      position: "QB",
+      positionGroup: null,
+      jerseyNumber: 1,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+    const assignmentId = await ctx.db.insert("rosterAssignments", {
+      seasonId: upcomingSeason,
+      teamId: teamA,
+      playerId: player,
+      leagueId,
+      depthRank: 1,
+      positionSlot: "WR",
+      status: "active",
+      assignedAt: new Date().toISOString(),
+      assignedBy: ACTOR,
+    });
+    const depthId = await ctx.db.insert("depthChartEntries", {
+      teamId: teamA,
+      seasonId: upcomingSeason,
+      playerId: player,
+      positionSlot: "WR",
+      sortOrder: 0,
+      updatedAt: new Date().toISOString(),
+    });
+    return {
+      leagueId,
+      teamA,
+      teamB,
+      activeSeason,
+      upcomingSeason,
+      player,
+      rostered,
+      assignmentId,
+      depthId,
+    };
+  });
+}
+
+describe("releasePlayerToFreeAgency", () => {
+  it("sets free_agent and removes assignment + depth rows for offseason seasons", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    const result = await t.mutation(internal.sports.releasePlayerToFreeAgency, {
+      playerId: seed.player,
+    });
+    expect(result.playerId).toBe(seed.player);
+
+    const player = await t.run((ctx) => ctx.db.get(seed.player));
+    expect(player?.status).toBe("free_agent");
+    expect(player?.teamId).toBe(seed.teamA);
+
+    const assignments = await t.run((ctx) =>
+      ctx.db.query("rosterAssignments").collect(),
+    );
+    expect(assignments.find((a) => a._id === seed.assignmentId)).toBeUndefined();
+
+    const depth = await t.run((ctx) =>
+      ctx.db.query("depthChartEntries").collect(),
+    );
+    expect(depth.find((d) => d._id === seed.depthId)).toBeUndefined();
+  });
+});
+
+describe("signFreeAgent", () => {
+  async function seedFreeAgent(t: ReturnType<typeof convexTest>) {
+    const base = await seedLeague(t);
+    await t.mutation(internal.sports.releasePlayerToFreeAgency, {
+      playerId: base.player,
+    });
+    return base;
+  }
+
+  it("restores active status with assignment and depth chart entry", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedFreeAgent(t);
+
+    const result = await t.mutation(internal.sports.signFreeAgent, {
+      playerId: seed.player,
+      teamId: seed.teamB,
+      seasonId: seed.upcomingSeason,
+      actorUserId: ACTOR,
+    });
+    expect(result.teamId).toBe(seed.teamB);
+    expect(result.overCap).toBe(false);
+
+    const player = await t.run((ctx) => ctx.db.get(seed.player));
+    expect(player?.status).toBe("active");
+    expect(player?.teamId).toBe(seed.teamB);
+
+    const assignments = await t.run((ctx) =>
+      ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", seed.upcomingSeason).eq("teamId", seed.teamB),
+        )
+        .collect(),
+    );
+    expect(assignments.some((a) => a.playerId === seed.player)).toBe(true);
+
+    const depth = await t.run((ctx) =>
+      ctx.db
+        .query("depthChartEntries")
+        .withIndex("by_team_season", (q) =>
+          q.eq("teamId", seed.teamB).eq("seasonId", seed.upcomingSeason),
+        )
+        .collect(),
+    );
+    expect(depth.some((d) => d.playerId === seed.player)).toBe(true);
+  });
+
+  it("returns overCap when the team is already at target roster size", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedFreeAgent(t);
+    const cap = targetRosterSize();
+
+    await t.run(async (ctx) => {
+      for (let i = 0; i < cap; i++) {
+        await ctx.db.insert("players", {
+          name: `Bench ${i}`,
+          leagueId: seed.leagueId,
+          teamId: seed.teamB,
+          position: "HB",
+          positionGroup: null,
+          jerseyNumber: i + 20,
+          dateOfBirth: null,
+          status: "active",
+          headshotUrl: null,
+        });
+      }
+    });
+
+    const result = await t.mutation(internal.sports.signFreeAgent, {
+      playerId: seed.player,
+      teamId: seed.teamB,
+      seasonId: seed.upcomingSeason,
+      actorUserId: ACTOR,
+    });
+    expect(result.overCap).toBe(true);
+
+    const player = await t.run((ctx) => ctx.db.get(seed.player));
+    expect(player?.status).toBe("active");
+  });
+});
+
+describe("listFreeAgents", () => {
+  it("returns only free_agent players in the league with ratings when present", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await t.mutation(internal.sports.releasePlayerToFreeAgency, {
+      playerId: seed.player,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("playerAttributes", {
+        playerId: seed.player,
+        seasonId: seed.upcomingSeason,
+        positionGroup: "WR",
+        attributesJson: "{}",
+        pffSourceJson: null,
+        maddenSourceJson: null,
+        pffWeight: 0,
+        maddenWeight: 1,
+        weightedOverall: 82,
+        ingestedAt: new Date().toISOString(),
+      });
+    });
+
+    const rows = await t.query(api.sports.listFreeAgents, {
+      leagueId: seed.leagueId,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(seed.player);
+    expect(rows[0].name).toBe("Release Me");
+    expect(rows[0].position).toBe("WR");
+    expect(rows[0].grade).toBe(11);
+    expect(rows[0].overall).toBe(82);
+    expect(rows[0].teamId).toBe(seed.teamA);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -36,6 +36,8 @@ void internal.sports.ingestMaddenRatingsBatch;
 void internal.sports.ingestPlayerAttributesBatch;
 void internal.sports.rolloverGraduateAndAdvancePlayers;
 void internal.sports.removePlayersFromSeasonRoster;
+void internal.sports.releasePlayerToFreeAgency;
+void internal.sports.signFreeAgent;
 void internal.sports.updatePlayerAttributes;
 void internal.sports.setOrgMemberRole;
 void internal.sports.updateDivision;
@@ -172,6 +174,7 @@ type AllowedPublicSportsReads =
   | "listConferences"
   | "listDivisions"
   | "listFixturesBySeason"
+  | "listFreeAgents"
   | "listLeagues"
   | "listOrgMemberRoles"
   | "listPlayers"

--- a/apps/web/convex/lib/offseason.ts
+++ b/apps/web/convex/lib/offseason.ts
@@ -1,0 +1,14 @@
+/**
+ * Offseason free-agency helpers (WSM-000231).
+ *
+ * Target roster size matches the synthetic-roster generator cap in
+ * `apps/web/src/app/dashboard/_actions/synthetic-rosters.ts` and dynasty rollover
+ * (`DEFAULT_ROSTER_SIZE` = 48, clamped to `MAX_ROSTER_SIZE` = 60).
+ */
+export const DEFAULT_TARGET_ROSTER_SIZE = 48;
+export const MAX_TARGET_ROSTER_SIZE = 60;
+
+export function targetRosterSize(override?: number | null): number {
+  const raw = override ?? DEFAULT_TARGET_ROSTER_SIZE;
+  return Math.max(1, Math.min(raw, MAX_TARGET_ROSTER_SIZE));
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -32,6 +32,9 @@ import {
   nextPowerOfTwo,
 } from "./lib/bracket";
 import { squadForGrade } from "./lib/dynasty";
+import {
+  targetRosterSize,
+} from "./lib/offseason";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -2629,6 +2632,171 @@ export const setRosterLocked = internalMutation({
   },
 });
 
+async function assignPlayerToRosterCore(
+  ctx: MutationCtx,
+  args: {
+    seasonId: Id<"seasons">;
+    teamId: Id<"teams">;
+    playerId: Id<"players">;
+    positionSlot: string;
+    actorUserId: string;
+    enforceRosterLimit?: boolean;
+  },
+): Promise<Infer<typeof rosterAssignmentDtoValidator>> {
+  const [season, team, player] = await Promise.all([
+    ctx.db.get(args.seasonId),
+    ctx.db.get(args.teamId),
+    ctx.db.get(args.playerId),
+  ]);
+  if (!season) throw new Error("season_not_found");
+  if (!team) throw new Error("team_not_found");
+  if (!player) throw new Error("player_not_found");
+  if (season.rosterLocked === true) throw new Error("season_locked");
+  if (team.leagueId !== season.leagueId) {
+    throw new Error("team_season_league_mismatch");
+  }
+  if (player.teamId !== args.teamId) {
+    throw new Error("player_not_on_team");
+  }
+
+  const teamAssignments = await ctx.db
+    .query("rosterAssignments")
+    .withIndex("by_seasonId_teamId", (q) =>
+      q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+    )
+    .collect();
+
+  const activeForPlayer = teamAssignments.find(
+    (row) => row.playerId === args.playerId && row.status === "active",
+  );
+  if (activeForPlayer) {
+    throw new Error("player_already_on_roster");
+  }
+
+  const activeCount = teamAssignments.filter(
+    (row) => row.status === "active",
+  ).length;
+  if (
+    args.enforceRosterLimit !== false &&
+    team.rosterLimit !== null &&
+    activeCount >= team.rosterLimit
+  ) {
+    throw new Error("roster_limit_exceeded");
+  }
+
+  const slotActive = teamAssignments.filter(
+    (row) => row.status === "active" && row.positionSlot === args.positionSlot,
+  );
+  const nextDepthRank =
+    slotActive.reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+
+  const assignedAt = new Date().toISOString();
+  const insertedId = await ctx.db.insert("rosterAssignments", {
+    seasonId: args.seasonId,
+    teamId: args.teamId,
+    playerId: args.playerId,
+    leagueId: team.leagueId,
+    depthRank: nextDepthRank,
+    positionSlot: args.positionSlot,
+    status: "active",
+    assignedAt,
+    assignedBy: args.actorUserId,
+  });
+
+  const after = {
+    id: insertedId,
+    seasonId: args.seasonId,
+    teamId: args.teamId,
+    playerId: args.playerId,
+    leagueId: team.leagueId,
+    depthRank: nextDepthRank,
+    positionSlot: args.positionSlot,
+    status: "active",
+    assignedAt,
+    assignedBy: args.actorUserId,
+  };
+
+  await writeAuditLog(ctx, {
+    leagueId: team.leagueId,
+    teamId: args.teamId,
+    seasonId: args.seasonId,
+    actorUserId: args.actorUserId,
+    action: "assign",
+    before: null,
+    after,
+  });
+
+  return toRosterAssignmentDto({ _id: insertedId, ...after });
+}
+
+async function appendDefaultDepthChartSlot(
+  ctx: MutationCtx,
+  args: {
+    teamId: Id<"teams">;
+    seasonId: Id<"seasons">;
+    playerId: Id<"players">;
+    positionSlot: string;
+  },
+): Promise<void> {
+  const existing = await ctx.db
+    .query("depthChartEntries")
+    .withIndex("by_team_season_position", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("seasonId", args.seasonId)
+        .eq("positionSlot", args.positionSlot),
+    )
+    .collect();
+  const nextSortOrder =
+    existing.reduce((max, row) => Math.max(max, row.sortOrder), -1) + 1;
+  await ctx.db.insert("depthChartEntries", {
+    teamId: args.teamId,
+    seasonId: args.seasonId,
+    playerId: args.playerId,
+    positionSlot: args.positionSlot,
+    sortOrder: nextSortOrder,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+async function resolveOffseasonSeasonIds(
+  ctx: MutationCtx,
+  leagueId: Id<"leagues">,
+): Promise<Id<"seasons">[]> {
+  const seasons = await ctx.db
+    .query("seasons")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+    .collect();
+  return seasons
+    .filter((s) => s.status === "active" || s.status === "upcoming")
+    .map((s) => s._id);
+}
+
+async function resolvePlayerOverall(
+  ctx: QueryCtx,
+  playerId: Id<"players">,
+  seasonId: Id<"seasons"> | null,
+): Promise<number | null> {
+  const player = await ctx.db.get(playerId);
+  const ratingPlayerId = player?.sourcePlayerId ?? playerId;
+
+  if (seasonId) {
+    const attr = await ctx.db
+      .query("playerAttributes")
+      .withIndex("by_playerId_seasonId", (q) =>
+        q.eq("playerId", ratingPlayerId).eq("seasonId", seasonId),
+      )
+      .unique();
+    if (attr?.weightedOverall != null) return attr.weightedOverall;
+  }
+
+  const madden = await ctx.db
+    .query("maddenRatings")
+    .withIndex("by_playerId", (q) => q.eq("playerId", ratingPlayerId))
+    .unique();
+  return madden?.overall ?? null;
+}
+
 export const assignPlayerToRoster = internalMutation({
   args: {
     seasonId: v.id("seasons"),
@@ -2638,89 +2806,7 @@ export const assignPlayerToRoster = internalMutation({
     actorUserId: v.string(),
   },
   returns: rosterAssignmentDtoValidator,
-  handler: async (ctx, args) => {
-    const [season, team, player] = await Promise.all([
-      ctx.db.get(args.seasonId),
-      ctx.db.get(args.teamId),
-      ctx.db.get(args.playerId),
-    ]);
-    if (!season) throw new Error("season_not_found");
-    if (!team) throw new Error("team_not_found");
-    if (!player) throw new Error("player_not_found");
-    if (season.rosterLocked === true) throw new Error("season_locked");
-    if (team.leagueId !== season.leagueId) {
-      throw new Error("team_season_league_mismatch");
-    }
-    if (player.teamId !== args.teamId) {
-      throw new Error("player_not_on_team");
-    }
-
-    const teamAssignments = await ctx.db
-      .query("rosterAssignments")
-      .withIndex("by_seasonId_teamId", (q) =>
-        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
-      )
-      .collect();
-
-    const activeForPlayer = teamAssignments.find(
-      (row) => row.playerId === args.playerId && row.status === "active",
-    );
-    if (activeForPlayer) {
-      throw new Error("player_already_on_roster");
-    }
-
-    const activeCount = teamAssignments.filter(
-      (row) => row.status === "active",
-    ).length;
-    if (team.rosterLimit !== null && activeCount >= team.rosterLimit) {
-      throw new Error("roster_limit_exceeded");
-    }
-
-    const slotActive = teamAssignments.filter(
-      (row) =>
-        row.status === "active" && row.positionSlot === args.positionSlot,
-    );
-    const nextDepthRank =
-      slotActive.reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
-
-    const assignedAt = new Date().toISOString();
-    const insertedId = await ctx.db.insert("rosterAssignments", {
-      seasonId: args.seasonId,
-      teamId: args.teamId,
-      playerId: args.playerId,
-      leagueId: team.leagueId,
-      depthRank: nextDepthRank,
-      positionSlot: args.positionSlot,
-      status: "active",
-      assignedAt,
-      assignedBy: args.actorUserId,
-    });
-
-    const after = {
-      id: insertedId,
-      seasonId: args.seasonId,
-      teamId: args.teamId,
-      playerId: args.playerId,
-      leagueId: team.leagueId,
-      depthRank: nextDepthRank,
-      positionSlot: args.positionSlot,
-      status: "active",
-      assignedAt,
-      assignedBy: args.actorUserId,
-    };
-
-    await writeAuditLog(ctx, {
-      leagueId: team.leagueId,
-      teamId: args.teamId,
-      seasonId: args.seasonId,
-      actorUserId: args.actorUserId,
-      action: "assign",
-      before: null,
-      after,
-    });
-
-    return toRosterAssignmentDto({ _id: insertedId, ...after });
-  },
+  handler: async (ctx, args) => assignPlayerToRosterCore(ctx, args),
 });
 
 async function compactSlotRanks(
@@ -4348,6 +4434,161 @@ export const removePlayersFromSeasonRoster = internalMutation({
     }
 
     return { removedAssignments, removedDepthEntries };
+  },
+});
+
+/*
+ * Offseason free agency (WSM-000231). Release sets status "free_agent" and
+ * clears assignment-backed roster rows for active/upcoming seasons. teamId is
+ * retained as the player's last team for pool display.
+ */
+export const releasePlayerToFreeAgency = internalMutation({
+  args: { playerId: v.id("players") },
+  returns: v.object({ playerId: v.string() }),
+  handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+    if (player.status === "graduated") {
+      throw new Error("cannot_release_graduated");
+    }
+
+    const offseasonSeasonIds = await resolveOffseasonSeasonIds(
+      ctx,
+      player.leagueId,
+    );
+    const seasonIdSet = new Set(offseasonSeasonIds.map((id) => id as string));
+
+    const assignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_playerId", (q) => q.eq("playerId", args.playerId))
+      .collect();
+    for (const ra of assignments) {
+      if (!seasonIdSet.has(ra.seasonId as string)) continue;
+      await ctx.db.delete(ra._id);
+    }
+
+    for (const d of await ctx.db.query("depthChartEntries").collect()) {
+      if (d.playerId !== args.playerId) continue;
+      if (!seasonIdSet.has(d.seasonId as string)) continue;
+      await ctx.db.delete(d._id);
+    }
+
+    await ctx.db.patch(args.playerId, { status: "free_agent" });
+    return { playerId: args.playerId as string };
+  },
+});
+
+export const signFreeAgent = internalMutation({
+  args: {
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    playerId: v.string(),
+    teamId: v.string(),
+    overCap: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const [player, team, season] = await Promise.all([
+      ctx.db.get(args.playerId),
+      ctx.db.get(args.teamId),
+      ctx.db.get(args.seasonId),
+    ]);
+    if (!player) throw new Error("player_not_found");
+    if (!team) throw new Error("team_not_found");
+    if (!season) throw new Error("season_not_found");
+    if (player.status !== "free_agent") {
+      throw new Error("player_not_free_agent");
+    }
+    if (team.leagueId !== season.leagueId) {
+      throw new Error("team_season_league_mismatch");
+    }
+    if (player.leagueId !== team.leagueId) {
+      throw new Error("player_league_mismatch");
+    }
+
+    const activeOnTeam = await ctx.db
+      .query("players")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    const activeCount = activeOnTeam.filter((p) => p.status === "active").length;
+    const overCap = activeCount >= targetRosterSize();
+
+    const positionSlot = player.position;
+    await ctx.db.patch(args.playerId, {
+      status: "active",
+      teamId: args.teamId,
+    });
+
+    await assignPlayerToRosterCore(ctx, {
+      seasonId: args.seasonId,
+      teamId: args.teamId,
+      playerId: args.playerId,
+      positionSlot,
+      actorUserId: args.actorUserId,
+      enforceRosterLimit: false,
+    });
+
+    await appendDefaultDepthChartSlot(ctx, {
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      playerId: args.playerId,
+      positionSlot,
+    });
+
+    return {
+      playerId: args.playerId as string,
+      teamId: args.teamId as string,
+      overCap,
+    };
+  },
+});
+
+const freeAgentDtoValidator = v.object({
+  id: v.string(),
+  name: v.string(),
+  position: v.string(),
+  grade: v.union(v.number(), v.null()),
+  overall: v.union(v.number(), v.null()),
+  teamId: v.string(),
+});
+
+export const listFreeAgents = queryGeneric({
+  args: { leagueId: v.id("leagues") },
+  returns: v.array(freeAgentDtoValidator),
+  handler: async (ctx, args) => {
+    const seasons = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    const ratingSeason =
+      seasons.find((s) => s.status === "upcoming") ??
+      seasons.find((s) => s.status === "active") ??
+      null;
+
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+
+    const freeAgents = players.filter((p) => p.status === "free_agent");
+    const rows = await Promise.all(
+      freeAgents.map(async (player) => ({
+        id: player._id as string,
+        name: player.name,
+        position: player.position,
+        grade: player.grade ?? null,
+        overall: await resolvePlayerOverall(
+          ctx,
+          player._id,
+          ratingSeason?._id ?? null,
+        ),
+        teamId: player.teamId as string,
+      })),
+    );
+    return sortByName(rows);
   },
 });
 

--- a/apps/web/src/app/dashboard/_actions/__tests__/offseason.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/offseason.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockCanManageTeam,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockGetLeagueOrgId,
+  mockGetPlayer,
+  mockGetTeamLeagueId,
+  mockRelease,
+  mockSign,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCanManageTeam: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetPlayer: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockRelease: vi.fn(),
+  mockSign: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getPlayer: mockGetPlayer,
+  getTeamLeagueId: mockGetTeamLeagueId,
+  releasePlayerToFreeAgency: mockRelease,
+  signFreeAgent: mockSign,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  releaseToFreeAgencyAction,
+  signFreeAgentAction,
+} from "../offseason";
+
+const USER = "user_1";
+const ORG = "org_1";
+const LEAGUE = "league_1";
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const PLAYER = "player_1";
+const SEASON = "season_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: USER });
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE], orgIds: [ORG] });
+  mockGetLeagueOrgId.mockResolvedValue(ORG);
+  mockGetTeamLeagueId.mockResolvedValue(LEAGUE);
+  mockGetPlayer.mockResolvedValue({
+    id: PLAYER,
+    teamId: TEAM_A,
+    status: "active",
+    name: "Test",
+    position: "WR",
+    positionGroup: null,
+    jerseyNumber: null,
+    dateOfBirth: null,
+    headshotUrl: null,
+    experienceYears: null,
+    grade: null,
+    squad: null,
+    hometown: null,
+  });
+  mockRelease.mockResolvedValue({ playerId: PLAYER });
+  mockSign.mockResolvedValue({ playerId: PLAYER, teamId: TEAM_B, overCap: false });
+});
+
+describe("releaseToFreeAgencyAction", () => {
+  it("allows an org admin", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    const result = await releaseToFreeAgencyAction({ playerId: PLAYER });
+    expect(result).toEqual({ ok: true, data: { playerId: PLAYER } });
+    expect(mockRelease).toHaveBeenCalledWith({ playerId: PLAYER });
+  });
+
+  it("allows the coach of the player's team", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockResolvedValue(true);
+
+    const result = await releaseToFreeAgencyAction({ playerId: PLAYER });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a coach acting on another team's player", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    const result = await releaseToFreeAgencyAction({ playerId: PLAYER });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockRelease).not.toHaveBeenCalled();
+  });
+});
+
+describe("signFreeAgentAction", () => {
+  it("allows an org admin to sign to any team", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    const result = await signFreeAgentAction({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { playerId: PLAYER, teamId: TEAM_B, overCap: false },
+    });
+    expect(mockSign).toHaveBeenCalledWith({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+      actorUserId: USER,
+    });
+  });
+
+  it("allows the coach of the target team", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockResolvedValue(true);
+
+    const result = await signFreeAgentAction({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a coach signing to another team", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    const result = await signFreeAgentAction({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/offseason.ts
+++ b/apps/web/src/app/dashboard/_actions/offseason.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  getLeagueOrgId,
+  getPlayer,
+  getTeamLeagueId,
+  releasePlayerToFreeAgency,
+  signFreeAgent,
+} from "@/lib/data-api";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function canAdminOrManageTeam(
+  userId: string,
+  teamId: string,
+): Promise<boolean> {
+  const leagueId = await getTeamLeagueId(teamId);
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (canManageOrgSettings(role)) return true;
+  return canManageTeam(teamId, userId);
+}
+
+export async function releaseToFreeAgencyAction(input: {
+  playerId: string;
+}): Promise<ActionResult<{ playerId: string }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  let player;
+  try {
+    player = await getPlayer(input.playerId, orgContext);
+  } catch {
+    return { ok: false, error: "player_not_found" };
+  }
+  if (!(await canAdminOrManageTeam(userId, player.teamId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const leagueId = await getTeamLeagueId(player.teamId);
+    const data = await releasePlayerToFreeAgency({ playerId: input.playerId });
+    revalidatePath(`/dashboard/teams/${player.teamId}`);
+    revalidatePath(`/dashboard/leagues/${leagueId}`);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function signFreeAgentAction(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+}): Promise<
+  ActionResult<{ playerId: string; teamId: string; overCap: boolean }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const leagueId = await getTeamLeagueId(input.teamId);
+    const data = await signFreeAgent({
+      playerId: input.playerId,
+      teamId: input.teamId,
+      seasonId: input.seasonId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    revalidatePath(`/dashboard/leagues/${leagueId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -595,6 +595,30 @@ const refs = {
     { leagueId: string; seasonId: string; playerIds: string[] },
     { removedAssignments: number; removedDepthEntries: number }
   >("sports:removePlayersFromSeasonRoster"),
+  releasePlayerToFreeAgency: mutationRef<
+    { playerId: string },
+    { playerId: string }
+  >("sports:releasePlayerToFreeAgency"),
+  signFreeAgent: mutationRef<
+    {
+      playerId: string;
+      teamId: string;
+      seasonId: string;
+      actorUserId: string;
+    },
+    { playerId: string; teamId: string; overCap: boolean }
+  >("sports:signFreeAgent"),
+  listFreeAgents: queryRef<
+    { leagueId: string },
+    Array<{
+      id: string;
+      name: string;
+      position: string;
+      grade: number | null;
+      overall: number | null;
+      teamId: string;
+    }>
+  >("sports:listFreeAgents"),
   generatePlayoffBracket: mutationRef<
     {
       seasonId: string;
@@ -1900,6 +1924,34 @@ export async function removePlayersFromSeasonRoster(input: {
   playerIds: string[];
 }): Promise<{ removedAssignments: number; removedDepthEntries: number }> {
   return mutateConvex(refs.removePlayersFromSeasonRoster, input);
+}
+
+export async function releasePlayerToFreeAgency(input: {
+  playerId: string;
+}): Promise<{ playerId: string }> {
+  return mutateConvex(refs.releasePlayerToFreeAgency, input);
+}
+
+export async function signFreeAgent(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  actorUserId: string;
+}): Promise<{ playerId: string; teamId: string; overCap: boolean }> {
+  return mutateConvex(refs.signFreeAgent, input);
+}
+
+export async function listFreeAgents(leagueId: string): Promise<
+  Array<{
+    id: string;
+    name: string;
+    position: string;
+    grade: number | null;
+    overall: number | null;
+    teamId: string;
+  }>
+> {
+  return queryConvex(refs.listFreeAgents, { leagueId });
 }
 
 export async function listSeasonPlayerAttributes(seasonId: string): Promise<


### PR DESCRIPTION
Fixes #513. Epic #510 (offseason). Backend only — no UI, no draft (O3).

## What
- Free agency modeled as player `status: "free_agent"` (teamId retained; `players.teamId` is required so a null team isn't possible). Pool = players `by_leagueId` where status is `free_agent`.
- `releasePlayerToFreeAgency` / `signFreeAgent` (internalMutation, WSM-000096; registered in the writes-are-internal guard). Sign writes a rosterAssignment + default depth slot via a new shared `assignPlayerToRosterCore` (refactor, no divergent duplication) and returns an informational `overCap` flag against `targetRosterSize()` = 48 — **warn, never block** per the locked decision.
- `listFreeAgents` query with return validator (DTO parity).
- Server actions `releaseToFreeAgencyAction` / `signFreeAgentAction` gate on **admin OR coach of the target team** (`canManageTeam`), revalidate affected pages.

## Verification
- `type-check`, `lint`, `test:unit` green — **1010/1010** (new convex FA tests incl. overCap at 48; server-action permission-gate tests)

## Deploy note
Convex code — merge does not deploy. Needs `convex deploy` (or local `convex dev`) to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK