### PR TITLE
feat(web): accessible lifecycle confirmation and process dialogs (WSM-000237)

### DIFF
--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -17,6 +17,14 @@ export function acceptBrowserConfirms(page: Page): void {
   page.on("dialog", (dialog) => void dialog.accept());
 }
 
+/** Confirm an in-app ActionConfirmDialog (lifecycle surfaces from PR #535). */
+export async function confirmLifecycleDialog(page: Page): Promise<void> {
+  const dialog = page.getByTestId("action-confirm-dialog");
+  await expect(dialog).toBeVisible();
+  await page.getByTestId("action-confirm-submit").click();
+  await expect(dialog).toBeHidden();
+}
+
 export async function addTeamsToLeague(
   page: Page,
   leagueId: string,
@@ -58,9 +66,11 @@ export async function generateLeagueSyntheticData(
   await page.goto(`/dashboard/leagues/${leagueId}`);
   const rostersBtn = page.getByRole("button", { name: "Generate rosters" });
   await rostersBtn.click();
+  await confirmLifecycleDialog(page);
   await expect(rostersBtn).toBeEnabled({ timeout: 120_000 });
   const ratingsBtn = page.getByRole("button", { name: "Generate ratings" });
   await ratingsBtn.click();
+  await confirmLifecycleDialog(page);
   await expect(ratingsBtn).toBeEnabled({ timeout: 120_000 });
 }
 
@@ -71,6 +81,7 @@ export async function generateRoundRobinSchedule(
   await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
   const generate = page.getByRole("button", { name: /Generate schedule/ });
   await expect(generate).toBeVisible();
+  // Fresh leagues have no fixtures — GenerateScheduleButton skips the dialog.
   await generate.click();
   await expect(page.getByText("Week 1", { exact: true })).toBeVisible({
     timeout: 60_000,
@@ -105,9 +116,17 @@ export async function openSimulateScopeMenu(page: Page) {
   await page.getByRole("button", { name: "Simulate", exact: true }).click();
 }
 
+export async function simWeek(page: Page, week: number) {
+  await weekCard(page, week)
+    .getByRole("button", { name: "Sim week" })
+    .click();
+  await confirmLifecycleDialog(page);
+}
+
 export async function simRegularSeason(page: Page) {
   await openSimulateScopeMenu(page);
   await page.getByRole("menuitem", { name: "Sim regular season" }).click();
+  await confirmLifecycleDialog(page);
   await expect(
     page.getByText(/Simulated \d+ regular-season game/),
   ).toBeVisible({ timeout: 120_000 });
@@ -116,12 +135,24 @@ export async function simRegularSeason(page: Page) {
 export async function simPlayoffsScope(page: Page) {
   await openSimulateScopeMenu(page);
   await page.getByRole("menuitem", { name: "Sim playoffs" }).click();
+  await confirmLifecycleDialog(page);
 }
 
 export async function simToChampion(page: Page) {
   await openSimulateScopeMenu(page);
   await page.getByRole("menuitem", { name: "Sim to champion" }).click();
+  await confirmLifecycleDialog(page);
   await expect(page.getByText(/wins — simulated/)).toBeVisible({
     timeout: 180_000,
   });
+}
+
+export async function advanceToPlayoffs(page: Page) {
+  await page.getByRole("button", { name: "Advance to playoffs" }).click();
+  await confirmLifecycleDialog(page);
+}
+
+export async function startNextSeason(page: Page) {
+  await page.getByRole("button", { name: "Start next season" }).click();
+  await confirmLifecycleDialog(page);
 }

--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -17,12 +17,21 @@ export function acceptBrowserConfirms(page: Page): void {
   page.on("dialog", (dialog) => void dialog.accept());
 }
 
-/** Confirm an in-app ActionConfirmDialog (lifecycle surfaces from PR #535). */
-export async function confirmLifecycleDialog(page: Page): Promise<void> {
+/**
+ * Confirm an in-app ActionConfirmDialog (lifecycle surfaces from PR #535).
+ * Pass `expectClose: false` for error paths — failed actions keep the dialog
+ * open for retry, surfacing the error via toast.
+ */
+export async function confirmLifecycleDialog(
+  page: Page,
+  opts: { expectClose?: boolean } = {},
+): Promise<void> {
   const dialog = page.getByTestId("action-confirm-dialog");
   await expect(dialog).toBeVisible();
   await page.getByTestId("action-confirm-submit").click();
-  await expect(dialog).toBeHidden();
+  if (opts.expectClose !== false) {
+    await expect(dialog).toBeHidden();
+  }
 }
 
 export async function addTeamsToLeague(
@@ -132,10 +141,13 @@ export async function simRegularSeason(page: Page) {
   ).toBeVisible({ timeout: 120_000 });
 }
 
-export async function simPlayoffsScope(page: Page) {
+export async function simPlayoffsScope(
+  page: Page,
+  opts: { expectClose?: boolean } = {},
+) {
   await openSimulateScopeMenu(page);
   await page.getByRole("menuitem", { name: "Sim playoffs" }).click();
-  await confirmLifecycleDialog(page);
+  await confirmLifecycleDialog(page, opts);
 }
 
 export async function simToChampion(page: Page) {

--- a/apps/web/e2e/tests/dynasty.spec.ts
+++ b/apps/web/e2e/tests/dynasty.spec.ts
@@ -10,6 +10,7 @@ import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
   simToChampion,
+  startNextSeason,
 } from "../helpers/sim-league-setup";
 
 /*
@@ -103,7 +104,7 @@ test.describe("Dynasty panel (dynasty rollover)", () => {
 
     await page.goto(`/dashboard/leagues/${leagueId}`);
     await expect(startBtn).toBeEnabled();
-    await startBtn.click();
+    await startNextSeason(page);
     await expect(page.getByText("Next season started.")).toBeVisible({
       timeout: 60_000,
     });

--- a/apps/web/e2e/tests/offseason-draft.spec.ts
+++ b/apps/web/e2e/tests/offseason-draft.spec.ts
@@ -10,6 +10,7 @@ import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
   simToChampion,
+  startNextSeason,
 } from "../helpers/sim-league-setup";
 
 /*
@@ -51,7 +52,7 @@ test.describe("Offseason draft", () => {
     await page.goto(`/dashboard/leagues/${fixture.leagueId}`);
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });
-    await startBtn.click();
+    await startNextSeason(page);
     await expect(page.getByText("Next season started.")).toBeVisible({
       timeout: 60_000,
     });

--- a/apps/web/e2e/tests/offseason-free-agency.spec.ts
+++ b/apps/web/e2e/tests/offseason-free-agency.spec.ts
@@ -10,6 +10,7 @@ import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
   simToChampion,
+  startNextSeason,
 } from "../helpers/sim-league-setup";
 
 /*
@@ -51,7 +52,7 @@ test.describe("Offseason free agency", () => {
     await page.goto(`/dashboard/leagues/${fixture.leagueId}`);
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });
-    await startBtn.click();
+    await startNextSeason(page);
     await expect(page.getByText("Next season started.")).toBeVisible({
       timeout: 60_000,
     });

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -8,6 +8,7 @@ import {
 import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
+  advanceToPlayoffs,
   bootstrapFourTeamSimLeague,
   simPlayoffsScope,
   simRegularSeason,
@@ -79,7 +80,7 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
     await expect(page.getByText(/Regular season complete/)).toBeVisible();
     const advance = page.getByRole("button", { name: "Advance to playoffs" });
     await expect(advance).toBeEnabled();
-    await advance.click();
+    await advanceToPlayoffs(page);
     await expect(
       page.getByText(/Playoffs started — \d+ matchups/),
     ).toBeVisible({ timeout: 60_000 });

--- a/apps/web/e2e/tests/sim-scopes.spec.ts
+++ b/apps/web/e2e/tests/sim-scopes.spec.ts
@@ -104,11 +104,15 @@ test.describe("Simulation scopes (WSM-000183)", () => {
     ).toBeVisible();
     await page.keyboard.press("Escape");
 
-    await simPlayoffsScope(page);
+    // Without a bracket the action fails: the error surfaces as a toast and
+    // the confirm dialog stays open for retry.
+    await simPlayoffsScope(page, { expectClose: false });
     await expect(
       page.getByText(
         "No playoff bracket yet. Generate a bracket on the Playoffs page first.",
       ),
     ).toBeVisible({ timeout: 30_000 });
+    await page.getByTestId("action-confirm-cancel").click();
+    await expect(page.getByTestId("action-confirm-dialog")).toBeHidden();
   });
 });

--- a/apps/web/e2e/tests/sim-scopes.spec.ts
+++ b/apps/web/e2e/tests/sim-scopes.spec.ts
@@ -11,6 +11,7 @@ import {
   bootstrapFourTeamSimLeague,
   openSimulateScopeMenu,
   simPlayoffsScope,
+  simWeek,
   weekCard,
 } from "../helpers/sim-league-setup";
 
@@ -80,7 +81,7 @@ test.describe("Simulation scopes (WSM-000183)", () => {
       .count();
     expect(week1ScheduledBefore).toBeGreaterThan(0);
 
-    await week1.getByRole("button", { name: "Sim week" }).click();
+    await simWeek(page, 1);
     await expect(week1.getByText("Scheduled", { exact: true })).toHaveCount(0, {
       timeout: 60_000,
     });

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { Plus, Trash2, Pencil, CheckCircle2, Users, Trophy } from "lucide-react";
 import type { UndersizedTeam } from "@/lib/offseason-activate";
 import { ActivateSeasonWarningDialog } from "@/components/offseason/ActivateSeasonWarningDialog";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
   createSeasonAction,
   updateSeasonAction,
@@ -310,6 +311,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
 export function CopyRostersButton({ season }: { season: SeasonDto }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   async function run(confirm: boolean) {
     setBusy(true);
@@ -326,14 +328,12 @@ export function CopyRostersButton({ season }: { season: SeasonDto }) {
         } into ${season.name}.`,
       );
       router.refresh();
+      setConfirmOpen(false);
       return;
     }
 
     if ("needsConfirm" in res) {
-      const proceed = window.confirm(
-        `${season.name} already has rosters. Copying replaces them with last season's rosters. This can't be undone. Continue?`,
-      );
-      if (proceed) run(true);
+      setConfirmOpen(true);
       return;
     }
 
@@ -345,16 +345,28 @@ export function CopyRostersButton({ season }: { season: SeasonDto }) {
   }
 
   return (
-    <Button
-      size="sm"
-      variant="outline"
-      disabled={busy}
-      onClick={() => run(false)}
-      aria-label={`Copy rosters from last season into ${season.name}`}
-    >
-      <Users className="mr-1 h-3.5 w-3.5" />
-      {busy ? "…" : "Copy rosters"}
-    </Button>
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={busy}
+        onClick={() => void run(false)}
+        aria-label={`Copy rosters from last season into ${season.name}`}
+      >
+        <Users className="mr-1 h-3.5 w-3.5" />
+        {busy ? "…" : "Copy rosters"}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Replace existing rosters?"
+        description={`${season.name} already has rosters. Copying replaces them with last season's rosters. This can't be undone. Continue?`}
+        confirmLabel="Continue"
+        destructive
+        pending={busy}
+        onConfirm={() => void run(true)}
+      />
+    </>
   );
 }
 
@@ -379,6 +391,8 @@ export function SeasonRowActions({
   );
   const [busy, setBusy] = useState(false);
   const [activateWarningOpen, setActivateWarningOpen] = useState(false);
+  const [completeStep, setCompleteStep] = useState<"complete" | "force" | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const isActive = season.status === "active";
 
@@ -403,26 +417,16 @@ export function SeasonRowActions({
     void runActivate();
   }
 
-  async function complete() {
-    if (
-      !window.confirm(
-        `Mark "${season.name}" as completed? Schedule generation, result recording, and simulations will be locked for it.`,
-      )
-    ) {
-      return;
-    }
+  async function runComplete(force = false) {
     setBusy(true);
-    let res = await completeSeasonAction({ seasonId: season.id });
-    if (!res.ok && res.error === "no_champion") {
-      const force = window.confirm(
-        "No playoff champion has been decided for this season. Complete it anyway?",
-      );
-      if (force) {
-        res = await completeSeasonAction({ seasonId: season.id, force: true });
-      } else {
-        setBusy(false);
-        return;
-      }
+    const res = await completeSeasonAction({
+      seasonId: season.id,
+      ...(force ? { force: true } : {}),
+    });
+    if (!res.ok && res.error === "no_champion" && !force) {
+      setBusy(false);
+      setCompleteStep("force");
+      return;
     }
     setBusy(false);
     if (res.ok) {
@@ -435,11 +439,16 @@ export function SeasonRowActions({
         },
       });
       router.refresh();
+      setCompleteStep(null);
     } else {
       toast.error(
         res.error === "not_admin" ? "Only league admins can do that." : res.error,
       );
     }
+  }
+
+  function complete() {
+    setCompleteStep("complete");
   }
 
   async function save() {
@@ -466,19 +475,13 @@ export function SeasonRowActions({
   }
 
   async function remove() {
-    if (
-      !window.confirm(
-        `Delete "${season.name}" and its schedule, results, and attributes? This can't be undone.`,
-      )
-    ) {
-      return;
-    }
     setBusy(true);
     const res = await deleteSeasonAction(season.id);
     setBusy(false);
     if (res.ok) {
       toast.success(`Deleted ${season.name}.`);
       router.refresh();
+      setDeleteConfirmOpen(false);
     } else {
       toast.error(res.error === "not_admin" ? "Only league admins can delete seasons." : res.error);
     }
@@ -569,7 +572,7 @@ export function SeasonRowActions({
           size="sm"
           variant="ghost"
           disabled={busy}
-          onClick={remove}
+          onClick={() => setDeleteConfirmOpen(true)}
           aria-label={`Delete ${season.name}`}
         >
           <Trash2 className="h-4 w-4 text-destructive" />
@@ -582,6 +585,39 @@ export function SeasonRowActions({
         busy={busy}
         onCancel={() => setActivateWarningOpen(false)}
         onConfirm={() => void runActivate()}
+      />
+      <ActionConfirmDialog
+        open={completeStep === "complete"}
+        onOpenChange={(open) => {
+          if (!open && !busy) setCompleteStep(null);
+        }}
+        title={`Complete ${season.name}?`}
+        description="Schedule generation, result recording, and simulations will be locked for it."
+        confirmLabel="Complete"
+        pending={busy}
+        onConfirm={() => void runComplete(false)}
+      />
+      <ActionConfirmDialog
+        open={completeStep === "force"}
+        onOpenChange={(open) => {
+          if (!open && !busy) setCompleteStep(null);
+        }}
+        title="Complete without a champion?"
+        description="No playoff champion has been decided for this season. Complete it anyway?"
+        confirmLabel="Complete anyway"
+        destructive
+        pending={busy}
+        onConfirm={() => void runComplete(true)}
+      />
+      <ActionConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        title={`Delete ${season.name}?`}
+        description="This deletes its schedule, results, and attributes. This can't be undone."
+        confirmLabel="Delete"
+        destructive
+        pending={busy}
+        onConfirm={() => void remove()}
       />
     </>
   );

--- a/apps/web/src/components/dynasty/DynastyPanel.tsx
+++ b/apps/web/src/components/dynasty/DynastyPanel.tsx
@@ -15,6 +15,7 @@ import {
 import type { ClassDistribution } from "@/lib/class-year";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
   Accordion,
   AccordionContent,
@@ -63,16 +64,10 @@ export function DynastyPanel({
   const router = useRouter();
   const [pending, start] = useTransition();
   const [lastSuccess, setLastSuccess] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function runStartNextSeason() {
     if (!gate.canStart) return;
-    if (
-      !window.confirm(
-        "Start the next season? Seniors will graduate, other players advance a grade, and freshmen will be generated.",
-      )
-    ) {
-      return;
-    }
 
     start(async () => {
       const res = await startNextSeasonAction({ leagueId });
@@ -95,6 +90,7 @@ export function DynastyPanel({
       setLastSuccess(summary);
       toast.success("Next season started.");
       router.refresh();
+      setConfirmOpen(false);
     });
   }
 
@@ -106,6 +102,7 @@ export function DynastyPanel({
     classDistribution.unknown;
 
   return (
+    <>
     <div id="dynasty-panel" className="space-y-4 border-t border-border pt-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
@@ -135,7 +132,7 @@ export function DynastyPanel({
             type="button"
             size="sm"
             disabled={pending || !gate.canStart}
-            onClick={runStartNextSeason}
+            onClick={() => setConfirmOpen(true)}
             title={gate.message ?? "Start the next season (offseason rollover)"}
           >
             {pending ? "Starting…" : "Start next season"}
@@ -225,5 +222,15 @@ export function DynastyPanel({
         </Accordion>
       )}
     </div>
+    <ActionConfirmDialog
+      open={confirmOpen}
+      onOpenChange={setConfirmOpen}
+      title="Start the next season?"
+      description="Seniors will graduate, other players advance a grade, and freshmen will be generated."
+      confirmLabel="Start season"
+      pending={pending}
+      onConfirm={runStartNextSeason}
+    />
+    </>
   );
 }

--- a/apps/web/src/components/lifecycle/ActionConfirmDialog.tsx
+++ b/apps/web/src/components/lifecycle/ActionConfirmDialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export interface ActionConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  pending?: boolean;
+  error?: string | null;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function ActionConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  pending: pendingProp,
+  error = null,
+  onConfirm,
+}: ActionConfirmDialogProps) {
+  const pending = pendingProp ?? false;
+  const hasPendingProp = pendingProp !== undefined;
+  const confirmInFlight = React.useRef(false);
+  const sawPendingAfterConfirm = React.useRef(false);
+  const restoreFocusElement = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      confirmInFlight.current = false;
+      sawPendingAfterConfirm.current = false;
+      return;
+    }
+
+    if (!confirmInFlight.current) return;
+
+    if (pending) {
+      sawPendingAfterConfirm.current = true;
+    } else if (sawPendingAfterConfirm.current) {
+      confirmInFlight.current = false;
+      sawPendingAfterConfirm.current = false;
+    }
+  }, [open, pending]);
+
+  function handleOpenChange(next: boolean) {
+    if (!next && pending) return;
+    onOpenChange(next);
+  }
+
+  async function handleConfirm() {
+    if (pending || confirmInFlight.current) return;
+    confirmInFlight.current = true;
+    sawPendingAfterConfirm.current = false;
+
+    let result: void | Promise<void>;
+    try {
+      result = onConfirm();
+    } catch (error) {
+      confirmInFlight.current = false;
+      throw error;
+    }
+
+    if (!hasPendingProp) {
+      try {
+        await result;
+      } finally {
+        confirmInFlight.current = false;
+      }
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent
+        data-testid="action-confirm-dialog"
+        onOpenAutoFocus={() => {
+          restoreFocusElement.current = document.activeElement as HTMLElement | null;
+        }}
+        onCloseAutoFocus={(event) => {
+          const element = restoreFocusElement.current;
+          restoreFocusElement.current = null;
+          if (element?.isConnected) {
+            event.preventDefault();
+            element.focus();
+          }
+        }}
+        onEscapeKeyDown={(event) => {
+          if (pending) event.preventDefault();
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild={typeof description !== "string"}>
+            {typeof description === "string" ? description : <div>{description}</div>}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {error ? (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+            data-testid="action-confirm-error"
+          >
+            <p>{error}</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              disabled={pending}
+              onClick={() => void handleConfirm()}
+              data-testid="action-confirm-retry"
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            disabled={pending}
+            data-testid="action-confirm-cancel"
+          >
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({
+              variant: destructive ? "destructive" : "default",
+            })}
+            disabled={pending}
+            onClick={(event) => {
+              event.preventDefault();
+              void handleConfirm();
+            }}
+            data-testid="action-confirm-submit"
+          >
+            {pending ? "Working…" : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/lifecycle/ProcessDialog.tsx
+++ b/apps/web/src/components/lifecycle/ProcessDialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type ProcessStageStatus = "pending" | "in_progress" | "complete" | "error";
+
+export interface ProcessStage {
+  id: string;
+  label: string;
+  status: ProcessStageStatus;
+  detail?: string;
+}
+
+export interface ProcessDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: React.ReactNode;
+  stages: ProcessStage[];
+  pending: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+function stageAnnouncement(stage: ProcessStage): string {
+  const statusLabel =
+    stage.status === "complete"
+      ? "completed"
+      : stage.status === "error"
+        ? "failed"
+        : stage.status === "in_progress"
+          ? "in progress"
+          : "pending";
+  return `${stage.label}: ${statusLabel}${stage.detail ? ` — ${stage.detail}` : ""}`;
+}
+
+export function ProcessDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  stages,
+  pending,
+  error = null,
+  onRetry,
+}: ProcessDialogProps) {
+  const liveMessage = React.useMemo(() => {
+    const active =
+      stages.find((stage) => stage.status === "in_progress") ??
+      stages.find((stage) => stage.status === "complete" || stage.status === "error");
+    if (active) return stageAnnouncement(active);
+    if (pending) return "Processing…";
+    return "";
+  }, [pending, stages]);
+
+  function handleOpenChange(next: boolean) {
+    if (!next && pending) return;
+    onOpenChange(next);
+  }
+
+  const dismissible = !pending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        role="dialog"
+        showCloseButton={dismissible}
+        data-testid="process-dialog"
+        onEscapeKeyDown={(event) => {
+          if (pending) event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          if (pending) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (pending) event.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+          data-testid="process-dialog-live-region"
+        >
+          {liveMessage}
+        </div>
+
+        <ol className="space-y-2" data-testid="process-dialog-stages">
+          {stages.map((stage) => (
+            <li
+              key={stage.id}
+              className="flex items-start gap-2 text-sm"
+              data-stage-id={stage.id}
+              data-stage-status={stage.status}
+            >
+              <span aria-hidden="true" className="mt-0.5 font-mono text-xs text-muted-foreground">
+                {stage.status === "complete"
+                  ? "✓"
+                  : stage.status === "error"
+                    ? "!"
+                    : stage.status === "in_progress"
+                      ? "…"
+                      : "○"}
+              </span>
+              <div>
+                <p className="font-medium text-foreground">{stage.label}</p>
+                {stage.detail ? (
+                  <p className="text-muted-foreground">{stage.detail}</p>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        {error ? (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+            data-testid="process-dialog-error"
+          >
+            <p>{error}</p>
+            {onRetry ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                disabled={pending}
+                onClick={onRetry}
+                data-testid="process-dialog-retry"
+              >
+                Retry
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {dismissible ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              data-testid="process-dialog-close"
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/lifecycle/__tests__/ActionConfirmDialog.test.ts
+++ b/apps/web/src/components/lifecycle/__tests__/ActionConfirmDialog.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import { createElement, useState, type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+
+type AlertDialogProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+};
+
+type ContentProps = {
+  children?: ReactNode;
+  onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
+};
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ open, onOpenChange, children }: AlertDialogProps) => {
+    const dialog = open
+      ? createElement(
+          "div",
+          {
+            "data-testid": "alert-dialog-root",
+            onKeyDown: (event: KeyboardEvent) => {
+              if (event.key === "Escape") onOpenChange?.(false);
+            },
+          },
+          children,
+        )
+      : null;
+    mockOpenChange = onOpenChange;
+    return dialog;
+  },
+  AlertDialogContent: ({ children, onEscapeKeyDown }: ContentProps) =>
+    createElement(
+      "div",
+      {
+        "data-testid": "action-confirm-dialog",
+        onKeyDown: (event: KeyboardEvent) => {
+          if (event.key === "Escape") {
+            onEscapeKeyDown?.({
+              preventDefault: () => event.preventDefault(),
+            });
+          }
+        },
+      },
+      children,
+    ),
+  AlertDialogHeader: ({ children }: { children?: ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogFooter: ({ children }: { children?: ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogTitle: ({ children }: { children?: ReactNode }) =>
+    createElement("h2", null, children),
+  AlertDialogDescription: ({ children }: { children?: ReactNode }) =>
+    createElement("p", null, children),
+  AlertDialogCancel: ({
+    children,
+    disabled,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement(
+      "button",
+      {
+        type: "button",
+        disabled,
+        onClick: () => mockOpenChange?.(false),
+        ...props,
+      },
+      children,
+    ),
+  AlertDialogAction: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement("button", { type: "button", ...props }, children),
+}));
+
+let mockOpenChange: AlertDialogProps["onOpenChange"];
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof ActionConfirmDialog>> & {
+    initialOpen?: boolean;
+  },
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const trigger = document.createElement("button");
+  trigger.textContent = "Trigger";
+  document.body.appendChild(trigger);
+  trigger.focus();
+
+  let root: Root | null = null;
+
+  function Harness() {
+    const [open, setOpen] = useState(props.initialOpen ?? true);
+    return createElement(ActionConfirmDialog, {
+      open,
+      onOpenChange: (next) => {
+        setOpen(next);
+        props.onOpenChange?.(next);
+      },
+      title: props.title ?? "Confirm action",
+      description: props.description ?? "Are you sure?",
+      confirmLabel: props.confirmLabel,
+      cancelLabel: props.cancelLabel,
+      destructive: props.destructive,
+      pending: props.pending,
+      error: props.error,
+      onConfirm: props.onConfirm ?? (() => undefined),
+    });
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(createElement(Harness));
+  });
+
+  return {
+    container,
+    trigger,
+    unmount() {
+      act(() => {
+        root?.unmount();
+      });
+      container.remove();
+      trigger.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ActionConfirmDialog", () => {
+  it("renders title and description when open", () => {
+    const view = renderDialog({
+      title: "Delete item?",
+      description: "This cannot be undone.",
+    });
+    expect(document.body.textContent).toContain("Delete item?");
+    expect(document.body.textContent).toContain("This cannot be undone.");
+    view.unmount();
+  });
+
+  it("calls onConfirm once when confirm is double-clicked", async () => {
+    const onConfirm = vi.fn(
+      () => new Promise<void>((resolve) => setTimeout(resolve, 25)),
+    );
+    renderDialog({ onConfirm, pending: false });
+
+    const confirm = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      confirm.click();
+      confirm.click();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms confirm after pending completes", () => {
+    const onConfirm = vi.fn();
+    let setPending: (pending: boolean) => void = () => undefined;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    function Harness() {
+      const [pending, updatePending] = useState(false);
+      setPending = updatePending;
+      return createElement(ActionConfirmDialog, {
+        open: true,
+        onOpenChange: vi.fn(),
+        title: "Confirm action",
+        description: "Are you sure?",
+        pending,
+        onConfirm,
+      });
+    }
+
+    act(() => {
+      root.render(createElement(Harness));
+    });
+
+    const confirm = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      confirm.click();
+      confirm.click();
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setPending(true);
+    });
+    act(() => {
+      setPending(false);
+    });
+    act(() => {
+      confirm.click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("closes on cancel when not pending", () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange, pending: false });
+
+    const cancel = document.querySelector(
+      '[data-testid="action-confirm-cancel"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      cancel.click();
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("blocks escape dismissal while pending", () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange, pending: true });
+
+    const dialog = document.querySelector(
+      '[data-testid="action-confirm-dialog"]',
+    ) as HTMLDivElement;
+    act(() => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("allows escape dismissal when not pending", () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange, pending: false });
+
+    const dialog = document.querySelector(
+      '[data-testid="action-confirm-dialog"]',
+    ) as HTMLDivElement;
+    act(() => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows error copy with retry that re-invokes onConfirm", () => {
+    const onConfirm = vi.fn();
+    renderDialog({
+      error: "Server failed",
+      onConfirm,
+      pending: false,
+    });
+
+    expect(document.body.textContent).toContain("Server failed");
+    const retry = document.querySelector(
+      '[data-testid="action-confirm-retry"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      retry.click();
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables confirm and cancel buttons while pending", () => {
+    renderDialog({ pending: true });
+    const confirm = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    const cancel = document.querySelector(
+      '[data-testid="action-confirm-cancel"]',
+    ) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    expect(cancel.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/lifecycle/__tests__/ProcessDialog.test.ts
+++ b/apps/web/src/components/lifecycle/__tests__/ProcessDialog.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ProcessDialog,
+  type ProcessStage,
+} from "@/components/lifecycle/ProcessDialog";
+
+type DialogProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+};
+
+type ContentProps = {
+  children?: ReactNode;
+  role?: string;
+  showCloseButton?: boolean;
+  onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
+  onPointerDownOutside?: (event: { preventDefault: () => void }) => void;
+  onInteractOutside?: (event: { preventDefault: () => void }) => void;
+};
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: DialogProps) =>
+    open ? createElement("div", { "data-testid": "dialog-root" }, children) : null,
+  DialogContent: ({
+    children,
+    role,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    onInteractOutside,
+  }: ContentProps) =>
+    createElement(
+      "div",
+      {
+        role,
+        "data-testid": "process-dialog",
+        onKeyDown: (event: KeyboardEvent) => {
+          if (event.key === "Escape") {
+            onEscapeKeyDown?.({
+              preventDefault: () => event.preventDefault(),
+            });
+          }
+        },
+        onPointerDown: () => {
+          onPointerDownOutside?.({ preventDefault: () => undefined });
+        },
+        onClick: () => {
+          onInteractOutside?.({ preventDefault: () => undefined });
+        },
+      },
+      children,
+    ),
+  DialogHeader: ({ children }: { children?: ReactNode }) =>
+    createElement("div", null, children),
+  DialogFooter: ({ children }: { children?: ReactNode }) =>
+    createElement("div", null, children),
+  DialogTitle: ({ children }: { children?: ReactNode }) =>
+    createElement("h2", null, children),
+  DialogDescription: ({ children }: { children?: ReactNode }) =>
+    createElement("p", null, children),
+}));
+
+const completedStages: ProcessStage[] = [
+  { id: "seed", label: "Seed bracket", status: "complete", detail: "8 teams" },
+  {
+    id: "schedule",
+    label: "Schedule games",
+    status: "complete",
+    detail: "3 rounds",
+  },
+];
+
+function renderProcessDialog(
+  props: Partial<React.ComponentProps<typeof ProcessDialog>>,
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  const onOpenChange = props.onOpenChange ?? vi.fn();
+
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      createElement(ProcessDialog, {
+        open: props.open ?? true,
+        onOpenChange,
+        title: props.title ?? "Processing",
+        description: props.description,
+        stages: props.stages ?? completedStages,
+        pending: props.pending ?? false,
+        error: props.error,
+        onRetry: props.onRetry,
+      }),
+    );
+  });
+
+  return {
+    onOpenChange,
+    unmount() {
+      act(() => {
+        root?.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ProcessDialog", () => {
+  it('renders role="dialog" and ordered stages from result payload', () => {
+    renderProcessDialog({});
+    const dialog = document.querySelector('[data-testid="process-dialog"]');
+    expect(dialog?.getAttribute("role")).toBe("dialog");
+
+    const items = document.querySelectorAll("[data-stage-id]");
+    expect(items).toHaveLength(2);
+    expect(items[0]?.getAttribute("data-stage-id")).toBe("seed");
+    expect(items[1]?.getAttribute("data-stage-id")).toBe("schedule");
+    expect(document.body.textContent).toContain("8 teams");
+    expect(document.body.textContent).toContain("3 rounds");
+  });
+
+  it("announces stage changes in the polite live region", () => {
+    renderProcessDialog({
+      stages: [
+        { id: "a", label: "Copy rosters", status: "in_progress" },
+        { id: "b", label: "Activate season", status: "pending" },
+      ],
+      pending: true,
+    });
+    const live = document.querySelector(
+      '[data-testid="process-dialog-live-region"]',
+    );
+    expect(live?.getAttribute("aria-live")).toBe("polite");
+    expect(live?.textContent).toContain("Copy rosters: in progress");
+  });
+
+  it("blocks dismissal while pending", () => {
+    const onOpenChange = vi.fn();
+    renderProcessDialog({ pending: true, onOpenChange });
+
+    const dialog = document.querySelector(
+      '[data-testid="process-dialog"]',
+    ) as HTMLDivElement;
+    act(() => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+      dialog.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      document.querySelector('[data-testid="process-dialog-close"]'),
+    ).toBeNull();
+  });
+
+  it("allows close once finished and shows retry on failure", () => {
+    const onRetry = vi.fn();
+    const onOpenChange = vi.fn();
+    renderProcessDialog({
+      pending: false,
+      error: "Mutation failed",
+      onRetry,
+      onOpenChange,
+    });
+
+    expect(document.body.textContent).toContain("Mutation failed");
+    const retry = document.querySelector(
+      '[data-testid="process-dialog-retry"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      retry.click();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    const close = document.querySelector(
+      '[data-testid="process-dialog-close"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      close.click();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/components/lifecycle/__tests__/lifecycle-dialogs.integration.test.ts
+++ b/apps/web/src/components/lifecycle/__tests__/lifecycle-dialogs.integration.test.ts
@@ -1,0 +1,340 @@
+// @vitest-environment jsdom
+
+import { createElement, useState } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+import {
+  ProcessDialog,
+  type ProcessStage,
+} from "@/components/lifecycle/ProcessDialog";
+
+type RenderedRoot = {
+  container: HTMLDivElement;
+  rerender: (element: React.ReactElement) => void;
+  unmount: () => void;
+};
+
+const originalPointerEvent = globalThis.PointerEvent;
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+const originalHasPointerCapture = Element.prototype.hasPointerCapture;
+const originalReleasePointerCapture = Element.prototype.releasePointerCapture;
+const originalSetPointerCapture = Element.prototype.setPointerCapture;
+
+function installRadixShims() {
+  if (!globalThis.PointerEvent) {
+    globalThis.PointerEvent = MouseEvent as typeof PointerEvent;
+  }
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined;
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined;
+  }
+}
+
+function restoreRadixShims() {
+  globalThis.PointerEvent = originalPointerEvent;
+  globalThis.ResizeObserver = originalResizeObserver;
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+  Element.prototype.hasPointerCapture = originalHasPointerCapture;
+  Element.prototype.releasePointerCapture = originalReleasePointerCapture;
+  Element.prototype.setPointerCapture = originalSetPointerCapture;
+}
+
+async function waitFor(assertion: () => void) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+  throw lastError;
+}
+
+function renderRoot(element: React.ReactElement): RenderedRoot {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root | null = null;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(element);
+  });
+
+  return {
+    container,
+    rerender(nextElement) {
+      act(() => {
+        root?.render(nextElement);
+      });
+    },
+    unmount() {
+      act(() => {
+        root?.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function dispatchEscape(target: Element) {
+  act(() => {
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+function dispatchPointerDownOutside() {
+  act(() => {
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        pointerId: 1,
+      } as PointerEventInit),
+    );
+  });
+}
+
+function queryActionDialog() {
+  return document.querySelector('[data-testid="action-confirm-dialog"]');
+}
+
+function queryProcessDialog() {
+  return document.querySelector('[data-testid="process-dialog"]');
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  installRadixShims();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  restoreRadixShims();
+});
+
+describe("lifecycle dialogs with real Radix primitives", () => {
+  it("focuses the alert dialog cancel action on open and restores prior focus after close", async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return createElement(
+        "div",
+        null,
+        createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "open-dialog",
+            onClick: () => setOpen(true),
+          },
+          "Open",
+        ),
+        createElement(ActionConfirmDialog, {
+          open,
+          onOpenChange: setOpen,
+          title: "Confirm archive",
+          description: "Archive this season?",
+          pending: false,
+          onConfirm: vi.fn(),
+        }),
+      );
+    }
+
+    const view = renderRoot(createElement(Harness));
+    const opener = document.querySelector(
+      '[data-testid="open-dialog"]',
+    ) as HTMLButtonElement;
+    opener.focus();
+
+    act(() => {
+      opener.click();
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        document.querySelector('[data-testid="action-confirm-cancel"]'),
+      );
+    });
+
+    act(() => {
+      (
+        document.querySelector(
+          '[data-testid="action-confirm-cancel"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(opener);
+    });
+
+    view.unmount();
+  });
+
+  it("blocks Escape while pending and allows it when idle", async () => {
+    const onOpenChange = vi.fn();
+    const view = renderRoot(
+      createElement(ActionConfirmDialog, {
+        open: true,
+        onOpenChange,
+        title: "Delete game",
+        description: "This cannot be undone.",
+        pending: true,
+        onConfirm: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => expect(queryActionDialog()).not.toBeNull());
+    dispatchEscape(queryActionDialog() as Element);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(queryActionDialog()).not.toBeNull();
+
+    view.rerender(
+      createElement(ActionConfirmDialog, {
+        open: true,
+        onOpenChange,
+        title: "Delete game",
+        description: "This cannot be undone.",
+        pending: false,
+        onConfirm: vi.fn(),
+      }),
+    );
+
+    dispatchEscape(queryActionDialog() as Element);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    view.unmount();
+  });
+
+  it("ignores rapid duplicate activation before a synchronous caller re-renders pending", async () => {
+    const onConfirm = vi.fn();
+
+    function Harness() {
+      const [pending, setPending] = useState(false);
+      return createElement(ActionConfirmDialog, {
+        open: true,
+        onOpenChange: vi.fn(),
+        title: "Generate playoffs",
+        description: "Create the bracket?",
+        pending,
+        onConfirm: () => {
+          onConfirm();
+          queueMicrotask(() => setPending(true));
+        },
+      });
+    }
+
+    const view = renderRoot(createElement(Harness));
+    await waitFor(() => expect(queryActionDialog()).not.toBeNull());
+
+    const submit = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      submit.click();
+      submit.click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    view.unmount();
+  });
+
+  it("keeps the process dialog locked while pending and announces stage updates", async () => {
+    const onOpenChange = vi.fn();
+    const onRetry = vi.fn();
+    const initialStages: ProcessStage[] = [
+      { id: "copy", label: "Copy rosters", status: "in_progress" },
+      { id: "activate", label: "Activate season", status: "pending" },
+    ];
+    const nextStages: ProcessStage[] = [
+      { id: "copy", label: "Copy rosters", status: "complete" },
+      { id: "activate", label: "Activate season", status: "in_progress" },
+    ];
+
+    const view = renderRoot(
+      createElement(ProcessDialog, {
+        open: true,
+        onOpenChange,
+        title: "Activating season",
+        stages: initialStages,
+        pending: true,
+        error: "Activation failed",
+        onRetry,
+      }),
+    );
+
+    await waitFor(() => expect(queryProcessDialog()).not.toBeNull());
+    expect(document.querySelector('[data-testid="process-dialog-close"]')).toBeNull();
+
+    dispatchEscape(queryProcessDialog() as Element);
+    dispatchPointerDownOutside();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    const live = document.querySelector(
+      '[data-testid="process-dialog-live-region"]',
+    );
+    expect(live?.textContent).toContain("Copy rosters: in progress");
+
+    const retry = document.querySelector(
+      '[data-testid="process-dialog-retry"]',
+    ) as HTMLButtonElement;
+    expect(retry.disabled).toBe(true);
+    act(() => {
+      retry.click();
+    });
+    expect(onRetry).not.toHaveBeenCalled();
+
+    view.rerender(
+      createElement(ProcessDialog, {
+        open: true,
+        onOpenChange,
+        title: "Activating season",
+        stages: nextStages,
+        pending: true,
+        error: "Activation failed",
+        onRetry,
+      }),
+    );
+
+    expect(live?.textContent).toContain("Activate season: in progress");
+    view.unmount();
+  });
+});

--- a/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import { advanceToPlayoffsAction } from "@/app/dashboard/leagues/[id]/playoffs/actions";
 
 export interface AdvanceToPlayoffsButtonProps {
@@ -18,16 +19,9 @@ export default function AdvanceToPlayoffsButton({
 }: AdvanceToPlayoffsButtonProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  function onClick() {
-    if (
-      !window.confirm(
-        "Advance to playoffs? A bracket will be seeded from the current standings and first-round games will be scheduled.",
-      )
-    ) {
-      return;
-    }
-
+  function onConfirm() {
     startTransition(async () => {
       const res = await advanceToPlayoffsAction({ leagueId });
       if (res.ok) {
@@ -35,6 +29,7 @@ export default function AdvanceToPlayoffsButton({
           `Playoffs started — ${res.matchups} matchups across ${res.rounds} rounds.`,
         );
         router.refresh();
+        setConfirmOpen(false);
         return;
       }
 
@@ -53,14 +48,25 @@ export default function AdvanceToPlayoffsButton({
   }
 
   return (
-    <Button
-      size="sm"
-      disabled={disabled || pending}
-      onClick={onClick}
-      className="gap-1.5"
-    >
-      <Trophy className="h-4 w-4" />
-      {pending ? "Advancing…" : "Advance to playoffs"}
-    </Button>
+    <>
+      <Button
+        size="sm"
+        disabled={disabled || pending}
+        onClick={() => setConfirmOpen(true)}
+        className="gap-1.5"
+      >
+        <Trophy className="h-4 w-4" />
+        {pending ? "Advancing…" : "Advance to playoffs"}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Advance to playoffs?"
+        description="A bracket will be seeded from the current standings and first-round games will be scheduled."
+        confirmLabel="Advance"
+        pending={pending}
+        onConfirm={onConfirm}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/GeneratePlayoffsButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import { generatePlayoffsAction } from "@/app/dashboard/leagues/[id]/playoffs/actions";
 
 export interface GeneratePlayoffsButtonProps {
@@ -23,6 +24,8 @@ export interface GeneratePlayoffsButtonProps {
 // the next power of two and gives top seeds first-round byes).
 const SIZES = [2, 4, 6, 8, 10, 12, 16] as const;
 
+type ConfirmStep = "replace" | "destructive" | null;
+
 export default function GeneratePlayoffsButton({
   leagueId,
   seasonId,
@@ -33,6 +36,7 @@ export default function GeneratePlayoffsButton({
 }: GeneratePlayoffsButtonProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [confirmStep, setConfirmStep] = useState<ConfirmStep>(null);
   // Default to the season's configured team count (fall back to 8). If the
   // configured count is not one of the offered options, it is still added below.
   const initialSize = defaultSize && defaultSize >= 2 ? defaultSize : 8;
@@ -62,14 +66,12 @@ export default function GeneratePlayoffsButton({
           }-elim bracket (${res.rounds} rounds).`,
         );
         router.refresh();
+        setConfirmStep(null);
         return;
       }
 
       if ("needsConfirm" in res) {
-        const proceed = window.confirm(
-          `${seasonName} already has a bracket with recorded results or a live game. Regenerating deletes the bracket and those results. This can't be undone. Continue?`,
-        );
-        if (proceed) run(true);
+        setConfirmStep("destructive");
         return;
       }
 
@@ -78,16 +80,35 @@ export default function GeneratePlayoffsButton({
   }
 
   function onClick() {
-    if (
-      hasBracket &&
-      !window.confirm(
-        `Replace the current bracket for ${seasonName} with a fresh ${size}-team bracket? Existing playoff games will be removed.`,
-      )
-    ) {
+    if (hasBracket) {
+      setConfirmStep("replace");
       return;
     }
     run(false);
   }
+
+  function handleConfirm() {
+    if (confirmStep === "replace") {
+      run(false);
+      return;
+    }
+    if (confirmStep === "destructive") {
+      run(true);
+    }
+  }
+
+  const confirmCopy =
+    confirmStep === "replace"
+      ? {
+          title: `Replace bracket for ${seasonName}?`,
+          description: `Replace the current bracket for ${seasonName} with a fresh ${size}-team bracket? Existing playoff games will be removed.`,
+        }
+      : confirmStep === "destructive"
+        ? {
+            title: "Regenerate bracket with existing results?",
+            description: `${seasonName} already has a bracket with recorded results or a live game. Regenerating deletes the bracket and those results. This can't be undone. Continue?`,
+          }
+        : null;
 
   return (
     <div className="flex items-center gap-2">
@@ -128,6 +149,20 @@ export default function GeneratePlayoffsButton({
             ? "Regenerate bracket"
             : "Generate bracket"}
       </Button>
+      {confirmCopy ? (
+        <ActionConfirmDialog
+          open={confirmStep !== null}
+          onOpenChange={(open) => {
+            if (!open && !pending) setConfirmStep(null);
+          }}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          confirmLabel={confirmStep === "destructive" ? "Continue" : "Replace"}
+          destructive={confirmStep === "destructive"}
+          pending={pending}
+          onConfirm={handleConfirm}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Sparkles, Trash2, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
   generateTeamRosterAction,
   generateLeagueRostersAction,
@@ -37,10 +38,9 @@ export function SyntheticRosterButton({
 }: SyntheticRosterButtonProps) {
   const router = useRouter();
   const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function run() {
-    if (!window.confirm(CONFIRM[action][kind])) return;
-
     start(async () => {
       if (action === "attributes" && kind === "team") {
         const res = await generateTeamAttributesAction({ teamId: id });
@@ -110,6 +110,7 @@ export function SyntheticRosterButton({
         );
       }
       router.refresh();
+      setConfirmOpen(false);
     });
   }
 
@@ -132,26 +133,38 @@ export function SyntheticRosterButton({
           : "Generate rosters";
 
   return (
-    <Button
-      type="button"
-      variant={isClear ? "ghost" : "outline"}
-      size="sm"
-      disabled={pending || blockedBySeason}
-      onClick={run}
-      className={isClear ? "text-destructive hover:text-destructive" : undefined}
-      title={
-        blockedBySeason
-          ? SEASON_STARTED_HINT
-          : isClear
-            ? "Delete generated test players (keeps real players)"
-            : isAttributes
-              ? "Generate Madden-style ratings for this roster's players (test data)"
-              : "Generate fake players to populate this roster for testing/demos"
-      }
-    >
-      <Icon className="mr-1 h-4 w-4" />
-      {label}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant={isClear ? "ghost" : "outline"}
+        size="sm"
+        disabled={pending || blockedBySeason}
+        onClick={() => setConfirmOpen(true)}
+        className={isClear ? "text-destructive hover:text-destructive" : undefined}
+        title={
+          blockedBySeason
+            ? SEASON_STARTED_HINT
+            : isClear
+              ? "Delete generated test players (keeps real players)"
+              : isAttributes
+                ? "Generate Madden-style ratings for this roster's players (test data)"
+                : "Generate fake players to populate this roster for testing/demos"
+        }
+      >
+        <Icon className="mr-1 h-4 w-4" />
+        {label}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={isClear ? "Clear synthetic players?" : isAttributes ? "Generate ratings?" : "Generate synthetic roster?"}
+        description={CONFIRM[action][kind]}
+        confirmLabel={isClear ? "Clear" : isAttributes ? "Generate" : "Generate"}
+        destructive={isClear}
+        pending={pending}
+        onConfirm={run}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/components/schedule/ClipsControl.tsx
+++ b/apps/web/src/components/schedule/ClipsControl.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import GameStreamPlayer from "@/components/games/GameStreamPlayer";
 import { parseTimecode, formatTimecode } from "@/lib/timecode";
 import {
@@ -55,6 +56,7 @@ export default function ClipsControl({
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
   const [label, setLabel] = useState("");
+  const [clipToDelete, setClipToDelete] = useState<ClientGameClip | null>(null);
 
   function loadClips() {
     startTransition(async () => {
@@ -101,14 +103,16 @@ export default function ClipsControl({
     });
   }
 
-  function remove(clip: ClientGameClip) {
-    if (!window.confirm(`Delete the clip “${clip.label}”?`)) return;
+  function remove() {
+    if (!clipToDelete) return;
+    const clip = clipToDelete;
     startTransition(async () => {
       const res = await deleteClip(leagueId, fixtureId, clip.id);
       if (res.ok) {
         toast.success("Clip deleted.");
         loadClips();
         router.refresh();
+        setClipToDelete(null);
       } else {
         toast.error(errorLabel(res.error));
       }
@@ -239,7 +243,7 @@ export default function ClipsControl({
                         size="sm"
                         variant="ghost"
                         disabled={pending}
-                        onClick={() => remove(clip)}
+                        onClick={() => setClipToDelete(clip)}
                         aria-label={`Delete clip ${clip.label}`}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
@@ -268,6 +272,19 @@ export default function ClipsControl({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ActionConfirmDialog
+        open={clipToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setClipToDelete(null);
+        }}
+        title={clipToDelete ? `Delete clip “${clipToDelete.label}”?` : "Delete clip?"}
+        description="This removes the clip permanently."
+        confirmLabel="Delete"
+        destructive
+        pending={pending}
+        onConfirm={remove}
+      />
     </>
   );
 }

--- a/apps/web/src/components/schedule/DeleteFixtureButton.tsx
+++ b/apps/web/src/components/schedule/DeleteFixtureButton.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import { deleteFixtureAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
 
 export interface DeleteFixtureButtonProps {
@@ -22,20 +23,15 @@ export default function DeleteFixtureButton({
 }: DeleteFixtureButtonProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function remove() {
-    if (
-      !window.confirm(
-        `Delete ${homeTeamName} vs ${awayTeamName}? Any recorded result is removed too. This can't be undone.`,
-      )
-    ) {
-      return;
-    }
     startTransition(async () => {
       const res = await deleteFixtureAction({ leagueId, fixtureId });
       if (res.ok) {
         toast.success("Fixture deleted.");
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(res.error);
       }
@@ -43,14 +39,26 @@ export default function DeleteFixtureButton({
   }
 
   return (
-    <Button
-      size="sm"
-      variant="ghost"
-      disabled={pending}
-      onClick={remove}
-      aria-label={`Delete ${homeTeamName} vs ${awayTeamName}`}
-    >
-      <Trash2 className="h-4 w-4 text-destructive" />
-    </Button>
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+        aria-label={`Delete ${homeTeamName} vs ${awayTeamName}`}
+      >
+        <Trash2 className="h-4 w-4 text-destructive" />
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Delete ${homeTeamName} vs ${awayTeamName}?`}
+        description="Any recorded result is removed too. This can't be undone."
+        confirmLabel="Delete"
+        destructive
+        pending={pending}
+        onConfirm={remove}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/schedule/GenerateScheduleButton.tsx
+++ b/apps/web/src/components/schedule/GenerateScheduleButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import { generateScheduleAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
 
 export interface GenerateScheduleButtonProps {
@@ -26,6 +27,7 @@ function friendlyError(code: string): string {
 }
 
 type ScheduleFormat = "single" | "double";
+type ConfirmStep = "replace" | "destructive" | null;
 
 export default function GenerateScheduleButton({
   leagueId,
@@ -37,6 +39,7 @@ export default function GenerateScheduleButton({
   const formatId = useId();
   const [format, setFormat] = useState<ScheduleFormat>("single");
   const [pending, startTransition] = useTransition();
+  const [confirmStep, setConfirmStep] = useState<ConfirmStep>(null);
 
   function run(confirm: boolean) {
     startTransition(async () => {
@@ -54,14 +57,12 @@ export default function GenerateScheduleButton({
           }games across ${res.weeks} weeks for ${res.teamCount} teams.`,
         );
         router.refresh();
+        setConfirmStep(null);
         return;
       }
 
       if ("needsConfirm" in res) {
-        const proceed = window.confirm(
-          `${seasonName} already has games with recorded results or a live game. Regenerating deletes the entire schedule and those results. This can't be undone. Continue?`,
-        );
-        if (proceed) run(true);
+        setConfirmStep("destructive");
         return;
       }
 
@@ -70,18 +71,35 @@ export default function GenerateScheduleButton({
   }
 
   function onClick() {
-    // Plain re-runs (no results yet) still wipe the current slate; confirm
-    // first so a stray click can't blow away manually-entered fixtures.
-    if (
-      hasFixtures &&
-      !window.confirm(
-        `Replace the current schedule for ${seasonName} with a fresh round-robin? Existing fixtures will be removed.`,
-      )
-    ) {
+    if (hasFixtures) {
+      setConfirmStep("replace");
       return;
     }
     run(false);
   }
+
+  function handleConfirm() {
+    if (confirmStep === "replace") {
+      run(false);
+      return;
+    }
+    if (confirmStep === "destructive") {
+      run(true);
+    }
+  }
+
+  const confirmCopy =
+    confirmStep === "replace"
+      ? {
+          title: `Replace schedule for ${seasonName}?`,
+          description: `Replace the current schedule for ${seasonName} with a fresh round-robin? Existing fixtures will be removed.`,
+        }
+      : confirmStep === "destructive"
+        ? {
+            title: "Regenerate schedule with existing results?",
+            description: `${seasonName} already has games with recorded results or a live game. Regenerating deletes the entire schedule and those results. This can't be undone. Continue?`,
+          }
+        : null;
 
   return (
     <div className="flex items-center gap-2">
@@ -106,6 +124,20 @@ export default function GenerateScheduleButton({
             ? "Regenerate schedule"
             : "Generate schedule"}
       </Button>
+      {confirmCopy ? (
+        <ActionConfirmDialog
+          open={confirmStep !== null}
+          onOpenChange={(open) => {
+            if (!open && !pending) setConfirmStep(null);
+          }}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          confirmLabel={confirmStep === "destructive" ? "Continue" : "Replace"}
+          destructive={confirmStep === "destructive"}
+          pending={pending}
+          onConfirm={handleConfirm}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/schedule/GoLiveControl.tsx
+++ b/apps/web/src/components/schedule/GoLiveControl.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
   startYoutubeStream,
   stopGameStream,
@@ -50,6 +51,7 @@ export default function GoLiveControl({
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
+  const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
   const [url, setUrl] = useState("");
 
   const isLive = status === "active";
@@ -77,16 +79,12 @@ export default function GoLiveControl({
   }
 
   function stop() {
-    if (
-      !window.confirm(`Stop the live stream for ${homeTeamName} vs ${awayTeamName}?`)
-    ) {
-      return;
-    }
     startTransition(async () => {
       const res = await stopGameStream(leagueId, fixtureId);
       if (res.ok) {
         toast.success("Live stream stopped — the recording stays on the game page.");
         router.refresh();
+        setStopConfirmOpen(false);
       } else {
         toast.error(errorLabel(res.error));
       }
@@ -104,11 +102,21 @@ export default function GoLiveControl({
             size="sm"
             variant="ghost"
             disabled={pending}
-            onClick={stop}
+            onClick={() => setStopConfirmOpen(true)}
             aria-label={`Stop live stream for ${homeTeamName} vs ${awayTeamName}`}
           >
             <Square className="h-4 w-4 text-destructive" />
           </Button>
+          <ActionConfirmDialog
+            open={stopConfirmOpen}
+            onOpenChange={setStopConfirmOpen}
+            title="Stop live stream?"
+            description={`Stop the live stream for ${homeTeamName} vs ${awayTeamName}?`}
+            confirmLabel="Stop stream"
+            destructive
+            pending={pending}
+            onConfirm={stop}
+          />
         </div>
       ) : gameOver ? null : (
         <Button

--- a/apps/web/src/components/schedule/SimulateControls.tsx
+++ b/apps/web/src/components/schedule/SimulateControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarDays, ChevronDown, Dices, Trophy, Wand2 } from "lucide-react";
@@ -13,6 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
   simulateGameAction,
   simulatePlayoffsAction,
@@ -84,15 +85,9 @@ export function SimulateWeekButton({
 }) {
   const router = useRouter();
   const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function run() {
-    if (
-      !window.confirm(
-        `Simulate every unplayed game in Week ${week}? Already-recorded games are left untouched.`,
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulateWeekAction({ leagueId, seasonId, week });
       if (res.ok) {
@@ -102,6 +97,7 @@ export function SimulateWeekButton({
             : `Simulated ${res.simulated} game${res.simulated === 1 ? "" : "s"} in Week ${week}.`,
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
@@ -109,17 +105,28 @@ export function SimulateWeekButton({
   }
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={pending}
-      onClick={run}
-      title={`Fill every unplayed game in Week ${week}`}
-    >
-      <CalendarDays className="mr-1 h-4 w-4" />
-      {pending ? "Simulating…" : "Sim week"}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+        title={`Fill every unplayed game in Week ${week}`}
+      >
+        <CalendarDays className="mr-1 h-4 w-4" />
+        {pending ? "Simulating…" : "Sim week"}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Simulate Week ${week}?`}
+        description={`Simulate every unplayed game in Week ${week}? Already-recorded games are left untouched.`}
+        confirmLabel="Simulate"
+        pending={pending}
+        onConfirm={run}
+      />
+    </>
   );
 }
 
@@ -133,15 +140,17 @@ export function SimulateScopeMenu({
 }) {
   const router = useRouter();
   const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<
+    "regular" | "playoffs" | "champion" | null
+  >(null);
+
+  function openConfirm(action: "regular" | "playoffs" | "champion") {
+    setConfirmAction(action);
+    setConfirmOpen(true);
+  }
 
   function runRegularSeason() {
-    if (
-      !window.confirm(
-        "Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched.",
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulateRegularSeasonAction({ leagueId, seasonId });
       if (res.ok) {
@@ -151,6 +160,7 @@ export function SimulateScopeMenu({
             : `Simulated ${res.simulated} regular-season game${res.simulated === 1 ? "" : "s"}.`,
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
@@ -158,13 +168,6 @@ export function SimulateScopeMenu({
   }
 
   function runPlayoffs() {
-    if (
-      !window.confirm(
-        "Simulate every unplayed playoff game round by round? Already-recorded games are left untouched.",
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulatePlayoffsAction({ leagueId, seasonId });
       if (res.ok) {
@@ -176,6 +179,7 @@ export function SimulateScopeMenu({
               : "No unplayed playoff games to simulate.",
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
@@ -183,13 +187,6 @@ export function SimulateScopeMenu({
   }
 
   function runToChampion() {
-    if (
-      !window.confirm(
-        "Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept.",
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulateSeasonThroughChampionAction({ leagueId, seasonId });
       if (res.ok) {
@@ -209,42 +206,83 @@ export function SimulateScopeMenu({
               : "Nothing left to simulate",
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
     });
   }
 
+  const confirmCopy =
+    confirmAction === "regular"
+      ? {
+          title: "Simulate regular season?",
+          description:
+            "Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched.",
+          onConfirm: runRegularSeason,
+        }
+      : confirmAction === "playoffs"
+        ? {
+            title: "Simulate playoffs?",
+            description:
+              "Simulate every unplayed playoff game round by round? Already-recorded games are left untouched.",
+            onConfirm: runPlayoffs,
+          }
+        : confirmAction === "champion"
+          ? {
+              title: "Simulate to champion?",
+              description:
+                "Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept.",
+              onConfirm: runToChampion,
+            }
+          : null;
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={pending}
-          title="Season simulation scopes"
-        >
-          <Wand2 className="mr-1 h-4 w-4" />
-          {pending ? "Simulating…" : "Simulate"}
-          <ChevronDown className="ml-1 h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuLabel>Simulation scope</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem disabled={pending} onSelect={runRegularSeason}>
-          Sim regular season
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={pending} onSelect={runPlayoffs}>
-          Sim playoffs
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={pending} onSelect={runToChampion}>
-          <Trophy className="h-4 w-4" />
-          Sim to champion
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            title="Season simulation scopes"
+          >
+            <Wand2 className="mr-1 h-4 w-4" />
+            {pending ? "Simulating…" : "Simulate"}
+            <ChevronDown className="ml-1 h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Simulation scope</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("regular")}>
+            Sim regular season
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("playoffs")}>
+            Sim playoffs
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("champion")}>
+            <Trophy className="h-4 w-4" />
+            Sim to champion
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {confirmCopy ? (
+        <ActionConfirmDialog
+          open={confirmOpen}
+          onOpenChange={(open) => {
+            setConfirmOpen(open);
+            if (!open) setConfirmAction(null);
+          }}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          confirmLabel="Simulate"
+          pending={pending}
+          onConfirm={confirmCopy.onConfirm}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -258,15 +296,9 @@ export function SimulateSeasonButton({
 }) {
   const router = useRouter();
   const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function run() {
-    if (
-      !window.confirm(
-        "Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched.",
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulateSeasonAction({ leagueId, seasonId });
       if (res.ok) {
@@ -276,6 +308,7 @@ export function SimulateSeasonButton({
             : `Simulated ${res.simulated} game${res.simulated === 1 ? "" : "s"}.`,
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
@@ -283,17 +316,28 @@ export function SimulateSeasonButton({
   }
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={pending}
-      onClick={run}
-      title="Fill every unplayed regular-season game with a ratings-weighted score"
-    >
-      <Wand2 className="mr-1 h-4 w-4" />
-      {pending ? "Simulating…" : "Simulate season"}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+        title="Fill every unplayed regular-season game with a ratings-weighted score"
+      >
+        <Wand2 className="mr-1 h-4 w-4" />
+        {pending ? "Simulating…" : "Simulate season"}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Simulate regular season?"
+        description="Simulate every unplayed regular-season game? Scores are generated from team ratings. Already-recorded games are left untouched."
+        confirmLabel="Simulate"
+        pending={pending}
+        onConfirm={run}
+      />
+    </>
   );
 }
 
@@ -306,15 +350,9 @@ export function SimulateChampionButton({
 }) {
   const router = useRouter();
   const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function run() {
-    if (
-      !window.confirm(
-        "Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept.",
-      )
-    ) {
-      return;
-    }
     start(async () => {
       const res = await simulateSeasonThroughChampionAction({ leagueId, seasonId });
       if (res.ok) {
@@ -334,6 +372,7 @@ export function SimulateChampionButton({
               : "Nothing left to simulate",
         );
         router.refresh();
+        setConfirmOpen(false);
       } else {
         toast.error(simError(res.error));
       }
@@ -341,17 +380,28 @@ export function SimulateChampionButton({
   }
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={pending}
-      onClick={run}
-      title="Simulate the rest of the season and the playoffs to crown a champion"
-    >
-      <Trophy className="mr-1 h-4 w-4" />
-      {pending ? "Simulating…" : "Sim to champion"}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+        title="Simulate the rest of the season and the playoffs to crown a champion"
+      >
+        <Trophy className="mr-1 h-4 w-4" />
+        {pending ? "Simulating…" : "Sim to champion"}
+      </Button>
+      <ActionConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Simulate to champion?"
+        description="Simulate the rest of the season AND the playoffs to crown a champion? This generates a fresh bracket from the season's playoff settings and fills every remaining game. Already-recorded regular-season games are kept."
+        confirmLabel="Simulate"
+        pending={pending}
+        onConfirm={run}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/components/stats/StatsEntry.tsx
+++ b/apps/web/src/components/stats/StatsEntry.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { ChevronDown, ChevronUp, Check, Plus, Trash2 } from "lucide-react";
 import type { PlayerGameStatLine } from "@sports-management/shared-types";
 import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { abbreviateName, groupPlayersByPosition } from "@/lib/position-group";
@@ -53,6 +54,9 @@ export default function StatsEntry({
     () => new Set(Object.keys(initial)),
   );
   const [extraGroups, setExtraGroups] = useState<Record<string, string[]>>({});
+  const [clearTarget, setClearTarget] = useState<{ id: string; name: string } | null>(
+    null,
+  );
 
   const grouped = useMemo(() => groupPlayersByPosition(players), [players]);
 
@@ -108,8 +112,9 @@ export default function StatsEntry({
     });
   }
 
-  function clear(playerId: string, name: string) {
-    if (!window.confirm(`Clear ${name}'s stats for this game?`)) return;
+  function clear() {
+    if (!clearTarget) return;
+    const { id: playerId, name } = clearTarget;
     setSavingId(playerId);
     startSaving(async () => {
       const res = await clearPlayerGameStatsAction({ teamId, fixtureId, playerId });
@@ -127,6 +132,7 @@ export default function StatsEntry({
         });
         toast.success(`Cleared ${name}`);
         router.refresh();
+        setClearTarget(null);
       } else {
         toast.error(errorLabel(res.error));
       }
@@ -280,7 +286,7 @@ export default function StatsEntry({
                               size="sm"
                               variant="ghost"
                               disabled={isBusy}
-                              onClick={() => clear(p.id, p.name)}
+                              onClick={() => setClearTarget({ id: p.id, name: p.name })}
                               className="text-destructive hover:text-destructive"
                             >
                               <Trash2 className="mr-1 h-4 w-4" /> Clear
@@ -296,6 +302,18 @@ export default function StatsEntry({
           </div>
         </div>
       ))}
+      <ActionConfirmDialog
+        open={clearTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setClearTarget(null);
+        }}
+        title={clearTarget ? `Clear ${clearTarget.name}'s stats?` : "Clear stats?"}
+        description="This removes all entered stats for this game."
+        confirmLabel="Clear"
+        destructive
+        pending={saving}
+        onConfirm={clear}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces every native `window.confirm`/`alert` in the approved Leagues & Seasons lifecycle scope with two new shared, accessible components composed from the app's existing Radix/shadcn primitives:

- **`ActionConfirmDialog`** (`components/lifecycle/`) — composes `ui/alert-dialog` with real `AlertDialogCancel`/`AlertDialogAction` primitives. Keyboard operable, focus trapped and restored, Escape/cancel blocked while pending, duplicate submission impossible (guard holds until dialog close or a `pending` true→false cycle, covering synchronous `onConfirm` wrappers), actionable error copy with retry.
- **`ProcessDialog`** (`components/lifecycle/`) — composes `ui/dialog`. Blocking processing state with an `aria-live` step log of genuine server-reported stages (no fake timers or percentages), dismissal blocked while a mutation is committed, error + retry states. Component is shipped with tests here; call-site wiring lands with WSM-000242/000243 per the epic plan.

### Call sites converted (22 native confirms across 11 files)

- `schedule/`: SimulateControls (6), GenerateScheduleButton (two-step regenerate), DeleteFixtureButton, GoLiveControl, ClipsControl
- `playoffs/`: AdvanceToPlayoffsButton, GeneratePlayoffsButton (two-step regenerate)
- `dynasty/DynastyPanel`, `roster/SyntheticRosterButton`, `stats/StatsEntry`
- `seasons/season-actions.tsx`: complete, force-complete (preserved as an explicit second confirmation step), copy-rosters (`needsConfirm`), delete

Behavior preservation was independently reviewed: identical guard conditions, identical mutation arguments, unchanged success/error/toast handling, and original two-step sequential semantics.

### Intentionally out of scope (not in the WSM-000237 approved list)

`LiveScoreboard.tsx`, `leagues-actions.tsx`, `members/member-list.tsx`, and `division-controls.tsx` still use native dialogs; they are untouched here.

## Testing

- `type-check`, `lint` — clean
- `test:unit` — 155 files, 1074 tests passing (16 new: mocked unit tests plus integration tests against the unmocked Radix primitives covering initial focus, Escape gating while pending, focus restoration, exactly-once double-activation with synchronous `onConfirm`, ProcessDialog dismissal blocking and live-region announcements)
- `rg 'window\.(confirm|alert)'` across scoped lifecycle directories returns no matches

## Related Issue

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
