### PR TITLE
feat(web): offseason snake-draft backend (WSM-000233)

### DIFF
--- a/apps/web/convex/__tests__/draftSnakeOrder.test.ts
+++ b/apps/web/convex/__tests__/draftSnakeOrder.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { pickRound, teamOnClock } from "../lib/draft";
+
+const ORDER = ["t1", "t2", "t3", "t4"];
+
+describe("pickRound", () => {
+  it("maps pick numbers to rounds for four teams", () => {
+    expect(pickRound(1, 4)).toBe(1);
+    expect(pickRound(4, 4)).toBe(1);
+    expect(pickRound(5, 4)).toBe(2);
+    expect(pickRound(8, 4)).toBe(2);
+    expect(pickRound(9, 4)).toBe(3);
+  });
+});
+
+describe("teamOnClock", () => {
+  it("uses forward order in odd rounds", () => {
+    expect(teamOnClock(ORDER, 1, 3)).toBe("t1");
+    expect(teamOnClock(ORDER, 2, 3)).toBe("t2");
+    expect(teamOnClock(ORDER, 4, 3)).toBe("t4");
+  });
+
+  it("uses reverse order in even rounds", () => {
+    expect(teamOnClock(ORDER, 5, 3)).toBe("t4");
+    expect(teamOnClock(ORDER, 6, 3)).toBe("t3");
+    expect(teamOnClock(ORDER, 8, 3)).toBe("t1");
+  });
+
+  it("returns null past the final pick", () => {
+    expect(teamOnClock(ORDER, 12, 3)).toBe("t4");
+    expect(teamOnClock(ORDER, 13, 3)).toBeNull();
+    expect(teamOnClock(ORDER, 0, 3)).toBeNull();
+  });
+
+  it("handles two-team boundaries", () => {
+    const two = ["a", "b"];
+    expect(teamOnClock(two, 1, 2)).toBe("a");
+    expect(teamOnClock(two, 2, 2)).toBe("b");
+    expect(teamOnClock(two, 3, 2)).toBe("b");
+    expect(teamOnClock(two, 4, 2)).toBe("a");
+    expect(teamOnClock(two, 5, 2)).toBeNull();
+  });
+});

--- a/apps/web/convex/__tests__/offseasonDraft.test.ts
+++ b/apps/web/convex/__tests__/offseasonDraft.test.ts
@@ -1,0 +1,372 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { teamOnClock } from "../lib/draft";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_draft_actor";
+
+async function seedDraftLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Draft League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamWinner = await ctx.db.insert("teams", {
+      name: "Winner FC",
+      leagueId,
+      divisionId: null,
+      city: "W",
+      stadium: "W",
+      foundedYear: null,
+      location: "W",
+      logoUrl: null,
+      rosterLimit: null,
+    });
+    const teamLoser = await ctx.db.insert("teams", {
+      name: "Loser FC",
+      leagueId,
+      divisionId: null,
+      city: "L",
+      stadium: "L",
+      foundedYear: null,
+      location: "L",
+      logoUrl: null,
+      rosterLimit: null,
+    });
+    const activeSeason = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: "2026-09-01",
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const upcomingSeason = await ctx.db.insert("seasons", {
+      name: "2027",
+      leagueId,
+      startDate: "2027-09-01",
+      endDate: null,
+      status: "upcoming",
+      rosterLocked: false,
+    });
+    const fixtureId = await ctx.db.insert("fixtures", {
+      seasonId: activeSeason,
+      homeTeamId: teamWinner,
+      awayTeamId: teamLoser,
+      scheduledAt: null,
+      week: 1,
+      venue: null,
+      status: "final",
+      stage: "regular",
+      createdAt: new Date().toISOString(),
+      createdBy: ACTOR,
+    });
+    await ctx.db.insert("gameResults", {
+      fixtureId,
+      homeScore: 28,
+      awayScore: 7,
+      playerStatsJson: null,
+      recordedAt: new Date().toISOString(),
+      recordedBy: ACTOR,
+    });
+    const fa1 = await ctx.db.insert("players", {
+      name: "Pool One",
+      leagueId,
+      teamId: teamLoser,
+      position: "WR",
+      positionGroup: null,
+      jerseyNumber: 80,
+      dateOfBirth: null,
+      status: "free_agent",
+      headshotUrl: null,
+      grade: 11,
+    });
+    const fa2 = await ctx.db.insert("players", {
+      name: "Pool Two",
+      leagueId,
+      teamId: teamLoser,
+      position: "RB",
+      positionGroup: null,
+      jerseyNumber: 81,
+      dateOfBirth: null,
+      status: "free_agent",
+      headshotUrl: null,
+      grade: 10,
+    });
+    const extraFreeAgents: Id<"players">[] = [];
+    for (let i = 3; i <= 6; i++) {
+      extraFreeAgents.push(
+        await ctx.db.insert("players", {
+          name: `Pool ${i}`,
+          leagueId,
+          teamId: teamLoser,
+          position: "WR",
+          positionGroup: null,
+          jerseyNumber: 80 + i,
+          dateOfBirth: null,
+          status: "free_agent",
+          headshotUrl: null,
+          grade: 11,
+        }),
+      );
+    }
+    return {
+      leagueId,
+      teamWinner,
+      teamLoser,
+      activeSeason,
+      upcomingSeason,
+      fa1,
+      fa2,
+      extraFreeAgents,
+    };
+  });
+}
+
+describe("startDraft", () => {
+  it("orders teams reverse final standings (worst team first)", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    const res = await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    expect(res.order).toEqual([
+      seed.teamLoser as string,
+      seed.teamWinner as string,
+    ]);
+  });
+
+  it("rejects when a draft already exists for the season", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    await expect(
+      t.mutation(internal.sports.startDraft, {
+        leagueId: seed.leagueId,
+        seasonId: seed.upcomingSeason,
+      }),
+    ).rejects.toThrow("draft_exists");
+  });
+
+  it("rejects when the free-agent pool is empty", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    await t.run(async (ctx) => {
+      const players = await ctx.db
+        .query("players")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", seed.leagueId))
+        .collect();
+      for (const p of players) {
+        if (p.status === "free_agent") {
+          await ctx.db.patch(p._id, { status: "active" });
+        }
+      }
+    });
+
+    await expect(
+      t.mutation(internal.sports.startDraft, {
+        leagueId: seed.leagueId,
+        seasonId: seed.upcomingSeason,
+      }),
+    ).rejects.toThrow("empty_pool");
+  });
+});
+
+describe("makeDraftPick", () => {
+  it("rosters the player and advances the snake draft", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    const { draftId } = await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    const afterPick1 = await t.mutation(internal.sports.makeDraftPick, {
+      draftId: draftId as Id<"drafts">,
+      playerId: seed.fa1,
+      actorUserId: ACTOR,
+    });
+
+    expect(afterPick1.currentPick).toBe(2);
+    expect(afterPick1.onClockTeamId).toBe(seed.teamWinner as string);
+    expect(afterPick1.picks).toHaveLength(1);
+    expect(afterPick1.picks[0]).toMatchObject({
+      pickNumber: 1,
+      round: 1,
+      teamId: seed.teamLoser as string,
+      playerId: seed.fa1 as string,
+    });
+
+    const player = await t.run((ctx) => ctx.db.get(seed.fa1));
+    expect(player?.status).toBe("active");
+    expect(player?.teamId).toBe(seed.teamLoser);
+
+    const assignment = await t.run(async (ctx) =>
+      ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", seed.upcomingSeason).eq("teamId", seed.teamLoser),
+        )
+        .first(),
+    );
+    expect(assignment?.playerId).toBe(seed.fa1);
+  });
+
+  it("rejects re-picking a filled slot", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    const { draftId } = await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("draftPicks", {
+        draftId: draftId as Id<"drafts">,
+        round: 1,
+        pickNumber: 1,
+        teamId: seed.teamLoser,
+        playerId: seed.fa1,
+        madeAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.mutation(internal.sports.makeDraftPick, {
+        draftId: draftId as Id<"drafts">,
+        playerId: seed.fa2,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("pick_already_made");
+  });
+
+  it("completes the draft after all picks are made", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    const extraFaIds = await t.run(async (ctx) => {
+      const ids: Id<"players">[] = [];
+      for (let i = 0; i < 4; i++) {
+        ids.push(
+          await ctx.db.insert("players", {
+            name: `Pool Extra ${i}`,
+            leagueId: seed.leagueId,
+            teamId: seed.teamLoser,
+            position: "OL",
+            positionGroup: null,
+            jerseyNumber: 90 + i,
+            dateOfBirth: null,
+            status: "free_agent",
+            headshotUrl: null,
+          }),
+        );
+      }
+      return ids;
+    });
+
+    const { draftId, order } = await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    const rounds = 3;
+    const picks: string[] = [
+      seed.fa1 as string,
+      seed.fa2 as string,
+      ...extraFaIds.map((id) => id as string),
+    ];
+    let state = await t.query(api.sports.getDraft, {
+      seasonId: seed.upcomingSeason,
+    });
+    expect(state?.status).toBe("active");
+
+    for (let pickNum = 1; pickNum <= rounds * order.length; pickNum++) {
+      const onClock = teamOnClock(order, pickNum, rounds);
+      const playerId = picks[pickNum - 1] as Id<"players">;
+      state = await t.mutation(internal.sports.makeDraftPick, {
+        draftId: draftId as Id<"drafts">,
+        playerId,
+        actorUserId: ACTOR,
+      });
+      expect(state.onClockTeamId).toBe(
+        pickNum < rounds * order.length
+          ? teamOnClock(order, pickNum + 1, rounds)
+          : null,
+      );
+      if (onClock) {
+        expect(state.picks[pickNum - 1]?.teamId).toBe(onClock);
+      }
+    }
+
+    expect(state?.status).toBe("complete");
+    expect(state?.currentPick).toBe(rounds * order.length + 1);
+  });
+});
+
+describe("endDraft", () => {
+  it("marks the draft complete while pool players stay free agents", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    const { draftId } = await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    const res = await t.mutation(internal.sports.endDraft, {
+      draftId: draftId as Id<"drafts">,
+    });
+    expect(res).toEqual({ draftId, status: "complete" });
+
+    const draft = await t.query(api.sports.getDraft, {
+      seasonId: seed.upcomingSeason,
+    });
+    expect(draft?.status).toBe("complete");
+
+    const fa2 = await t.run((ctx) => ctx.db.get(seed.fa2));
+    expect(fa2?.status).toBe("free_agent");
+  });
+});
+
+describe("getDraft", () => {
+  it("returns draft state with on-clock team for an active draft", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedDraftLeague(t);
+
+    await t.mutation(internal.sports.startDraft, {
+      leagueId: seed.leagueId,
+      seasonId: seed.upcomingSeason,
+    });
+
+    const draft = await t.query(api.sports.getDraft, {
+      seasonId: seed.upcomingSeason,
+    });
+    expect(draft).toMatchObject({
+      seasonId: seed.upcomingSeason as string,
+      type: "snake",
+      rounds: 3,
+      status: "active",
+      currentPick: 1,
+      onClockTeamId: seed.teamLoser as string,
+      picks: [],
+    });
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -38,6 +38,9 @@ void internal.sports.rolloverGraduateAndAdvancePlayers;
 void internal.sports.removePlayersFromSeasonRoster;
 void internal.sports.releasePlayerToFreeAgency;
 void internal.sports.signFreeAgent;
+void internal.sports.startDraft;
+void internal.sports.makeDraftPick;
+void internal.sports.endDraft;
 void internal.sports.updatePlayerAttributes;
 void internal.sports.setOrgMemberRole;
 void internal.sports.updateDivision;
@@ -129,6 +132,7 @@ type AllowedPublicSportsReads =
   | "computeSeasonSprt"
   | "computeStandings"
   | "computeStandingsPublic"
+  | "getDraft"
   | "getDepthChartByTeamSeason"
   | "getDivision"
   | "getFixture"

--- a/apps/web/convex/lib/draft.ts
+++ b/apps/web/convex/lib/draft.ts
@@ -1,0 +1,30 @@
+/**
+ * Snake-draft helpers (WSM-000233). Pure functions for unit testing.
+ */
+
+/** 1-based round number for a global pick slot. */
+export function pickRound(pickNumber: number, teamCount: number): number {
+  if (teamCount <= 0) return 0;
+  return Math.ceil(pickNumber / teamCount);
+}
+
+/**
+ * Team on the clock for a 1-based pickNumber in a snake draft.
+ * Round 1 = forward order, round 2 = reverse, etc.
+ */
+export function teamOnClock(
+  order: readonly string[],
+  pickNumber: number,
+  rounds: number,
+): string | null {
+  const teamCount = order.length;
+  if (teamCount === 0 || pickNumber < 1) return null;
+  const totalPicks = rounds * teamCount;
+  if (pickNumber > totalPicks) return null;
+
+  const round = pickRound(pickNumber, teamCount);
+  const posInRound = (pickNumber - 1) % teamCount;
+  const index =
+    round % 2 === 1 ? posInRound : teamCount - 1 - posInRound;
+  return order[index] ?? null;
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -464,4 +464,34 @@ export default defineSchema({
   })
     .index("by_bracketId", ["bracketId"])
     .index("by_seasonId", ["seasonId"]),
+
+  /*
+   * Offseason snake draft (WSM-000233). One draft per target season; order is
+   * reverse final standings. Writes are internalMutation only.
+   */
+  drafts: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    type: v.string(), // "snake"
+    rounds: v.number(),
+    order: v.array(v.id("teams")),
+    status: v.string(), // "pending" | "active" | "complete"
+    currentPick: v.number(),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_seasonId", ["seasonId"]),
+
+  /*
+   * Append-only draft pick log (WSM-000233). pickNumber is global 1-based slot.
+   */
+  draftPicks: defineTable({
+    draftId: v.id("drafts"),
+    round: v.number(),
+    pickNumber: v.number(),
+    teamId: v.id("teams"),
+    playerId: v.id("players"),
+    madeAt: v.number(),
+  })
+    .index("by_draftId", ["draftId"])
+    .index("by_draftId_pickNumber", ["draftId", "pickNumber"]),
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -35,6 +35,7 @@ import { squadForGrade } from "./lib/dynasty";
 import {
   targetRosterSize,
 } from "./lib/offseason";
+import { pickRound, teamOnClock } from "./lib/draft";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -4589,6 +4590,284 @@ export const listFreeAgents = queryGeneric({
       })),
     );
     return sortByName(rows);
+  },
+});
+
+/* ───────────────────── Offseason draft (WSM-000233) ───────────────────── */
+
+const DRAFT_ROUNDS = 3;
+
+const draftPickDtoValidator = v.object({
+  id: v.string(),
+  round: v.number(),
+  pickNumber: v.number(),
+  teamId: v.string(),
+  playerId: v.string(),
+  madeAt: v.number(),
+});
+
+const draftDtoValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  type: v.string(),
+  rounds: v.number(),
+  order: v.array(v.string()),
+  status: v.string(),
+  currentPick: v.number(),
+  onClockTeamId: v.union(v.string(), v.null()),
+  picks: v.array(draftPickDtoValidator),
+});
+
+async function loadDraftPicks(
+  ctx: QueryCtx | MutationCtx,
+  draftId: Id<"drafts">,
+) {
+  return ctx.db
+    .query("draftPicks")
+    .withIndex("by_draftId", (q) => q.eq("draftId", draftId))
+    .collect();
+}
+
+async function toDraftDto(
+  ctx: QueryCtx | MutationCtx,
+  draft: {
+    _id: Id<"drafts">;
+    leagueId: Id<"leagues">;
+    seasonId: Id<"seasons">;
+    type: string;
+    rounds: number;
+    order: Id<"teams">[];
+    status: string;
+    currentPick: number;
+  },
+) {
+  const picks = await loadDraftPicks(ctx, draft._id);
+  const sortedPicks = picks.sort((a, b) => a.pickNumber - b.pickNumber);
+  const onClockTeamId =
+    draft.status === "active"
+      ? teamOnClock(
+          draft.order.map((id) => id as string),
+          draft.currentPick,
+          draft.rounds,
+        )
+      : null;
+  return {
+    id: draft._id as string,
+    leagueId: draft.leagueId as string,
+    seasonId: draft.seasonId as string,
+    type: draft.type,
+    rounds: draft.rounds,
+    order: draft.order.map((id) => id as string),
+    status: draft.status,
+    currentPick: draft.currentPick,
+    onClockTeamId,
+    picks: sortedPicks.map((p) => ({
+      id: p._id as string,
+      round: p.round,
+      pickNumber: p.pickNumber,
+      teamId: p.teamId as string,
+      playerId: p.playerId as string,
+      madeAt: p.madeAt,
+    })),
+  };
+}
+
+async function resolveStandingsSeasonForDraft(
+  ctx: MutationCtx,
+  leagueId: Id<"leagues">,
+  draftSeasonId: Id<"seasons">,
+): Promise<Id<"seasons">> {
+  const seasons = await ctx.db
+    .query("seasons")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+    .collect();
+  const active = seasons.find(
+    (s) => s.status === "active" && s._id !== draftSeasonId,
+  );
+  if (active) return active._id;
+  const completed = seasons
+    .filter((s) => s.status === "completed" && s._id !== draftSeasonId)
+    .sort((a, b) => (b.startDate ?? "").localeCompare(a.startDate ?? ""));
+  if (completed[0]) return completed[0]._id;
+  throw new Error("no_standings_season");
+}
+
+export const startDraft = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+  },
+  returns: v.object({
+    draftId: v.string(),
+    order: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.leagueId !== args.leagueId) {
+      throw new Error("league_season_mismatch");
+    }
+
+    const existing = await ctx.db
+      .query("drafts")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (existing) throw new Error("draft_exists");
+
+    const freeAgents = await ctx.db
+      .query("players")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    if (!freeAgents.some((p) => p.status === "free_agent")) {
+      throw new Error("empty_pool");
+    }
+
+    const standingsSeasonId = await resolveStandingsSeasonForDraft(
+      ctx,
+      args.leagueId,
+      args.seasonId,
+    );
+    const standingsSeason = await ctx.db.get(standingsSeasonId);
+    if (!standingsSeason) throw new Error("no_standings_season");
+
+    const standingOrder = await seasonStandingTeamIds(ctx, standingsSeason);
+    const order = [...standingOrder].reverse() as Id<"teams">[];
+
+    const draftId = await ctx.db.insert("drafts", {
+      leagueId: args.leagueId,
+      seasonId: args.seasonId,
+      type: "snake",
+      rounds: DRAFT_ROUNDS,
+      order,
+      status: "active",
+      currentPick: 1,
+    });
+
+    return {
+      draftId: draftId as string,
+      order: order.map((id) => id as string),
+    };
+  },
+});
+
+export const makeDraftPick = internalMutation({
+  args: {
+    draftId: v.id("drafts"),
+    playerId: v.id("players"),
+    actorUserId: v.string(),
+  },
+  returns: draftDtoValidator,
+  handler: async (ctx, args) => {
+    const draft = await ctx.db.get(args.draftId);
+    if (!draft) throw new Error("draft_not_found");
+    if (draft.status !== "active") throw new Error("draft_not_active");
+
+    const teamCount = draft.order.length;
+    const totalPicks = draft.rounds * teamCount;
+    if (draft.currentPick > totalPicks) throw new Error("draft_complete");
+
+    const existingSlot = await ctx.db
+      .query("draftPicks")
+      .withIndex("by_draftId_pickNumber", (q) =>
+        q.eq("draftId", args.draftId).eq("pickNumber", draft.currentPick),
+      )
+      .first();
+    if (existingSlot) throw new Error("pick_already_made");
+
+    const onClockId = teamOnClock(
+      draft.order.map((id) => id as string),
+      draft.currentPick,
+      draft.rounds,
+    );
+    if (!onClockId) throw new Error("draft_complete");
+
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+    if (player.status !== "free_agent") {
+      throw new Error("player_not_free_agent");
+    }
+    if (player.leagueId !== draft.leagueId) {
+      throw new Error("player_league_mismatch");
+    }
+
+    const priorPicks = await loadDraftPicks(ctx, args.draftId);
+    if (priorPicks.some((p) => p.playerId === args.playerId)) {
+      throw new Error("player_already_drafted");
+    }
+
+    const teamId = onClockId as Id<"teams">;
+    const seasonId = draft.seasonId;
+    const positionSlot = player.position;
+
+    await ctx.db.patch(args.playerId, {
+      status: "active",
+      teamId,
+    });
+
+    await assignPlayerToRosterCore(ctx, {
+      seasonId,
+      teamId,
+      playerId: args.playerId,
+      positionSlot,
+      actorUserId: args.actorUserId,
+      enforceRosterLimit: false,
+    });
+
+    await appendDefaultDepthChartSlot(ctx, {
+      teamId,
+      seasonId,
+      playerId: args.playerId,
+      positionSlot,
+    });
+
+    const round = pickRound(draft.currentPick, teamCount);
+    await ctx.db.insert("draftPicks", {
+      draftId: args.draftId,
+      round,
+      pickNumber: draft.currentPick,
+      teamId,
+      playerId: args.playerId,
+      madeAt: Date.now(),
+    });
+
+    const nextPick = draft.currentPick + 1;
+    const isComplete = nextPick > totalPicks;
+    await ctx.db.patch(args.draftId, {
+      currentPick: nextPick,
+      status: isComplete ? "complete" : "active",
+    });
+
+    const updated = await ctx.db.get(args.draftId);
+    if (!updated) throw new Error("draft_not_found");
+    return await toDraftDto(ctx, updated);
+  },
+});
+
+export const endDraft = internalMutation({
+  args: { draftId: v.id("drafts") },
+  returns: v.object({
+    draftId: v.string(),
+    status: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const draft = await ctx.db.get(args.draftId);
+    if (!draft) throw new Error("draft_not_found");
+    await ctx.db.patch(args.draftId, { status: "complete" });
+    return { draftId: args.draftId as string, status: "complete" };
+  },
+});
+
+export const getDraft = queryGeneric({
+  args: { seasonId: v.id("seasons") },
+  returns: v.union(draftDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const draft = await ctx.db
+      .query("drafts")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (!draft) return null;
+    return await toDraftDto(ctx, draft);
   },
 });
 

--- a/apps/web/src/app/dashboard/_actions/__tests__/draft.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/draft.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockAuth,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockGetLeagueOrgId,
+  mockStartDraft,
+  mockMakeDraftPick,
+  mockEndDraft,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockStartDraft: vi.fn(),
+  mockMakeDraftPick: vi.fn(),
+  mockEndDraft: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+  startDraft: mockStartDraft,
+  makeDraftPick: mockMakeDraftPick,
+  endDraft: mockEndDraft,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  startDraftAction,
+  makeDraftPickAction,
+  endDraftAction,
+} from "../draft";
+
+const USER = "user_1";
+const ORG = "org_1";
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+const DRAFT = "draft_1";
+const PLAYER = "player_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: USER });
+  mockResolveOrgContext.mockResolvedValue({
+    visibleLeagueIds: [LEAGUE],
+    orgIds: [ORG],
+  });
+  mockGetLeagueOrgId.mockResolvedValue(ORG);
+  mockStartDraft.mockResolvedValue({ draftId: DRAFT, order: ["t2", "t1"] });
+  mockMakeDraftPick.mockResolvedValue({
+    id: DRAFT,
+    leagueId: LEAGUE,
+    seasonId: SEASON,
+    type: "snake",
+    rounds: 3,
+    order: ["t2", "t1"],
+    status: "active",
+    currentPick: 2,
+    onClockTeamId: "t1",
+    picks: [],
+  });
+  mockEndDraft.mockResolvedValue({ draftId: DRAFT, status: "complete" });
+});
+
+describe("startDraftAction", () => {
+  it("allows an org admin", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+
+    const result = await startDraftAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { draftId: DRAFT, order: ["t2", "t1"] },
+    });
+    expect(mockStartDraft).toHaveBeenCalledWith({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+  });
+
+  it("rejects a coach (not org admin)", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+
+    const result = await startDraftAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockStartDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeDraftPickAction", () => {
+  it("allows an org admin", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+
+    const result = await makeDraftPickAction({
+      draftId: DRAFT,
+      playerId: PLAYER,
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result.ok).toBe(true);
+    expect(mockMakeDraftPick).toHaveBeenCalledWith({
+      draftId: DRAFT,
+      playerId: PLAYER,
+      actorUserId: USER,
+    });
+  });
+
+  it("rejects a coach", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+
+    const result = await makeDraftPickAction({
+      draftId: DRAFT,
+      playerId: PLAYER,
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockMakeDraftPick).not.toHaveBeenCalled();
+  });
+});
+
+describe("endDraftAction", () => {
+  it("allows an org admin", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+
+    const result = await endDraftAction({
+      draftId: DRAFT,
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { draftId: DRAFT, status: "complete" },
+    });
+  });
+
+  it("rejects a coach", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+
+    const result = await endDraftAction({
+      draftId: DRAFT,
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockEndDraft).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -283,4 +283,22 @@ describe("startNextSeasonAction success path", () => {
       expect.arrayContaining([expect.objectContaining({ grade: 9 })]),
     );
   });
+
+  it("routes freshmen to the free-agent pool when freshmenToPool is true", async () => {
+    await startNextSeasonAction({ leagueId: LEAGUE, freshmenToPool: true });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledWith(
+      "team_1",
+      expect.arrayContaining([
+        expect.objectContaining({ grade: 9, status: "free_agent" }),
+      ]),
+    );
+  });
+
+  it("auto-assigns freshmen with Active status by default", async () => {
+    await startNextSeasonAction({ leagueId: LEAGUE });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledWith(
+      "team_1",
+      expect.arrayContaining([expect.objectContaining({ status: "Active" })]),
+    );
+  });
 });

--- a/apps/web/src/app/dashboard/_actions/draft.ts
+++ b/apps/web/src/app/dashboard/_actions/draft.ts
@@ -1,0 +1,122 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  getLeagueOrgId,
+  startDraft,
+  makeDraftPick,
+  endDraft,
+} from "@/lib/data-api";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function requireOrgAdmin(
+  userId: string,
+  leagueId: string,
+): Promise<boolean> {
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  return canManageOrgSettings(role);
+}
+
+export async function startDraftAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<ActionResult<{ draftId: string; order: string[] }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(input.leagueId)) {
+    return { ok: false, error: "not_authorized" };
+  }
+  if (!(await requireOrgAdmin(userId, input.leagueId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await startDraft({
+      leagueId: input.leagueId,
+      seasonId: input.seasonId,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function makeDraftPickAction(input: {
+  draftId: string;
+  playerId: string;
+  leagueId: string;
+  seasonId: string;
+}): Promise<
+  ActionResult<Awaited<ReturnType<typeof makeDraftPick>>>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(input.leagueId)) {
+    return { ok: false, error: "not_authorized" };
+  }
+  if (!(await requireOrgAdmin(userId, input.leagueId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await makeDraftPick({
+      draftId: input.draftId,
+      playerId: input.playerId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function endDraftAction(input: {
+  draftId: string;
+  leagueId: string;
+  seasonId: string;
+}): Promise<ActionResult<{ draftId: string; status: string }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(input.leagueId)) {
+    return { ok: false, error: "not_authorized" };
+  }
+  if (!(await requireOrgAdmin(userId, input.leagueId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await endDraft({ draftId: input.draftId });
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -57,6 +57,7 @@ function activeRosterCount(players: PlayerDto[]): number {
 
 export async function startNextSeasonAction(input: {
   leagueId: string;
+  freshmenToPool?: boolean;
 }): Promise<RolloverResult> {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
@@ -193,8 +194,11 @@ export async function startNextSeasonAction(input: {
         excludeNames: Array.from(usedNames),
         seed: seedFromString(`${team.id}:${nextSeason.id}`),
       });
-      for (const p of batch) usedNames.add(p.name);
-      const { created } = await bulkCreatePlayers(team.id, batch);
+      const players = input.freshmenToPool
+        ? batch.map((p) => ({ ...p, status: "free_agent" }))
+        : batch;
+      for (const p of players) usedNames.add(p.name);
+      const { created } = await bulkCreatePlayers(team.id, players);
       freshmen += created;
     }
 

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -608,6 +608,58 @@ const refs = {
     },
     { playerId: string; teamId: string; overCap: boolean }
   >("sports:signFreeAgent"),
+  startDraft: mutationRef<
+    { leagueId: string; seasonId: string },
+    { draftId: string; order: string[] }
+  >("sports:startDraft"),
+  makeDraftPick: mutationRef<
+    { draftId: string; playerId: string; actorUserId: string },
+    {
+      id: string;
+      leagueId: string;
+      seasonId: string;
+      type: string;
+      rounds: number;
+      order: string[];
+      status: string;
+      currentPick: number;
+      onClockTeamId: string | null;
+      picks: Array<{
+        id: string;
+        round: number;
+        pickNumber: number;
+        teamId: string;
+        playerId: string;
+        madeAt: number;
+      }>;
+    }
+  >("sports:makeDraftPick"),
+  endDraft: mutationRef<
+    { draftId: string },
+    { draftId: string; status: string }
+  >("sports:endDraft"),
+  getDraft: queryRef<
+    { seasonId: string },
+    {
+      id: string;
+      leagueId: string;
+      seasonId: string;
+      type: string;
+      rounds: number;
+      order: string[];
+      status: string;
+      currentPick: number;
+      onClockTeamId: string | null;
+      picks: Array<{
+        id: string;
+        round: number;
+        pickNumber: number;
+        teamId: string;
+        playerId: string;
+        madeAt: number;
+      }>;
+    } | null
+  >("sports:getDraft"),
   listFreeAgents: queryRef<
     { leagueId: string },
     Array<{
@@ -1939,6 +1991,51 @@ export async function signFreeAgent(input: {
   actorUserId: string;
 }): Promise<{ playerId: string; teamId: string; overCap: boolean }> {
   return mutateConvex(refs.signFreeAgent, input);
+}
+
+export type DraftDto = {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  type: string;
+  rounds: number;
+  order: string[];
+  status: string;
+  currentPick: number;
+  onClockTeamId: string | null;
+  picks: Array<{
+    id: string;
+    round: number;
+    pickNumber: number;
+    teamId: string;
+    playerId: string;
+    madeAt: number;
+  }>;
+};
+
+export async function startDraft(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<{ draftId: string; order: string[] }> {
+  return mutateConvex(refs.startDraft, input);
+}
+
+export async function makeDraftPick(input: {
+  draftId: string;
+  playerId: string;
+  actorUserId: string;
+}): Promise<DraftDto> {
+  return mutateConvex(refs.makeDraftPick, input);
+}
+
+export async function endDraft(input: {
+  draftId: string;
+}): Promise<{ draftId: string; status: string }> {
+  return mutateConvex(refs.endDraft, input);
+}
+
+export async function getDraft(seasonId: string): Promise<DraftDto | null> {
+  return queryConvex(refs.getDraft, { seasonId });
 }
 
 export async function listFreeAgents(leagueId: string): Promise<


### PR DESCRIPTION
Fixes #515. Epic #510 (offseason). Backend + tests only — no UI (O4). Admin-only.

## What
- **New tables**: `drafts` (leagueId, seasonId, type, rounds, order, status, currentPick) + `draftPicks` (append-only, unique per pickNumber).
- **`startDraft`** — order = **reverse final standings** of the completed season (reuses the existing `computeStandingsPure` / `seasonStandingTeamIds`, deterministic tiebreaks); snake, fixed **3 rounds**; rejects `draft_exists` / `empty_pool`.
- **`makeDraftPick`** — on-clock team (pure `teamOnClock` snake helper) drafts a pooled free agent via the shared `assignPlayerToRosterCore` (same path as signing); idempotent per pick slot; completes after `rounds × teams`.
- **`endDraft`**, **`getDraft`** query (return-validated).
- **Freshman routing**: optional `freshmenToPool` flag on `startNextSeasonAction` (default `false` → current auto-assign unchanged); `true` routes freshmen into the FA pool.
- All writes `internalMutation` (registered in the writes-are-internal guard); server actions **admin-only** (`canManageOrgSettings`, not `canManageTeam`).

## Verification
- `type-check`, `lint`, `test:unit` green — **1039** (snake helper, draft integration, admin-gate, freshman-routing tests)

## Deploy note
Convex schema + functions — needs `convex deploy` to reach prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xm9ojyjyPSmt2P3u3XzVK