### PR TITLE
feat(web): enforce season lifecycle invariants (WSM-000238)

### DIFF
--- a/apps/web/convex/__tests__/completeSeason.test.ts
+++ b/apps/web/convex/__tests__/completeSeason.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
-import { internal } from "../_generated/api";
+import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 
 const modules = import.meta.glob("../**/*.*s");
@@ -206,12 +206,127 @@ describe("completed seasons are read-only for game data", () => {
     ).rejects.toThrow("season_completed");
   });
 
-  it("setActiveSeason reactivates a completed season (escape hatch)", async () => {
+  it("rejects fixture update and deletion", async () => {
+    const t = convexTest(schema, modules);
+    const { fixtureId } = await completedSeason(t);
+    await expect(t.mutation(internal.sports.updateFixture, { fixtureId, week: 2 }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.deleteFixture, { fixtureId }))
+      .rejects.toThrow("season_completed");
+  });
+
+  it("rejects game logs and all box-score writes", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId, fixtureId, teamIds } = await completedSeason(t);
+    const playerId = await t.run((ctx) => ctx.db.insert("players", {
+      name: "Player", leagueId, teamId: teamIds[0], position: "QB",
+      positionGroup: null, jerseyNumber: 1, dateOfBirth: null,
+      status: "active", headshotUrl: null,
+    }));
+    await expect(t.mutation(internal.sports.upsertPlayerGameStats, {
+      fixtureId, seasonId, playerId, teamId: teamIds[0],
+      statsJson: "{}", actorUserId: "actor",
+    })).rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.bulkUpsertPlayerGameStats, {
+      fixtureId, seasonId, actorUserId: "actor", lines: [],
+    })).rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.upsertGamePlayLog, {
+      fixtureId, seasonId, logJson: "{}", engineVersion: "test", actorUserId: "actor",
+    })).rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.deletePlayerGameStats, {
+      fixtureId, playerId,
+    })).rejects.toThrow("season_completed");
+  });
+
+  it("rejects every live-score mutation and manual bracket advancement", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, fixtureId } = await completedSeason(t);
+    await expect(t.mutation(internal.sports.startLiveGame, { fixtureId, actorUserId: "actor" }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.addLiveScore, { fixtureId, team: "home", points: 7 }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.setLiveScore, { fixtureId, homeScore: 7, awayScore: 0 }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.updateLiveState, { fixtureId, period: 2 }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.endLiveGame, { fixtureId, actorUserId: "actor" }))
+      .rejects.toThrow("season_completed");
+    await expect(t.mutation(internal.sports.advancePlayoffBracket, { seasonId }))
+      .rejects.toThrow("season_completed");
+  });
+
+  it("blocks go-live creation but preserves historical media annotations", async () => {
+    const t = convexTest(schema, modules);
+    const { fixtureId } = await completedSeason(t);
+    await expect(t.mutation(internal.sports.createGameStream, {
+      fixtureId, provider: "youtube", youtubeVideoId: "video", startedBy: "actor", maxDurationMinutes: 60,
+    })).rejects.toThrow("season_completed");
+
+    const { clipId } = await t.run(async (ctx) => {
+      await ctx.db.insert("gameStreams", {
+        fixtureId, provider: "mux", muxLiveStreamId: "live_1", muxPlaybackId: "pb",
+        youtubeVideoId: null, status: "ended", vodAssetId: null, vodPlaybackId: null,
+        startedBy: "actor", startedAt: "now", endedAt: "now", maxDurationMinutes: 60,
+      });
+      const clipId = await ctx.db.insert("gameClips", {
+        fixtureId, muxAssetId: "clip_1", playbackId: null, label: "Clip",
+        startTime: 0, endTime: 10, status: "preparing", createdBy: "actor", createdAt: "now",
+      });
+      return { clipId };
+    });
+    await expect(t.mutation(internal.sports.updateGameStreamStatus, {
+      muxLiveStreamId: "live_1", status: "ended", vodAssetId: "vod_1",
+    })).resolves.toBe(true);
+    await expect(t.mutation(internal.sports.createGameClip, {
+      fixtureId, muxAssetId: "clip_2", playbackId: null, label: "Archive", startTime: 0,
+      endTime: 10, createdBy: "actor",
+    })).resolves.toMatchObject({ id: expect.any(String) });
+    await expect(t.mutation(internal.sports.deleteGameClip, { clipId, fixtureId }))
+      .resolves.toBe(true);
+  });
+
+  it("preserves archive, Gamecast, and statistics reads after completion", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId, fixtureId, teamIds } = await seedSeason(t);
+    const playerId = await t.run((ctx) => ctx.db.insert("players", {
+      name: "Archive QB", leagueId, teamId: teamIds[0], position: "QB",
+      positionGroup: null, jerseyNumber: 12, dateOfBirth: null,
+      status: "active", headshotUrl: null,
+    }));
+    await t.run(async (ctx) => {
+      await ctx.db.insert("playerGameStats", {
+        fixtureId, seasonId, playerId, teamId: teamIds[0], statsJson: "{\"passingYards\":250}",
+        enteredBy: "actor", updatedAt: "now",
+      });
+      await ctx.db.insert("gamePlayLogs", {
+        fixtureId, seasonId, logJson: "[]", engineVersion: "test",
+        createdAt: "now", createdBy: "actor",
+      });
+      await ctx.db.insert("gameStreams", {
+        fixtureId, provider: "youtube", muxLiveStreamId: "archive-stream",
+        youtubeVideoId: "archive-video", status: "ended", vodAssetId: null,
+        vodPlaybackId: null, startedBy: "actor", startedAt: "now", endedAt: "now",
+        maxDurationMinutes: 60,
+      });
+    });
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+
+    await expect(t.query(api.sports.listFixturesBySeason, { seasonId }))
+      .resolves.toEqual(expect.arrayContaining([expect.objectContaining({ id: fixtureId })]));
+    await expect(t.query(api.sports.getStreamByFixture, { fixtureId }))
+      .resolves.toMatchObject({ youtubeVideoId: "archive-video", status: "ended" });
+    await expect(t.query(api.sports.getGamePlayLog, { fixtureId }))
+      .resolves.toMatchObject({ seasonId, engineVersion: "test" });
+    await expect(t.query(api.sports.getPlayerGameStatsByFixture, { fixtureId }))
+      .resolves.toEqual(expect.arrayContaining([expect.objectContaining({ playerId, seasonId })]));
+  });
+
+  it("rejects completed-season reactivation", async () => {
     const t = convexTest(schema, modules);
     const { seasonId } = await completedSeason(t);
 
-    await t.mutation(internal.sports.setActiveSeason, { seasonId });
-
-    expect(await seasonStatus(t, seasonId)).toBe("active");
+    await expect(t.mutation(internal.sports.setActiveSeason, { seasonId }))
+      .rejects.toThrow("completed_season_cannot_reactivate");
+    expect(await seasonStatus(t, seasonId)).toBe("completed");
   });
 });

--- a/apps/web/convex/__tests__/currentSeasonId.test.ts
+++ b/apps/web/convex/__tests__/currentSeasonId.test.ts
@@ -169,4 +169,37 @@ describe("currentSeasonId fallback (dynasty D1)", () => {
     });
     expect(attrs?.weightedOverall).toBe(77);
   });
+
+  it("prefers an upcoming season over completed history when no season is active", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, upcomingId } = await t.run(async (ctx) => {
+      const leagueId = await ctx.db.insert("leagues", {
+        name: "Dynasty", orgId: "org_1", isPublic: false, inviteToken: null,
+      });
+      await ctx.db.insert("seasons", {
+        name: "2025", leagueId, startDate: "2025-09-01", endDate: null,
+        status: "completed", rosterLocked: false,
+      });
+      const upcomingId = await ctx.db.insert("seasons", {
+        name: "2026", leagueId, startDate: "2026-09-01", endDate: null,
+        status: "upcoming", rosterLocked: false,
+      });
+      return { leagueId, upcomingId };
+    });
+    const teamId = await t.run((ctx) => ctx.db.insert("teams", {
+      name: "T", leagueId, divisionId: null, city: "C", stadium: "S",
+      foundedYear: null, location: "L", logoUrl: null, rosterLimit: 53,
+    }));
+    const playerId = await t.run((ctx) => ctx.db.insert("players", {
+      name: "QB", leagueId, teamId, position: "QB", positionGroup: null,
+      jerseyNumber: 1, dateOfBirth: null, status: "Active", headshotUrl: null,
+    }));
+    await t.run((ctx) => ctx.db.insert("playerAttributes", {
+      playerId, seasonId: upcomingId, positionGroup: "QB",
+      attributesJson: JSON.stringify({ SPD: 88 }), pffSourceJson: null,
+      maddenSourceJson: null, pffWeight: 0, maddenWeight: 1,
+      weightedOverall: 88, ingestedAt: new Date().toISOString(),
+    }));
+    expect((await t.query(api.sports.getPlayerSeasonAttributes, { playerId }))?.weightedOverall).toBe(88);
+  });
 });

--- a/apps/web/convex/__tests__/seasonCrud.test.ts
+++ b/apps/web/convex/__tests__/seasonCrud.test.ts
@@ -103,6 +103,107 @@ describe("season CRUD (WSM-000126)", () => {
     expect(dto?.status).toBe("active");
   });
 
+  it("claims exactly one upcoming rollover target for a completed source", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "completed");
+
+    const first = await t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    });
+    const retry = await t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    });
+
+    expect(first.resumed).toBe(false);
+    expect(retry).toMatchObject({
+      resumed: true,
+      targetSeasonId: first.targetSeasonId,
+    });
+    const target = await t.run((ctx) => ctx.db.get(first.targetSeasonId as Id<"seasons">));
+    expect(target?.status).toBe("upcoming");
+  });
+
+  it("rejects rollover before the source is completed", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "active");
+    await expect(t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    })).rejects.toThrow("rollover_source_not_completed");
+  });
+
+  it("enforces the newest completed source in the mutation", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId: olderId } = await seedLeagueWithSeason(t, "completed");
+    await t.mutation(internal.sports.upsertSeason, {
+      name: "2027",
+      leagueId,
+      startDate: "2027-09-01",
+      endDate: null,
+      status: "completed",
+    });
+
+    await expect(t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: olderId,
+    })).rejects.toThrow("rollover_source_not_newest_completed");
+  });
+
+  it("finalizes an existing claim when its target was completed", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "completed");
+    const claim = await t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    });
+    await t.run((ctx) => ctx.db.patch(claim.targetSeasonId as Id<"seasons">, {
+      status: "completed",
+    }));
+
+    await expect(t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    })).resolves.toMatchObject({ status: "completed", stage: "completed" });
+  });
+
+  it("does not resume an in-progress claim whose target was activated", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "completed");
+    const claim = await t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    });
+    await t.run((ctx) => ctx.db.patch(claim.targetSeasonId as Id<"seasons">, {
+      status: "active",
+    }));
+
+    await expect(t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    })).rejects.toThrow("rollover_target_not_upcoming");
+  });
+
+  it("returns a completed claim after its target was activated", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "completed");
+    const claim = await t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(claim.rolloverId as Id<"seasonRollovers">, {
+        status: "completed",
+        stage: "completed",
+        completedAt: new Date().toISOString(),
+      });
+      await ctx.db.patch(claim.targetSeasonId as Id<"seasons">, {
+        status: "active",
+      });
+    });
+
+    await expect(t.mutation(internal.sports.beginSeasonRollover, {
+      sourceSeasonId: seasonId,
+    })).resolves.toMatchObject({
+      resumed: true,
+      targetSeasonId: claim.targetSeasonId,
+      status: "completed",
+      stage: "completed",
+    });
+  });
+
   it("deleteSeason removes the season and cascades fixtures, results, attributes, and assignments", async () => {
     const t = convexTest(schema, modules);
     const { leagueId, teamIds, seasonId } = await seedLeagueWithSeason(t);

--- a/apps/web/convex/__tests__/seasonLifecycle.test.ts
+++ b/apps/web/convex/__tests__/seasonLifecycle.test.ts
@@ -1,0 +1,38 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { selectLifecycleSeason, selectNewestSeason } from "../lib/seasonLifecycle";
+
+const season = (
+  id: string,
+  status: string,
+  name: string,
+  startDate: string,
+) => ({
+  _id: id as never,
+  _creationTime: 1,
+  status,
+  name,
+  startDate,
+  endDate: null,
+});
+
+describe("season lifecycle selection", () => {
+  it("prefers the newest active season over all upcoming candidates", () => {
+    const olderActive = season("active-1", "active", "2025", "2025-09-01");
+    const newestActive = season("active-2", "active", "2026", "2026-09-01");
+    const upcoming = season("upcoming", "upcoming", "2027", "2027-09-01");
+    expect(selectLifecycleSeason([olderActive, upcoming, newestActive])).toBe(newestActive);
+  });
+
+  it("selects the newest upcoming season deterministically when there is no active season", () => {
+    const earlier = season("upcoming-1", "upcoming", "2026", "2026-09-01");
+    const latest = season("upcoming-2", "upcoming", "2027", "2027-09-01");
+    expect(selectLifecycleSeason([earlier, latest])).toBe(latest);
+  });
+
+  it("selects the newest eligible completed rollover source", () => {
+    const older = season("completed-1", "completed", "2025", "2025-09-01");
+    const latest = season("completed-2", "completed", "2026", "2026-09-01");
+    expect(selectNewestSeason([older, latest])).toBe(latest);
+  });
+});

--- a/apps/web/convex/lib/seasonLifecycle.ts
+++ b/apps/web/convex/lib/seasonLifecycle.ts
@@ -1,0 +1,60 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+type SeasonLike = {
+  _id: Id<"seasons">;
+  status: string;
+  _creationTime: number;
+  name: string;
+  startDate: string | null;
+  endDate: string | null;
+};
+
+function compareNewestSeason<T extends SeasonLike>(a: T, b: T): number {
+  const aDate = a.startDate ?? a.endDate ?? "";
+  const bDate = b.startDate ?? b.endDate ?? "";
+  return (
+    bDate.localeCompare(aDate) ||
+    b.name.localeCompare(a.name) ||
+    String(b._id).localeCompare(String(a._id))
+  );
+}
+
+/** Deterministically choose the newest season from an eligible set. */
+export function selectNewestSeason<T extends SeasonLike>(
+  seasons: readonly T[],
+): T | null {
+  return [...seasons].sort(compareNewestSeason)[0] ?? null;
+}
+
+/** The shared lifecycle fallback: active, newest upcoming, then most recent. */
+export function selectLifecycleSeason<T extends SeasonLike>(
+  seasons: readonly T[],
+): T | null {
+  return selectNewestSeason(seasons.filter((s) => s.status === "active")) ??
+    selectNewestSeason(seasons.filter((s) => s.status === "upcoming")) ??
+    selectNewestSeason(seasons);
+}
+
+type DbCtx = Pick<MutationCtx | QueryCtx, "db">;
+
+/** Central competition-state gate. Historical-media annotations do not use it. */
+export async function assertSeasonWritable(
+  ctx: DbCtx,
+  seasonId: Id<"seasons">,
+) {
+  const season = await ctx.db.get(seasonId);
+  if (!season) throw new Error("season_not_found");
+  if (season.status === "completed") throw new Error("season_completed");
+  return season;
+}
+
+export async function assertFixtureSeasonWritable(
+  ctx: DbCtx,
+  fixtureId: Id<"fixtures">,
+) {
+  const fixture = await ctx.db.get(fixtureId);
+  if (!fixture) throw new Error("fixture_not_found");
+  await assertSeasonWritable(ctx, fixture.seasonId);
+  return fixture;
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -135,6 +135,24 @@ export default defineSchema({
     .index("by_leagueId", ["leagueId"])
     .index("by_leagueId_name", ["leagueId", "name"]),
 
+  // A durable, one-to-one source → target claim lets a rollover retry resume
+  // its original upcoming season instead of creating a duplicate.
+  seasonRollovers: defineTable({
+    leagueId: v.id("leagues"),
+    sourceSeasonId: v.id("seasons"),
+    targetSeasonId: v.id("seasons"),
+    status: v.string(), // "in_progress" | "completed" | "failed"
+    stage: v.string(),
+    graduatedPlayerIds: v.optional(v.array(v.id("players"))),
+    advancedPlayerIds: v.optional(v.array(v.id("players"))),
+    startedAt: v.string(),
+    completedAt: v.optional(v.string()),
+    lastError: v.optional(v.string()),
+  })
+    .index("by_sourceSeasonId", ["sourceSeasonId"])
+    .index("by_targetSeasonId", ["targetSeasonId"])
+    .index("by_leagueId", ["leagueId"]),
+
   depthChartEntries: defineTable({
     teamId: v.id("teams"),
     seasonId: v.id("seasons"),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2219,10 +2219,15 @@ export const advanceSeasonRollover = internalMutationGeneric({
 });
 
 function nextRolloverSeasonName(name: string): string {
-  const match = name.match(/(\d{4})(?!.*\d)/);
-  if (!match || match.index === undefined) return `${name} Next`;
-  const next = String(Number(match[1]) + 1);
-  return `${name.slice(0, match.index)}${next}${name.slice(match.index + 4)}`;
+  const trailing = name.match(/^(.*?)(\d{4})(\D*)$/);
+  if (trailing) {
+    return `${trailing[1]}${Number(trailing[2]) + 1}${trailing[3]}`;
+  }
+  const embedded = name.match(/\d{4}/);
+  if (embedded) {
+    return name.replace(embedded[0], String(Number(embedded[0]) + 1));
+  }
+  return `${name} ${new Date().getFullYear() + 1}`;
 }
 
 /**

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -36,6 +36,12 @@ import {
   targetRosterSize,
 } from "./lib/offseason";
 import { pickRound, teamOnClock } from "./lib/draft";
+import {
+  assertFixtureSeasonWritable,
+  assertSeasonWritable,
+  selectLifecycleSeason,
+  selectNewestSeason,
+} from "./lib/seasonLifecycle";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -1944,6 +1950,9 @@ export const setActiveSeason = internalMutationGeneric({
   handler: async (ctx, args) => {
     const target = await ctx.db.get(args.seasonId);
     if (!target) return null;
+    if (target.status === "completed") {
+      throw new Error("completed_season_cannot_reactivate");
+    }
     const siblings = await ctx.db
       .query("seasons")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", target.leagueId))
@@ -1966,7 +1975,6 @@ export const setActiveSeason = internalMutationGeneric({
  * data: createFixture / generateSeasonSchedule / recordGameResult /
  * generatePlayoffBracket all reject with "season_completed" (which also blocks
  * every simulation path, since sims persist through recordGameResult).
- * Reactivating via setActiveSeason is the escape hatch.
  */
 export const completeSeason = internalMutationGeneric({
   args: { seasonId: v.id("seasons"), force: v.optional(v.boolean()) },
@@ -1997,6 +2005,225 @@ export const completeSeason = internalMutationGeneric({
     return null;
   },
 });
+
+/**
+ * Transactionally claim one completed source season for rollover. The remaining
+ * roster/progression stages intentionally remain separate from completion; a
+ * retry gets this same target and can resume rather than create another season.
+ */
+export const beginSeasonRollover = internalMutationGeneric({
+  args: { sourceSeasonId: v.id("seasons") },
+  returns: v.object({
+    rolloverId: v.string(),
+    targetSeasonId: v.string(),
+    resumed: v.boolean(),
+    stage: v.string(),
+    status: v.string(),
+    graduatedPlayerIds: v.array(v.string()),
+    advancedPlayerIds: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const source = await ctx.db.get(args.sourceSeasonId);
+    if (!source) throw new Error("season_not_found");
+    if (source.status !== "completed") {
+      throw new Error("rollover_source_not_completed");
+    }
+
+    const seasons = await ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", source.leagueId))
+      .collect();
+    const existing = await ctx.db
+      .query("seasonRollovers")
+      .withIndex("by_sourceSeasonId", (q) =>
+        q.eq("sourceSeasonId", args.sourceSeasonId),
+      )
+      .unique();
+    if (existing) {
+      const target = await ctx.db.get(existing.targetSeasonId);
+      if (!target) throw new Error("rollover_target_not_found");
+      if (target.status === "completed" && existing.status !== "completed") {
+        const completedAt = new Date().toISOString();
+        await ctx.db.patch(existing._id, {
+          status: "completed",
+          stage: "completed",
+          completedAt,
+        });
+        return {
+          rolloverId: existing._id,
+          targetSeasonId: existing.targetSeasonId,
+          resumed: true,
+          stage: "completed",
+          status: "completed",
+          graduatedPlayerIds: (existing.graduatedPlayerIds ?? []).map(String),
+          advancedPlayerIds: (existing.advancedPlayerIds ?? []).map(String),
+        };
+      }
+      // A completed rollover remains a successful idempotent result after its
+      // target is activated. An in-progress rollover may only mutate upcoming
+      // targets and must not resume against an active season.
+      if (existing.status === "completed") {
+        return {
+          rolloverId: existing._id,
+          targetSeasonId: existing.targetSeasonId,
+          resumed: true,
+          stage: existing.stage,
+          status: existing.status,
+          graduatedPlayerIds: (existing.graduatedPlayerIds ?? []).map(String),
+          advancedPlayerIds: (existing.advancedPlayerIds ?? []).map(String),
+        };
+      }
+      if (target.status !== "upcoming") {
+        throw new Error("rollover_target_not_upcoming");
+      }
+      return {
+        rolloverId: existing._id,
+        targetSeasonId: existing.targetSeasonId,
+        resumed: true,
+        stage: existing.stage,
+        status: existing.status,
+        graduatedPlayerIds: (existing.graduatedPlayerIds ?? []).map(String),
+        advancedPlayerIds: (existing.advancedPlayerIds ?? []).map(String),
+      };
+    }
+
+    const newestCompleted = selectNewestSeason(
+      seasons.filter((season) => season.status === "completed"),
+    );
+    if (newestCompleted?._id !== source._id) {
+      throw new Error("rollover_source_not_newest_completed");
+    }
+
+    if (seasons.some((season) => season.status === "upcoming")) {
+      throw new Error("next_season_exists");
+    }
+
+    const targetSeasonId = await ctx.db.insert("seasons", {
+      name: nextRolloverSeasonName(source.name),
+      leagueId: source.leagueId,
+      startDate: source.startDate,
+      endDate: source.endDate,
+      status: "upcoming",
+      rosterLocked: false,
+      playoffTeams: source.playoffTeams,
+      playoffFormat: source.playoffFormat,
+      divisionWinnersQualify: source.divisionWinnersQualify,
+    });
+    const startedAt = new Date().toISOString();
+    const rolloverId = await ctx.db.insert("seasonRollovers", {
+      leagueId: source.leagueId,
+      sourceSeasonId: args.sourceSeasonId,
+      targetSeasonId,
+      status: "in_progress",
+      stage: "target_created",
+      startedAt,
+    });
+    return {
+      rolloverId,
+      targetSeasonId,
+      resumed: false,
+      stage: "target_created",
+      status: "in_progress",
+      graduatedPlayerIds: [],
+      advancedPlayerIds: [],
+    };
+  },
+});
+
+const rolloverStageOrder = [
+  "target_created",
+  "players_progressed",
+  "attributes_copied",
+  "rosters_copied",
+  "freshmen_created",
+  "completed",
+] as const;
+
+function rolloverStageIndex(stage: string): number {
+  return rolloverStageOrder.indexOf(stage as (typeof rolloverStageOrder)[number]);
+}
+
+function rolloverResult(rollover: {
+  _id: string;
+  targetSeasonId: string;
+  status: string;
+  stage: string;
+  graduatedPlayerIds?: Id<"players">[];
+  advancedPlayerIds?: Id<"players">[];
+}) {
+  return {
+    rolloverId: rollover._id,
+    targetSeasonId: rollover.targetSeasonId,
+    stage: rollover.stage,
+    status: rollover.status,
+    graduatedPlayerIds: (rollover.graduatedPlayerIds ?? []).map(String),
+    advancedPlayerIds: (rollover.advancedPlayerIds ?? []).map(String),
+  };
+}
+
+/**
+ * Atomically checkpoint a completed rollover stage. A later stage is a no-op,
+ * which makes retries safe after a successful checkpoint response is lost.
+ */
+export const advanceSeasonRollover = internalMutationGeneric({
+  args: {
+    rolloverId: v.id("seasonRollovers"),
+    stage: v.string(),
+  },
+  returns: v.object({
+    rolloverId: v.string(),
+    targetSeasonId: v.string(),
+    stage: v.string(),
+    status: v.string(),
+    graduatedPlayerIds: v.array(v.string()),
+    advancedPlayerIds: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const rollover = await ctx.db.get(args.rolloverId);
+    if (!rollover) throw new Error("rollover_not_found");
+    const target = await ctx.db.get(rollover.targetSeasonId);
+    if (!target) throw new Error("rollover_target_not_found");
+
+    if (target.status === "completed" && rollover.status !== "completed") {
+      const completed = { ...rollover, status: "completed", stage: "completed" };
+      await ctx.db.patch(rollover._id, {
+        status: "completed",
+        stage: "completed",
+        completedAt: new Date().toISOString(),
+      });
+      return rolloverResult(completed);
+    }
+    if (target.status !== "upcoming") {
+      throw new Error("rollover_target_not_upcoming");
+    }
+
+    const current = rolloverStageIndex(rollover.stage);
+    const requested = rolloverStageIndex(args.stage);
+    if (current < 0) throw new Error("invalid_rollover_stage");
+    if (requested < 0) throw new Error("invalid_rollover_stage");
+    if (requested <= current) return rolloverResult(rollover);
+    if (requested !== current + 1) throw new Error("rollover_stage_out_of_order");
+
+    const patch: {
+      stage: string;
+      status?: string;
+      completedAt?: string;
+    } = { stage: args.stage };
+    if (args.stage === "completed") {
+      patch.status = "completed";
+      patch.completedAt = new Date().toISOString();
+    }
+    await ctx.db.patch(rollover._id, patch);
+    return rolloverResult({ ...rollover, ...patch });
+  },
+});
+
+function nextRolloverSeasonName(name: string): string {
+  const match = name.match(/(\d{4})(?!.*\d)/);
+  if (!match || match.index === undefined) return `${name} Next`;
+  const next = String(Number(match[1]) + 1);
+  return `${name.slice(0, match.index)}${next}${name.slice(match.index + 4)}`;
+}
 
 /**
  * Delete a season and cascade its season-scoped rows (WSM-000126, WSM-000209):
@@ -3439,7 +3666,7 @@ export const getSeasonAttributesByPosition = queryGeneric({
  */
 /*
  * The season whose attributes represent a league's "current" SPRT ratings —
- * the active season, else the most recently created. Matches the convention the
+ * the active season, then upcoming, else the most recently created. Matches the convention the
  * dashboard pages used to apply caller-side; centralized here so workspace
  * forks (whose own league has no seasons) resolve against their SOURCE league.
  */
@@ -3451,11 +3678,7 @@ async function currentSeasonId(
     .query("seasons")
     .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
     .collect();
-  const active = seasons.find((s) => s.status === "active");
-  if (active) return active._id;
-  if (seasons.length === 0) return null;
-  const sorted = [...seasons].sort((a, b) => b._creationTime - a._creationTime);
-  return sorted[0]!._id;
+  return selectLifecycleSeason(seasons)?._id ?? null;
 }
 
 /*
@@ -3903,9 +4126,7 @@ export const createFixture = internalMutationGeneric({
       throw new Error("home_and_away_must_differ");
     }
 
-    const season = await ctx.db.get(args.seasonId);
-    if (!season) throw new Error("season_not_found");
-    if (season.status === "completed") throw new Error("season_completed");
+    const season = await assertSeasonWritable(ctx, args.seasonId);
 
     const home = await ctx.db.get(args.homeTeamId);
     const away = await ctx.db.get(args.awayTeamId);
@@ -3960,6 +4181,7 @@ export const updateFixture = internalMutationGeneric({
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.fixtureId);
     if (!existing) return null;
+    await assertSeasonWritable(ctx, existing.seasonId);
 
     const patch: Record<string, unknown> = {};
     if (args.scheduledAt !== undefined) patch.scheduledAt = args.scheduledAt;
@@ -3997,6 +4219,7 @@ export const deleteFixture = internalMutationGeneric({
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.fixtureId);
     if (!existing) return null;
+    await assertSeasonWritable(ctx, existing.seasonId);
 
     // Cascade: drop any gameResults row attached to this fixture so
     // standings computation doesn't keep counting an orphaned result.
@@ -4074,9 +4297,7 @@ export const generateSeasonSchedule = internalMutationGeneric({
     teamCount: v.number(),
   }),
   handler: async (ctx, args) => {
-    const season = await ctx.db.get(args.seasonId);
-    if (!season) throw new Error("season_not_found");
-    if (season.status === "completed") throw new Error("season_completed");
+    const season = await assertSeasonWritable(ctx, args.seasonId);
 
     const teams = await ctx.db
       .query("teams")
@@ -4350,12 +4571,46 @@ export const rolloverGraduateAndAdvancePlayers = internalMutation({
   args: {
     leagueId: v.id("leagues"),
     seasonId: v.id("seasons"),
+    rolloverId: v.optional(v.id("seasonRollovers")),
   },
   returns: v.object({
     graduatedPlayerIds: v.array(v.string()),
     advancedPlayerIds: v.array(v.string()),
   }),
   handler: async (ctx, args) => {
+    let rollover: {
+      _id: Id<"seasonRollovers">;
+      leagueId: Id<"leagues">;
+      sourceSeasonId: Id<"seasons">;
+      targetSeasonId: Id<"seasons">;
+      stage: string;
+      status: string;
+      graduatedPlayerIds?: Id<"players">[];
+      advancedPlayerIds?: Id<"players">[];
+    } | null = null;
+    if (args.rolloverId) {
+      rollover = await ctx.db.get(args.rolloverId);
+      if (!rollover) throw new Error("rollover_not_found");
+      if (rollover.sourceSeasonId !== args.seasonId || rollover.leagueId !== args.leagueId) {
+        throw new Error("rollover_source_mismatch");
+      }
+      const target = await ctx.db.get(rollover.targetSeasonId);
+      if (!target) throw new Error("rollover_target_not_found");
+      if (target.status !== "upcoming") {
+        throw new Error("rollover_target_not_upcoming");
+      }
+      const stage = rolloverStageIndex(rollover.stage);
+      if (stage >= rolloverStageIndex("players_progressed")) {
+        return {
+          graduatedPlayerIds: (rollover.graduatedPlayerIds ?? []).map(String),
+          advancedPlayerIds: (rollover.advancedPlayerIds ?? []).map(String),
+        };
+      }
+      if (stage !== rolloverStageIndex("target_created")) {
+        throw new Error("rollover_stage_out_of_order");
+      }
+    }
+
     const playerIds = await resolveSeasonRosterPlayerIds(
       ctx,
       args.leagueId,
@@ -4392,6 +4647,15 @@ export const rolloverGraduateAndAdvancePlayers = internalMutation({
       advancedPlayerIds.push(playerId as string);
     }
 
+    if (rollover) {
+      // Player progression and its checkpoint commit in this same Convex
+      // transaction, so a retry cannot advance grades or experience twice.
+      await ctx.db.patch(rollover._id, {
+        stage: "players_progressed",
+        graduatedPlayerIds: graduatedPlayerIds as Id<"players">[],
+        advancedPlayerIds: advancedPlayerIds as Id<"players">[],
+      });
+    }
     return { graduatedPlayerIds, advancedPlayerIds };
   },
 });
@@ -4924,13 +5188,9 @@ export const recordGameResult = internalMutationGeneric({
   },
   returns: gameResultDtoValidator,
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
-
-    // Completed seasons are read-only (WSM-000217). This single gate also
-    // blocks all simulation paths, which persist via recordGameResult.
-    const season = await ctx.db.get(fixture.seasonId);
-    if (season?.status === "completed") throw new Error("season_completed");
+    // This blocks manual results and every simulation path, which persists
+    // through this mutation.
+    const fixture = await assertFixtureSeasonWritable(ctx, args.fixtureId);
 
     const recordedAt = new Date().toISOString();
     const payload = {
@@ -5205,8 +5465,8 @@ export const computeStandingsPublic = query({
       .collect();
     if (seasonRows.length === 0) return null;
 
-    const activeSeason =
-      seasonRows.find((s) => s.status === "active") ?? seasonRows[0];
+    const activeSeason = selectLifecycleSeason(seasonRows);
+    if (!activeSeason) return null;
 
     const teamRows = await ctx.db
       .query("teams")
@@ -5303,8 +5563,9 @@ export const createGameStream = internalMutationGeneric({
     status: v.string(),
   }),
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
+    // Starting a stream changes the live competition surface. Provider/VOD
+    // updates and clip annotations below intentionally remain archival writes.
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
 
     const provider = args.provider ?? "mux";
     const payload = {
@@ -5497,6 +5758,8 @@ export const createGameClip = internalMutationGeneric({
   },
   returns: v.object({ id: v.string() }),
   handler: async (ctx, args) => {
+    // Archived clips annotate historical media; unlike go-live creation they
+    // deliberately remain writable after the season has completed.
     const fixture = await ctx.db.get(args.fixtureId);
     if (!fixture) throw new Error("fixture_not_found");
     const id = await ctx.db.insert("gameClips", {
@@ -5645,8 +5908,10 @@ export const upsertPlayerGameStats = internalMutation({
   },
   returns: v.object({ id: v.string() }),
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
+    const fixture = await assertFixtureSeasonWritable(ctx, args.fixtureId);
+    if (fixture.seasonId !== args.seasonId) {
+      throw new Error("fixture_season_mismatch");
+    }
 
     const payload = {
       fixtureId: args.fixtureId,
@@ -5692,8 +5957,10 @@ export const bulkUpsertPlayerGameStats = internalMutation({
   },
   returns: v.object({ upserted: v.number() }),
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
+    const fixture = await assertFixtureSeasonWritable(ctx, args.fixtureId);
+    if (fixture.seasonId !== args.seasonId) {
+      throw new Error("fixture_season_mismatch");
+    }
 
     const updatedAt = new Date().toISOString();
     let upserted = 0;
@@ -5747,8 +6014,10 @@ export const upsertGamePlayLog = internalMutation({
   },
   returns: v.object({ id: v.string() }),
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
+    const fixture = await assertFixtureSeasonWritable(ctx, args.fixtureId);
+    if (fixture.seasonId !== args.seasonId) {
+      throw new Error("fixture_season_mismatch");
+    }
 
     const createdAt = new Date().toISOString();
     const payload = {
@@ -5800,6 +6069,7 @@ export const deletePlayerGameStats = internalMutation({
   args: { fixtureId: v.id("fixtures"), playerId: v.id("players") },
   returns: v.boolean(),
   handler: async (ctx, args) => {
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
     const row = await ctx.db
       .query("playerGameStats")
       .withIndex("by_fixtureId_playerId", (q) =>
@@ -5998,9 +6268,8 @@ export const getSeasonStatLeadersPublic = query({
       .query("seasons")
       .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
       .collect();
-    if (seasonRows.length === 0) return null;
-    const activeSeason =
-      seasonRows.find((s) => s.status === "active") ?? seasonRows[0];
+    const activeSeason = selectLifecycleSeason(seasonRows);
+    if (!activeSeason) return null;
 
     return {
       seasonName: activeSeason.name,
@@ -6077,8 +6346,7 @@ export const startLiveGame = internalMutation({
   args: { fixtureId: v.id("fixtures"), actorUserId: v.string() },
   returns: liveStateDtoValidator,
   handler: async (ctx, args) => {
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
 
     const now = new Date().toISOString();
     const payload = {
@@ -6115,6 +6383,7 @@ export const addLiveScore = internalMutation({
   },
   returns: liveStateDtoValidator,
   handler: async (ctx, args) => {
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
     const row = await ctx.db
       .query("liveGameState")
       .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
@@ -6142,6 +6411,7 @@ export const setLiveScore = internalMutation({
     if (!isNonNegInt(args.homeScore) || !isNonNegInt(args.awayScore)) {
       throw new Error("invalid_score");
     }
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
     const row = await ctx.db
       .query("liveGameState")
       .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
@@ -6172,6 +6442,7 @@ export const updateLiveState = internalMutation({
     if (args.status !== undefined && !isLiveStatus(args.status)) {
       throw new Error("invalid_status");
     }
+    await assertFixtureSeasonWritable(ctx, args.fixtureId);
     const row = await ctx.db
       .query("liveGameState")
       .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
@@ -6195,14 +6466,12 @@ export const endLiveGame = internalMutation({
   args: { fixtureId: v.id("fixtures"), actorUserId: v.string() },
   returns: liveStateDtoValidator,
   handler: async (ctx, args) => {
+    const fixture = await assertFixtureSeasonWritable(ctx, args.fixtureId);
     const row = await ctx.db
       .query("liveGameState")
       .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
       .first();
     if (!row) throw new Error("live_not_started");
-    const fixture = await ctx.db.get(args.fixtureId);
-    if (!fixture) throw new Error("fixture_not_found");
-
     const now = new Date().toISOString();
     // 1) live state → final
     await ctx.db.patch(row._id, { status: "final", updatedAt: now });
@@ -6579,9 +6848,7 @@ export const generatePlayoffBracket = internalMutationGeneric({
     if (!Number.isInteger(teamCount) || teamCount < 2 || teamCount > 64) {
       throw new Error("invalid_bracket_size");
     }
-    const season = await ctx.db.get(args.seasonId);
-    if (!season) throw new Error("season_not_found");
-    if (season.status === "completed") throw new Error("season_completed");
+    const season = await assertSeasonWritable(ctx, args.seasonId);
     const format =
       (args.format ?? season.playoffFormat) === "double" ? "double" : "single";
     // Honor the season's configured qualification rule (overridable per call).
@@ -6765,6 +7032,7 @@ export const advancePlayoffBracket = internalMutationGeneric({
   args: { seasonId: v.id("seasons") },
   returns: v.null(),
   handler: async (ctx, args) => {
+    await assertSeasonWritable(ctx, args.seasonId);
     await advanceBracketForSeason(ctx as MutationCtx, args.seasonId);
     return null;
   },

--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -164,6 +164,13 @@ export async function advanceToPlayoffs(page: Page) {
   await confirmLifecycleDialog(page);
 }
 
+export async function completeSeason(page: Page, seasonId: string) {
+  await page.goto(`/dashboard/seasons/${seasonId}`);
+  await page.getByRole("button", { name: /^Complete / }).click();
+  await confirmLifecycleDialog(page);
+  await expect(page.getByText(/completed\./)).toBeVisible({ timeout: 60_000 });
+}
+
 export async function startNextSeason(page: Page) {
   await page.getByRole("button", { name: "Start next season" }).click();
   await confirmLifecycleDialog(page);

--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -165,8 +165,11 @@ export async function advanceToPlayoffs(page: Page) {
 }
 
 export async function completeSeason(page: Page, seasonId: string) {
-  await page.goto(`/dashboard/seasons/${seasonId}`);
-  await page.getByRole("button", { name: /^Complete / }).click();
+  await page.goto("/dashboard/seasons");
+  const seasonRow = page.locator("li").filter({
+    has: page.locator(`a[href="/dashboard/seasons/${seasonId}"]`),
+  });
+  await seasonRow.getByRole("button", { name: /^Complete / }).click();
   await confirmLifecycleDialog(page);
   await expect(page.getByText(/completed\./)).toBeVisible({ timeout: 60_000 });
 }

--- a/apps/web/e2e/tests/dynasty.spec.ts
+++ b/apps/web/e2e/tests/dynasty.spec.ts
@@ -9,6 +9,7 @@ import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
+  completeSeason,
   simToChampion,
   startNextSeason,
 } from "../helpers/sim-league-setup";
@@ -102,6 +103,11 @@ test.describe("Dynasty panel (dynasty rollover)", () => {
     await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
     await simToChampion(page);
 
+    await page.goto(`/dashboard/leagues/${leagueId}`);
+    await expect(startBtn).toBeDisabled();
+    await expect(page.getByText(/Complete the decided season/)).toBeVisible();
+
+    await completeSeason(page, fixture!.seasonId);
     await page.goto(`/dashboard/leagues/${leagueId}`);
     await expect(startBtn).toBeEnabled();
     await startNextSeason(page);

--- a/apps/web/e2e/tests/offseason-draft.spec.ts
+++ b/apps/web/e2e/tests/offseason-draft.spec.ts
@@ -9,6 +9,7 @@ import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
+  completeSeason,
   simToChampion,
   startNextSeason,
 } from "../helpers/sim-league-setup";
@@ -49,6 +50,7 @@ test.describe("Offseason draft", () => {
     await page.goto(`/dashboard/leagues/${fixture.leagueId}/schedule`);
     await simToChampion(page);
 
+    await completeSeason(page, fixture.seasonId);
     await page.goto(`/dashboard/leagues/${fixture.leagueId}`);
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });

--- a/apps/web/e2e/tests/offseason-free-agency.spec.ts
+++ b/apps/web/e2e/tests/offseason-free-agency.spec.ts
@@ -9,6 +9,7 @@ import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
+  completeSeason,
   simToChampion,
   startNextSeason,
 } from "../helpers/sim-league-setup";
@@ -49,6 +50,7 @@ test.describe("Offseason free agency", () => {
     await page.goto(`/dashboard/leagues/${fixture.leagueId}/schedule`);
     await simToChampion(page);
 
+    await completeSeason(page, fixture.seasonId);
     await page.goto(`/dashboard/leagues/${fixture.leagueId}`);
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -6,9 +6,8 @@ const {
   mockResolveOrgRole,
   mockGetLeagueOrgId,
   mockGetSeasons,
-  mockListFixturesBySeason,
-  mockGetPlayoffBracket,
-  mockUpsertSeason,
+  mockBeginSeasonRollover,
+  mockAdvanceSeasonRollover,
   mockRollover,
   mockListSeasonPlayerAttributes,
   mockGetPlayers,
@@ -24,9 +23,8 @@ const {
   mockResolveOrgRole: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
   mockGetSeasons: vi.fn(),
-  mockListFixturesBySeason: vi.fn(),
-  mockGetPlayoffBracket: vi.fn(),
-  mockUpsertSeason: vi.fn(),
+  mockBeginSeasonRollover: vi.fn(),
+  mockAdvanceSeasonRollover: vi.fn(),
   mockRollover: vi.fn(),
   mockListSeasonPlayerAttributes: vi.fn(),
   mockGetPlayers: vi.fn(),
@@ -46,9 +44,8 @@ vi.mock("@/lib/org-context", () => ({
 vi.mock("@/lib/data-api", () => ({
   getLeagueOrgId: mockGetLeagueOrgId,
   getSeasons: mockGetSeasons,
-  listFixturesBySeason: mockListFixturesBySeason,
-  getPlayoffBracket: mockGetPlayoffBracket,
-  upsertSeason: mockUpsertSeason,
+  beginSeasonRollover: mockBeginSeasonRollover,
+  advanceSeasonRollover: mockAdvanceSeasonRollover,
   rolloverGraduateAndAdvancePlayers: mockRollover,
   listSeasonPlayerAttributes: mockListSeasonPlayerAttributes,
   getPlayers: mockGetPlayers,
@@ -71,7 +68,7 @@ const ACTIVE = {
   leagueId: LEAGUE,
   startDate: "2026-09-01",
   endDate: null,
-  status: "active",
+  status: "completed",
   rosterLocked: false,
   playoffTeams: 8,
   playoffFormat: "single",
@@ -85,28 +82,25 @@ beforeEach(() => {
   mockGetLeagueOrgId.mockResolvedValue(ORG);
   mockResolveOrgRole.mockResolvedValue("admin");
   mockGetSeasons.mockResolvedValue([ACTIVE]);
-  mockListFixturesBySeason.mockResolvedValue([
-    {
-      id: "f1",
-      seasonId: ACTIVE.id,
-      homeTeamId: "h",
-      awayTeamId: "a",
-      homeTeamName: "H",
-      awayTeamName: "A",
-      scheduledAt: null,
-      week: 1,
-      venue: null,
-      status: "final",
-      stage: "regular",
-      createdAt: "",
-      createdBy: "",
-    },
-  ]);
-  mockGetPlayoffBracket.mockResolvedValue(null);
-  mockUpsertSeason.mockResolvedValue({
-    dto: { ...ACTIVE, id: "season_next", name: "2027", status: "upcoming" },
-    created: true,
+  mockBeginSeasonRollover.mockResolvedValue({
+    rolloverId: "rollover_1",
+    targetSeasonId: "season_next",
+    resumed: false,
+    stage: "target_created",
+    status: "in_progress",
+    graduatedPlayerIds: [],
+    advancedPlayerIds: [],
   });
+  mockAdvanceSeasonRollover.mockImplementation(({ stage }: { stage: string }) =>
+    Promise.resolve({
+      rolloverId: "rollover_1",
+      targetSeasonId: "season_next",
+      stage,
+      status: stage === "completed" ? "completed" : "in_progress",
+      graduatedPlayerIds: [],
+      advancedPlayerIds: ["p1"],
+    }),
+  );
   mockRollover.mockResolvedValue({
     graduatedPlayerIds: [],
     advancedPlayerIds: ["p1"],
@@ -168,84 +162,35 @@ beforeEach(() => {
 });
 
 describe("startNextSeasonAction preconditions", () => {
-  it("returns no_season when no active season exists", async () => {
-    mockGetSeasons.mockResolvedValue([
-      { ...ACTIVE, id: "s2", status: "completed" },
-    ]);
+  it("requires a completed source season", async () => {
+    mockGetSeasons.mockResolvedValue([{ ...ACTIVE, status: "active" }]);
     expect(await startNextSeasonAction({ leagueId: LEAGUE })).toEqual({
       ok: false,
-      error: "no_season",
+      error: "no_completed_season",
     });
   });
 
-  it("returns next_season_exists when an upcoming season already exists", async () => {
+  it("surfaces a conflicting upcoming target from the transactional claim", async () => {
     mockGetSeasons.mockResolvedValue([
       ACTIVE,
       { ...ACTIVE, id: "s_up", status: "upcoming", name: "2027" },
     ]);
+    mockBeginSeasonRollover.mockRejectedValueOnce(new Error("next_season_exists"));
     expect(await startNextSeasonAction({ leagueId: LEAGUE })).toEqual({
       ok: false,
       error: "next_season_exists",
     });
   });
 
-  it("returns season_not_decided when fixtures remain and no champion", async () => {
-    mockListFixturesBySeason.mockResolvedValue([
-      {
-        id: "f1",
-        seasonId: ACTIVE.id,
-        homeTeamId: "h",
-        awayTeamId: "a",
-        homeTeamName: "H",
-        awayTeamName: "A",
-        scheduledAt: null,
-        week: 1,
-        venue: null,
-        status: "scheduled",
-        stage: "regular",
-        createdAt: "",
-        createdBy: "",
-      },
+  it("chooses the newest completed source, not a still-active season", async () => {
+    mockGetSeasons.mockResolvedValue([
+      { ...ACTIVE, id: "old", name: "2025", startDate: "2025-09-01" },
+      { ...ACTIVE, id: "newest", name: "2026", startDate: "2026-09-01" },
+      { ...ACTIVE, id: "active", status: "active", startDate: "2027-09-01" },
     ]);
-    expect(await startNextSeasonAction({ leagueId: LEAGUE })).toEqual({
-      ok: false,
-      error: "season_not_decided",
-    });
-  });
-
-  it("returns season_not_decided when bracket exists without a champion", async () => {
-    mockGetPlayoffBracket.mockResolvedValue({
-      bracketId: "b1",
-      size: 4,
-      rounds: 2,
-      format: "single",
-      matchups: [
-        {
-          id: "m1",
-          round: 2,
-          slot: 1,
-          homeSeed: 1,
-          awaySeed: 2,
-          homeTeamId: "h",
-          awayTeamId: "a",
-          homeTeamName: "H",
-          awayTeamName: "A",
-          homeScore: null,
-          awayScore: null,
-          winnerTeamId: null,
-          fixtureId: null,
-          bracketType: "winners",
-          status: null,
-          isBye: false,
-          hasPlayLog: false,
-        },
-      ],
-      champion: null,
-    });
-    mockListFixturesBySeason.mockResolvedValue([]);
-    expect(await startNextSeasonAction({ leagueId: LEAGUE })).toEqual({
-      ok: false,
-      error: "season_not_decided",
+    await startNextSeasonAction({ leagueId: LEAGUE });
+    expect(mockBeginSeasonRollover).toHaveBeenCalledWith({
+      sourceSeasonId: "newest",
     });
   });
 
@@ -266,10 +211,15 @@ describe("startNextSeasonAction success path", () => {
       seasonId: "season_next",
       freshmen: 47,
     });
-    expect(mockUpsertSeason).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "upcoming", name: "2027" }),
-    );
+    expect(mockBeginSeasonRollover).toHaveBeenCalledWith({
+      sourceSeasonId: ACTIVE.id,
+    });
     expect(mockRollover).toHaveBeenCalled();
+    expect(mockRollover).toHaveBeenCalledWith({
+      leagueId: LEAGUE,
+      seasonId: ACTIVE.id,
+      rolloverId: "rollover_1",
+    });
     expect(mockIngestBatch).toHaveBeenCalled();
     expect(mockCopySeasonRosters).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -300,5 +250,48 @@ describe("startNextSeasonAction success path", () => {
       "team_1",
       expect.arrayContaining([expect.objectContaining({ status: "Active" })]),
     );
+  });
+
+  it("resumes after player progression without repeating irreversible work", async () => {
+    mockBeginSeasonRollover.mockResolvedValue({
+      rolloverId: "rollover_1",
+      targetSeasonId: "season_next",
+      resumed: true,
+      stage: "players_progressed",
+      status: "in_progress",
+      graduatedPlayerIds: [],
+      advancedPlayerIds: ["p1"],
+    });
+
+    await startNextSeasonAction({ leagueId: LEAGUE });
+
+    expect(mockRollover).not.toHaveBeenCalled();
+    expect(mockAdvanceSeasonRollover).toHaveBeenCalledWith({
+      rolloverId: "rollover_1",
+      stage: "attributes_copied",
+    });
+  });
+
+  it("returns a finalized claim without reopening a completed target", async () => {
+    mockBeginSeasonRollover.mockResolvedValue({
+      rolloverId: "rollover_1",
+      targetSeasonId: "season_next",
+      resumed: true,
+      stage: "completed",
+      status: "completed",
+      graduatedPlayerIds: ["graduated"],
+      advancedPlayerIds: ["p1"],
+    });
+
+    expect(await startNextSeasonAction({ leagueId: LEAGUE })).toEqual({
+      ok: true,
+      seasonId: "season_next",
+      graduated: 1,
+      advanced: 1,
+      progressed: 0,
+      freshmen: 0,
+    });
+    expect(mockRollover).not.toHaveBeenCalled();
+    expect(mockCopySeasonRosters).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -10,22 +10,18 @@ import {
   getTeamsByLeague,
   getPlayersByTeam,
   getPlayers,
-  upsertSeason,
+  beginSeasonRollover,
+  advanceSeasonRollover,
   rolloverGraduateAndAdvancePlayers,
   listSeasonPlayerAttributes,
   ingestPlayerAttributesBatch,
   copySeasonRosters,
   removePlayersFromSeasonRoster,
   bulkCreatePlayers,
-  listFixturesBySeason,
-  getPlayoffBracket,
 } from "@/lib/data-api";
-import {
-  incrementSeasonName,
-  isSeasonDecided,
-  activeNonGraduatedNames,
-} from "@/lib/dynasty";
+import { activeNonGraduatedNames } from "@/lib/dynasty";
 import { computeProgressedAttributes } from "@/lib/dynasty-progression";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 import {
   generateSyntheticRoster,
   seedFromString,
@@ -35,6 +31,19 @@ import type { PlayerDto } from "@sports-management/shared-types";
 
 const DEFAULT_ROSTER_SIZE = 48;
 const MAX_ROSTER_SIZE = 60;
+const ROLLOVER_STAGES = [
+  "target_created",
+  "players_progressed",
+  "attributes_copied",
+  "rosters_copied",
+  "freshmen_created",
+  "completed",
+] as const;
+
+function hasReachedRolloverStage(stage: string, expected: string): boolean {
+  return ROLLOVER_STAGES.indexOf(stage as (typeof ROLLOVER_STAGES)[number]) >=
+    ROLLOVER_STAGES.indexOf(expected as (typeof ROLLOVER_STAGES)[number]);
+}
 
 type RolloverResult =
   | {
@@ -72,142 +81,171 @@ export async function startNextSeasonAction(input: {
   }
 
   const seasons = await getSeasons([input.leagueId]).catch(() => []);
-  const activeSeason = seasons.find((s) => s.status === "active");
-  if (!activeSeason) return { ok: false, error: "no_season" };
-
-  if (seasons.some((s) => s.status === "upcoming")) {
-    return { ok: false, error: "next_season_exists" };
-  }
-
-  const [fixtures, bracket] = await Promise.all([
-    listFixturesBySeason(activeSeason.id).catch(() => []),
-    getPlayoffBracket(activeSeason.id).catch(() => null),
-  ]);
-  if (!isSeasonDecided(fixtures, bracket)) {
-    return { ok: false, error: "season_not_decided" };
-  }
-
-  const nextName = incrementSeasonName(activeSeason.name);
+  const activeSeason = resolveLifecycleSeason(
+    seasons.filter((season) => season.status === "completed"),
+  );
+  if (!activeSeason) return { ok: false, error: "no_completed_season" };
 
   try {
-    const { dto: nextSeason } = await upsertSeason({
-      name: nextName,
-      leagueId: input.leagueId,
-      startDate: activeSeason.startDate,
-      endDate: activeSeason.endDate,
-      status: "upcoming",
-      playoffTeams: activeSeason.playoffTeams ?? undefined,
-      playoffFormat: activeSeason.playoffFormat ?? undefined,
-      divisionWinnersQualify: activeSeason.divisionWinnersQualify,
+    const rollover = await beginSeasonRollover({
+      sourceSeasonId: activeSeason.id,
     });
+    const nextSeasonId = rollover.targetSeasonId;
+    let stage = rollover.stage;
+    let graduatedPlayerIds = rollover.graduatedPlayerIds;
+    let advancedPlayerIds = rollover.advancedPlayerIds;
 
-    const { graduatedPlayerIds, advancedPlayerIds } =
-      await rolloverGraduateAndAdvancePlayers({
+    // A target that was completed outside this action atomically finalizes its
+    // claim in beginSeasonRollover. Never reopen its progression on retry.
+    if (rollover.status === "completed" || stage === "completed") {
+      return {
+        ok: true,
+        seasonId: nextSeasonId,
+        graduated: graduatedPlayerIds.length,
+        advanced: advancedPlayerIds.length,
+        progressed: 0,
+        freshmen: 0,
+      };
+    }
+
+    if (!hasReachedRolloverStage(stage, "players_progressed")) {
+      const progressedPlayers = await rolloverGraduateAndAdvancePlayers({
         leagueId: input.leagueId,
         seasonId: activeSeason.id,
+        rolloverId: rollover.rolloverId,
       });
-
-    const priorAttributes = await listSeasonPlayerAttributes(activeSeason.id);
-    const attrByPlayer = new Map(priorAttributes.map((r) => [r.playerId, r]));
-    const leaguePlayers = await getPlayers([input.leagueId]).catch(() => []);
-    const playerById = new Map(leaguePlayers.map((p) => [p.id, p]));
-
-    const progressionRows: {
-      playerId: string;
-      positionGroup: string;
-      attributesJson: string;
-      weightedOverall: number | null;
-    }[] = [];
-
-    for (const playerId of advancedPlayerIds) {
-      const player = playerById.get(playerId);
-      if (!player) continue;
-      const prior = attrByPlayer.get(playerId);
-      const previousGrade =
-        player.grade !== null ? Math.max(9, player.grade - 1) : null;
-
-      const snapshot = prior
-        ? computeProgressedAttributes({
-            playerId,
-            newSeasonId: nextSeason.id,
-            position: player.position,
-            previousGrade,
-            previousAttributes: prior.attributes,
-            positionGroup: prior.positionGroup,
-          })
-        : generateSyntheticAttributes({
-            position: player.position,
-            seed: seedFromString(`${playerId}:${nextSeason.id}`),
-          });
-
-      progressionRows.push({
-        playerId,
-        positionGroup: snapshot.positionGroup,
-        attributesJson: JSON.stringify(snapshot.attributes),
-        weightedOverall: snapshot.weightedOverall,
-      });
+      graduatedPlayerIds = progressedPlayers.graduatedPlayerIds;
+      advancedPlayerIds = progressedPlayers.advancedPlayerIds;
+      stage = "players_progressed";
     }
+
+    const leaguePlayers = await getPlayers([input.leagueId]).catch(() => []);
 
     let progressed = 0;
-    if (progressionRows.length > 0) {
-      const res = await ingestPlayerAttributesBatch(nextSeason.id, progressionRows);
-      progressed = res.created + res.updated;
-    }
+    if (!hasReachedRolloverStage(stage, "attributes_copied")) {
+      const priorAttributes = await listSeasonPlayerAttributes(activeSeason.id);
+      const attrByPlayer = new Map(priorAttributes.map((r) => [r.playerId, r]));
+      const playerById = new Map(leaguePlayers.map((p) => [p.id, p]));
+      const progressionRows: {
+        playerId: string;
+        positionGroup: string;
+        attributesJson: string;
+        weightedOverall: number | null;
+      }[] = [];
 
-    await copySeasonRosters({
-      targetSeasonId: nextSeason.id,
-      sourceSeasonId: activeSeason.id,
-      actorUserId: userId,
-      confirm: true,
-    });
+      for (const playerId of advancedPlayerIds) {
+        const player = playerById.get(playerId);
+        if (!player) continue;
+        const prior = attrByPlayer.get(playerId);
+        const previousGrade =
+          player.grade !== null ? Math.max(9, player.grade - 1) : null;
 
-    if (graduatedPlayerIds.length > 0) {
-      await removePlayersFromSeasonRoster({
-        leagueId: input.leagueId,
-        seasonId: nextSeason.id,
-        playerIds: graduatedPlayerIds,
+        const snapshot = prior
+          ? computeProgressedAttributes({
+              playerId,
+              newSeasonId: nextSeasonId,
+              position: player.position,
+              previousGrade,
+              previousAttributes: prior.attributes,
+              positionGroup: prior.positionGroup,
+            })
+          : generateSyntheticAttributes({
+              position: player.position,
+              seed: seedFromString(`${playerId}:${nextSeasonId}`),
+            });
+
+        progressionRows.push({
+          playerId,
+          positionGroup: snapshot.positionGroup,
+          attributesJson: JSON.stringify(snapshot.attributes),
+          weightedOverall: snapshot.weightedOverall,
+        });
+      }
+
+      if (progressionRows.length > 0) {
+        const res = await ingestPlayerAttributesBatch(nextSeasonId, progressionRows);
+        progressed = res.created + res.updated;
+      }
+      const checkpoint = await advanceSeasonRollover({
+        rolloverId: rollover.rolloverId,
+        stage: "attributes_copied",
       });
+      stage = checkpoint.stage;
     }
 
-    const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(
-      () => [],
-    );
-    const excludeNames = activeNonGraduatedNames(leaguePlayers);
-    const usedNames = new Set(excludeNames);
-    const target = Math.max(
-      1,
-      Math.min(DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE),
-    );
-    let freshmen = 0;
+    if (!hasReachedRolloverStage(stage, "rosters_copied")) {
+      await copySeasonRosters({
+        targetSeasonId: nextSeasonId,
+        sourceSeasonId: activeSeason.id,
+        actorUserId: userId,
+        confirm: true,
+      });
 
-    for (const team of teams) {
-      const existing = await getPlayersByTeam(team.id, orgContext).catch(
+      if (graduatedPlayerIds.length > 0) {
+        await removePlayersFromSeasonRoster({
+          leagueId: input.leagueId,
+          seasonId: nextSeasonId,
+          playerIds: graduatedPlayerIds,
+        });
+      }
+      const checkpoint = await advanceSeasonRollover({
+        rolloverId: rollover.rolloverId,
+        stage: "rosters_copied",
+      });
+      stage = checkpoint.stage;
+    }
+
+    let freshmen = 0;
+    if (!hasReachedRolloverStage(stage, "freshmen_created")) {
+      const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(
         () => [],
       );
-      const toCreate = Math.max(0, target - activeRosterCount(existing));
-      if (toCreate === 0) continue;
+      const excludeNames = activeNonGraduatedNames(leaguePlayers);
+      const usedNames = new Set(excludeNames);
+      const target = Math.max(
+        1,
+        Math.min(DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE),
+      );
 
-      const batch = generateSyntheticRoster({
-        count: toCreate,
-        grade: 9,
-        excludeJerseys: existingJerseys(existing),
-        excludeNames: Array.from(usedNames),
-        seed: seedFromString(`${team.id}:${nextSeason.id}`),
+      for (const team of teams) {
+        const existing = await getPlayersByTeam(team.id, orgContext).catch(
+          () => [],
+        );
+        const toCreate = Math.max(0, target - activeRosterCount(existing));
+        if (toCreate === 0) continue;
+
+        const batch = generateSyntheticRoster({
+          count: toCreate,
+          grade: 9,
+          excludeJerseys: existingJerseys(existing),
+          excludeNames: Array.from(usedNames),
+          seed: seedFromString(`${team.id}:${nextSeasonId}`),
+        });
+        const players = input.freshmenToPool
+          ? batch.map((p) => ({ ...p, status: "free_agent" }))
+          : batch;
+        for (const p of players) usedNames.add(p.name);
+        const { created } = await bulkCreatePlayers(team.id, players);
+        freshmen += created;
+      }
+      const checkpoint = await advanceSeasonRollover({
+        rolloverId: rollover.rolloverId,
+        stage: "freshmen_created",
       });
-      const players = input.freshmenToPool
-        ? batch.map((p) => ({ ...p, status: "free_agent" }))
-        : batch;
-      for (const p of players) usedNames.add(p.name);
-      const { created } = await bulkCreatePlayers(team.id, players);
-      freshmen += created;
+      stage = checkpoint.stage;
     }
+
+    await advanceSeasonRollover({
+      rolloverId: rollover.rolloverId,
+      stage: "completed",
+    });
 
     revalidatePath(`/dashboard/leagues/${input.leagueId}`);
     revalidatePath("/dashboard/seasons");
 
     return {
       ok: true,
-      seasonId: nextSeason.id,
+      seasonId: nextSeasonId,
       graduated: graduatedPlayerIds.length,
       advanced: advancedPlayerIds.length,
       progressed,

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/synthetic-roster";
 import { generateSyntheticAttributes } from "@/lib/synthetic-attributes";
 import { isSeasonStarted } from "@/lib/season-started";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 
 /*
  * Synthetic-roster generation (WSM-000173) — fills demo/test rosters with fake
@@ -56,8 +57,7 @@ function existingJerseys(players: { jerseyNumber: number | null }[]): number[] {
 async function resolveActiveSeasonId(leagueId: string): Promise<string | null> {
   const seasons = await getSeasons([leagueId]).catch(() => []);
   if (seasons.length === 0) return null;
-  const active = seasons.find((s) => s.status === "active") ?? seasons[0];
-  return active.id;
+  return resolveLifecycleSeason(seasons)?.id ?? null;
 }
 
 /** Block roster/ratings generation once the active season has started. */
@@ -66,7 +66,8 @@ async function assertSeasonNotStarted(
 ): Promise<{ ok: true } | { ok: false; error: "season_started" }> {
   const seasons = await getSeasons([leagueId]).catch(() => []);
   if (seasons.length === 0) return { ok: true };
-  const active = seasons.find((s) => s.status === "active") ?? seasons[0];
+  const active = resolveLifecycleSeason(seasons);
+  if (!active) return { ok: true };
   const fixtures = await listFixturesBySeason(active.id).catch(() => []);
   if (isSeasonStarted(active, fixtures)) {
     return { ok: false, error: "season_started" };

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/dynasty-panel";
 import { DynastyPanel } from "@/components/dynasty/DynastyPanel";
 import { isSeasonStarted } from "@/lib/season-started";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 import { resolveOrgContext, requireOrgAdmin } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -68,6 +69,9 @@ export default async function LeagueDetailPage({
   const seasons = await getSeasons([id]).catch(() => []);
   const activeSeason = seasons.find((s) => s.status === "active") ?? null;
   const upcomingSeason = seasons.find((s) => s.status === "upcoming") ?? null;
+  const completedSeason = resolveLifecycleSeason(
+    seasons.filter((s) => s.status === "completed"),
+  );
   const [fixtures, bracket, leaguePlayers, teams] = await Promise.all([
     activeSeason
       ? listFixturesBySeason(activeSeason.id).catch(() => [])
@@ -117,6 +121,9 @@ export default async function LeagueDetailPage({
   const startNextSeasonGate = evaluateStartNextSeason({
     activeSeason: activeSeason
       ? { id: activeSeason.id, name: activeSeason.name }
+      : null,
+    completedSeason: completedSeason
+      ? { id: completedSeason.id, name: completedSeason.name }
       : null,
     upcomingSeason: upcomingSeason
       ? { id: upcomingSeason.id, name: upcomingSeason.name }

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
@@ -96,6 +96,18 @@ describe("generatePlayoffsAction (WSM-000164)", () => {
     expect(res).toEqual({ ok: false, needsConfirm: true });
   });
 
+  it("propagates a completed-season rejection as the stable typed result", async () => {
+    authorize();
+    mockGeneratePlayoffBracket.mockRejectedValue(
+      new Error("Uncaught Error: season_completed"),
+    );
+    await expect(generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 4,
+    })).resolves.toEqual({ ok: false, error: "season_completed" });
+  });
+
   it("passes confirm through", async () => {
     authorize();
     mockGeneratePlayoffBracket.mockResolvedValue({

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 
 /*
  * Auth chain for playoff actions (mirrors the schedule manager gate):
@@ -52,6 +53,9 @@ function friendlyError(code: string): string {
   }
   if (code.includes("season_not_found")) {
     return "This season no longer exists.";
+  }
+  if (code.includes("season_completed")) {
+    return "season_completed";
   }
   return "Could not generate the bracket.";
 }
@@ -124,8 +128,7 @@ export async function advanceToPlayoffsAction(input: {
   if (!userId) return { ok: false, error: "unauthorized" };
 
   const allSeasons = await getSeasons([input.leagueId]);
-  const activeSeason =
-    allSeasons.find((s) => s.status === "active") ?? allSeasons[0] ?? null;
+  const activeSeason = resolveLifecycleSeason(allSeasons);
   if (!activeSeason) return { ok: false, error: "no_season" };
 
   const existing = await getPlayoffBracket(activeSeason.id).catch(() => null);

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/clip-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/clip-actions.test.ts
@@ -64,7 +64,11 @@ function happyFixture() {
     awayTeamName: "Away",
     status: "final",
   });
-  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
+  mockGetPublicSeason.mockResolvedValue({
+    id: "season_1",
+    leagueId: LEAGUE,
+    status: "completed",
+  });
   mockCanAdministerTeam.mockResolvedValue(true);
   mockGetStreamByFixture.mockResolvedValue({
     status: "ended",

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/generate-schedule-action.test.ts
@@ -103,6 +103,18 @@ describe("generateScheduleAction (WSM-000153)", () => {
     expect(res).toEqual({ ok: false, needsConfirm: true });
   });
 
+  it("propagates a completed-season rejection as the stable typed result", async () => {
+    authorize();
+    mockGenerateSeasonSchedule.mockRejectedValue(
+      new Error("Uncaught Error: season_completed"),
+    );
+
+    await expect(generateScheduleAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    })).resolves.toEqual({ ok: false, error: "season_completed" });
+  });
+
   it("passes confirm through to the mutation", async () => {
     authorize();
     mockGenerateSeasonSchedule.mockResolvedValue({

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/stream-actions.test.ts
@@ -78,7 +78,11 @@ function happyFixture() {
     awayTeamName: "Away",
     status: "scheduled",
   });
-  mockGetPublicSeason.mockResolvedValue({ id: "season_1", leagueId: LEAGUE });
+  mockGetPublicSeason.mockResolvedValue({
+    id: "season_1",
+    leagueId: LEAGUE,
+    status: "active",
+  });
 }
 
 describe("startGameStream", () => {
@@ -114,6 +118,19 @@ describe("startGameStream", () => {
       ok: false,
       error: "unauthorized",
     });
+  });
+
+  it("blocks operator go-live creation for a completed season", async () => {
+    mockGetPublicSeason.mockResolvedValue({
+      id: "season_1",
+      leagueId: LEAGUE,
+      status: "completed",
+    });
+    expect(await startGameStream(LEAGUE, FIXTURE)).toEqual({
+      ok: false,
+      error: "season_completed",
+    });
+    expect(mockCreateMuxLiveStream).not.toHaveBeenCalled();
   });
 
   it("404s a fixture from another league (cross-league guard)", async () => {

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -99,6 +99,9 @@ export async function createFixtureAction(
     return { ok: true, id: fixture.id };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("season_completed")) {
+      return { ok: false, error: "season_completed" };
+    }
     return { ok: false, error: message };
   }
 }
@@ -140,6 +143,9 @@ export async function generateScheduleAction(input: {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes("schedule_has_results")) {
       return { ok: false, needsConfirm: true };
+    }
+    if (message.includes("season_completed")) {
+      return { ok: false, error: "season_completed" };
     }
     return { ok: false, error: message };
   }
@@ -189,6 +195,9 @@ export async function recordGameResultAction(
     return { ok: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("season_completed")) {
+      return { ok: false, error: "season_completed" };
+    }
     return { ok: false, error: message };
   }
 }

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-actions.ts
@@ -44,6 +44,9 @@ export async function startGameStream(
 ): Promise<StartResult> {
   const guard = await authorizeStreamAction(leagueId, fixtureId);
   if (!guard.ok) return guard;
+  if (guard.seasonStatus === "completed") {
+    return { ok: false, error: "season_completed" };
+  }
   // A finished/cancelled game can't go live.
   if (guard.fixtureStatus === "final" || guard.fixtureStatus === "cancelled") {
     return { ok: false, error: "game_over" };
@@ -100,6 +103,9 @@ export async function startYoutubeStream(
 ): Promise<StopResult> {
   const guard = await authorizeStreamAction(leagueId, fixtureId);
   if (!guard.ok) return guard;
+  if (guard.seasonStatus === "completed") {
+    return { ok: false, error: "season_completed" };
+  }
   // A finished/cancelled game can't go live.
   if (guard.fixtureStatus === "final" || guard.fixtureStatus === "cancelled") {
     return { ok: false, error: "game_over" };

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-auth.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/stream-auth.ts
@@ -17,7 +17,12 @@ export async function authorizeStreamAction(
   leagueId: string,
   fixtureId: string,
 ): Promise<
-  | { ok: true; userId: string; fixtureStatus: string }
+  | {
+      ok: true;
+      userId: string;
+      fixtureStatus: string;
+      seasonStatus: string;
+    }
   | { ok: false; error: string }
 > {
   const enabled = await liveStreamingV1();
@@ -41,5 +46,10 @@ export async function authorizeStreamAction(
   ]);
   if (!canHome && !canAway) return { ok: false, error: "not_authorized" };
 
-  return { ok: true, userId, fixtureStatus: fixture.status };
+  return {
+    ok: true,
+    userId,
+    fixtureStatus: fixture.status,
+    seasonStatus: season.status,
+  };
 }

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/dynasty-panel";
 import { DynastyPanel } from "@/components/dynasty/DynastyPanel";
 import { regularSeasonProgress } from "@/lib/playoffs";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 import { formatDate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatusBadge } from "@/components/status-badge";
@@ -75,6 +76,9 @@ export default async function SeasonHubPage({
   const seasons = await getSeasons([league.id]).catch(() => []);
   const activeSeason = seasons.find((s) => s.status === "active") ?? null;
   const upcomingSeason = seasons.find((s) => s.status === "upcoming") ?? null;
+  const completedSeason = resolveLifecycleSeason(
+    seasons.filter((s) => s.status === "completed"),
+  );
 
   const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
     await Promise.all([
@@ -126,6 +130,9 @@ export default async function SeasonHubPage({
   const startNextSeasonGate = evaluateStartNextSeason({
     activeSeason: activeSeason
       ? { id: activeSeason.id, name: activeSeason.name }
+      : null,
+    completedSeason: completedSeason
+      ? { id: completedSeason.id, name: completedSeason.name }
       : null,
     upcomingSeason: upcomingSeason
       ? { id: upcomingSeason.id, name: upcomingSeason.name }

--- a/apps/web/src/app/dashboard/seasons/__tests__/copy-rosters-action.test.ts
+++ b/apps/web/src/app/dashboard/seasons/__tests__/copy-rosters-action.test.ts
@@ -6,12 +6,14 @@ const {
   mockGetLeagueOrgId,
   mockGetUserRoleInOrg,
   mockCopySeasonRosters,
+  mockSetActiveSeason,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockGetSeasonLeagueId: vi.fn(),
   mockGetLeagueOrgId: vi.fn(),
   mockGetUserRoleInOrg: vi.fn(),
   mockCopySeasonRosters: vi.fn(),
+  mockSetActiveSeason: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
@@ -22,7 +24,7 @@ vi.mock("@/lib/data-api", () => ({
   // Imported by the module under test but unused by this action.
   upsertSeason: vi.fn(),
   updateSeason: vi.fn(),
-  setActiveSeason: vi.fn(),
+  setActiveSeason: mockSetActiveSeason,
   deleteSeason: vi.fn(),
   getSeasons: vi.fn(),
 }));
@@ -31,7 +33,7 @@ vi.mock("@/lib/org-context", () => ({
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-import { copyRostersAction } from "../actions";
+import { activateSeasonAction, copyRostersAction } from "../actions";
 
 const LEAGUE = "league_1";
 const SEASON = "season_1";
@@ -130,5 +132,23 @@ describe("copyRostersAction (WSM-000163)", () => {
 
     expect(res).toEqual({ ok: false, error: "unauthorized" });
     expect(mockCopySeasonRosters).not.toHaveBeenCalled();
+  });
+});
+
+describe("activateSeasonAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps completed-season reactivation to a stable typed result", async () => {
+    authorize();
+    mockSetActiveSeason.mockRejectedValue(
+      new Error("Uncaught Error: completed_season_cannot_reactivate"),
+    );
+
+    await expect(activateSeasonAction(SEASON)).resolves.toEqual({
+      ok: false,
+      error: "completed_season_cannot_reactivate",
+    });
   });
 });

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -111,9 +111,17 @@ export async function activateSeasonAction(seasonId: string): Promise<Result> {
   const leagueId = await getSeasonLeagueId(seasonId);
   const gate = await requireLeagueAdmin(leagueId);
   if (!gate.ok) return gate;
-  await setActiveSeasonMutation(seasonId);
-  revalidatePath("/dashboard/seasons");
-  return { ok: true };
+  try {
+    await setActiveSeasonMutation(seasonId);
+    revalidatePath("/dashboard/seasons");
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("completed_season_cannot_reactivate")) {
+      return { ok: false, error: "completed_season_cannot_reactivate" };
+    }
+    return { ok: false, error: message };
+  }
 }
 
 /*

--- a/apps/web/src/lib/__tests__/dynasty-panel.test.ts
+++ b/apps/web/src/lib/__tests__/dynasty-panel.test.ts
@@ -108,6 +108,7 @@ describe("evaluateStartNextSeason", () => {
     expect(
       evaluateStartNextSeason({
         activeSeason: null,
+        completedSeason: null,
         upcomingSeason: null,
         seasonDecided: false,
         unplayedGames: 0,
@@ -118,6 +119,7 @@ describe("evaluateStartNextSeason", () => {
     expect(
       evaluateStartNextSeason({
         activeSeason: active,
+        completedSeason: null,
         upcomingSeason: { id: "s2", name: "2027" },
         seasonDecided: true,
         unplayedGames: 0,
@@ -128,6 +130,7 @@ describe("evaluateStartNextSeason", () => {
     expect(
       evaluateStartNextSeason({
         activeSeason: active,
+        completedSeason: null,
         upcomingSeason: null,
         seasonDecided: false,
         unplayedGames: 2,
@@ -137,14 +140,26 @@ describe("evaluateStartNextSeason", () => {
       canStart: false,
       message: "2 games unplayed.",
     });
-  });
 
-  it("allows start when the active season is decided and no upcoming season", () => {
     expect(
       evaluateStartNextSeason({
         activeSeason: active,
+        completedSeason: null,
         upcomingSeason: null,
         seasonDecided: true,
+        unplayedGames: 0,
+        playoffsUndecided: false,
+      }).errorCode,
+    ).toBe("no_completed_season");
+  });
+
+  it("allows start from a completed source when no upcoming season exists", () => {
+    expect(
+      evaluateStartNextSeason({
+        activeSeason: null,
+        completedSeason: active,
+        upcomingSeason: null,
+        seasonDecided: false,
         unplayedGames: 0,
         playoffsUndecided: false,
       }),

--- a/apps/web/src/lib/__tests__/dynasty-panel.test.ts
+++ b/apps/web/src/lib/__tests__/dynasty-panel.test.ts
@@ -53,6 +53,18 @@ describe("dynastySeasonState", () => {
       status: "offseason_upcoming",
       statusLabel: "Offseason · upcoming 2027",
     });
+
+    expect(
+      dynastySeasonState({
+        activeSeason: null,
+        upcomingSeason: { name: "2027" },
+        seasonDecided: false,
+      }),
+    ).toMatchObject({
+      seasonName: "2027",
+      status: "offseason_upcoming",
+      statusLabel: "Offseason · upcoming 2027",
+    });
   });
 });
 

--- a/apps/web/src/lib/__tests__/season-view.test.ts
+++ b/apps/web/src/lib/__tests__/season-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SeasonDto } from "@sports-management/shared-types";
-import { resolveViewedSeason } from "../season-view";
+import { resolveLifecycleSeason, resolveViewedSeason } from "../season-view";
 
 function season(id: string, status: string): SeasonDto {
   return {
@@ -17,7 +17,7 @@ function season(id: string, status: string): SeasonDto {
   };
 }
 
-const finished = season("s1", "upcoming");
+const finished = season("s1", "completed");
 const active = season("s2", "active");
 const older = season("s3", "upcoming");
 
@@ -34,8 +34,26 @@ describe("resolveViewedSeason", () => {
     expect(resolveViewedSeason([finished, active], undefined)).toBe(active);
   });
 
-  it("falls back to the first season when none is active", () => {
-    expect(resolveViewedSeason([finished, older], undefined)).toBe(finished);
+  it("falls back to an upcoming season when none is active", () => {
+    expect(resolveViewedSeason([finished, older], undefined)).toBe(older);
+  });
+
+  it("chooses the newest upcoming season when lifecycle data conflicts", () => {
+    const earlier = { ...older, id: "s-up-1", name: "2026", startDate: "2026-09-01" };
+    const latest = { ...older, id: "s-up-2", name: "2027", startDate: "2027-09-01" };
+    expect(resolveLifecycleSeason([finished, earlier, latest])).toBe(latest);
+  });
+
+  it("resolves an active conflict deterministically before upcoming seasons", () => {
+    const olderActive = { ...active, id: "s-active-1", name: "2025", startDate: "2025-09-01" };
+    const latestActive = { ...active, id: "s-active-2", name: "2026", startDate: "2026-09-01" };
+    expect(resolveLifecycleSeason([olderActive, older, latestActive])).toBe(latestActive);
+  });
+
+  it("falls back to the most recent historical season when neither is current", () => {
+    const old = { ...finished, name: "2024", startDate: "2024-09-01" };
+    const recent = { ...finished, id: "s4", name: "2026", startDate: "2026-09-01" };
+    expect(resolveViewedSeason([old, recent], undefined)).toBe(recent);
   });
 
   it("returns null for a league with no seasons", () => {

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -23,6 +23,7 @@ import type {
   UpdatePlayerInput,
   UpdateTeamInput,
 } from "@sports-management/shared-types";
+import { resolveLifecycleSeason } from "@/lib/season-view";
 import type { LeagueImportPayload } from "@sports-management/api-contracts";
 import { getConvexClient } from "./convex-client";
 import type { OrgContext } from "./org-context";
@@ -342,6 +343,29 @@ const refs = {
   completeSeason: mutationRef<{ seasonId: string; force?: boolean }, null>(
     "sports:completeSeason",
   ),
+  beginSeasonRollover: mutationRef<
+    { sourceSeasonId: string },
+    {
+      rolloverId: string;
+      targetSeasonId: string;
+      resumed: boolean;
+      stage: string;
+      status: string;
+      graduatedPlayerIds: string[];
+      advancedPlayerIds: string[];
+    }
+  >("sports:beginSeasonRollover"),
+  advanceSeasonRollover: mutationRef<
+    { rolloverId: string; stage: string },
+    {
+      rolloverId: string;
+      targetSeasonId: string;
+      stage: string;
+      status: string;
+      graduatedPlayerIds: string[];
+      advancedPlayerIds: string[];
+    }
+  >("sports:advanceSeasonRollover"),
   deleteSeason: mutationRef<{ seasonId: string }, null>("sports:deleteSeason"),
   setLeagueInviteToken: mutationRef<
     { leagueId: string; token: string | null },
@@ -588,7 +612,7 @@ const refs = {
     }
   >("sports:copySeasonRosters"),
   rolloverGraduateAndAdvancePlayers: mutationRef<
-    { leagueId: string; seasonId: string },
+    { leagueId: string; seasonId: string; rolloverId?: string },
     { graduatedPlayerIds: string[]; advancedPlayerIds: string[] }
   >("sports:rolloverGraduateAndAdvancePlayers"),
   removePlayersFromSeasonRoster: mutationRef<
@@ -1464,6 +1488,34 @@ export async function completeSeason(input: {
   return mutateConvex(refs.completeSeason, input);
 }
 
+export async function beginSeasonRollover(input: {
+  sourceSeasonId: string;
+}): Promise<{
+  rolloverId: string;
+  targetSeasonId: string;
+  resumed: boolean;
+  stage: string;
+  status: string;
+  graduatedPlayerIds: string[];
+  advancedPlayerIds: string[];
+}> {
+  return mutateConvex(refs.beginSeasonRollover, input);
+}
+
+export async function advanceSeasonRollover(input: {
+  rolloverId: string;
+  stage: string;
+}): Promise<{
+  rolloverId: string;
+  targetSeasonId: string;
+  stage: string;
+  status: string;
+  graduatedPlayerIds: string[];
+  advancedPlayerIds: string[];
+}> {
+  return mutateConvex(refs.advanceSeasonRollover, input);
+}
+
 export async function setActiveSeason(seasonId: string): Promise<null> {
   return mutateConvex(refs.setActiveSeason, { seasonId });
 }
@@ -1966,6 +2018,7 @@ export async function copySeasonRosters(input: {
 export async function rolloverGraduateAndAdvancePlayers(input: {
   leagueId: string;
   seasonId: string;
+  rolloverId?: string;
 }): Promise<{ graduatedPlayerIds: string[]; advancedPlayerIds: string[] }> {
   return mutateConvex(refs.rolloverGraduateAndAdvancePlayers, input);
 }
@@ -2539,8 +2592,8 @@ export interface PublicScheduleRow {
 /**
  * The active season's fixtures for a public league, enriched with final scores.
  *
- * Mirrors `computeStandingsPublic`'s season selection (status "active", else the
- * first season) so the public Schedule and Standings always agree on which
+ * Mirrors `computeStandingsPublic`'s lifecycle selection so the public Schedule
+ * and Standings always agree on which
  * season they're showing. Composed entirely from ungated reads; call only after
  * `publicLeagueGuard` has confirmed the league is public. Returns null when the
  * league has no seasons.
@@ -2554,7 +2607,8 @@ export async function getPublicLeagueSchedule(leagueId: string): Promise<{
   });
   if (seasons.length === 0) return null;
 
-  const season = seasons.find((s) => s.status === "active") ?? seasons[0];
+  const season = resolveLifecycleSeason(seasons);
+  if (!season) return null;
   const fixtures = await listFixturesBySeason(season.id);
 
   // Pull final scores only for completed games (others have no result row).

--- a/apps/web/src/lib/dynasty-panel.ts
+++ b/apps/web/src/lib/dynasty-panel.ts
@@ -52,18 +52,18 @@ export function dynastySeasonState(input: {
   upcomingSeason: { name: string } | null;
   seasonDecided: boolean;
 }): DynastySeasonState {
+  if (input.upcomingSeason) {
+    return {
+      seasonName: input.activeSeason?.name ?? input.upcomingSeason.name,
+      status: "offseason_upcoming",
+      statusLabel: `Offseason · upcoming ${input.upcomingSeason.name}`,
+    };
+  }
   if (!input.activeSeason) {
     return {
       seasonName: null,
       status: "no_season",
       statusLabel: "No active season",
-    };
-  }
-  if (input.upcomingSeason) {
-    return {
-      seasonName: input.activeSeason.name,
-      status: "offseason_upcoming",
-      statusLabel: `Offseason · upcoming ${input.upcomingSeason.name}`,
     };
   }
   if (input.seasonDecided) {

--- a/apps/web/src/lib/dynasty-panel.ts
+++ b/apps/web/src/lib/dynasty-panel.ts
@@ -92,6 +92,8 @@ export function startNextSeasonErrorMessage(
   switch (errorCode) {
     case "no_season":
       return "Create an active season before starting the next year.";
+    case "no_completed_season":
+      return "Complete the decided season before starting the next year.";
     case "not_authorized":
       return "You don't have permission to start the next season.";
     case "unauthorized":
@@ -115,18 +117,12 @@ export function startNextSeasonErrorMessage(
 /** Evaluate whether the Start next season CTA should be enabled. */
 export function evaluateStartNextSeason(input: {
   activeSeason: { id: string; name: string } | null;
+  completedSeason: { id: string; name: string } | null;
   upcomingSeason: { id: string; name: string } | null;
   seasonDecided: boolean;
   unplayedGames: number;
   playoffsUndecided: boolean;
 }): StartNextSeasonGate {
-  if (!input.activeSeason) {
-    return {
-      canStart: false,
-      errorCode: "no_season",
-      message: startNextSeasonErrorMessage("no_season"),
-    };
-  }
   if (input.upcomingSeason) {
     return {
       canStart: false,
@@ -136,7 +132,10 @@ export function evaluateStartNextSeason(input: {
       }),
     };
   }
-  if (!input.seasonDecided) {
+  if (input.completedSeason) {
+    return { canStart: true, errorCode: null, message: null };
+  }
+  if (input.activeSeason && !input.seasonDecided) {
     return {
       canStart: false,
       errorCode: "season_not_decided",
@@ -146,7 +145,13 @@ export function evaluateStartNextSeason(input: {
       }),
     };
   }
-  return { canStart: true, errorCode: null, message: null };
+  return {
+    canStart: false,
+    errorCode: input.activeSeason ? "no_completed_season" : "no_season",
+    message: startNextSeasonErrorMessage(
+      input.activeSeason ? "no_completed_season" : "no_season",
+    ),
+  };
 }
 
 /** Whether gamecast should deep-link to the league dynasty panel. */

--- a/apps/web/src/lib/season-view.ts
+++ b/apps/web/src/lib/season-view.ts
@@ -7,8 +7,27 @@ import type { SeasonDto } from "@sports-management/shared-types";
  * season, which made finished seasons unreachable the moment a new one was
  * activated. These pages now accept `?season=<id>`: a valid id belonging to
  * the league wins; anything else falls back to the old behavior
- * (active season, else the first one).
+ * (active season, then upcoming season, then the most recent one).
  */
+export function resolveLifecycleSeason(seasons: SeasonDto[]): SeasonDto | null {
+  const newest = (eligible: SeasonDto[]) =>
+    [...eligible].sort((a, b) => {
+      const aDate = a.startDate ?? a.endDate ?? "";
+      const bDate = b.startDate ?? b.endDate ?? "";
+      return (
+        bDate.localeCompare(aDate) ||
+        b.name.localeCompare(a.name) ||
+        b.id.localeCompare(a.id)
+      );
+    })[0] ?? null;
+
+  return (
+    newest(seasons.filter((season) => season.status === "active")) ??
+    newest(seasons.filter((season) => season.status === "upcoming")) ??
+    newest(seasons)
+  );
+}
+
 export function resolveViewedSeason(
   seasons: SeasonDto[],
   seasonParam: string | undefined,
@@ -17,5 +36,5 @@ export function resolveViewedSeason(
     const requested = seasons.find((s) => s.id === seasonParam);
     if (requested) return requested;
   }
-  return seasons.find((s) => s.status === "active") ?? seasons[0] ?? null;
+  return resolveLifecycleSeason(seasons);
 }


### PR DESCRIPTION
## Summary
- centralize completed-season competition write guards while preserving narrow historical-media annotations
- reject completed-season reactivation and align deterministic lifecycle fallback selection
- add durable source-to-target rollover claims with resumable, idempotent stage checkpoints
- propagate stable lifecycle errors through affected server actions
- expand lifecycle, action, media-exception, rollover, and historical-read coverage

## Verification
- `pnpm --filter @sports-management/web test:unit` — 156 files, 1,097 tests passed
- `pnpm --filter @sports-management/web lint` — passed
- `pnpm --filter @sports-management/web type-check` — passed after clearing stale `.next` cache
- `git diff --check` — passed

Closes #526
