### PR TITLE
feat(web): contextual game preview and Gamecast drawer (WSM-000240)

### DIFF
--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -648,14 +648,30 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
     await page.goto(`/dashboard/leagues/${fixture!.leagueId}/schedule`);
     await revealAllScheduleRows(page);
 
+    const pageOverflow = () =>
+      page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+
+    const before = await pageOverflow();
+
     const row = page.locator("tbody tr").first();
     await row.getByRole("button").first().click();
-    await expect(page.getByTestId("game-context-drawer")).toBeVisible();
+    const drawer = page.getByTestId("game-context-drawer");
+    await expect(drawer).toBeVisible();
 
-    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
-      scrollWidth: document.documentElement.scrollWidth,
-      clientWidth: document.documentElement.clientWidth,
-    }));
-    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+    const after = await pageOverflow();
+    const beforeDelta = before.scrollWidth - before.clientWidth;
+    const afterDelta = after.scrollWidth - after.clientWidth;
+    // Opening the drawer must not widen the page beyond subpixel slack.
+    expect(afterDelta).toBeLessThanOrEqual(beforeDelta + 1);
+
+    const drawerBox = await drawer.boundingBox();
+    expect(drawerBox).not.toBeNull();
+    expect(drawerBox!.x).toBeGreaterThanOrEqual(0);
+    expect(drawerBox!.x + drawerBox!.width).toBeLessThanOrEqual(
+      after.clientWidth + 1,
+    );
   });
 });

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -566,4 +566,92 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
       0,
     );
   });
+
+  test("scheduled schedule row opens preview drawer with team context", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    const leagueId = fixture!.leagueId;
+
+    await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
+    await revealAllScheduleRows(page);
+
+    const scheduledRow = page
+      .locator("tbody tr")
+      .filter({ has: page.getByText("Scheduled", { exact: true }) })
+      .first();
+    const homeName = await scheduledRow.locator("td").nth(1).innerText();
+    const awayName = await scheduledRow.locator("td").nth(2).innerText();
+
+    await scheduledRow
+      .getByRole("button", {
+        name: new RegExp(`View preview for ${homeName} vs ${awayName}`),
+      })
+      .first()
+      .click();
+
+    const drawer = page.getByTestId("game-context-drawer");
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText("Preview")).toBeVisible();
+    await expect(
+      drawer.getByRole("heading", { name: `${homeName} vs ${awayName}` }),
+    ).toBeVisible();
+    await expect(drawer.getByTestId("game-drawer-open-gamecast")).toHaveCount(0);
+
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+  });
+
+  test("final schedule row opens summary drawer and links to full Gamecast", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    const ctx = await openSimmedGamecastFinal(page, fixture!.leagueId);
+
+    await page.goto(`/dashboard/leagues/${fixture!.leagueId}/schedule`);
+    await revealAllScheduleRows(page);
+
+    const finalRow = page.getByTestId(/^schedule-fixture-/).filter({
+      has: page.getByText("Final", { exact: true }),
+    }).first();
+    await finalRow
+      .getByRole("button", {
+        name: new RegExp(
+          `View final for ${ctx.homeName} vs ${ctx.awayName}`,
+        ),
+      })
+      .first()
+      .click();
+
+    const drawer = page.getByTestId("game-context-drawer");
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText("Final")).toBeVisible();
+    await expect(drawer.getByText(String(ctx.expectedHome))).toBeVisible();
+    await expect(drawer.getByText(String(ctx.expectedAway))).toBeVisible();
+
+    await drawer.getByTestId("game-drawer-open-gamecast").click();
+    await expect(page).toHaveURL(/\/dashboard\/games\/[^/]+\/gamecast$/);
+    await expect(
+      page.getByRole("heading", { name: "Gamecast" }),
+    ).toBeVisible();
+  });
+
+  test("drawer on schedule does not overflow a 375px viewport", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(`/dashboard/leagues/${fixture!.leagueId}/schedule`);
+    await revealAllScheduleRows(page);
+
+    const row = page.locator("tbody tr").first();
+    await row.getByRole("button").first().click();
+    await expect(page.getByTestId("game-context-drawer")).toBeVisible();
+
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  });
 });

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -600,6 +600,10 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
 
     await page.keyboard.press("Escape");
     await expect(drawer).toBeHidden();
+
+    await expect
+      .poll(() => scheduledRow.getByRole("button").first().evaluate((el) => el === document.activeElement))
+      .toBe(true);
   });
 
   test("final schedule row opens summary drawer and links to full Gamecast", async ({

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -592,7 +592,7 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
 
     const drawer = page.getByTestId("game-context-drawer");
     await expect(drawer).toBeVisible();
-    await expect(drawer.getByText("Preview")).toBeVisible();
+    await expect(drawer.getByTestId("game-drawer-mode")).toHaveText(/^Preview/);
     await expect(
       drawer.getByRole("heading", { name: `${homeName} vs ${awayName}` }),
     ).toBeVisible();
@@ -629,7 +629,7 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
 
     const drawer = page.getByTestId("game-context-drawer");
     await expect(drawer).toBeVisible();
-    await expect(drawer.getByText("Final")).toBeVisible();
+    await expect(drawer.getByTestId("game-drawer-mode")).toHaveText(/^Final/);
     await expect(drawer.getByText(String(ctx.expectedHome))).toBeVisible();
     await expect(drawer.getByText(String(ctx.expectedAway))).toBeVisible();
 

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -127,7 +127,7 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
     await bracketTrigger.click();
     const drawer = page.getByTestId("game-context-drawer");
     await expect(drawer).toBeVisible();
-    await expect(drawer.getByText("Preview")).toBeVisible();
+    await expect(drawer.getByTestId("game-drawer-mode")).toHaveText(/^Preview/);
     await page.keyboard.press("Escape");
     await expect(drawer).toBeHidden();
 
@@ -149,6 +149,8 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
       .first();
     await finalBracketTrigger.click();
     await expect(page.getByTestId("game-context-drawer")).toBeVisible();
-    await expect(page.getByTestId("game-context-drawer").getByText("Final")).toBeVisible();
+    await expect(
+      page.getByTestId("game-context-drawer").getByTestId("game-drawer-mode"),
+    ).toHaveText(/^Final/);
   });
 });

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -123,6 +123,14 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
       page.getByText(/Round 1|Semifinal|Quarterfinal/i).first(),
     ).toBeVisible();
 
+    const bracketTrigger = page.getByTestId(/^playoff-drawer-trigger-/).first();
+    await bracketTrigger.click();
+    const drawer = page.getByTestId("game-context-drawer");
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText("Preview")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+
     await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
     await simPlayoffsScope(page);
     await expect(page.getByText(/wins — simulated|Simulated \d+ playoff game/)).toBeVisible({
@@ -134,5 +142,13 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
     await expect(
       page.locator(".rounded-lg.border-primary\\/30").getByRole("link").first(),
     ).toBeVisible();
+
+    const finalBracketTrigger = page
+      .getByTestId(/^playoff-drawer-trigger-/)
+      .filter({ has: page.locator(".font-semibold") })
+      .first();
+    await finalBracketTrigger.click();
+    await expect(page.getByTestId("game-context-drawer")).toBeVisible();
+    await expect(page.getByTestId("game-context-drawer").getByText("Final")).toBeVisible();
   });
 });

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -118,7 +118,8 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
 
     await page.goto(`/dashboard/leagues/${leagueId}/playoffs`);
     await expect(page.getByText("Champion", { exact: true })).toHaveCount(0);
-    await expect(page.getByRole("link").filter({ hasText: /E2E PO|E2E Team/ }).first()).toBeVisible();
+    await expect(page.getByTestId(/^playoff-drawer-trigger-/).first()).toBeVisible();
+    await expect(page.getByText(/E2E PO|E2E Team/).first()).toBeVisible();
     await expect(
       page.getByText(/Round 1|Semifinal|Quarterfinal/i).first(),
     ).toBeVisible();

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -397,7 +397,7 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
     await archivedRow.getByRole("button").first().click();
     const drawer = page.getByTestId("game-context-drawer");
     await expect(drawer).toBeVisible();
-    await expect(drawer.getByText("Final")).toBeVisible();
+    await expect(drawer.getByTestId("game-drawer-mode")).toHaveText(/^Final/);
     await page.keyboard.press("Escape");
     await expect(drawer).toBeHidden();
   });

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -386,9 +386,20 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
 
     // Read paths remain: every week is completed (collapsed) — expand and
     // confirm the recorded scores are still there.
+    await page.goto(
+      `/dashboard/leagues/${leagueId}/schedule?season=${fixture!.seasonId}`,
+    );
     await page.getByRole("button", { name: "Expand all" }).click();
     await expect(page.getByText("21 – 7")).toBeVisible();
     await expect(page.getByText("28 – 3")).toBeVisible();
+
+    const archivedRow = page.getByTestId(/^schedule-fixture-/).first();
+    await archivedRow.getByRole("button").first().click();
+    const drawer = page.getByTestId("game-context-drawer");
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText("Final")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
   });
 });
 

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -104,9 +104,8 @@ test.describe("Schedules & standings — fixture loop (WSM-000074)", () => {
     // The new row appears in Week 1. Home/Away cells use exact team names;
     // action links use concise labels (Box score Home/Away, Live) instead.
     await expect(page.getByText("Week 1")).toBeVisible();
-    await expect(
-      page.getByRole("cell", { name: "E2E Home Hawks", exact: true }),
-    ).toBeVisible();
+    // Team names live in drawer trigger buttons (WSM-000240), not bare cells.
+    await expect(page.getByText("E2E Home Hawks").first()).toBeVisible();
 
     // 3. Record the result.
     await page.getByRole("button", { name: "Record result" }).click();
@@ -155,9 +154,8 @@ test.describe("Schedules & standings — fixture loop (WSM-000074)", () => {
     await expect(
       page.getByRole("heading", { name: "Standings" }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("cell", { name: "E2E Home Hawks", exact: true }),
-    ).toBeVisible();
+    // Team names live in drawer trigger buttons (WSM-000240), not bare cells.
+    await expect(page.getByText("E2E Home Hawks").first()).toBeVisible();
 
     // 7b. Landing hub (WSM-000083) renders and links to the standings viewer.
     const publicLanding = await page.goto(`/leagues/${leagueId}`);

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,7 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { ClipboardList, Radio, Tv } from "lucide-react";
 import {
   schedulesStandingsV1,
   liveStreamingV1,
@@ -20,15 +19,19 @@ import {
   getPlayoffBracket,
   getTeamsByLeague,
   listFixturesBySeason,
+  computeStandings,
   type PublicGameStream,
 } from "@/lib/data-api";
+import {
+  formatTeamRecord,
+  projectionFromFixture,
+} from "@/lib/game-drawer-projection";
 import type {
   FixtureDto,
   GameResultDto,
 } from "@sports-management/shared-types";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster, canManageOrgSettings } from "@/lib/permissions";
-import { formatFixtureWhen } from "@/lib/format";
 import { isSeasonStarted } from "@/lib/season-started";
 import { regularSeasonProgress } from "@/lib/playoffs";
 import { resolvePlayoffHandoff } from "@/lib/playoff-handoff";
@@ -39,21 +42,16 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import FixtureFormDialog from "@/components/schedule/FixtureFormDialog";
 import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
-import RecordResultDialog from "@/components/schedule/RecordResultDialog";
-import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
-import GoLiveControl from "@/components/schedule/GoLiveControl";
-import ClipsControl from "@/components/schedule/ClipsControl";
 import {
-  SimulateGameButton,
   SimulateScopeMenu,
   SimulateWeekButton,
 } from "@/components/schedule/SimulateControls";
 import ScheduleWeeks, {
   type ScheduleWeekView,
 } from "@/components/schedule/ScheduleWeeks";
+import { ScheduleFixtureRow } from "@/components/schedule/ScheduleFixtureRow";
 import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
-import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
 import { resolveLifecycleSeason, resolveViewedSeason } from "@/lib/season-view";
@@ -62,8 +60,6 @@ import { BackLink } from "@/components/workspace/BackLink";
 import { WorkspaceHeader } from "@/components/workspace/WorkspaceHeader";
 import { WorkspaceNav } from "@/components/workspace/WorkspaceNav";
 import { buildLeagueSeasonNavLinks } from "@/components/workspace/build-league-nav-links";
-
-type StreamStatus = "idle" | "active" | "ended";
 
 interface FixtureRow {
   fixture: FixtureDto;
@@ -147,6 +143,16 @@ export default async function LeagueSchedulePage({
     }),
   );
 
+  const standings = activeSeason
+    ? await computeStandings(activeSeason.id)
+    : [];
+  const recordByTeamId = new Map(
+    standings.map((s) => [
+      s.teamId,
+      formatTeamRecord(s.wins, s.losses, s.ties),
+    ]),
+  );
+
   // Per-fixture live-stream state — only fetched when the dark flag is on for
   // an admin, so the default (flag off) path adds zero reads. The full public
   // projection is kept (not just status): the clips control (WSM-000201)
@@ -202,6 +208,7 @@ export default async function LeagueSchedulePage({
       statsEnabled={statsEnabled}
       liveEnabled={liveEnabled}
       streams={streams}
+      recordByTeamId={recordByTeamId}
     />
   );
   const weekViews: ScheduleWeekView[] = weekGroups.map((group) => ({
@@ -374,6 +381,7 @@ function FixtureTable({
   statsEnabled,
   liveEnabled,
   streams,
+  recordByTeamId,
 }: {
   rows: FixtureRow[];
   leagueId: string;
@@ -384,6 +392,7 @@ function FixtureTable({
   statsEnabled: boolean;
   liveEnabled: boolean;
   streams: Map<string, PublicGameStream | null>;
+  recordByTeamId: Map<string, string>;
 }) {
   return (
     <div className="overflow-x-auto">
@@ -406,151 +415,26 @@ function FixtureTable({
         </thead>
         <tbody>
           {rows.map(({ fixture, result, hasPlayLog }) => (
-            <tr
+            <ScheduleFixtureRow
               key={fixture.id}
-              data-testid={`schedule-fixture-${fixture.id}`}
-              className="border-b border-border"
-            >
-              <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
-                {formatFixtureWhen(fixture.scheduledAt)}
-              </td>
-              <td className="px-4 py-2 text-foreground">
-                {fixture.homeTeamName}
-              </td>
-              <td className="px-4 py-2 text-foreground">
-                {fixture.awayTeamName}
-              </td>
-              <td className="px-4 py-2 text-right font-mono text-foreground">
-                {result ? (
-                  statsEnabled ? (
-                    <Link
-                      href={`/dashboard/games/${fixture.id}/boxscore`}
-                      className="hover:underline"
-                      title="View box score"
-                    >
-                      {result.homeScore} – {result.awayScore}
-                    </Link>
-                  ) : (
-                    `${result.homeScore} – ${result.awayScore}`
-                  )
-                ) : (
-                  "—"
-                )}
-              </td>
-              <td className="px-4 py-2">
-                <StatusBadge status={fixture.status} />
-              </td>
-              {isAdmin ? (
-                <td className="px-4 py-2">
-                  <div className="flex flex-wrap items-center gap-1">
-                    {canMutate ? (
-                      <RecordResultDialog
-                        leagueId={leagueId}
-                        fixtureId={fixture.id}
-                        homeTeamName={fixture.homeTeamName}
-                        awayTeamName={fixture.awayTeamName}
-                        initialHomeScore={result?.homeScore ?? null}
-                        initialAwayScore={result?.awayScore ?? null}
-                        triggerLabel={result ? "Edit result" : "Record result"}
-                      />
-                    ) : null}
-                    {canMutate && fixture.status === "scheduled" ? (
-                      <SimulateGameButton
-                        leagueId={leagueId}
-                        fixtureId={fixture.id}
-                        homeTeamName={fixture.homeTeamName}
-                        awayTeamName={fixture.awayTeamName}
-                      />
-                    ) : null}
-                    {canMutate ? (
-                      <DeleteFixtureButton
-                        leagueId={leagueId}
-                        fixtureId={fixture.id}
-                        homeTeamName={fixture.homeTeamName}
-                        awayTeamName={fixture.awayTeamName}
-                      />
-                    ) : null}
-                    {canGoLive ? (
-                      <GoLiveControl
-                        leagueId={leagueId}
-                        fixtureId={fixture.id}
-                        homeTeamName={fixture.homeTeamName}
-                        awayTeamName={fixture.awayTeamName}
-                        status={
-                          (streams.get(fixture.id)?.status as
-                            | StreamStatus
-                            | undefined) ?? null
-                        }
-                        gameStatus={fixture.status}
-                      />
-                    ) : null}
-                    {canStream &&
-                    streams.get(fixture.id)?.provider === "mux" &&
-                    streams.get(fixture.id)?.vodAssetId ? (
-                      <ClipsControl
-                        leagueId={leagueId}
-                        fixtureId={fixture.id}
-                        homeTeamName={fixture.homeTeamName}
-                        awayTeamName={fixture.awayTeamName}
-                        vodPlaybackId={
-                          streams.get(fixture.id)?.vodPlaybackId ?? null
-                        }
-                      />
-                    ) : null}
-                    {statsEnabled ? (
-                      <span className="flex items-center gap-1 text-xs">
-                        <ClipboardList className="h-3.5 w-3.5 text-muted-foreground" />
-                        <span className="text-muted-foreground">
-                          Box score
-                        </span>
-                        <Link
-                          href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/stats`}
-                          className="text-primary hover:underline"
-                        >
-                          Home
-                        </Link>
-                        <span className="text-muted-foreground">/</span>
-                        <Link
-                          href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
-                          className="text-primary hover:underline"
-                        >
-                          Away
-                        </Link>
-                      </span>
-                    ) : null}
-                    {liveEnabled ? (
-                      <span className="flex items-center gap-1 text-xs">
-                        <Radio className="h-3.5 w-3.5 text-muted-foreground" />
-                        <Link
-                          href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
-                          className="text-primary hover:underline"
-                        >
-                          Live (Home)
-                        </Link>
-                        <span className="text-muted-foreground">/</span>
-                        <Link
-                          href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
-                          className="text-primary hover:underline"
-                        >
-                          Away
-                        </Link>
-                      </span>
-                    ) : null}
-                    {fixture.status === "final" && hasPlayLog ? (
-                      <span className="flex items-center gap-1 text-xs">
-                        <Tv className="h-3.5 w-3.5 text-muted-foreground" />
-                        <Link
-                          href={`/dashboard/games/${fixture.id}/gamecast`}
-                          className="text-primary hover:underline"
-                        >
-                          Gamecast
-                        </Link>
-                      </span>
-                    ) : null}
-                  </div>
-                </td>
-              ) : null}
-            </tr>
+              fixture={fixture}
+              result={result}
+              hasPlayLog={hasPlayLog}
+              projection={projectionFromFixture({
+                fixture,
+                result,
+                hasPlayLog,
+                recordByTeamId,
+              })}
+              leagueId={leagueId}
+              isAdmin={isAdmin}
+              canMutate={canMutate}
+              canGoLive={canGoLive}
+              canStream={canStream}
+              statsEnabled={statsEnabled}
+              liveEnabled={liveEnabled}
+              stream={streams.get(fixture.id)}
+            />
           ))}
         </tbody>
       </table>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -206,6 +206,20 @@
 }
 
 /*
+ * Radix Dialog/Sheet scroll lock adds padding-right for the scrollbar gutter.
+ * On narrow viewports (and headless Linux CI) that padding can widen the page
+ * even when no scrollbar is visible — WSM-000240 drawer overflow E2E.
+ */
+html {
+  overflow-x: clip;
+}
+
+body[data-scroll-locked] {
+  padding-right: 0 !important;
+  margin-right: 0 !important;
+}
+
+/*
  * Reduced-motion a11y override (WSM-000136 P7). When the user has requested
  * reduced motion at the OS level, collapse all transitions/animations to a
  * near-instant duration and disable smooth scrolling. This neutralises the

--- a/apps/web/src/components/games/GameContextDrawer.tsx
+++ b/apps/web/src/components/games/GameContextDrawer.tsx
@@ -106,7 +106,7 @@ export function GameContextDrawer({
         side="right"
         aria-labelledby={titleId}
         data-testid="game-context-drawer"
-        className="flex w-full max-w-md flex-col overflow-y-auto overscroll-contain"
+        className="flex w-[min(100vw,24rem)] max-w-[100vw] flex-col overflow-x-hidden overflow-y-auto overscroll-contain"
       >
         {projection ? (
           <>

--- a/apps/web/src/components/games/GameContextDrawer.tsx
+++ b/apps/web/src/components/games/GameContextDrawer.tsx
@@ -111,7 +111,10 @@ export function GameContextDrawer({
         {projection ? (
           <>
             <div className="space-y-1 pr-8">
-              <p className="font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
+              <p
+                data-testid="game-drawer-mode"
+                className="font-mono text-caption-12 uppercase tracking-wide text-muted-foreground"
+              >
                 {isFinal ? "Final" : "Preview"}
                 {projection.roundLabel ? ` · ${projection.roundLabel}` : ""}
               </p>

--- a/apps/web/src/components/games/GameContextDrawer.tsx
+++ b/apps/web/src/components/games/GameContextDrawer.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { ExternalLink, MapPin, Calendar } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetClose,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/status-badge";
+import { formatFixtureWhen } from "@/lib/format";
+import {
+  type GameDrawerProjection,
+  gameDrawerCanOpenGamecast,
+  gameDrawerIsFinal,
+  gameDrawerMatchupLabel,
+} from "@/lib/game-drawer-projection";
+import { cn } from "@/lib/utils";
+
+export interface GameContextDrawerProps {
+  projection: GameDrawerProjection | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Element to restore focus to when the drawer closes. */
+  restoreFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+function TeamBlock({
+  team,
+  score,
+  won,
+  dim,
+  align,
+}: {
+  team: GameDrawerProjection["home"];
+  score: number | null;
+  won: boolean;
+  dim: boolean;
+  align: "left" | "right";
+}) {
+  const meta = [
+    team.seed != null ? `#${team.seed} seed` : null,
+    team.record,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const nameClass = cn(
+    "text-base font-semibold text-foreground",
+    won && "text-foreground",
+    dim && !won && "text-muted-foreground",
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-1 flex-col gap-1",
+        align === "right" && "items-end text-right",
+      )}
+    >
+      {team.id ? (
+        <Link href={`/dashboard/teams/${team.id}`} className={cn(nameClass, "hover:underline")}>
+          {team.name}
+        </Link>
+      ) : (
+        <span className={nameClass}>{team.name}</span>
+      )}
+      {meta ? (
+        <span className="text-xs text-muted-foreground">{meta}</span>
+      ) : null}
+      {score != null ? (
+        <span className="font-mono text-2xl tabular-nums text-foreground">
+          {score}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function GameContextDrawer({
+  projection,
+  open,
+  onOpenChange,
+  restoreFocusRef,
+}: GameContextDrawerProps) {
+  const titleId = React.useId();
+  const isFinal = projection ? gameDrawerIsFinal(projection) : false;
+  const canOpenGamecast = projection
+    ? gameDrawerCanOpenGamecast(projection)
+    : false;
+
+  const handleOpenChange = (next: boolean) => {
+    onOpenChange(next);
+    if (!next && restoreFocusRef?.current) {
+      requestAnimationFrame(() => {
+        restoreFocusRef.current?.focus();
+      });
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent
+        side="right"
+        aria-labelledby={titleId}
+        data-testid="game-context-drawer"
+        className="flex w-full max-w-md flex-col overflow-y-auto overscroll-contain"
+      >
+        {projection ? (
+          <>
+            <div className="space-y-1 pr-8">
+              <p className="font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
+                {isFinal ? "Final" : "Preview"}
+                {projection.roundLabel ? ` · ${projection.roundLabel}` : ""}
+              </p>
+              <h2 id={titleId} className="text-lg font-semibold text-foreground">
+                {gameDrawerMatchupLabel(projection)}
+              </h2>
+              {projection.status ? (
+                <StatusBadge status={projection.status} />
+              ) : null}
+            </div>
+
+            <div className="flex items-start justify-between gap-4 border-y border-border py-4">
+              <TeamBlock
+                team={projection.home}
+                score={isFinal ? projection.homeScore : null}
+                won={
+                  isFinal &&
+                  projection.homeScore != null &&
+                  projection.awayScore != null &&
+                  projection.homeScore > projection.awayScore
+                }
+                dim={isFinal}
+                align="left"
+              />
+              <span className="shrink-0 pt-6 font-mono text-sm text-muted-foreground">
+                {isFinal ? "–" : "vs"}
+              </span>
+              <TeamBlock
+                team={projection.away}
+                score={isFinal ? projection.awayScore : null}
+                won={
+                  isFinal &&
+                  projection.homeScore != null &&
+                  projection.awayScore != null &&
+                  projection.awayScore > projection.homeScore
+                }
+                dim={isFinal}
+                align="right"
+              />
+            </div>
+
+            <dl className="space-y-3 text-sm">
+              {projection.scheduledAt ? (
+                <div className="flex items-start gap-2">
+                  <Calendar className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <div>
+                    <dt className="sr-only">Scheduled</dt>
+                    <dd>{formatFixtureWhen(projection.scheduledAt)}</dd>
+                  </div>
+                </div>
+              ) : null}
+              {projection.venue ? (
+                <div className="flex items-start gap-2">
+                  <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <div>
+                    <dt className="sr-only">Venue</dt>
+                    <dd>{projection.venue}</dd>
+                  </div>
+                </div>
+              ) : null}
+            </dl>
+
+            {isFinal && !canOpenGamecast ? (
+              <p className="text-sm text-muted-foreground">
+                Final score recorded. Full Gamecast is available for simulated
+                games with a stored play-by-play log.
+              </p>
+            ) : null}
+
+            {!isFinal ? (
+              <p className="text-sm text-muted-foreground">
+                Kickoff preview — open the full Gamecast after the game is
+                played and a play log exists.
+              </p>
+            ) : null}
+
+            <div className="mt-auto flex flex-col gap-2 pt-4">
+              {canOpenGamecast && projection.fixtureId ? (
+                <Button asChild className="w-full">
+                  <Link
+                    href={`/dashboard/games/${projection.fixtureId}/gamecast`}
+                    data-testid="game-drawer-open-gamecast"
+                  >
+                    Open full Gamecast
+                    <ExternalLink className="ml-2 h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </Button>
+              ) : null}
+              <SheetClose asChild>
+                <Button type="button" variant="outline" className="w-full">
+                  Close
+                </Button>
+              </SheetClose>
+            </div>
+          </>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/games/GameDrawerTrigger.tsx
+++ b/apps/web/src/components/games/GameDrawerTrigger.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import { GameContextDrawer } from "@/components/games/GameContextDrawer";
+import type { GameDrawerProjection } from "@/lib/game-drawer-projection";
+import { gameDrawerMatchupLabel } from "@/lib/game-drawer-projection";
+import { cn } from "@/lib/utils";
+
+export interface GameDrawerTriggerProps {
+  projection: GameDrawerProjection;
+  /** Visible trigger content (team names, card, etc.). */
+  children: React.ReactNode;
+  className?: string;
+  /** Optional override for the trigger's accessible name. */
+  ariaLabel?: string;
+}
+
+/**
+ * Accessible drawer opener — keeps interactive admin controls OUTSIDE the
+ * trigger so nested buttons/links do not fight the sheet (WSM-000240).
+ */
+export function GameDrawerTrigger({
+  projection,
+  children,
+  className,
+  ariaLabel,
+}: GameDrawerTriggerProps) {
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const label =
+    ariaLabel ??
+    `View ${projection.status === "final" ? "final" : "preview"} for ${gameDrawerMatchupLabel(projection)}`;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={label}
+        data-testid={`game-drawer-trigger-${projection.id}`}
+        onClick={() => setOpen(true)}
+        className={cn(
+          "rounded-sm text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className,
+        )}
+      >
+        {children}
+      </button>
+      <GameContextDrawer
+        projection={projection}
+        open={open}
+        onOpenChange={setOpen}
+        restoreFocusRef={triggerRef}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/games/__tests__/GameContextDrawer.test.ts
+++ b/apps/web/src/components/games/__tests__/GameContextDrawer.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GameContextDrawer } from "@/components/games/GameContextDrawer";
+import type { GameDrawerProjection } from "@/lib/game-drawer-projection";
+
+type SheetProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+};
+
+type ContentProps = {
+  children?: ReactNode;
+  className?: string;
+  side?: string;
+  "data-testid"?: string;
+  "aria-labelledby"?: string;
+};
+
+let mockOpenChange: ((open: boolean) => void) | undefined;
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ open, onOpenChange, children }: SheetProps) => {
+    mockOpenChange = onOpenChange;
+    return open
+      ? createElement("div", { "data-testid": "sheet-root", role: "dialog" }, children)
+      : null;
+  },
+  SheetContent: ({ children, ...props }: ContentProps) =>
+    createElement("div", { "data-testid": props["data-testid"] ?? "sheet-content" }, children),
+  SheetClose: ({ children }: { children?: ReactNode }) =>
+    createElement("button", { type: "button", onClick: () => mockOpenChange?.(false) }, children),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children?: ReactNode;
+  }) => createElement("a", { href, ...props }, children),
+}));
+
+const scheduledProjection: GameDrawerProjection = {
+  id: "fx1",
+  surface: "schedule",
+  fixtureId: "fx1",
+  status: "scheduled",
+  home: { id: "h1", name: "Alpha", seed: null, record: "2-1" },
+  away: { id: "a1", name: "Beta", seed: null, record: "1-2" },
+  scheduledAt: "2026-07-01T18:00:00.000Z",
+  venue: "Memorial Field",
+  homeScore: null,
+  awayScore: null,
+  hasPlayLog: false,
+  roundLabel: null,
+  isBye: false,
+};
+
+const finalProjection: GameDrawerProjection = {
+  ...scheduledProjection,
+  status: "final",
+  homeScore: 21,
+  awayScore: 14,
+  hasPlayLog: true,
+};
+
+describe("GameContextDrawer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+  });
+
+  function renderDrawer(
+    projection: GameDrawerProjection | null,
+    open = true,
+  ) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(GameContextDrawer, {
+          projection,
+          open,
+          onOpenChange: vi.fn(),
+        }),
+      );
+    });
+  }
+
+  it("renders preview mode for scheduled games", () => {
+    renderDrawer(scheduledProjection);
+    expect(container.textContent).toContain("Preview");
+    expect(container.textContent).toContain("Alpha vs Beta");
+    expect(container.textContent).toContain("Memorial Field");
+    expect(container.textContent).toContain("2-1");
+    expect(container.querySelector('[data-testid="game-drawer-open-gamecast"]')).toBeNull();
+  });
+
+  it("renders final summary and gamecast link when play log exists", () => {
+    renderDrawer(finalProjection);
+    expect(container.textContent).toContain("Final");
+    expect(container.textContent).toContain("21");
+    expect(container.textContent).toContain("14");
+    const link = container.querySelector('[data-testid="game-drawer-open-gamecast"]');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("/dashboard/games/fx1/gamecast");
+  });
+
+  it("renders nothing when closed", () => {
+    renderDrawer(scheduledProjection, false);
+    expect(container.querySelector('[data-testid="game-context-drawer"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -17,25 +17,24 @@ function TeamName({
   name,
   won,
   dim,
+  linkable,
 }: {
   teamId: string | null;
   name: string | null;
   won: boolean;
   dim: boolean;
+  linkable: boolean;
 }) {
   const label = name ?? "TBD";
   const className = cn(
-    "truncate hover:underline",
+    "truncate",
+    linkable && "hover:underline",
     won && "font-semibold text-foreground",
     dim && !won && "text-muted-foreground",
   );
-  if (teamId) {
+  if (teamId && linkable) {
     return (
-      <Link
-        href={`/dashboard/teams/${teamId}`}
-        className={className}
-        onClick={(event) => event.stopPropagation()}
-      >
+      <Link href={`/dashboard/teams/${teamId}`} className={className}>
         {label}
       </Link>
     );
@@ -50,6 +49,7 @@ function Side({
   score,
   won,
   dim,
+  linkable,
 }: {
   teamId: string | null;
   seed: number | null;
@@ -57,6 +57,7 @@ function Side({
   score: number | null;
   won: boolean;
   dim: boolean;
+  linkable: boolean;
 }) {
   return (
     <div
@@ -71,7 +72,13 @@ function Side({
             {seed}
           </span>
         ) : null}
-        <TeamName teamId={teamId} name={name} won={won} dim={dim} />
+        <TeamName
+          teamId={teamId}
+          name={name}
+          won={won}
+          dim={dim}
+          linkable={linkable}
+        />
       </span>
       <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
         {score ?? ""}
@@ -102,6 +109,7 @@ function MatchupCard({
         score={null}
         won={true}
         dim={false}
+        linkable={false}
       />
       <div className="border-t border-border" />
       <div className="px-2 py-1 text-xs italic text-muted-foreground">
@@ -117,6 +125,7 @@ function MatchupCard({
         score={m.homeScore}
         won={side === "home"}
         dim={decided}
+        linkable={false}
       />
       <div className="border-t border-border" />
       <Side
@@ -126,6 +135,7 @@ function MatchupCard({
         score={m.awayScore}
         won={side === "away"}
         dim={decided}
+        linkable={false}
       />
     </div>
   );

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -1,7 +1,16 @@
+"use client";
+
+import * as React from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import type { PlayoffBracketDto, PlayoffMatchupDto } from "@/lib/data-api";
+import type { PlayoffMatchupDto } from "@/lib/data-api";
 import { bracketSections, winnerSide } from "@/lib/playoffs";
+import type { PlayoffBracketDto } from "@/lib/data-api";
+import {
+  projectionFromMatchup,
+  gameDrawerMatchupLabel,
+} from "@/lib/game-drawer-projection";
+import { GameContextDrawer } from "@/components/games/GameContextDrawer";
 
 function TeamName({
   teamId,
@@ -22,7 +31,11 @@ function TeamName({
   );
   if (teamId) {
     return (
-      <Link href={`/dashboard/teams/${teamId}`} className={className}>
+      <Link
+        href={`/dashboard/teams/${teamId}`}
+        className={className}
+        onClick={(event) => event.stopPropagation()}
+      >
         {label}
       </Link>
     );
@@ -67,13 +80,18 @@ function Side({
   );
 }
 
-function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
+function MatchupCard({
+  m,
+  roundLabel,
+}: {
+  m: PlayoffMatchupDto;
+  roundLabel: string;
+}) {
   const side = winnerSide(m);
   const decided = side !== null;
-  const gamecastHref =
-    m.fixtureId && m.status === "final" && m.hasPlayLog
-      ? `/dashboard/games/${m.fixtureId}/gamecast`
-      : null;
+  const projection = projectionFromMatchup(m, roundLabel);
+  const [open, setOpen] = React.useState(false);
+  const restoreFocusRef = React.useRef<HTMLButtonElement | null>(null);
 
   const card = m.isBye ? (
     <div className="overflow-hidden rounded-md border border-dashed border-border bg-card">
@@ -112,19 +130,33 @@ function MatchupCard({ m }: { m: PlayoffMatchupDto }) {
     </div>
   );
 
-  if (gamecastHref) {
-    return (
-      <Link
-        href={gamecastHref}
-        className="block rounded-md transition-colors hover:ring-2 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        title="View gamecast"
-      >
-        {card}
-      </Link>
-    );
+  if (!projection) {
+    return card;
   }
 
-  return card;
+  const drawerLabel = `View ${projection.status === "final" ? "final" : "preview"} for ${gameDrawerMatchupLabel(projection)}`;
+
+  return (
+    <>
+      <button
+        ref={restoreFocusRef}
+        type="button"
+        aria-label={drawerLabel}
+        aria-haspopup="dialog"
+        data-testid={`playoff-drawer-trigger-${m.id}`}
+        onClick={() => setOpen(true)}
+        className="block w-full rounded-md text-left transition-colors hover:ring-2 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {card}
+      </button>
+      <GameContextDrawer
+        projection={projection}
+        open={open}
+        onOpenChange={setOpen}
+        restoreFocusRef={restoreFocusRef}
+      />
+    </>
+  );
 }
 
 /**
@@ -187,7 +219,7 @@ export default function PlayoffBracket({
                     </h4>
                     <div className="flex flex-1 flex-col justify-around gap-4">
                       {r.matchups.map((m) => (
-                        <MatchupCard key={m.id} m={m} />
+                        <MatchupCard key={m.id} m={m} roundLabel={r.label} />
                       ))}
                     </div>
                   </div>

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -54,7 +54,7 @@ function MatchupCell({
       data-testid="schedule-fixture-drawer-cell"
       onClick={onOpen}
       className={cn(
-        "block w-full rounded-sm text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "block w-full rounded-sm text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         className,
       )}
     >
@@ -90,11 +90,10 @@ export function ScheduleFixtureRow({
     result != null ? `${result.homeScore} – ${result.awayScore}` : "—";
 
   return (
-    <>
-      <tr
-        data-testid={`schedule-fixture-${fixture.id}`}
-        className="border-b border-border"
-      >
+    <tr
+      data-testid={`schedule-fixture-${fixture.id}`}
+      className="border-b border-border"
+    >
         <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
           <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>
             {formatFixtureWhen(fixture.scheduledAt)}
@@ -133,6 +132,12 @@ export function ScheduleFixtureRow({
           <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel} className="inline-flex">
             <StatusBadge status={fixture.status} />
           </MatchupCell>
+          <GameContextDrawer
+            projection={projection}
+            open={open}
+            onOpenChange={setOpen}
+            restoreFocusRef={restoreFocusRef}
+          />
         </td>
         {isAdmin ? (
           <td className="px-4 py-2">
@@ -236,13 +241,6 @@ export function ScheduleFixtureRow({
             </div>
           </td>
         ) : null}
-      </tr>
-      <GameContextDrawer
-        projection={projection}
-        open={open}
-        onOpenChange={setOpen}
-        restoreFocusRef={restoreFocusRef}
-      />
-    </>
+    </tr>
   );
 }

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { ClipboardList, Radio, Tv } from "lucide-react";
+import { formatFixtureWhen } from "@/lib/format";
+import type { GameDrawerProjection } from "@/lib/game-drawer-projection";
+import { gameDrawerMatchupLabel } from "@/lib/game-drawer-projection";
+import { GameContextDrawer } from "@/components/games/GameContextDrawer";
+import { StatusBadge } from "@/components/status-badge";
+import RecordResultDialog from "@/components/schedule/RecordResultDialog";
+import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
+import GoLiveControl from "@/components/schedule/GoLiveControl";
+import ClipsControl from "@/components/schedule/ClipsControl";
+import { SimulateGameButton } from "@/components/schedule/SimulateControls";
+import type { PublicGameStream } from "@/lib/data-api";
+import type { GameResultDto } from "@sports-management/shared-types";
+import type { FixtureDto } from "@sports-management/shared-types";
+import { cn } from "@/lib/utils";
+
+type StreamStatus = "idle" | "active" | "ended";
+
+export interface ScheduleFixtureRowProps {
+  fixture: FixtureDto;
+  result: GameResultDto | null;
+  hasPlayLog: boolean;
+  projection: GameDrawerProjection;
+  leagueId: string;
+  isAdmin: boolean;
+  canMutate: boolean;
+  canGoLive: boolean;
+  canStream: boolean;
+  statsEnabled: boolean;
+  liveEnabled: boolean;
+  stream: PublicGameStream | null | undefined;
+}
+
+function MatchupCell({
+  children,
+  className,
+  onOpen,
+  ariaLabel,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  onOpen: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-haspopup="dialog"
+      data-testid="schedule-fixture-drawer-cell"
+      onClick={onOpen}
+      className={cn(
+        "block w-full rounded-sm text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ScheduleFixtureRow({
+  fixture,
+  result,
+  hasPlayLog,
+  projection,
+  leagueId,
+  isAdmin,
+  canMutate,
+  canGoLive,
+  canStream,
+  statsEnabled,
+  liveEnabled,
+  stream,
+}: ScheduleFixtureRowProps) {
+  const [open, setOpen] = React.useState(false);
+  const restoreFocusRef = React.useRef<HTMLElement | null>(null);
+  const drawerLabel = `View ${projection.status === "final" ? "final" : "preview"} for ${gameDrawerMatchupLabel(projection)}`;
+
+  const openDrawer = (event: React.MouseEvent<HTMLButtonElement>) => {
+    restoreFocusRef.current = event.currentTarget;
+    setOpen(true);
+  };
+
+  const scoreDisplay = result ? (
+    statsEnabled ? (
+      <Link
+        href={`/dashboard/games/${fixture.id}/boxscore`}
+        className="hover:underline"
+        title="View box score"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {result.homeScore} – {result.awayScore}
+      </Link>
+    ) : (
+      `${result.homeScore} – ${result.awayScore}`
+    )
+  ) : (
+    "—"
+  );
+
+  return (
+    <>
+      <tr
+        data-testid={`schedule-fixture-${fixture.id}`}
+        className="border-b border-border"
+      >
+        <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+          <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>
+            {formatFixtureWhen(fixture.scheduledAt)}
+          </MatchupCell>
+        </td>
+        <td className="px-4 py-2 text-foreground">
+          <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>
+            {fixture.homeTeamName}
+          </MatchupCell>
+        </td>
+        <td className="px-4 py-2 text-foreground">
+          <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>
+            {fixture.awayTeamName}
+          </MatchupCell>
+        </td>
+        <td className="px-4 py-2 text-right font-mono text-foreground">
+          <MatchupCell
+            onOpen={openDrawer}
+            ariaLabel={drawerLabel}
+            className="text-right"
+          >
+            {scoreDisplay}
+          </MatchupCell>
+        </td>
+        <td className="px-4 py-2">
+          <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel} className="inline-flex">
+            <StatusBadge status={fixture.status} />
+          </MatchupCell>
+        </td>
+        {isAdmin ? (
+          <td className="px-4 py-2">
+            <div className="flex flex-wrap items-center gap-1">
+              {canMutate ? (
+                <RecordResultDialog
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                  initialHomeScore={result?.homeScore ?? null}
+                  initialAwayScore={result?.awayScore ?? null}
+                  triggerLabel={result ? "Edit result" : "Record result"}
+                />
+              ) : null}
+              {canMutate && fixture.status === "scheduled" ? (
+                <SimulateGameButton
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                />
+              ) : null}
+              {canMutate ? (
+                <DeleteFixtureButton
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                />
+              ) : null}
+              {canGoLive ? (
+                <GoLiveControl
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                  status={(stream?.status as StreamStatus | undefined) ?? null}
+                  gameStatus={fixture.status}
+                />
+              ) : null}
+              {canStream &&
+              stream?.provider === "mux" &&
+              stream?.vodAssetId ? (
+                <ClipsControl
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                  vodPlaybackId={stream?.vodPlaybackId ?? null}
+                />
+              ) : null}
+              {statsEnabled ? (
+                <span className="flex items-center gap-1 text-xs">
+                  <ClipboardList className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-muted-foreground">Box score</span>
+                  <Link
+                    href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/stats`}
+                    className="text-primary hover:underline"
+                  >
+                    Home
+                  </Link>
+                  <span className="text-muted-foreground">/</span>
+                  <Link
+                    href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/stats`}
+                    className="text-primary hover:underline"
+                  >
+                    Away
+                  </Link>
+                </span>
+              ) : null}
+              {liveEnabled ? (
+                <span className="flex items-center gap-1 text-xs">
+                  <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+                  <Link
+                    href={`/dashboard/teams/${fixture.homeTeamId}/games/${fixture.id}/live`}
+                    className="text-primary hover:underline"
+                  >
+                    Live (Home)
+                  </Link>
+                  <span className="text-muted-foreground">/</span>
+                  <Link
+                    href={`/dashboard/teams/${fixture.awayTeamId}/games/${fixture.id}/live`}
+                    className="text-primary hover:underline"
+                  >
+                    Live (Away)
+                  </Link>
+                </span>
+              ) : null}
+              {fixture.status === "final" && hasPlayLog ? (
+                <span className="flex items-center gap-1 text-xs">
+                  <Tv className="h-3.5 w-3.5 text-muted-foreground" />
+                  <Link
+                    href={`/dashboard/games/${fixture.id}/gamecast`}
+                    className="text-primary hover:underline"
+                  >
+                    Gamecast
+                  </Link>
+                </span>
+              ) : null}
+            </div>
+          </td>
+        ) : null}
+      </tr>
+      <GameContextDrawer
+        projection={projection}
+        open={open}
+        onOpenChange={setOpen}
+        restoreFocusRef={restoreFocusRef}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -43,7 +43,7 @@ function MatchupCell({
 }: {
   children: React.ReactNode;
   className?: string;
-  onOpen: () => void;
+  onOpen: React.MouseEventHandler<HTMLButtonElement>;
   ariaLabel: string;
 }) {
   return (
@@ -86,22 +86,8 @@ export function ScheduleFixtureRow({
     setOpen(true);
   };
 
-  const scoreDisplay = result ? (
-    statsEnabled ? (
-      <Link
-        href={`/dashboard/games/${fixture.id}/boxscore`}
-        className="hover:underline"
-        title="View box score"
-        onClick={(event) => event.stopPropagation()}
-      >
-        {result.homeScore} – {result.awayScore}
-      </Link>
-    ) : (
-      `${result.homeScore} – ${result.awayScore}`
-    )
-  ) : (
-    "—"
-  );
+  const scoreDisplay =
+    result != null ? `${result.homeScore} – ${result.awayScore}` : "—";
 
   return (
     <>
@@ -125,13 +111,23 @@ export function ScheduleFixtureRow({
           </MatchupCell>
         </td>
         <td className="px-4 py-2 text-right font-mono text-foreground">
-          <MatchupCell
-            onOpen={openDrawer}
-            ariaLabel={drawerLabel}
-            className="text-right"
-          >
-            {scoreDisplay}
-          </MatchupCell>
+          {result && statsEnabled ? (
+            <Link
+              href={`/dashboard/games/${fixture.id}/boxscore`}
+              className="hover:underline"
+              title="View box score"
+            >
+              {scoreDisplay}
+            </Link>
+          ) : (
+            <MatchupCell
+              onOpen={openDrawer}
+              ariaLabel={drawerLabel}
+              className="text-right"
+            >
+              {scoreDisplay}
+            </MatchupCell>
+          )}
         </td>
         <td className="px-4 py-2">
           <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel} className="inline-flex">

--- a/apps/web/src/lib/__tests__/game-drawer-projection.test.ts
+++ b/apps/web/src/lib/__tests__/game-drawer-projection.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTeamRecord,
+  gameDrawerCanOpenGamecast,
+  gameDrawerIsFinal,
+  gameDrawerMatchupLabel,
+  projectionFromFixture,
+  projectionFromMatchup,
+} from "@/lib/game-drawer-projection";
+import type { PlayoffMatchupDto } from "@/lib/data-api";
+import type { FixtureDto } from "@sports-management/shared-types";
+
+const baseFixture: FixtureDto = {
+  id: "fx1",
+  seasonId: "s1",
+  homeTeamId: "h1",
+  awayTeamId: "a1",
+  homeTeamName: "Alpha",
+  awayTeamName: "Beta",
+  scheduledAt: "2026-07-01T18:00:00.000Z",
+  week: 1,
+  venue: "Memorial Field",
+  status: "scheduled",
+  stage: "regular",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  createdBy: "user",
+};
+
+describe("game-drawer-projection", () => {
+  it("builds a scheduled fixture preview with team records", () => {
+    const records = new Map([
+      ["h1", "2-1"],
+      ["a1", "1-2"],
+    ]);
+    const projection = projectionFromFixture({
+      fixture: baseFixture,
+      result: null,
+      hasPlayLog: false,
+      recordByTeamId: records,
+    });
+
+    expect(projection.surface).toBe("schedule");
+    expect(projection.status).toBe("scheduled");
+    expect(projection.home.record).toBe("2-1");
+    expect(projection.away.record).toBe("1-2");
+    expect(projection.venue).toBe("Memorial Field");
+    expect(gameDrawerIsFinal(projection)).toBe(false);
+    expect(gameDrawerCanOpenGamecast(projection)).toBe(false);
+  });
+
+  it("builds a final fixture summary with gamecast availability", () => {
+    const projection = projectionFromFixture({
+      fixture: { ...baseFixture, status: "final" },
+      result: {
+        id: "r1",
+        fixtureId: "fx1",
+        homeScore: 21,
+        awayScore: 14,
+        playerStatsJson: null,
+        recordedAt: "2026-01-02T00:00:00.000Z",
+        recordedBy: "user",
+      },
+      hasPlayLog: true,
+    });
+
+    expect(projection.homeScore).toBe(21);
+    expect(projection.awayScore).toBe(14);
+    expect(gameDrawerIsFinal(projection)).toBe(true);
+    expect(gameDrawerCanOpenGamecast(projection)).toBe(true);
+    expect(gameDrawerMatchupLabel(projection)).toBe("Alpha vs Beta");
+  });
+
+  it("builds a playoff matchup projection with seeds", () => {
+    const matchup: PlayoffMatchupDto = {
+      id: "m1",
+      round: 1,
+      slot: 0,
+      homeSeed: 1,
+      awaySeed: 4,
+      homeTeamId: "h1",
+      awayTeamId: "a1",
+      homeTeamName: "Alpha",
+      awayTeamName: "Beta",
+      winnerTeamId: "h1",
+      fixtureId: "fx1",
+      status: "final",
+      homeScore: 28,
+      awayScore: 21,
+      bracketType: null,
+      isBye: false,
+      hasPlayLog: true,
+    };
+
+    const projection = projectionFromMatchup(matchup, "Semifinals");
+    expect(projection?.roundLabel).toBe("Semifinals");
+    expect(projection?.home.seed).toBe(1);
+    expect(projection?.away.seed).toBe(4);
+    expect(gameDrawerCanOpenGamecast(projection!)).toBe(true);
+  });
+
+  it("returns null for bye matchups", () => {
+    const bye: PlayoffMatchupDto = {
+      id: "bye1",
+      round: 1,
+      slot: 0,
+      homeSeed: 1,
+      awaySeed: null,
+      homeTeamId: "h1",
+      awayTeamId: null,
+      homeTeamName: "Alpha",
+      awayTeamName: null,
+      winnerTeamId: "h1",
+      fixtureId: null,
+      status: null,
+      homeScore: null,
+      awayScore: null,
+      bracketType: null,
+      isBye: true,
+      hasPlayLog: false,
+    };
+
+    expect(projectionFromMatchup(bye, "Round 1")).toBeNull();
+  });
+
+  it("formats team records with ties", () => {
+    expect(formatTeamRecord(3, 1, 1)).toBe("3-1-1");
+    expect(formatTeamRecord(0, 0, 0)).toBe("0-0");
+  });
+});

--- a/apps/web/src/lib/game-drawer-projection.ts
+++ b/apps/web/src/lib/game-drawer-projection.ts
@@ -1,0 +1,145 @@
+import type { GameResultDto } from "@sports-management/shared-types";
+import type { FixtureDto } from "@sports-management/shared-types";
+import type { PlayoffMatchupDto } from "@/lib/data-api";
+
+/** Where the drawer was opened from — affects labels only. */
+export type GameDrawerSurface = "schedule" | "playoffs";
+
+export interface GameDrawerTeam {
+  id: string | null;
+  name: string;
+  seed: number | null;
+  /** Regular-season W-L(-T), e.g. "3-1". Null when unavailable. */
+  record: string | null;
+}
+
+/**
+ * Serializable, bounded payload for the contextual game drawer (WSM-000240).
+ * Built on the server from already-fetched fixture/bracket data — no extra
+ * per-matchup queries in the client.
+ */
+export interface GameDrawerProjection {
+  /** Fixture id for schedule rows; playoff matchup id for bracket cards. */
+  id: string;
+  surface: GameDrawerSurface;
+  /** Linked fixture when one exists (playoffs may be null until played). */
+  fixtureId: string | null;
+  status: "scheduled" | "final" | "cancelled" | null;
+  home: GameDrawerTeam;
+  away: GameDrawerTeam;
+  scheduledAt: string | null;
+  venue: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  hasPlayLog: boolean;
+  /** Playoffs: "Round 1", "Semifinals", etc. */
+  roundLabel: string | null;
+  isBye: boolean;
+}
+
+export function formatTeamRecord(
+  wins: number,
+  losses: number,
+  ties: number,
+): string {
+  return `${wins}-${losses}${ties ? `-${ties}` : ""}`;
+}
+
+export function projectionFromFixture(input: {
+  fixture: FixtureDto;
+  result: GameResultDto | null;
+  hasPlayLog: boolean;
+  recordByTeamId?: ReadonlyMap<string, string>;
+}): GameDrawerProjection {
+  const { fixture, result, hasPlayLog, recordByTeamId } = input;
+  const record = (teamId: string) => recordByTeamId?.get(teamId) ?? null;
+
+  return {
+    id: fixture.id,
+    surface: "schedule",
+    fixtureId: fixture.id,
+    status: fixture.status,
+    home: {
+      id: fixture.homeTeamId,
+      name: fixture.homeTeamName,
+      seed: null,
+      record: record(fixture.homeTeamId),
+    },
+    away: {
+      id: fixture.awayTeamId,
+      name: fixture.awayTeamName,
+      seed: null,
+      record: record(fixture.awayTeamId),
+    },
+    scheduledAt: fixture.scheduledAt,
+    venue: fixture.venue,
+    homeScore: result?.homeScore ?? null,
+    awayScore: result?.awayScore ?? null,
+    hasPlayLog,
+    roundLabel: null,
+    isBye: false,
+  };
+}
+
+export function projectionFromMatchup(
+  matchup: PlayoffMatchupDto,
+  roundLabel: string,
+): GameDrawerProjection | null {
+  if (matchup.isBye) return null;
+  if (!matchup.homeTeamId && !matchup.awayTeamId) return null;
+
+  const status =
+    matchup.status === "final"
+      ? "final"
+      : matchup.status === "scheduled"
+        ? "scheduled"
+        : matchup.status === "cancelled"
+          ? "cancelled"
+          : matchup.homeScore != null && matchup.awayScore != null
+            ? "final"
+            : "scheduled";
+
+  return {
+    id: matchup.id,
+    surface: "playoffs",
+    fixtureId: matchup.fixtureId,
+    status,
+    home: {
+      id: matchup.homeTeamId,
+      name: matchup.homeTeamName ?? "TBD",
+      seed: matchup.homeSeed,
+      record: null,
+    },
+    away: {
+      id: matchup.awayTeamId,
+      name: matchup.awayTeamName ?? "TBD",
+      seed: matchup.awaySeed,
+      record: null,
+    },
+    scheduledAt: null,
+    venue: null,
+    homeScore: matchup.homeScore,
+    awayScore: matchup.awayScore,
+    hasPlayLog: matchup.hasPlayLog,
+    roundLabel,
+    isBye: false,
+  };
+}
+
+export function gameDrawerMatchupLabel(projection: GameDrawerProjection): string {
+  return `${projection.home.name} vs ${projection.away.name}`;
+}
+
+export function gameDrawerIsFinal(projection: GameDrawerProjection): boolean {
+  return projection.status === "final";
+}
+
+export function gameDrawerCanOpenGamecast(
+  projection: GameDrawerProjection,
+): boolean {
+  return (
+    gameDrawerIsFinal(projection) &&
+    projection.hasPlayLog &&
+    projection.fixtureId !== null
+  );
+}


### PR DESCRIPTION
## Summary

- Add `GameContextDrawer` with bounded `GameDrawerProjection` types for schedule fixtures and playoff matchups
- Wire accessible drawer triggers into schedule rows (`ScheduleFixtureRow`) and playoff bracket cards (`PlayoffBracket`)
- Preview scheduled games with team/record/venue context; summarize finals with score and optional "Open full Gamecast" when a play log exists
- Extend Gamecast, playoffs-bracket, and schedules-standings E2E coverage for drawer modes, archived `?season=` reads, Escape/focus, and 375px overflow

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/game-drawer-projection.test.ts src/components/games/__tests__/GameContextDrawer.test.ts`
- [x] ESLint on changed files
- [ ] `pnpm --filter @sports-management/web test:e2e -- e2e/tests/gamecast.spec.ts e2e/tests/playoffs-bracket.spec.ts e2e/tests/schedules-standings.spec.ts --project=chromium`

## Related Issue

Closes #528
