### PR TITLE
feat(web): lifecycle schedule accordions and season-safe playoff handoff (WSM-000239)

### DIFF
--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -19,16 +19,22 @@ export function acceptBrowserConfirms(page: Page): void {
 
 /**
  * Confirm an in-app ActionConfirmDialog (lifecycle surfaces from PR #535).
- * Pass `expectClose: false` for error paths — failed actions keep the dialog
- * open for retry, surfacing the error via toast.
+ * Pass `expectClose: false` for paths where confirming does NOT close the
+ * dialog (error-retry states, or flows that chain into a second dialog).
+ * Pass `name` (the dialog's accessible name = its title) when more than one
+ * ActionConfirmDialog can be mounted at once — e.g. season completion without
+ * a champion keeps the first dialog in the DOM while the force-completion
+ * dialog opens, so the bare testid locator hits a strict-mode violation.
  */
 export async function confirmLifecycleDialog(
   page: Page,
-  opts: { expectClose?: boolean } = {},
+  opts: { expectClose?: boolean; name?: string | RegExp } = {},
 ): Promise<void> {
-  const dialog = page.getByTestId("action-confirm-dialog");
+  const dialog = opts.name
+    ? page.getByRole("alertdialog", { name: opts.name })
+    : page.getByTestId("action-confirm-dialog");
   await expect(dialog).toBeVisible();
-  await page.getByTestId("action-confirm-submit").click();
+  await dialog.getByTestId("action-confirm-submit").click();
   if (opts.expectClose !== false) {
     await expect(dialog).toBeHidden();
   }
@@ -164,13 +170,30 @@ export async function advanceToPlayoffs(page: Page) {
   await confirmLifecycleDialog(page);
 }
 
-export async function completeSeason(page: Page, seasonId: string) {
+export async function completeSeason(
+  page: Page,
+  seasonId: string,
+  opts: { forceWithoutChampion?: boolean } = {},
+) {
   await page.goto("/dashboard/seasons");
   const seasonRow = page.locator("li").filter({
     has: page.locator(`a[href="/dashboard/seasons/${seasonId}"]`),
   });
   await seasonRow.getByRole("button", { name: /^Complete / }).click();
-  await confirmLifecycleDialog(page);
+  if (opts.forceWithoutChampion) {
+    // No playoff champion: confirming "Complete <season>?" opens a second
+    // "Complete without a champion?" force-completion dialog instead of
+    // closing. Name-scope both confirms (both dialogs share the testid).
+    await confirmLifecycleDialog(page, {
+      name: /^Complete (?!without a champion\?)/,
+      expectClose: false,
+    });
+    await confirmLifecycleDialog(page, {
+      name: "Complete without a champion?",
+    });
+  } else {
+    await confirmLifecycleDialog(page);
+  }
   await expect(page.getByText(/completed\./)).toBeVisible({ timeout: 60_000 });
 }
 

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -43,6 +43,29 @@ function playByPlayRows(page: import("@playwright/test").Page) {
     .locator("ul button");
 }
 
+/*
+ * WSM-000239: the schedule is a lifecycle accordion — completed weeks start
+ * collapsed (rows unmounted) and a mixed week's finished games sit inside a
+ * nested, collapsed "Completed" disclosure. Expand every week, then open any
+ * collapsed disclosures, so rows can be found by content instead of position.
+ */
+async function revealAllScheduleRows(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  const expandAll = page.getByRole("button", { name: "Expand all" });
+  if (await expandAll.isVisible().catch(() => false)) {
+    await expandAll.click();
+  }
+  const toggles = page.getByRole("button", { name: /^Completed games — / });
+  const count = await toggles.count();
+  for (let i = 0; i < count; i++) {
+    const toggle = toggles.nth(i);
+    if ((await toggle.getAttribute("aria-expanded")) === "false") {
+      await toggle.click();
+    }
+  }
+}
+
 async function openSimmedGamecastFinal(
   page: import("@playwright/test").Page,
   leagueId: string,
@@ -52,24 +75,41 @@ async function openSimmedGamecastFinal(
     page.getByRole("heading", { name: LEAGUE_NAME }),
   ).toBeVisible();
 
-  const simRow = page.locator("tbody tr").first();
-  const homeName = await simRow.locator("td").nth(1).innerText();
-  const awayName = await simRow.locator("td").nth(2).innerText();
+  await revealAllScheduleRows(page);
 
-  const isFinal = await simRow
-    .getByText("Final", { exact: true })
-    .isVisible()
-    .catch(() => false);
-  if (!isFinal) {
+  // Reuse a previously simmed final: only simmed finals carry a Gamecast
+  // link (manually recorded finals don't).
+  let simRow = page
+    .locator("tbody tr")
+    .filter({ has: page.getByRole("link", { name: "Gamecast" }) })
+    .first();
+
+  if ((await simRow.count()) === 0) {
+    const scheduledRow = page
+      .locator("tbody tr")
+      .filter({ has: page.getByText("Scheduled", { exact: true }) })
+      .first();
+    const homeName = await scheduledRow.locator("td").nth(1).innerText();
+    const awayName = await scheduledRow.locator("td").nth(2).innerText();
+    const simTestId = await scheduledRow.getAttribute("data-testid");
+    expect(simTestId).toMatch(/^schedule-fixture-/);
+
     await page
       .getByRole("button", {
         name: `Simulate ${homeName} vs ${awayName}`,
       })
       .click();
-    await expect(simRow.getByText("Final", { exact: true })).toBeVisible({
-      timeout: 60_000,
-    });
+    // The refresh moves the freshly-final game into its week's (new,
+    // collapsed) Completed disclosure — reveal again and re-find by testid.
+    simRow = page.getByTestId(simTestId!);
+    await expect(async () => {
+      await revealAllScheduleRows(page);
+      await expect(simRow.getByText("Final", { exact: true })).toBeVisible();
+    }).toPass({ timeout: 60_000 });
   }
+
+  const homeName = await simRow.locator("td").nth(1).innerText();
+  const awayName = await simRow.locator("td").nth(2).innerText();
 
   const scoreText = (await simRow.locator("td").nth(3).innerText()).trim();
   const scoreMatch = scoreText.match(/(\d+)\s*[–-]\s*(\d+)/);
@@ -154,10 +194,14 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
       page.getByRole("heading", { name: LEAGUE_NAME }),
     ).toBeVisible();
 
-    const simRow = page.locator("tbody tr").first();
-    const homeName = await simRow.locator("td").nth(1).innerText();
-    const awayName = await simRow.locator("td").nth(2).innerText();
-    const simFixtureId = await simRow.getAttribute("data-testid");
+    await revealAllScheduleRows(page);
+    const scheduledRow = page
+      .locator("tbody tr")
+      .filter({ has: page.getByText("Scheduled", { exact: true }) })
+      .first();
+    const homeName = await scheduledRow.locator("td").nth(1).innerText();
+    const awayName = await scheduledRow.locator("td").nth(2).innerText();
+    const simFixtureId = await scheduledRow.getAttribute("data-testid");
     expect(simFixtureId).toMatch(/^schedule-fixture-/);
 
     await page
@@ -165,9 +209,13 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
         name: `Simulate ${homeName} vs ${awayName}`,
       })
       .click();
-    await expect(simRow.getByText("Final", { exact: true })).toBeVisible({
-      timeout: 60_000,
-    });
+    // WSM-000239: the freshly-final game lands in its week's collapsed
+    // "Completed" disclosure — reveal, then re-find the row by its testid.
+    const simRow = page.getByTestId(simFixtureId!);
+    await expect(async () => {
+      await revealAllScheduleRows(page);
+      await expect(simRow.getByText("Final", { exact: true })).toBeVisible();
+    }).toPass({ timeout: 60_000 });
 
     const scoreText = (await simRow.locator("td").nth(3).innerText()).trim();
     const scoreMatch = scoreText.match(/(\d+)\s*[–-]\s*(\d+)/);

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -8,14 +8,25 @@ import {
 import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
-  advanceToPlayoffs,
   bootstrapFourTeamSimLeague,
+  confirmLifecycleDialog,
   simPlayoffsScope,
   simRegularSeason,
 } from "../helpers/sim-league-setup";
 
 /*
  * Playoffs bracket (WSM-000164/165) — advance gate, bracket render, champion.
+ *
+ * WSM-000239: playoffs are now STARTED from the schedule page's handoff panel
+ * ("Start playoffs"), which appears only when the decided active season's
+ * regular slate is fully final and no bracket exists. The playoffs page keeps
+ * its own (disabled/enabled) "Advance to playoffs" gate, asserted alongside.
+ *
+ * Read-only waiting state ("Regular season complete — waiting for playoffs to
+ * start"): NOT driven end-to-end. The e2e environment has no viewer-role
+ * Clerk user — user A is org A's admin, user B is org B's admin and 404s on
+ * org A leagues (see coach-roster cross-org spec) — so that branch is covered
+ * by unit tests on resolvePlayoffHandoff (src/lib/playoff-handoff.ts) instead.
  */
 const FIXTURE_KEY = "playoffs-bracket";
 const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
@@ -73,18 +84,39 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
       page.getByRole("button", { name: "Advance to playoffs" }),
     ).toBeDisabled();
 
+    // WSM-000239: while games remain, the schedule page offers NO handoff.
     await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+    await expect(page.getByTestId("playoff-handoff")).toHaveCount(0);
     await simRegularSeason(page);
 
+    // Playoffs page flips to ready (its advance button enables)…
     await page.goto(`/dashboard/leagues/${leagueId}/playoffs`);
     await expect(page.getByText(/Regular season complete/)).toBeVisible();
-    const advance = page.getByRole("button", { name: "Advance to playoffs" });
-    await expect(advance).toBeEnabled();
-    await advanceToPlayoffs(page);
+    await expect(
+      page.getByRole("button", { name: "Advance to playoffs" }),
+    ).toBeEnabled();
+
+    // …and the schedule page now shows the admin handoff panel. Start the
+    // playoffs from HERE (WSM-000239).
+    await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+    const handoff = page.getByTestId("playoff-handoff");
+    await expect(handoff).toBeVisible();
+    await expect(handoff.getByText(/Regular season complete/)).toBeVisible();
+    const startPlayoffs = handoff.getByRole("button", {
+      name: "Start playoffs",
+    });
+    await expect(startPlayoffs).toBeEnabled();
+    await startPlayoffs.click();
+    await confirmLifecycleDialog(page);
     await expect(
       page.getByText(/Playoffs started — \d+ matchups/),
     ).toBeVisible({ timeout: 60_000 });
 
+    // Once the bracket exists the handoff disappears from the schedule page.
+    await page.reload();
+    await expect(page.getByTestId("playoff-handoff")).toHaveCount(0);
+
+    await page.goto(`/dashboard/leagues/${leagueId}/playoffs`);
     await expect(page.getByText("Champion", { exact: true })).toHaveCount(0);
     await expect(page.getByRole("link").filter({ hasText: /E2E PO|E2E Team/ }).first()).toBeVisible();
     await expect(

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -8,6 +8,12 @@ import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical
 import { getTestOrgId } from "../helpers/seed-roster";
 import { pickSelectOption } from "../helpers/select";
 import { TEAMS } from "../helpers/test-data";
+import {
+  acceptBrowserConfirms,
+  completeSeason,
+  weekCard,
+} from "../helpers/sim-league-setup";
+import type { Page } from "@playwright/test";
 
 /*
  * Schedules & standings (Phase 3 / WSM-000074) e2e smoke.
@@ -178,6 +184,210 @@ test.describe("Schedules & standings — fixture loop (WSM-000074)", () => {
   });
 });
 
+/*
+ * Schedule lifecycle accordion + completed-season read-only (WSM-000239).
+ *
+ * Own seeded league (not the canonical fixture) because the flow ends by
+ * COMPLETING the season — irreversible for the league, so nothing else may
+ * share it. One sequential test for the same retry-safety reason as the
+ * smoke above: a worker retry re-seeds a fresh league and replays everything.
+ *
+ * Week states exercised:
+ *   Week 1 → one final game (completed, starts collapsed), then a second
+ *            scheduled game is added (mixed: open, scheduled row always
+ *            visible, finished game inside the collapsed "Completed"
+ *            subsection).
+ *   Week 2 → scheduled only (upcoming, starts open).
+ */
+const ACCORDION_KEY = "schedule-accordion";
+const ACC_HOME = "E2E Acc Home";
+const ACC_AWAY = "E2E Acc Away";
+
+test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: ACCORDION_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: ACC_HOME,
+      awayTeamName: ACC_AWAY,
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Long sequential flow (fixture creation, three results, season
+    // completion with a 60s toast wait) — same budget as sibling lifecycle
+    // specs.
+    test.setTimeout(240_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  async function createFixture(
+    page: Page,
+    week: number,
+    home: string,
+    away: string,
+  ) {
+    await page.getByRole("button", { name: "New fixture" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await pickSelectOption(page, "#fix-home", home);
+    await pickSelectOption(page, "#fix-away", away);
+    await dialog.getByLabel("Week").fill(String(week));
+    await dialog.getByRole("button", { name: "Create fixture" }).click();
+    await expect(dialog).toBeHidden();
+  }
+
+  async function recordResult(
+    page: Page,
+    card: ReturnType<typeof weekCard>,
+    homeLabel: RegExp,
+    awayLabel: RegExp,
+    homeScore: number,
+    awayScore: number,
+  ) {
+    await card.getByRole("button", { name: "Record result" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(homeLabel).fill(String(homeScore));
+    await dialog.getByLabel(awayLabel).fill(String(awayScore));
+    await dialog.getByRole("button", { name: "Save result" }).click();
+    await expect(dialog).toBeHidden();
+  }
+
+  test("accordion lifecycle states, mixed-week subsection, expand/collapse, completed-season read-only", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    const leagueId = fixture!.leagueId;
+    await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+    await expect(page.getByText("Schedule · E2E Season")).toBeVisible();
+
+    // Seed: Week 1 final game, Week 2 future game.
+    await createFixture(page, 1, ACC_HOME, ACC_AWAY);
+    await recordResult(
+      page,
+      weekCard(page, 1),
+      new RegExp(`${ACC_HOME} \\(home\\)`),
+      new RegExp(`${ACC_AWAY} \\(away\\)`),
+      21,
+      7,
+    );
+    await createFixture(page, 2, ACC_HOME, ACC_AWAY);
+
+    // Initial accordion state: completed week collapsed, future week open.
+    await page.reload();
+    const week1Trigger = page.getByRole("button", { name: /^Week 1/ });
+    const week2Trigger = page.getByRole("button", { name: /^Week 2/ });
+    await expect(week1Trigger).toHaveAttribute("aria-expanded", "false");
+    await expect(week2Trigger).toHaveAttribute("aria-expanded", "true");
+    // Collapsed week hides its rows; the open week shows its scheduled row.
+    await expect(page.getByText("21 – 7")).toBeHidden();
+    await expect(weekCard(page, 2).getByText("Scheduled")).toBeVisible();
+
+    // Add a second Week 1 game → the week becomes MIXED and opens.
+    await createFixture(page, 1, ACC_AWAY, ACC_HOME);
+    await page.reload();
+    await expect(week1Trigger).toHaveAttribute("aria-expanded", "true");
+
+    // Mixed week: the scheduled game stays visible while the finished game
+    // lives in the nested "Completed" subsection (collapsed by default).
+    const w1 = weekCard(page, 1);
+    await expect(w1.getByText("Scheduled")).toBeVisible();
+    const completedToggle = w1.getByRole("button", {
+      name: /Completed games — Week 1/,
+    });
+    await expect(completedToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(w1.getByText("21 – 7")).toBeHidden();
+
+    await completedToggle.click();
+    await expect(completedToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(w1.getByText("21 – 7")).toBeVisible();
+    // Scheduled game still visible with the subsection open.
+    await expect(w1.getByText("Scheduled")).toBeVisible();
+
+    // Keyboard operability: Enter toggles it closed again.
+    await completedToggle.focus();
+    await page.keyboard.press("Enter");
+    await expect(completedToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(w1.getByText("21 – 7")).toBeHidden();
+
+    // Expand all / collapse all drive EVERY trigger's aria-expanded.
+    await page.getByRole("button", { name: "Collapse all" }).click();
+    await expect(week1Trigger).toHaveAttribute("aria-expanded", "false");
+    await expect(week2Trigger).toHaveAttribute("aria-expanded", "false");
+    await page.getByRole("button", { name: "Expand all" }).click();
+    await expect(week1Trigger).toHaveAttribute("aria-expanded", "true");
+    await expect(week2Trigger).toHaveAttribute("aria-expanded", "true");
+
+    // Finish the remaining games so the season can complete.
+    await recordResult(
+      page,
+      weekCard(page, 1),
+      new RegExp(`${ACC_AWAY} \\(home\\)`),
+      new RegExp(`${ACC_HOME} \\(away\\)`),
+      10,
+      13,
+    );
+    await recordResult(
+      page,
+      weekCard(page, 2),
+      new RegExp(`${ACC_HOME} \\(home\\)`),
+      new RegExp(`${ACC_AWAY} \\(away\\)`),
+      28,
+      3,
+    );
+
+    // Complete the season (WSM-000238 lifecycle), then re-open the schedule:
+    // read-only history — every mutation control is gone.
+    await completeSeason(page, fixture!.seasonId);
+    await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+    await expect(page.getByText("Schedule · E2E Season")).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "New fixture" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Generate schedule/ }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Simulate", exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Simulate .* vs / }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Sim week" })).toHaveCount(
+      0,
+    );
+    await expect(
+      page.getByRole("button", { name: /Record result|Edit result/ }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Delete / })).toHaveCount(
+      0,
+    );
+    await expect(
+      page.getByRole("button", { name: "Start playoffs" }),
+    ).toHaveCount(0);
+
+    // Read paths remain: every week is completed (collapsed) — expand and
+    // confirm the recorded scores are still there.
+    await page.getByRole("button", { name: "Expand all" }).click();
+    await expect(page.getByText("21 – 7")).toBeVisible();
+    await expect(page.getByText("28 – 3")).toBeVisible();
+  });
+});
+
 test.describe("Standings — division groups (canonical)", () => {
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page });
@@ -201,7 +411,17 @@ test.describe("Standings — division groups (canonical)", () => {
       .click();
     await expect(fixtureDialog).toBeHidden();
 
-    await page.getByRole("button", { name: "Record result" }).click();
+    // WSM-000239: the canonical league is seeded once per run, so a CI retry
+    // can find Week 1 already full of finals (collapsed accordion). Expand
+    // the week if needed and scope the click to its card.
+    const week1Trigger = page.getByRole("button", { name: /^Week 1/ });
+    if ((await week1Trigger.getAttribute("aria-expanded")) === "false") {
+      await week1Trigger.click();
+    }
+    await weekCard(page, 1)
+      .getByRole("button", { name: "Record result" })
+      .first()
+      .click();
     const resultDialog = page.getByRole("dialog");
     await resultDialog.getByLabel(/Dallas Cowboys/).fill("17");
     await resultDialog.getByLabel(/New England Patriots/).fill("14");

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -350,8 +350,12 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
     );
 
     // Complete the season (WSM-000238 lifecycle), then re-open the schedule:
-    // read-only history — every mutation control is gone.
-    await completeSeason(page, fixture!.seasonId);
+    // read-only history — every mutation control is gone. This league never
+    // ran playoffs, so completion chains into the "Complete without a
+    // champion?" force-confirmation.
+    await completeSeason(page, fixture!.seasonId, {
+      forceWithoutChampion: true,
+    });
     await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
     await expect(page.getByText("Schedule · E2E Season")).toBeVisible();
 

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
@@ -80,7 +80,10 @@ describe("advanceToPlayoffsAction", () => {
       { stage: "regular", status: "scheduled" },
     ]);
 
-    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
 
     expect(res).toEqual({ ok: false, error: "regular_season_incomplete" });
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
@@ -100,7 +103,10 @@ describe("advanceToPlayoffsAction", () => {
       champion: null,
     });
 
-    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
 
     expect(res).toEqual({ ok: false, error: "already_advanced" });
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
@@ -110,13 +116,80 @@ describe("advanceToPlayoffsAction", () => {
     authorize();
     mockGetSeasons.mockResolvedValue([]);
 
-    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
 
     expect(res).toEqual({ ok: false, error: "no_season" });
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
   });
 
-  it("generates a bracket when preconditions pass", async () => {
+  it("rejects a missing seasonId (WSM-000239)", async () => {
+    authorize();
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: "",
+    });
+
+    expect(res).toEqual({ ok: false, error: "season_required" });
+    expect(mockGetSeasons).not.toHaveBeenCalled();
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects a seasonId that does not belong to the league (WSM-000239)", async () => {
+    authorize();
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: "season_other_league",
+    });
+
+    expect(res).toEqual({ ok: false, error: "season_not_found" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects a completed season (WSM-000239)", async () => {
+    authorize();
+    // Only season in the league — lifecycle resolution would still pick it,
+    // so the status check must reject it explicitly.
+    mockGetSeasons.mockResolvedValue([
+      { ...ACTIVE_SEASON, status: "completed" },
+    ]);
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "season_completed" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects a season that is not the lifecycle-decided one (WSM-000239)", async () => {
+    authorize();
+    const staleUpcoming = {
+      ...ACTIVE_SEASON,
+      id: "season_upcoming",
+      status: "upcoming",
+      startDate: "2025-09-01",
+    };
+    mockGetSeasons.mockResolvedValue([
+      { ...ACTIVE_SEASON, startDate: "2026-09-01" },
+      staleUpcoming,
+    ]);
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: "season_upcoming",
+    });
+
+    expect(res).toEqual({ ok: false, error: "season_mismatch" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("generates a bracket for a valid, lifecycle-decided seasonId", async () => {
     authorize();
     mockListFixturesBySeason.mockResolvedValue([
       { stage: "regular", status: "final" },
@@ -130,7 +203,10 @@ describe("advanceToPlayoffsAction", () => {
       matchups: 7,
     });
 
-    const res = await advanceToPlayoffsAction({ leagueId: LEAGUE });
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
 
     expect(res).toEqual({
       ok: true,

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -114,9 +114,14 @@ function revalidatePlayoffPaths(leagueId: string) {
  * Advance an active season to playoffs once every regular-season game is final
  * (WSM-bracket-view). Seeds and first-round fixtures come from the season's
  * configured playoff settings via the existing generatePlayoffBracket path.
+ *
+ * Season-safe (WSM-000239): the caller must name the season explicitly, and it
+ * must be the league's lifecycle-decided season and not completed — a stale
+ * page viewing an old season can never advance the wrong (or a finished) one.
  */
 export async function advanceToPlayoffsAction(input: {
   leagueId: string;
+  seasonId: string;
 }): Promise<
   | { ok: true; bracketId: string; size: number; rounds: number; matchups: number }
   | { ok: false; error: string }
@@ -127,9 +132,25 @@ export async function advanceToPlayoffsAction(input: {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
 
+  if (!input.seasonId) return { ok: false, error: "season_required" };
+
   const allSeasons = await getSeasons([input.leagueId]);
-  const activeSeason = resolveLifecycleSeason(allSeasons);
-  if (!activeSeason) return { ok: false, error: "no_season" };
+  if (allSeasons.length === 0) return { ok: false, error: "no_season" };
+
+  // The named season must belong to this league…
+  const activeSeason = allSeasons.find((s) => s.id === input.seasonId);
+  if (!activeSeason) return { ok: false, error: "season_not_found" };
+
+  // …must not already be finished…
+  if (activeSeason.status === "completed") {
+    return { ok: false, error: "season_completed" };
+  }
+
+  // …and must be the season the lifecycle would decide on right now.
+  const decidedSeason = resolveLifecycleSeason(allSeasons);
+  if (!decidedSeason || decidedSeason.id !== activeSeason.id) {
+    return { ok: false, error: "season_mismatch" };
+  }
 
   const existing = await getPlayoffBracket(activeSeason.id).catch(() => null);
   if (existing) return { ok: false, error: "already_advanced" };

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -53,6 +53,10 @@ export default async function LeaguePlayoffsPage({
   const allSeasons = await getSeasons([leagueId]);
   const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
 
+  // Completed seasons are read-only history (WSM-000238/239): never render
+  // an advance control — the action would reject it server-side anyway.
+  const seasonCompleted = activeSeason?.status === "completed";
+
   const fixtures = activeSeason
     ? await listFixturesBySeason(activeSeason.id)
     : [];
@@ -140,8 +144,15 @@ export default async function LeaguePlayoffsPage({
               Regular season complete ({progress.final} of {progress.total} games
               final). Ready to seed the bracket from current standings.
             </p>
-            {isAdmin ? (
-              <AdvanceToPlayoffsButton leagueId={leagueId} />
+            {isAdmin && !seasonCompleted ? (
+              <AdvanceToPlayoffsButton
+                leagueId={leagueId}
+                seasonId={activeSeason.id}
+              />
+            ) : seasonCompleted ? (
+              <p className="text-xs text-muted-foreground">
+                This season is completed — playoffs can no longer be started.
+              </p>
             ) : (
               <p className="text-xs text-muted-foreground">
                 Waiting for a league manager to advance to playoffs.
@@ -156,8 +167,12 @@ export default async function LeaguePlayoffsPage({
               Regular season in progress — {progress.final} of {progress.total}{" "}
               games final.
             </p>
-            {isAdmin ? (
-              <AdvanceToPlayoffsButton leagueId={leagueId} disabled />
+            {isAdmin && !seasonCompleted ? (
+              <AdvanceToPlayoffsButton
+                leagueId={leagueId}
+                seasonId={activeSeason.id}
+                disabled
+              />
             ) : null}
           </CardContent>
         </Card>

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -17,15 +17,26 @@ import {
   getResultByFixture,
   getStreamByFixture,
   getGamePlayLog,
+  getPlayoffBracket,
   getTeamsByLeague,
   listFixturesBySeason,
   type PublicGameStream,
 } from "@/lib/data-api";
+import type {
+  FixtureDto,
+  GameResultDto,
+} from "@sports-management/shared-types";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
 import { formatFixtureWhen } from "@/lib/format";
 import { isSeasonStarted } from "@/lib/season-started";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { regularSeasonProgress } from "@/lib/playoffs";
+import { resolvePlayoffHandoff } from "@/lib/playoff-handoff";
+import {
+  groupFixturesByWeek,
+  initialOpenWeekKeys,
+} from "@/lib/schedule-weeks";
+import { Card, CardContent } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
@@ -37,11 +48,15 @@ import {
   SimulateScopeMenu,
   SimulateWeekButton,
 } from "@/components/schedule/SimulateControls";
+import ScheduleWeeks, {
+  type ScheduleWeekView,
+} from "@/components/schedule/ScheduleWeeks";
+import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
-import { resolveViewedSeason } from "@/lib/season-view";
+import { resolveLifecycleSeason, resolveViewedSeason } from "@/lib/season-view";
 import { Breadcrumbs } from "@/components/workspace/Breadcrumbs";
 import { BackLink } from "@/components/workspace/BackLink";
 import { WorkspaceHeader } from "@/components/workspace/WorkspaceHeader";
@@ -49,6 +64,12 @@ import { WorkspaceNav } from "@/components/workspace/WorkspaceNav";
 import { buildLeagueSeasonNavLinks } from "@/components/workspace/build-league-nav-links";
 
 type StreamStatus = "idle" | "active" | "ended";
+
+interface FixtureRow {
+  fixture: FixtureDto;
+  result: GameResultDto | null;
+  hasPlayLog: boolean;
+}
 
 export default async function LeagueSchedulePage({
   params,
@@ -91,12 +112,19 @@ export default async function LeagueSchedulePage({
   // Synthetic rosters (WSM-000173): discoverability shortcut — admins setting up
   // a schedule often need rosters first. Same admin + flag gate as the league
   // detail page; the server actions re-check flag + role.
-  const canGenerateRosters = canManageOrgSettings(role) && (await syntheticRostersV1());
+  const rosterGenEnabled = canManageOrgSettings(role) && (await syntheticRostersV1());
 
   // Season being VIEWED (WSM-000214): `?season=` wins, else active, else first.
   const { season: seasonParam } = await searchParams;
   const allSeasons = await getSeasons([leagueId]);
   const activeSeason = resolveViewedSeason(allSeasons, seasonParam);
+
+  // Completed seasons are read-only history (WSM-000238/239): every mutation
+  // control disappears; results, Gamecast links, and clips annotation remain.
+  const seasonCompleted = activeSeason?.status === "completed";
+  const canMutate = isAdmin && !seasonCompleted;
+  const canGoLive = canStream && !seasonCompleted;
+  const canGenerateRosters = rosterGenEnabled && !seasonCompleted;
 
   const teams = await getTeamsByLeague(leagueId, orgContext);
 
@@ -109,7 +137,7 @@ export default async function LeagueSchedulePage({
     : false;
 
   // Hydrate per-fixture result for "Record result" pre-fill + score display.
-  const fixturesWithResults = await Promise.all(
+  const fixturesWithResults: FixtureRow[] = await Promise.all(
     fixtures.map(async (f) => {
       const result =
         f.status === "final" ? await getResultByFixture(f.id) : null;
@@ -132,19 +160,76 @@ export default async function LeagueSchedulePage({
     );
   }
 
-  // Group by week (null week → "Unscheduled" bucket at the end).
-  const buckets = new Map<number | null, typeof fixturesWithResults>();
-  for (const row of fixturesWithResults) {
-    const key = row.fixture.week;
-    const arr = buckets.get(key) ?? [];
-    arr.push(row);
-    buckets.set(key, arr);
-  }
-  const weekKeys = Array.from(buckets.keys()).sort((a, b) => {
-    if (a === null) return 1;
-    if (b === null) return -1;
-    return a - b;
+  // Playoff handoff (WSM-000239): the schedule page offers "Start playoffs"
+  // the moment the DECIDED active season's regular slate is done and no
+  // bracket exists yet. Bracket lookup only runs when the cheap pure checks
+  // could possibly surface the panel.
+  const decidedSeason = resolveLifecycleSeason(allSeasons);
+  const progress = regularSeasonProgress(fixtures);
+  const bracket =
+    playoffsEnabled &&
+    activeSeason &&
+    activeSeason.id === decidedSeason?.id &&
+    progress.total > 0 &&
+    progress.complete
+      ? await getPlayoffBracket(activeSeason.id).catch(() => null)
+      : null;
+  const handoff = resolvePlayoffHandoff({
+    playoffsEnabled,
+    viewedSeasonId: activeSeason?.id ?? null,
+    viewedSeasonStatus: activeSeason?.status ?? null,
+    decidedSeasonId: decidedSeason?.id ?? null,
+    playoffTeams: activeSeason?.playoffTeams,
+    regularTotal: progress.total,
+    regularComplete: progress.complete,
+    bracketExists: bracket !== null,
+    canManage: isAdmin,
   });
+
+  // Lifecycle accordion timeline (WSM-000239): weeks grouped and classified by
+  // the pure helper; completed weeks start collapsed, mixed weeks split their
+  // finished games into a nested subsection. The client component receives
+  // fully-rendered table slots — all fetching stays here on the server.
+  const weekGroups = groupFixturesByWeek(fixturesWithResults, (r) => r.fixture);
+  const fixtureTable = (rows: FixtureRow[]) => (
+    <FixtureTable
+      rows={rows}
+      leagueId={leagueId}
+      isAdmin={isAdmin}
+      canMutate={canMutate}
+      canGoLive={canGoLive}
+      canStream={canStream}
+      statsEnabled={statsEnabled}
+      liveEnabled={liveEnabled}
+      streams={streams}
+    />
+  );
+  const weekViews: ScheduleWeekView[] = weekGroups.map((group) => ({
+    key: group.key,
+    label: group.label,
+    status: group.status,
+    // "completed", not "final" — completedRows also counts cancelled games.
+    summary: `${group.completedRows.length} of ${group.rows.length} completed`,
+    actions:
+      canMutate &&
+      activeSeason &&
+      group.week !== null &&
+      group.rows.some(({ fixture }) => fixture.status === "scheduled") ? (
+        <SimulateWeekButton
+          leagueId={leagueId}
+          seasonId={activeSeason.id}
+          week={group.week}
+        />
+      ) : undefined,
+    content:
+      group.status === "mixed"
+        ? fixtureTable(group.remainingRows)
+        : fixtureTable(group.rows),
+    completedContent:
+      group.status === "mixed" ? fixtureTable(group.completedRows) : undefined,
+    completedCount: group.completedRows.length,
+  }));
+  const initialOpenKeys = initialOpenWeekKeys(weekGroups);
 
   const peerNavLinks = buildLeagueSeasonNavLinks({
     leagueId,
@@ -185,7 +270,7 @@ export default async function LeagueSchedulePage({
                 currentSeasonId={activeSeason.id}
               />
             ) : null}
-            {isAdmin && activeSeason && teams.length >= 2 ? (
+            {canMutate && activeSeason && teams.length >= 2 ? (
               <GenerateScheduleButton
                 leagueId={leagueId}
                 seasonId={activeSeason.id}
@@ -193,14 +278,14 @@ export default async function LeagueSchedulePage({
                 hasFixtures={fixtures.length > 0}
               />
             ) : null}
-            {isAdmin && activeSeason ? (
+            {canMutate && activeSeason ? (
               <FixtureFormDialog
                 leagueId={leagueId}
                 seasonId={activeSeason.id}
                 teams={teams.map((t) => ({ id: t.id, name: t.name }))}
               />
             ) : null}
-            {isAdmin && activeSeason && fixtures.length > 0 ? (
+            {canMutate && activeSeason && fixtures.length > 0 ? (
               <SimulateScopeMenu
                 leagueId={leagueId}
                 seasonId={activeSeason.id}
@@ -226,6 +311,28 @@ export default async function LeagueSchedulePage({
       />
       <WorkspaceNav links={peerNavLinks} />
 
+      {handoff !== "hidden" && activeSeason ? (
+        <Card className="mb-6" data-testid="playoff-handoff">
+          <CardContent className="flex flex-col items-center gap-3 p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              Regular season complete ({progress.final} of {progress.total}{" "}
+              games final).
+            </p>
+            {handoff === "start" ? (
+              <AdvanceToPlayoffsButton
+                leagueId={leagueId}
+                seasonId={activeSeason.id}
+                triggerLabel="Start playoffs"
+              />
+            ) : (
+              <p className="text-sm text-foreground">
+                Regular season complete — waiting for playoffs to start.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
+
       {!activeSeason ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 p-8 text-center">
@@ -238,217 +345,215 @@ export default async function LeagueSchedulePage({
             </Button>
           </CardContent>
         </Card>
-      ) : weekKeys.length === 0 ? (
+      ) : weekViews.length === 0 ? (
         <Card>
           <CardContent className="p-6 text-center text-muted-foreground">
             No fixtures scheduled yet for {activeSeason.name}.
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-6">
-          {weekKeys.map((week) => {
-            const rows = buckets.get(week)!;
-            const weekHasUnplayed = rows.some(
-              ({ fixture }) => fixture.status === "scheduled",
-            );
-            return (
-              <Card key={week ?? "unscheduled"}>
-                <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
-                  <CardTitle>
-                    {week === null ? "Unscheduled" : `Week ${week}`}
-                  </CardTitle>
-                  {isAdmin &&
-                  activeSeason &&
-                  week !== null &&
-                  weekHasUnplayed ? (
-                    <SimulateWeekButton
-                      leagueId={leagueId}
-                      seasonId={activeSeason.id}
-                      week={week}
-                    />
-                  ) : null}
-                </CardHeader>
-                <CardContent className="p-0">
-                  <div className="overflow-x-auto">
-                  <table className="w-full min-w-[640px] text-sm">
-                    <thead>
-                      <tr className="border-b-2 border-border bg-muted text-left text-foreground">
-                        <th className="px-4 py-2 font-mono text-xs uppercase">
-                          When
-                        </th>
-                        <th className="px-4 py-2 font-mono text-xs uppercase">
-                          Home
-                        </th>
-                        <th className="px-4 py-2 font-mono text-xs uppercase">
-                          Away
-                        </th>
-                        <th className="px-4 py-2 text-right font-mono text-xs uppercase">
-                          Score
-                        </th>
-                        <th className="px-4 py-2 font-mono text-xs uppercase">
-                          Status
-                        </th>
-                        {isAdmin ? (
-                          <th className="px-4 py-2 font-mono text-xs uppercase">
-                            Actions
-                          </th>
-                        ) : null}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {rows.map(({ fixture, result, hasPlayLog }) => (
-                        <tr
-                          key={fixture.id}
-                          data-testid={`schedule-fixture-${fixture.id}`}
-                          className="border-b border-border"
-                        >
-                          <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-                            {formatFixtureWhen(fixture.scheduledAt)}
-                          </td>
-                          <td className="px-4 py-2 text-foreground">
-                            {fixture.homeTeamName}
-                          </td>
-                          <td className="px-4 py-2 text-foreground">
-                            {fixture.awayTeamName}
-                          </td>
-                          <td className="px-4 py-2 text-right font-mono text-foreground">
-                            {result ? (
-                              statsEnabled ? (
-                                <Link
-                                  href={`/dashboard/games/${fixture.id}/boxscore`}
-                                  className="hover:underline"
-                                  title="View box score"
-                                >
-                                  {result.homeScore} – {result.awayScore}
-                                </Link>
-                              ) : (
-                                `${result.homeScore} – ${result.awayScore}`
-                              )
-                            ) : (
-                              "—"
-                            )}
-                          </td>
-                          <td className="px-4 py-2">
-                            <StatusBadge status={fixture.status} />
-                          </td>
-                          {isAdmin ? (
-                            <td className="px-4 py-2">
-                              <div className="flex flex-wrap items-center gap-1">
-                                <RecordResultDialog
-                                  leagueId={leagueId}
-                                  fixtureId={fixture.id}
-                                  homeTeamName={fixture.homeTeamName}
-                                  awayTeamName={fixture.awayTeamName}
-                                  initialHomeScore={result?.homeScore ?? null}
-                                  initialAwayScore={result?.awayScore ?? null}
-                                  triggerLabel={result ? "Edit result" : "Record result"}
-                                />
-                                {fixture.status === "scheduled" ? (
-                                  <SimulateGameButton
-                                    leagueId={leagueId}
-                                    fixtureId={fixture.id}
-                                    homeTeamName={fixture.homeTeamName}
-                                    awayTeamName={fixture.awayTeamName}
-                                  />
-                                ) : null}
-                                <DeleteFixtureButton
-                                  leagueId={leagueId}
-                                  fixtureId={fixture.id}
-                                  homeTeamName={fixture.homeTeamName}
-                                  awayTeamName={fixture.awayTeamName}
-                                />
-                                {canStream ? (
-                                  <GoLiveControl
-                                    leagueId={leagueId}
-                                    fixtureId={fixture.id}
-                                    homeTeamName={fixture.homeTeamName}
-                                    awayTeamName={fixture.awayTeamName}
-                                    status={
-                                      (streams.get(fixture.id)?.status as
-                                        | StreamStatus
-                                        | undefined) ?? null
-                                    }
-                                    gameStatus={fixture.status}
-                                  />
-                                ) : null}
-                                {canStream &&
-                                streams.get(fixture.id)?.provider === "mux" &&
-                                streams.get(fixture.id)?.vodAssetId ? (
-                                  <ClipsControl
-                                    leagueId={leagueId}
-                                    fixtureId={fixture.id}
-                                    homeTeamName={fixture.homeTeamName}
-                                    awayTeamName={fixture.awayTeamName}
-                                    vodPlaybackId={
-                                      streams.get(fixture.id)?.vodPlaybackId ??
-                                      null
-                                    }
-                                  />
-                                ) : null}
-                                {statsEnabled ? (
-                                  <span className="flex items-center gap-1 text-xs">
-                                    <ClipboardList className="h-3.5 w-3.5 text-muted-foreground" />
-                                    <span className="text-muted-foreground">
-                                      Box score
-                                    </span>
-                                    <Link
-                                      href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/stats`}
-                                      className="text-primary hover:underline"
-                                    >
-                                      Home
-                                    </Link>
-                                    <span className="text-muted-foreground">/</span>
-                                    <Link
-                                      href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
-                                      className="text-primary hover:underline"
-                                    >
-                                      Away
-                                    </Link>
-                                  </span>
-                                ) : null}
-                                {liveEnabled ? (
-                                  <span className="flex items-center gap-1 text-xs">
-                                    <Radio className="h-3.5 w-3.5 text-muted-foreground" />
-                                    <Link
-                                      href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
-                                      className="text-primary hover:underline"
-                                    >
-                                      Live (Home)
-                                    </Link>
-                                    <span className="text-muted-foreground">/</span>
-                                    <Link
-                                      href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
-                                      className="text-primary hover:underline"
-                                    >
-                                      Away
-                                    </Link>
-                                  </span>
-                                ) : null}
-                                {fixture.status === "final" && hasPlayLog ? (
-                                  <span className="flex items-center gap-1 text-xs">
-                                    <Tv className="h-3.5 w-3.5 text-muted-foreground" />
-                                    <Link
-                                      href={`/dashboard/games/${fixture.id}/gamecast`}
-                                      className="text-primary hover:underline"
-                                    >
-                                      Gamecast
-                                    </Link>
-                                  </span>
-                                ) : null}
-                              </div>
-                            </td>
-                          ) : null}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
+        <ScheduleWeeks weeks={weekViews} initialOpenKeys={initialOpenKeys} />
       )}
+    </div>
+  );
+}
+
+/*
+ * One week's fixture table — server-rendered and handed to the client
+ * accordion as a slot. `isAdmin` keeps the Actions column (read links, clips)
+ * for managers even on completed seasons; `canMutate` gates every control
+ * that would change the season; `canGoLive` gates stream creation.
+ */
+function FixtureTable({
+  rows,
+  leagueId,
+  isAdmin,
+  canMutate,
+  canGoLive,
+  canStream,
+  statsEnabled,
+  liveEnabled,
+  streams,
+}: {
+  rows: FixtureRow[];
+  leagueId: string;
+  isAdmin: boolean;
+  canMutate: boolean;
+  canGoLive: boolean;
+  canStream: boolean;
+  statsEnabled: boolean;
+  liveEnabled: boolean;
+  streams: Map<string, PublicGameStream | null>;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
+        <thead>
+          <tr className="border-b-2 border-border bg-muted text-left text-foreground">
+            <th className="px-4 py-2 font-mono text-xs uppercase">When</th>
+            <th className="px-4 py-2 font-mono text-xs uppercase">Home</th>
+            <th className="px-4 py-2 font-mono text-xs uppercase">Away</th>
+            <th className="px-4 py-2 text-right font-mono text-xs uppercase">
+              Score
+            </th>
+            <th className="px-4 py-2 font-mono text-xs uppercase">Status</th>
+            {isAdmin ? (
+              <th className="px-4 py-2 font-mono text-xs uppercase">
+                Actions
+              </th>
+            ) : null}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ fixture, result, hasPlayLog }) => (
+            <tr
+              key={fixture.id}
+              data-testid={`schedule-fixture-${fixture.id}`}
+              className="border-b border-border"
+            >
+              <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                {formatFixtureWhen(fixture.scheduledAt)}
+              </td>
+              <td className="px-4 py-2 text-foreground">
+                {fixture.homeTeamName}
+              </td>
+              <td className="px-4 py-2 text-foreground">
+                {fixture.awayTeamName}
+              </td>
+              <td className="px-4 py-2 text-right font-mono text-foreground">
+                {result ? (
+                  statsEnabled ? (
+                    <Link
+                      href={`/dashboard/games/${fixture.id}/boxscore`}
+                      className="hover:underline"
+                      title="View box score"
+                    >
+                      {result.homeScore} – {result.awayScore}
+                    </Link>
+                  ) : (
+                    `${result.homeScore} – ${result.awayScore}`
+                  )
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td className="px-4 py-2">
+                <StatusBadge status={fixture.status} />
+              </td>
+              {isAdmin ? (
+                <td className="px-4 py-2">
+                  <div className="flex flex-wrap items-center gap-1">
+                    {canMutate ? (
+                      <RecordResultDialog
+                        leagueId={leagueId}
+                        fixtureId={fixture.id}
+                        homeTeamName={fixture.homeTeamName}
+                        awayTeamName={fixture.awayTeamName}
+                        initialHomeScore={result?.homeScore ?? null}
+                        initialAwayScore={result?.awayScore ?? null}
+                        triggerLabel={result ? "Edit result" : "Record result"}
+                      />
+                    ) : null}
+                    {canMutate && fixture.status === "scheduled" ? (
+                      <SimulateGameButton
+                        leagueId={leagueId}
+                        fixtureId={fixture.id}
+                        homeTeamName={fixture.homeTeamName}
+                        awayTeamName={fixture.awayTeamName}
+                      />
+                    ) : null}
+                    {canMutate ? (
+                      <DeleteFixtureButton
+                        leagueId={leagueId}
+                        fixtureId={fixture.id}
+                        homeTeamName={fixture.homeTeamName}
+                        awayTeamName={fixture.awayTeamName}
+                      />
+                    ) : null}
+                    {canGoLive ? (
+                      <GoLiveControl
+                        leagueId={leagueId}
+                        fixtureId={fixture.id}
+                        homeTeamName={fixture.homeTeamName}
+                        awayTeamName={fixture.awayTeamName}
+                        status={
+                          (streams.get(fixture.id)?.status as
+                            | StreamStatus
+                            | undefined) ?? null
+                        }
+                        gameStatus={fixture.status}
+                      />
+                    ) : null}
+                    {canStream &&
+                    streams.get(fixture.id)?.provider === "mux" &&
+                    streams.get(fixture.id)?.vodAssetId ? (
+                      <ClipsControl
+                        leagueId={leagueId}
+                        fixtureId={fixture.id}
+                        homeTeamName={fixture.homeTeamName}
+                        awayTeamName={fixture.awayTeamName}
+                        vodPlaybackId={
+                          streams.get(fixture.id)?.vodPlaybackId ?? null
+                        }
+                      />
+                    ) : null}
+                    {statsEnabled ? (
+                      <span className="flex items-center gap-1 text-xs">
+                        <ClipboardList className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="text-muted-foreground">
+                          Box score
+                        </span>
+                        <Link
+                          href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/stats`}
+                          className="text-primary hover:underline"
+                        >
+                          Home
+                        </Link>
+                        <span className="text-muted-foreground">/</span>
+                        <Link
+                          href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
+                          className="text-primary hover:underline"
+                        >
+                          Away
+                        </Link>
+                      </span>
+                    ) : null}
+                    {liveEnabled ? (
+                      <span className="flex items-center gap-1 text-xs">
+                        <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+                        <Link
+                          href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
+                          className="text-primary hover:underline"
+                        >
+                          Live (Home)
+                        </Link>
+                        <span className="text-muted-foreground">/</span>
+                        <Link
+                          href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
+                          className="text-primary hover:underline"
+                        >
+                          Away
+                        </Link>
+                      </span>
+                    ) : null}
+                    {fixture.status === "final" && hasPlayLog ? (
+                      <span className="flex items-center gap-1 text-xs">
+                        <Tv className="h-3.5 w-3.5 text-muted-foreground" />
+                        <Link
+                          href={`/dashboard/games/${fixture.id}/gamecast`}
+                          className="text-primary hover:underline"
+                        >
+                          Gamecast
+                        </Link>
+                      </span>
+                    ) : null}
+                  </div>
+                </td>
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
@@ -10,12 +10,35 @@ import { advanceToPlayoffsAction } from "@/app/dashboard/leagues/[id]/playoffs/a
 
 export interface AdvanceToPlayoffsButtonProps {
   leagueId: string;
+  /**
+   * The season being advanced (WSM-000239). Sent explicitly so the server can
+   * verify it is still the lifecycle-decided, non-completed season — a stale
+   * tab viewing an old season can never advance the wrong one.
+   */
+  seasonId: string;
   disabled?: boolean;
+  /** Button label — the schedule page hands off with "Start playoffs". */
+  triggerLabel?: string;
 }
+
+const ERROR_MESSAGES: Record<string, string> = {
+  regular_season_incomplete:
+    "Finish every regular-season game before advancing.",
+  already_advanced: "Playoffs have already started for this season.",
+  no_season: "No active season found.",
+  no_playoffs_configured: "This season is not configured for playoffs.",
+  season_required: "No season selected — reload and try again.",
+  season_not_found: "This season no longer exists.",
+  season_completed: "This season is already completed.",
+  season_mismatch:
+    "This is not the league's current season — switch to the active season to start playoffs.",
+};
 
 export default function AdvanceToPlayoffsButton({
   leagueId,
+  seasonId,
   disabled = false,
+  triggerLabel = "Advance to playoffs",
 }: AdvanceToPlayoffsButtonProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -23,7 +46,7 @@ export default function AdvanceToPlayoffsButton({
 
   function onConfirm() {
     startTransition(async () => {
-      const res = await advanceToPlayoffsAction({ leagueId });
+      const res = await advanceToPlayoffsAction({ leagueId, seasonId });
       if (res.ok) {
         toast.success(
           `Playoffs started — ${res.matchups} matchups across ${res.rounds} rounds.`,
@@ -33,17 +56,7 @@ export default function AdvanceToPlayoffsButton({
         return;
       }
 
-      const message =
-        res.error === "regular_season_incomplete"
-          ? "Finish every regular-season game before advancing."
-          : res.error === "already_advanced"
-            ? "Playoffs have already started for this season."
-            : res.error === "no_season"
-              ? "No active season found."
-              : res.error === "no_playoffs_configured"
-                ? "This season is not configured for playoffs."
-                : res.error;
-      toast.error(message);
+      toast.error(ERROR_MESSAGES[res.error] ?? res.error);
     });
   }
 
@@ -56,7 +69,7 @@ export default function AdvanceToPlayoffsButton({
         className="gap-1.5"
       >
         <Trophy className="h-4 w-4" />
-        {pending ? "Advancing…" : "Advance to playoffs"}
+        {pending ? "Advancing…" : triggerLabel}
       </Button>
       <ActionConfirmDialog
         open={confirmOpen}

--- a/apps/web/src/components/schedule/ScheduleWeeks.tsx
+++ b/apps/web/src/components/schedule/ScheduleWeeks.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/*
+ * WSM-000239 — lifecycle-aware accordion timeline for the schedule page.
+ *
+ * Presentation-only: the server page does ALL data fetching and renders each
+ * week's fixture table (and per-week action buttons) into slots; this
+ * component just composes them into a controlled multi-open accordion.
+ * `initialOpenKeys` comes from the same pure helper the server used
+ * (initialOpenWeekKeys), so the first client render matches the server HTML.
+ */
+
+import { useId, useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface ScheduleWeekView {
+  /** Stable accordion value from weekKey(): "week-<n>" | "unscheduled". */
+  key: string;
+  /** "Week <n>" | "Unscheduled" — the trigger's accessible name starts with this. */
+  label: string;
+  status: "completed" | "upcoming" | "mixed";
+  /** Muted per-week summary shown in the trigger, e.g. "2 of 4 final". */
+  summary?: string;
+  /** Per-week action controls (e.g. Sim week) — rendered OUTSIDE the trigger button. */
+  actions?: ReactNode;
+  /**
+   * The week's fixture table. For mixed weeks this is the REMAINING
+   * (scheduled/live) games only — always visible while the week is open.
+   */
+  content: ReactNode;
+  /** Mixed weeks: completed games, shown inside the nested collapsed subsection. */
+  completedContent?: ReactNode;
+  /** Mixed weeks: how many games sit in the completed subsection. */
+  completedCount?: number;
+}
+
+export interface ScheduleWeeksProps {
+  weeks: ScheduleWeekView[];
+  /** Initial open accordion values — completed weeks closed, others open. */
+  initialOpenKeys: string[];
+}
+
+export default function ScheduleWeeks({
+  weeks,
+  initialOpenKeys,
+}: ScheduleWeeksProps) {
+  const [openKeys, setOpenKeys] = useState<string[]>(initialOpenKeys);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setOpenKeys(weeks.map((week) => week.key))}
+        >
+          Expand all
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setOpenKeys([])}
+        >
+          Collapse all
+        </Button>
+      </div>
+      <Accordion
+        type="multiple"
+        value={openKeys}
+        onValueChange={setOpenKeys}
+        className="space-y-4"
+      >
+        {weeks.map((week) => (
+          <AccordionItem
+            key={week.key}
+            value={week.key}
+            // Keeps the e2e weekCard() helper working: week containers were
+            // previously ui/Card elements, which carry data-slot="card".
+            data-slot="card"
+            data-week-status={week.status}
+            className="rounded-lg border border-border bg-card px-4 last:border-b"
+          >
+            <div className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
+                <AccordionTrigger>
+                  <span className="flex flex-wrap items-baseline gap-x-2">
+                    <span>{week.label}</span>
+                    {week.summary ? (
+                      <span className="text-xs font-normal text-muted-foreground">
+                        {week.summary}
+                      </span>
+                    ) : null}
+                  </span>
+                </AccordionTrigger>
+              </div>
+              {week.actions ? (
+                <div className="flex shrink-0 items-center gap-1">
+                  {week.actions}
+                </div>
+              ) : null}
+            </div>
+            <AccordionContent>
+              {week.status === "mixed" ? (
+                <div className="space-y-3">
+                  {week.content}
+                  <CompletedSubsection
+                    weekLabel={week.label}
+                    count={week.completedCount ?? 0}
+                  >
+                    {week.completedContent}
+                  </CompletedSubsection>
+                </div>
+              ) : (
+                week.content
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+}
+
+/*
+ * Nested disclosure for the completed games inside a mixed week. Collapsed by
+ * default; a plain <button> keeps it keyboard operable, with aria-expanded /
+ * aria-controls wired to an always-present (hidden) content region.
+ */
+function CompletedSubsection({
+  weekLabel,
+  count,
+  children,
+}: {
+  weekLabel: string;
+  count: number;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="rounded-md border border-border">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={contentId}
+        aria-label={`Completed games — ${weekLabel} (${count})`}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+            open ? "rotate-180" : "",
+          )}
+        />
+        Completed ({count})
+      </button>
+      <div id={contentId} hidden={!open}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/playoff-handoff.test.ts
+++ b/apps/web/src/lib/__tests__/playoff-handoff.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolvePlayoffHandoff,
+  type PlayoffHandoffInput,
+} from "../playoff-handoff";
+
+function input(overrides: Partial<PlayoffHandoffInput> = {}): PlayoffHandoffInput {
+  return {
+    playoffsEnabled: true,
+    viewedSeasonId: "s1",
+    viewedSeasonStatus: "active",
+    decidedSeasonId: "s1",
+    playoffTeams: 4,
+    regularTotal: 6,
+    regularComplete: true,
+    bracketExists: false,
+    canManage: true,
+    ...overrides,
+  };
+}
+
+describe("resolvePlayoffHandoff", () => {
+  it("offers the start button to a manager when the decided active season is complete", () => {
+    expect(resolvePlayoffHandoff(input())).toBe("start");
+  });
+
+  it("shows the non-interactive waiting state for a read-only role", () => {
+    expect(resolvePlayoffHandoff(input({ canManage: false }))).toBe("waiting");
+  });
+
+  it("hides the handoff when the playoffs flag is off", () => {
+    expect(resolvePlayoffHandoff(input({ playoffsEnabled: false }))).toBe(
+      "hidden",
+    );
+  });
+
+  it("hides the handoff when viewing a season other than the decided one", () => {
+    expect(resolvePlayoffHandoff(input({ viewedSeasonId: "s0" }))).toBe(
+      "hidden",
+    );
+  });
+
+  it("hides the handoff on a completed season even if it is the decided season", () => {
+    // resolveLifecycleSeason falls back to the newest season of ANY status,
+    // so a league whose only season is completed still "decides" it — the
+    // status check keeps the button off read-only history.
+    expect(
+      resolvePlayoffHandoff(input({ viewedSeasonStatus: "completed" })),
+    ).toBe("hidden");
+  });
+
+  it("hides the handoff when no season is viewed", () => {
+    expect(
+      resolvePlayoffHandoff(
+        input({ viewedSeasonId: null, viewedSeasonStatus: null }),
+      ),
+    ).toBe("hidden");
+  });
+
+  it("hides the handoff when playoffs are not configured", () => {
+    expect(resolvePlayoffHandoff(input({ playoffTeams: null }))).toBe("hidden");
+    expect(resolvePlayoffHandoff(input({ playoffTeams: 0 }))).toBe("hidden");
+    expect(resolvePlayoffHandoff(input({ playoffTeams: 1 }))).toBe("hidden");
+  });
+
+  it("hides the handoff while the regular season is incomplete", () => {
+    expect(resolvePlayoffHandoff(input({ regularComplete: false }))).toBe(
+      "hidden",
+    );
+  });
+
+  it("hides the handoff on an empty schedule even though it is vacuously complete", () => {
+    expect(resolvePlayoffHandoff(input({ regularTotal: 0 }))).toBe("hidden");
+  });
+
+  it("hides the handoff once a bracket exists", () => {
+    expect(resolvePlayoffHandoff(input({ bracketExists: true }))).toBe(
+      "hidden",
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/schedule-weeks.test.ts
+++ b/apps/web/src/lib/__tests__/schedule-weeks.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupFixturesByWeek,
+  initialOpenWeekKeys,
+  isFixtureDone,
+  weekKey,
+  weekLabel,
+  type FixtureLite,
+} from "../schedule-weeks";
+
+interface Row {
+  fixture: FixtureLite & { id: string };
+}
+
+function row(id: string, week: number | null, status: string): Row {
+  return { fixture: { id, week, status } };
+}
+
+const getFixture = (r: Row) => r.fixture;
+
+describe("weekKey / weekLabel", () => {
+  it("produces stable keys for numeric weeks and the unscheduled bucket", () => {
+    expect(weekKey(1)).toBe("week-1");
+    expect(weekKey(12)).toBe("week-12");
+    expect(weekKey(null)).toBe("unscheduled");
+    expect(weekLabel(3)).toBe("Week 3");
+    expect(weekLabel(null)).toBe("Unscheduled");
+  });
+});
+
+describe("isFixtureDone", () => {
+  it("treats final and cancelled as done, everything else as not done", () => {
+    expect(isFixtureDone("final")).toBe(true);
+    expect(isFixtureDone("cancelled")).toBe(true);
+    expect(isFixtureDone("scheduled")).toBe(false);
+    expect(isFixtureDone("live")).toBe(false);
+    expect(isFixtureDone("in_progress")).toBe(false);
+  });
+});
+
+describe("groupFixturesByWeek", () => {
+  it("classifies an all-final week as completed", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", 1, "final"), row("b", 1, "final")],
+      getFixture,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].status).toBe("completed");
+    expect(groups[0].completedRows).toHaveLength(2);
+    expect(groups[0].remainingRows).toHaveLength(0);
+  });
+
+  it("classifies an all-cancelled week as completed", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", 2, "cancelled"), row("b", 2, "cancelled")],
+      getFixture,
+    );
+    expect(groups[0].status).toBe("completed");
+  });
+
+  it("classifies a week with some done and some not as mixed, splitting the rows", () => {
+    const groups = groupFixturesByWeek(
+      [
+        row("a", 1, "final"),
+        row("b", 1, "scheduled"),
+        row("c", 1, "cancelled"),
+      ],
+      getFixture,
+    );
+    expect(groups[0].status).toBe("mixed");
+    expect(groups[0].completedRows.map((r) => r.fixture.id)).toEqual([
+      "a",
+      "c",
+    ]);
+    expect(groups[0].remainingRows.map((r) => r.fixture.id)).toEqual(["b"]);
+  });
+
+  it("classifies an all-scheduled week as upcoming", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", 4, "scheduled"), row("b", 4, "scheduled")],
+      getFixture,
+    );
+    expect(groups[0].status).toBe("upcoming");
+    expect(groups[0].completedRows).toHaveLength(0);
+    expect(groups[0].remainingRows).toHaveLength(2);
+  });
+
+  it("counts a live fixture as NOT completed (week with finals + a live game is mixed)", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", 1, "final"), row("b", 1, "live")],
+      getFixture,
+    );
+    expect(groups[0].status).toBe("mixed");
+    expect(groups[0].remainingRows.map((r) => r.fixture.id)).toEqual(["b"]);
+  });
+
+  it("keeps a week of only live games open (upcoming, not completed)", () => {
+    const groups = groupFixturesByWeek([row("a", 1, "live")], getFixture);
+    expect(groups[0].status).toBe("upcoming");
+  });
+
+  it("applies the same classification to the unscheduled bucket", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", null, "final"), row("b", null, "cancelled")],
+      getFixture,
+    );
+    expect(groups[0].key).toBe("unscheduled");
+    expect(groups[0].label).toBe("Unscheduled");
+    expect(groups[0].status).toBe("completed");
+  });
+
+  it("sorts numeric weeks ascending with the unscheduled bucket last", () => {
+    const groups = groupFixturesByWeek(
+      [
+        row("u", null, "scheduled"),
+        row("c", 3, "scheduled"),
+        row("a", 1, "scheduled"),
+        row("b", 2, "scheduled"),
+      ],
+      getFixture,
+    );
+    expect(groups.map((g) => g.key)).toEqual([
+      "week-1",
+      "week-2",
+      "week-3",
+      "unscheduled",
+    ]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "Week 1",
+      "Week 2",
+      "Week 3",
+      "Unscheduled",
+    ]);
+  });
+
+  it("preserves input row order within a bucket", () => {
+    const groups = groupFixturesByWeek(
+      [row("first", 1, "scheduled"), row("second", 1, "final")],
+      getFixture,
+    );
+    expect(groups[0].rows.map((r) => r.fixture.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("returns no groups for an empty schedule", () => {
+    expect(groupFixturesByWeek([], getFixture)).toEqual([]);
+  });
+});
+
+describe("initialOpenWeekKeys", () => {
+  it("opens upcoming and mixed weeks, closes completed weeks", () => {
+    const groups = groupFixturesByWeek(
+      [
+        row("a", 1, "final"), // week 1 completed → closed
+        row("b", 2, "final"),
+        row("c", 2, "scheduled"), // week 2 mixed → open
+        row("d", 3, "scheduled"), // week 3 upcoming → open
+        row("e", null, "scheduled"), // unscheduled upcoming → open
+      ],
+      getFixture,
+    );
+    expect(initialOpenWeekKeys(groups)).toEqual([
+      "week-2",
+      "week-3",
+      "unscheduled",
+    ]);
+  });
+
+  it("returns an empty list when every week is completed", () => {
+    const groups = groupFixturesByWeek(
+      [row("a", 1, "final"), row("b", 2, "cancelled")],
+      getFixture,
+    );
+    expect(initialOpenWeekKeys(groups)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/playoff-handoff.ts
+++ b/apps/web/src/lib/playoff-handoff.ts
@@ -1,0 +1,50 @@
+/*
+ * WSM-000239 — season-safe playoff handoff gating for the schedule page.
+ *
+ * Pure so the read-only "waiting" branch has deterministic unit coverage (the
+ * e2e environment has no viewer-role Clerk user, so this branch cannot be
+ * driven end-to-end — see schedules e2e spec notes).
+ */
+
+export type PlayoffHandoffState = "start" | "waiting" | "hidden";
+
+export interface PlayoffHandoffInput {
+  /** playoffs_v1 flag. */
+  playoffsEnabled: boolean;
+  /** The season the page is currently viewing (via ?season= or fallback). */
+  viewedSeasonId: string | null;
+  viewedSeasonStatus: string | null;
+  /** The lifecycle-decided season (resolveLifecycleSeason over all seasons). */
+  decidedSeasonId: string | null;
+  /** Season playoff config; <2 means playoffs are not configured. */
+  playoffTeams: number | null | undefined;
+  /** Regular-season fixture count — an empty schedule never offers a handoff. */
+  regularTotal: number;
+  /** Every regular-season fixture is final or cancelled. */
+  regularComplete: boolean;
+  bracketExists: boolean;
+  /** canManageRoster(role) — admins and coaches may start playoffs. */
+  canManage: boolean;
+}
+
+/**
+ * - "start"   — render the interactive Start-playoffs button.
+ * - "waiting" — readiness holds but the viewer can't manage: render the
+ *               non-interactive "waiting for playoffs to start" state.
+ * - "hidden"  — no handoff surface at all (wrong/completed season, playoffs
+ *               not configured, season not finished, or bracket already live).
+ */
+export function resolvePlayoffHandoff(
+  input: PlayoffHandoffInput,
+): PlayoffHandoffState {
+  if (!input.playoffsEnabled) return "hidden";
+  if (!input.viewedSeasonId) return "hidden";
+  // Season-safety: only the lifecycle-decided ACTIVE season may hand off.
+  // Viewing a historical or upcoming season never surfaces the button.
+  if (input.viewedSeasonId !== input.decidedSeasonId) return "hidden";
+  if (input.viewedSeasonStatus !== "active") return "hidden";
+  if (!input.playoffTeams || input.playoffTeams < 2) return "hidden";
+  if (input.regularTotal === 0 || !input.regularComplete) return "hidden";
+  if (input.bracketExists) return "hidden";
+  return input.canManage ? "start" : "waiting";
+}

--- a/apps/web/src/lib/schedule-weeks.ts
+++ b/apps/web/src/lib/schedule-weeks.ts
@@ -1,0 +1,122 @@
+/*
+ * WSM-000239 — pure week-grouping helpers for the league schedule page.
+ *
+ * The schedule page renders fixtures as a lifecycle-aware accordion timeline:
+ * completed weeks collapse out of the way, current/mixed weeks stay open.
+ * Grouping + classification live here (node-testable, no React) so the server
+ * page and the client accordion derive the SAME initial open state — the
+ * client seeds its controlled accordion from `initialOpenWeekKeys`, keeping
+ * hydration deterministic.
+ */
+
+export type WeekKey = string;
+
+/**
+ * Lifecycle classification of one week bucket:
+ * - `completed` — every fixture is final or cancelled (and the bucket is
+ *   non-empty; empty buckets never exist since grouping only creates a bucket
+ *   per seen fixture).
+ * - `upcoming`  — no fixture is final or cancelled yet. Live/in-progress
+ *   fixtures are NOT done, so a week of live games stays open.
+ * - `mixed`     — some fixtures done, some not.
+ *
+ * The "Unscheduled" (null-week) bucket follows the same rules; its only
+ * special treatment is sorting last.
+ */
+export type WeekStatus = "completed" | "upcoming" | "mixed";
+
+export interface FixtureLite {
+  week: number | null;
+  status: string;
+}
+
+export interface WeekGroup<T> {
+  /** Stable accordion value: "week-<n>" or "unscheduled". */
+  key: WeekKey;
+  week: number | null;
+  /** Display label: "Week <n>" or "Unscheduled". */
+  label: string;
+  status: WeekStatus;
+  /** Every row in the bucket, in input order. */
+  rows: T[];
+  /** Rows whose fixture is final or cancelled (the nested subsection for mixed weeks). */
+  completedRows: T[];
+  /** Rows still to be played (scheduled, live, anything not final/cancelled). */
+  remainingRows: T[];
+}
+
+export function weekKey(week: number | null): WeekKey {
+  return week === null ? "unscheduled" : `week-${week}`;
+}
+
+export function weekLabel(week: number | null): string {
+  return week === null ? "Unscheduled" : `Week ${week}`;
+}
+
+/** A fixture no longer awaiting play: final or cancelled. Live is NOT done. */
+export function isFixtureDone(status: string): boolean {
+  return status === "final" || status === "cancelled";
+}
+
+/**
+ * Bucket rows by fixture week (numeric weeks ascending, null week — the
+ * "Unscheduled" bucket — last) and classify each bucket's lifecycle status.
+ * Generic over the row type so the page can group its hydrated
+ * `{ fixture, result, ... }` rows without this module knowing their shape.
+ */
+export function groupFixturesByWeek<T>(
+  rows: T[],
+  getFixture: (row: T) => FixtureLite,
+): WeekGroup<T>[] {
+  const buckets = new Map<number | null, T[]>();
+  for (const row of rows) {
+    const week = getFixture(row).week;
+    const bucket = buckets.get(week) ?? [];
+    bucket.push(row);
+    buckets.set(week, bucket);
+  }
+
+  const weeks = Array.from(buckets.keys()).sort((a, b) => {
+    if (a === null) return 1;
+    if (b === null) return -1;
+    return a - b;
+  });
+
+  return weeks.map((week) => {
+    const bucket = buckets.get(week)!;
+    const completedRows = bucket.filter((row) =>
+      isFixtureDone(getFixture(row).status),
+    );
+    const remainingRows = bucket.filter(
+      (row) => !isFixtureDone(getFixture(row).status),
+    );
+    const status: WeekStatus =
+      remainingRows.length === 0
+        ? "completed"
+        : completedRows.length === 0
+          ? "upcoming"
+          : "mixed";
+    return {
+      key: weekKey(week),
+      week,
+      label: weekLabel(week),
+      status,
+      rows: bucket,
+      completedRows,
+      remainingRows,
+    };
+  });
+}
+
+/**
+ * Initial accordion open state: completed weeks closed, upcoming and mixed
+ * weeks open. Server page and client component both call this so the first
+ * client render matches the server HTML exactly.
+ */
+export function initialOpenWeekKeys(
+  groups: Array<{ key: WeekKey; status: WeekStatus }>,
+): WeekKey[] {
+  return groups
+    .filter((group) => group.status !== "completed")
+    .map((group) => group.key);
+}


### PR DESCRIPTION
## Summary

Implements WSM-000239 (Phase 4 of epic #523): the league schedule becomes a lifecycle-aware accordion timeline, and the playoff handoff becomes explicit and season-safe.

- **Schedule accordions** — new pure helper `lib/schedule-weeks.ts` groups fixtures by week and classifies each as completed / upcoming / mixed (live counts as not completed; cancelled counts as done). Completed weeks render collapsed, future weeks expanded, and mixed weeks stay expanded with completed games in a nested collapsible "Completed" subsection. New presentation-only `ScheduleWeeks` client component provides controlled multi-open accordions with Expand all / Collapse all and accurate `aria-expanded`; all data loading stays in the server page.
- **Season-safe playoff handoff** — `advanceToPlayoffsAction` now requires an explicit `seasonId`, authorized server-side (must belong to the league, must equal the lifecycle-decided season, must not be completed) with stable error codes: `season_required`, `season_not_found`, `season_completed`, `season_mismatch`. A stale `?season=` view can never advance the wrong season. The schedule page surfaces a readiness-gated "Start playoffs" button for managers (pure gating in `lib/playoff-handoff.ts`) and a non-interactive waiting state for read-only viewers.
- **Completed-season read-only UI** — schedule and playoffs pages stop rendering generation, fixture, simulation, result, go-live, roster, and advance controls for completed seasons per the WSM-000238 policy; clip management remains (historical-media exception); all read paths (results, box scores, Gamecast links) preserved.
- **Tests** — 24 new unit tests (`schedule-weeks`, `playoff-handoff`) plus updated advance-action tests for the seasonId contract; e2e coverage for accordion initial states, mixed-week nesting, expand/collapse-all, schedule-page handoff, and completed-season read-only assertions; gamecast spec updated for the new mixed-week markup with content-based (non-positional) row selection.

## Verification

- `pnpm --filter @sports-management/web type-check` — pass
- `pnpm --filter @sports-management/web lint` — pass
- `pnpm --filter @sports-management/web test:unit` — 158 files, 1125 tests, all pass
- Two independent review rounds: round 1 REQUEST_CHANGES (5 findings — gamecast spec compatibility blocker, retry-safety, timeout budget, completed-season gate on playoffs page, summary wording), all fixed; round 2 APPROVED with no new defects.
- Playwright and visual suites run in CI (required checks).

## Related Issue

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
