### PR TITLE
feat(web): round-aware playoff ops with championship stop (WSM-000241)

### DIFF
--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -165,6 +165,11 @@ export async function simToChampion(page: Page) {
   });
 }
 
+export async function simChampionship(page: Page) {
+  await page.getByRole("button", { name: "Sim championship" }).click();
+  await confirmLifecycleDialog(page);
+}
+
 export async function advanceToPlayoffs(page: Page) {
   await page.getByRole("button", { name: "Advance to playoffs" }).click();
   await confirmLifecycleDialog(page);

--- a/apps/web/e2e/tests/playoffs-bracket.spec.ts
+++ b/apps/web/e2e/tests/playoffs-bracket.spec.ts
@@ -10,6 +10,7 @@ import {
   acceptBrowserConfirms,
   bootstrapFourTeamSimLeague,
   confirmLifecycleDialog,
+  simChampionship,
   simPlayoffsScope,
   simRegularSeason,
 } from "../helpers/sim-league-setup";
@@ -69,7 +70,7 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
     acceptBrowserConfirms(page);
   });
 
-  test("advance gate, bracket generation, and champion after sim playoffs", async ({
+  test("advance gate, bracket generation, semifinal sim, and explicit championship", async ({
     page,
   }) => {
     if (!fixture) test.skip();
@@ -125,11 +126,18 @@ test.describe("Playoffs bracket (WSM-000164)", () => {
 
     await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
     await simPlayoffsScope(page);
-    await expect(page.getByText(/wins — simulated|Simulated \d+ playoff game/)).toBeVisible({
+    await expect(
+      page.getByText(/through the semifinals|Simulated \d+ playoff game/),
+    ).toBeVisible({
       timeout: 120_000,
     });
 
     await page.goto(`/dashboard/leagues/${leagueId}/playoffs`);
+    await expect(page.getByText("Champion", { exact: true })).toHaveCount(0);
+    await simChampionship(page);
+    await expect(page.getByText(/wins the championship!/)).toBeVisible({
+      timeout: 120_000,
+    });
     await expect(page.getByText("Champion", { exact: true })).toBeVisible();
     await expect(
       page.locator(".rounded-lg.border-primary\\/30").getByRole("link").first(),

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
@@ -189,6 +189,37 @@ describe("advanceToPlayoffsAction", () => {
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
   });
 
+  it("rejects non-standard playoff team counts (WSM-000241)", async () => {
+    authorize();
+    mockGetSeasons.mockResolvedValue([
+      { ...ACTIVE_SEASON, playoffTeams: 6 },
+    ]);
+    mockListFixturesBySeason.mockResolvedValue([
+      { stage: "regular", status: "final" },
+    ]);
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "invalid_playoff_team_count" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects viewers (not_authorized)", async () => {
+    authorize();
+    mockCanManageRoster.mockReturnValue(false);
+
+    const res = await advanceToPlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
   it("generates a bracket for a valid, lifecycle-decided seasonId", async () => {
     authorize();
     mockListFixturesBySeason.mockResolvedValue([

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/generate-playoffs-action.test.ts
@@ -9,6 +9,7 @@ const {
   mockResolveOrgRole,
   mockCanManageRoster,
   mockGeneratePlayoffBracket,
+  mockGetSeason,
 } = vi.hoisted(() => ({
   mockPlayoffsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -18,6 +19,7 @@ const {
   mockResolveOrgRole: vi.fn(),
   mockCanManageRoster: vi.fn(),
   mockGeneratePlayoffBracket: vi.fn(),
+  mockGetSeason: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({ playoffsV1: mockPlayoffsV1 }));
@@ -26,6 +28,7 @@ vi.mock("@/lib/data-api", () => ({
   generatePlayoffBracket: mockGeneratePlayoffBracket,
   getLeague: mockGetLeague,
   getLeagueOrgId: mockGetLeagueOrgId,
+  getSeason: mockGetSeason,
 }));
 vi.mock("@/lib/org-context", () => ({
   resolveOrgContext: mockResolveOrgContext,
@@ -47,6 +50,12 @@ function authorize() {
   mockGetLeagueOrgId.mockResolvedValue("org_1");
   mockResolveOrgRole.mockResolvedValue("org:admin");
   mockCanManageRoster.mockReturnValue(true);
+  mockGetSeason.mockResolvedValue({
+    id: SEASON,
+    leagueId: LEAGUE,
+    status: "active",
+    playoffTeams: 8,
+  });
 }
 
 describe("generatePlayoffsAction (WSM-000164)", () => {
@@ -98,14 +107,18 @@ describe("generatePlayoffsAction (WSM-000164)", () => {
 
   it("propagates a completed-season rejection as the stable typed result", async () => {
     authorize();
-    mockGeneratePlayoffBracket.mockRejectedValue(
-      new Error("Uncaught Error: season_completed"),
-    );
+    mockGetSeason.mockResolvedValue({
+      id: SEASON,
+      leagueId: LEAGUE,
+      status: "completed",
+      playoffTeams: 4,
+    });
     await expect(generatePlayoffsAction({
       leagueId: LEAGUE,
       seasonId: SEASON,
       size: 4,
     })).resolves.toEqual({ ok: false, error: "season_completed" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
   });
 
   it("passes confirm through", async () => {
@@ -162,5 +175,33 @@ describe("generatePlayoffsAction (WSM-000164)", () => {
       size: 4,
     });
     expect(res).toEqual({ ok: false, error: "flag_disabled" });
+  });
+
+  it("rejects legacy bracket sizes", async () => {
+    authorize();
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 6,
+    });
+    expect(res).toEqual({ ok: false, error: "invalid_playoff_size" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects season/league mismatch", async () => {
+    authorize();
+    mockGetSeason.mockResolvedValue({
+      id: SEASON,
+      leagueId: "other_league",
+      status: "active",
+      playoffTeams: 8,
+    });
+    const res = await generatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      size: 8,
+    });
+    expect(res).toEqual({ ok: false, error: "season_league_mismatch" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -8,6 +8,7 @@ import {
   getLeague,
   getLeagueOrgId,
   getPlayoffBracket,
+  getSeason,
   getSeasons,
   listFixturesBySeason,
 } from "@/lib/data-api";
@@ -49,8 +50,8 @@ function friendlyError(code: string): string {
   if (code.includes("not_enough_teams")) {
     return "Not enough teams in the standings for a bracket of this size.";
   }
-  if (code.includes("invalid_bracket_size")) {
-    return "Pick a playoff team count between 2 and 64.";
+  if (code.includes("invalid_bracket_size") || code.includes("invalid_playoff_size")) {
+    return "Playoff team count must be 4, 8, or 16.";
   }
   if (code.includes("season_not_found")) {
     return "This season no longer exists.";
@@ -58,16 +59,18 @@ function friendlyError(code: string): string {
   if (code.includes("season_completed")) {
     return "season_completed";
   }
+  if (code.includes("season_league_mismatch")) {
+    return "That season does not belong to this league.";
+  }
   return "Could not generate the bracket.";
 }
 
 /*
  * Seed a playoff bracket from the season's standings (WSM-000164,
- * WSM-flex-brackets). `size` is the qualifying team count (any value ≥ 2, with
- * byes for non-powers-of-two); `format` selects single/double elimination
- * (defaults to the season config). The mutation refuses to overwrite a bracket
- * that already has a played game; that surfaces here as `needsConfirm` so the
- * UI can re-call with confirm.
+ * WSM-flex-brackets). New brackets require standard 4/8/16 sizes (WSM-000241);
+ * format still selects single/double elimination. The mutation refuses to
+ * overwrite a bracket that already has a played game; that surfaces here as
+ * `needsConfirm` so the UI can re-call with confirm.
  */
 export async function generatePlayoffsAction(input: {
   leagueId: string;
@@ -85,6 +88,20 @@ export async function generatePlayoffsAction(input: {
 
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
+
+  if (!canStartPlayoffs(input.size)) {
+    return { ok: false, error: "invalid_playoff_size" };
+  }
+
+  const orgContext = await resolveOrgContext(userId);
+  const season = await getSeason(input.seasonId, orgContext).catch(() => null);
+  if (!season) return { ok: false, error: "season_not_found" };
+  if (season.leagueId !== input.leagueId) {
+    return { ok: false, error: "season_league_mismatch" };
+  }
+  if (season.status === "completed") {
+    return { ok: false, error: "season_completed" };
+  }
 
   try {
     const res = await generatePlayoffBracket({

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/actions.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
+import { canStartPlayoffs } from "@/lib/playoffs";
 import { resolveLifecycleSeason } from "@/lib/season-view";
 
 /*
@@ -165,8 +166,8 @@ export async function advanceToPlayoffsAction(input: {
   }
 
   const size = activeSeason.playoffTeams ?? 0;
-  if (!size || size < 2) {
-    return { ok: false, error: "no_playoffs_configured" };
+  if (!canStartPlayoffs(size)) {
+    return { ok: false, error: "invalid_playoff_team_count" };
   }
 
   try {

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -15,6 +15,7 @@ import { playoffPagePhase, regularSeasonProgress } from "@/lib/playoffs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import PlayoffBracket from "@/components/playoffs/PlayoffBracket";
+import PlayoffRoundControls from "@/components/playoffs/PlayoffRoundControls";
 import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
 import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
 import { resolveViewedSeason } from "@/lib/season-view";
@@ -135,8 +136,26 @@ export default async function LeaguePlayoffsPage({
             count on the season to enable the bracket.
           </CardContent>
         </Card>
+      ) : phase === "invalid_playoff_size" ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            {activeSeason.name} uses a legacy playoff size ({activeSeason.playoffTeams}{" "}
+            teams). New brackets require 4, 8, or 16 teams — update the season
+            settings before starting playoffs.
+          </CardContent>
+        </Card>
       ) : phase === "bracket_live" && bracket ? (
-        <PlayoffBracket bracket={bracket} />
+        <div className="flex flex-col gap-4">
+          {!seasonCompleted ? (
+            <PlayoffRoundControls
+              leagueId={leagueId}
+              seasonId={activeSeason.id}
+              bracket={bracket}
+              canManage={isAdmin}
+            />
+          ) : null}
+          <PlayoffBracket bracket={bracket} />
+        </div>
       ) : phase === "ready" ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-4 p-8 text-center">

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -527,7 +527,7 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
     mockGeneratePlayoffBracket.mockResolvedValue({ ok: true });
   });
 
-  it("rejects legacy playoff sizes", async () => {
+  it("rejects legacy playoff sizes before mutating fixtures", async () => {
     mockGetSeason.mockResolvedValue({
       id: SEASON,
       leagueId: LEAGUE,
@@ -535,6 +535,9 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
       playoffFormat: "single",
       divisionWinnersQualify: false,
     });
+    mockListFixturesBySeason.mockResolvedValue([
+      fixture({ id: "reg", stage: "regular" }),
+    ]);
 
     const res = await simulateSeasonThroughChampionAction({
       leagueId: LEAGUE,
@@ -543,9 +546,10 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
 
     expect(res).toEqual({ ok: false, error: "invalid_playoff_size" });
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
   });
 
-  it("rejects double-elimination seasons", async () => {
+  it("rejects double-elimination seasons before mutating fixtures", async () => {
     mockGetSeason.mockResolvedValue({
       id: SEASON,
       leagueId: LEAGUE,
@@ -553,6 +557,9 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
       playoffFormat: "double",
       divisionWinnersQualify: false,
     });
+    mockListFixturesBySeason.mockResolvedValue([
+      fixture({ id: "reg", stage: "regular" }),
+    ]);
 
     const res = await simulateSeasonThroughChampionAction({
       leagueId: LEAGUE,
@@ -561,6 +568,7 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
 
     expect(res).toEqual({ ok: false, error: "unsupported_format" });
     expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -14,6 +14,8 @@ const {
   mockSimulateAndPersistFixture,
   mockListFixturesBySeason,
   mockGetPlayoffBracket,
+  mockGetSeason,
+  mockGeneratePlayoffBracket,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -28,6 +30,8 @@ const {
   mockSimulateAndPersistFixture: vi.fn(),
   mockListFixturesBySeason: vi.fn(),
   mockGetPlayoffBracket: vi.fn(),
+  mockGetSeason: vi.fn(),
+  mockGeneratePlayoffBracket: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
@@ -41,8 +45,8 @@ vi.mock("@/lib/data-api", () => ({
   getLeague: mockGetLeague,
   getLeagueOrgId: mockGetLeagueOrgId,
   listFixturesBySeason: mockListFixturesBySeason,
-  getSeason: vi.fn(),
-  generatePlayoffBracket: vi.fn(),
+  getSeason: mockGetSeason,
+  generatePlayoffBracket: mockGeneratePlayoffBracket,
   getPlayoffBracket: mockGetPlayoffBracket,
   createFixture: vi.fn(),
   deleteFixture: vi.fn(),
@@ -70,6 +74,9 @@ import {
   simulatePlayoffsAction,
   simulateRegularSeasonAction,
   simulateWeekAction,
+  advancePlayoffRoundAction,
+  simulateChampionshipAction,
+  simulateSeasonThroughChampionAction,
 } from "../actions";
 
 const LEAGUE = "league_1";
@@ -111,6 +118,13 @@ function authorize() {
   mockResolveOrgRole.mockResolvedValue("org:admin");
   mockCanManageRoster.mockReturnValue(true);
   mockGetFixture.mockResolvedValue(fixture());
+  mockGetSeason.mockResolvedValue({
+    id: SEASON,
+    leagueId: LEAGUE,
+    playoffTeams: 4,
+    playoffFormat: "single",
+    divisionWinnersQualify: false,
+  });
   mockSimulateAndPersistFixture.mockResolvedValue({
     homeScore: 21,
     awayScore: 14,
@@ -223,28 +237,108 @@ describe("simulatePlayoffsAction", () => {
     expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
   });
 
-  it("sims playoff fixtures decisively when a bracket exists", async () => {
-    const playoff = fixture({ id: "po1", stage: "playoff", week: null });
+  it("rejects double-elimination brackets", async () => {
+    mockGetPlayoffBracket.mockResolvedValue({
+      seasonId: SEASON,
+      format: "double",
+      rounds: 2,
+      matchups: [{ round: 1, bracketType: "winners" }],
+    });
+
+    const res = await simulatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "unsupported_format" });
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
+  });
+
+  it("sims playoff fixtures through semifinal only (champion null)", async () => {
+    const semi = fixture({ id: "semi", stage: "playoff", week: null });
     mockGetPlayoffBracket
       .mockResolvedValueOnce({
         seasonId: SEASON,
-        matchups: [{ round: 1, homeTeamId: "team_home" }],
+        format: "single",
+        rounds: 2,
+        matchups: [
+          {
+            round: 1,
+            fixtureId: "semi",
+            bracketType: "winners",
+            isBye: false,
+            winnerTeamId: null,
+          },
+          {
+            round: 2,
+            fixtureId: "final",
+            bracketType: "winners",
+            isBye: false,
+            winnerTeamId: null,
+          },
+        ],
       })
       .mockResolvedValueOnce({
         seasonId: SEASON,
+        format: "single",
+        rounds: 2,
         matchups: [
           {
+            round: 1,
+            fixtureId: "semi",
+            bracketType: "winners",
+            isBye: false,
+            winnerTeamId: null,
+          },
+          {
             round: 2,
-            homeTeamId: "team_home",
-            homeTeamName: "Home",
-            awayTeamName: "Away",
+            fixtureId: "final",
+            bracketType: "winners",
+            isBye: false,
+            winnerTeamId: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        format: "single",
+        rounds: 2,
+        matchups: [
+          {
+            round: 1,
+            fixtureId: "semi",
+            bracketType: "winners",
             winnerTeamId: "team_home",
+          },
+          {
+            round: 2,
+            fixtureId: "final",
+            bracketType: "winners",
+            winnerTeamId: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        format: "single",
+        rounds: 2,
+        matchups: [
+          {
+            round: 1,
+            fixtureId: "semi",
+            bracketType: "winners",
+            winnerTeamId: "team_home",
+            homeTeamName: "Home",
+          },
+          {
+            round: 2,
+            fixtureId: "final",
+            bracketType: "winners",
+            winnerTeamId: null,
           },
         ],
       });
-    mockListFixturesBySeason
-      .mockResolvedValueOnce([playoff])
-      .mockResolvedValueOnce([]);
+    mockListFixturesBySeason.mockResolvedValue([semi]);
 
     const res = await simulatePlayoffsAction({
       leagueId: LEAGUE,
@@ -254,16 +348,219 @@ describe("simulatePlayoffsAction", () => {
     expect(res).toEqual({
       ok: true,
       playoffGames: 1,
-      champion: "Home",
+      champion: null,
     });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledTimes(1);
     expect(mockSimulateAndPersistFixture).toHaveBeenCalledWith({
-      fixture: playoff,
+      fixture: semi,
       orgContext: { visibleLeagueIds: [LEAGUE] },
       actorUserId: USER,
       decisive: true,
       profileCache: expect.any(Map),
       bulkStats: true,
     });
+  });
+
+  it("rejects viewers (not_authorized)", async () => {
+    authorize();
+    mockCanManageRoster.mockReturnValue(false);
+
+    const res = await simulatePlayoffsAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "not_authorized" });
+  });
+});
+
+describe("advancePlayoffRoundAction (WSM-000241)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("simulates only the minimum unresolved round", async () => {
+    const semi = fixture({ id: "semi", stage: "playoff", week: null });
+    mockGetPlayoffBracket.mockResolvedValue({
+      seasonId: SEASON,
+      format: "single",
+      rounds: 2,
+      matchups: [
+        {
+          round: 1,
+          fixtureId: "semi",
+          bracketType: "winners",
+          isBye: false,
+          winnerTeamId: null,
+        },
+        {
+          round: 2,
+          fixtureId: "final",
+          bracketType: "winners",
+          isBye: false,
+          winnerTeamId: null,
+        },
+      ],
+    });
+    mockListFixturesBySeason.mockResolvedValue([semi]);
+
+    const res = await advancePlayoffRoundAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: true, simulated: 1, round: 1 });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects advancing the championship round explicitly", async () => {
+    mockGetPlayoffBracket.mockResolvedValue({
+      seasonId: SEASON,
+      format: "single",
+      rounds: 2,
+      matchups: [
+        {
+          round: 1,
+          bracketType: "winners",
+          isBye: false,
+          winnerTeamId: "team_home",
+        },
+        {
+          round: 2,
+          fixtureId: "final",
+          bracketType: "winners",
+          isBye: false,
+          winnerTeamId: null,
+        },
+      ],
+    });
+
+    const res = await advancePlayoffRoundAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({
+      ok: false,
+      error: "championship_requires_explicit_sim",
+    });
+  });
+});
+
+describe("simulateChampionshipAction (WSM-000241)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it("simulates only the final and returns the champion name", async () => {
+    const finalGame = fixture({ id: "final", stage: "playoff", week: null });
+    mockGetPlayoffBracket
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        format: "single",
+        rounds: 2,
+        matchups: [
+          {
+            round: 2,
+            fixtureId: "final",
+            bracketType: "winners",
+            isBye: false,
+            winnerTeamId: null,
+            homeTeamId: "team_home",
+            homeTeamName: "Home",
+            awayTeamName: "Away",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        seasonId: SEASON,
+        format: "single",
+        rounds: 2,
+        matchups: [
+          {
+            round: 2,
+            fixtureId: "final",
+            bracketType: "winners",
+            winnerTeamId: "team_home",
+            homeTeamId: "team_home",
+            homeTeamName: "Home",
+            awayTeamName: "Away",
+          },
+        ],
+      });
+    mockListFixturesBySeason.mockResolvedValue([finalGame]);
+
+    const res = await simulateChampionshipAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: true, simulated: 1, champion: "Home" });
+    expect(mockSimulateAndPersistFixture).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects season/league mismatch", async () => {
+    mockGetSeason.mockResolvedValue({
+      id: SEASON,
+      leagueId: "other_league",
+      playoffTeams: 4,
+      playoffFormat: "single",
+    });
+
+    const res = await simulateChampionshipAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "season_league_mismatch" });
+    expect(mockSimulateAndPersistFixture).not.toHaveBeenCalled();
+  });
+});
+
+describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+    mockListFixturesBySeason.mockResolvedValue([]);
+    mockGeneratePlayoffBracket.mockResolvedValue({ ok: true });
+  });
+
+  it("rejects legacy playoff sizes", async () => {
+    mockGetSeason.mockResolvedValue({
+      id: SEASON,
+      leagueId: LEAGUE,
+      playoffTeams: 6,
+      playoffFormat: "single",
+      divisionWinnersQualify: false,
+    });
+
+    const res = await simulateSeasonThroughChampionAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "invalid_playoff_size" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
+  });
+
+  it("rejects double-elimination seasons", async () => {
+    mockGetSeason.mockResolvedValue({
+      id: SEASON,
+      leagueId: LEAGUE,
+      playoffTeams: 4,
+      playoffFormat: "double",
+      divisionWinnersQualify: false,
+    });
+
+    const res = await simulateSeasonThroughChampionAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+
+    expect(res).toEqual({ ok: false, error: "unsupported_format" });
+    expect(mockGeneratePlayoffBracket).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -741,6 +741,20 @@ export async function simulateSeasonThroughChampionAction(input: {
 
   const profileCache: TeamSimProfileCache = new Map();
   try {
+    const season = await getSeason(input.seasonId, orgContext).catch(() => null);
+    const size = season?.playoffTeams ?? 0;
+
+    // Validate playoff config before mutating any fixtures so rejected
+    // requests are side-effect free (WSM-000241).
+    if (season && size) {
+      if (!isStandardPlayoffTeamCount(size)) {
+        return { ok: false, error: "invalid_playoff_size" };
+      }
+      if ((season.playoffFormat ?? "single") === "double") {
+        return { ok: false, error: "unsupported_format" };
+      }
+    }
+
     const regularSimulated = await simulateUnplayedRegularSeason(
       input.seasonId,
       userId,
@@ -748,19 +762,10 @@ export async function simulateSeasonThroughChampionAction(input: {
       profileCache,
     );
 
-    const season = await getSeason(input.seasonId, orgContext).catch(() => null);
-    const size = season?.playoffTeams ?? 0;
     if (!season || !size) {
       // No playoffs configured — regular season is the whole story.
       revalidateSchedulePaths(input.leagueId);
       return { ok: true, regularSimulated, playoffGames: 0, champion: null };
-    }
-
-    if (!isStandardPlayoffTeamCount(size)) {
-      return { ok: false, error: "invalid_playoff_size" };
-    }
-    if ((season.playoffFormat ?? "single") === "double") {
-      return { ok: false, error: "unsupported_format" };
     }
 
     // Fresh bracket from the configured size + qualification rule.

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -23,6 +23,14 @@ import { canManageRoster } from "@/lib/permissions";
 import { type TeamSimProfileCache } from "@/lib/build-team-sim-profile";
 import { simulateAndPersistFixture } from "@/lib/simulate-fixture";
 import {
+  deriveChampion,
+  fixtureIdsForRound,
+  isChampionshipRound,
+  isStandardPlayoffTeamCount,
+  minimumUnresolvedRound,
+  supportsBulkPlayoffOps,
+} from "@/lib/playoffs";
+import {
   trackFixtureCreated,
   trackResultRecorded,
 } from "@/lib/analytics";
@@ -64,6 +72,20 @@ async function authorizeManagerAction(
   const role = await resolveOrgRole(orgId, userId);
   if (!canManageRoster(role)) return { ok: false, error: "not_authorized" };
 
+  return { ok: true };
+}
+
+/** Ensure the viewed season belongs to the authorized league before mutating. */
+async function assertSeasonBelongsToLeague(
+  seasonId: string,
+  leagueId: string,
+  orgContext: OrgContext,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const season = await getSeason(seasonId, orgContext).catch(() => null);
+  if (!season) return { ok: false, error: "season_not_found" };
+  if (season.leagueId !== leagueId) {
+    return { ok: false, error: "season_league_mismatch" };
+  }
   return { ok: true };
 }
 
@@ -306,47 +328,181 @@ async function simulateUnplayedRegularSeason(
   return simulated;
 }
 
-/** Sim playoff fixtures round by round until the bracket is decided. */
-async function simulateUnplayedPlayoffs(
+/** Sim playoff fixtures by id; skips missing or already-final games. */
+async function simulatePlayoffFixtureIds(
+  seasonId: string,
+  fixtureIds: string[],
+  userId: string,
+  orgContext: OrgContext,
+  profileCache: TeamSimProfileCache,
+): Promise<number> {
+  if (fixtureIds.length === 0) return 0;
+  const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
+  const byId = new Map(fixtures.map((f) => [f.id, f]));
+  let simulated = 0;
+  for (const fixtureId of fixtureIds) {
+    const fixture = byId.get(fixtureId);
+    if (
+      !fixture ||
+      fixture.stage !== "playoff" ||
+      fixture.status !== "scheduled"
+    ) {
+      continue;
+    }
+    await simulateAndPersistFixture({
+      fixture,
+      orgContext,
+      actorUserId: userId,
+      decisive: true,
+      profileCache,
+      bulkStats: true,
+    });
+    simulated += 1;
+  }
+  return simulated;
+}
+
+/**
+ * Advance one single-elim round: sim only unfinished fixtures in the minimum
+ * unresolved round. Championship uses {@link simulateChampionshipAction}.
+ */
+async function simulateCurrentPlayoffRound(
+  seasonId: string,
+  userId: string,
+  orgContext: OrgContext,
+  profileCache: TeamSimProfileCache,
+): Promise<
+  | { ok: true; simulated: number; round: number | null }
+  | { ok: false; error: string }
+> {
+  const bracket = await getPlayoffBracket(seasonId).catch(() => null);
+  if (!bracket || bracket.matchups.length === 0) {
+    return { ok: false, error: "no_playoffs" };
+  }
+  if (!supportsBulkPlayoffOps(bracket.format)) {
+    return { ok: false, error: "unsupported_format" };
+  }
+
+  const round = minimumUnresolvedRound(bracket.matchups, bracket.rounds);
+  if (round === null) {
+    return { ok: true, simulated: 0, round: null };
+  }
+  if (isChampionshipRound(round, bracket.rounds)) {
+    return { ok: false, error: "championship_requires_explicit_sim" };
+  }
+
+  const fixtureIds = fixtureIdsForRound(bracket.matchups, round);
+  const simulated = await simulatePlayoffFixtureIds(
+    seasonId,
+    fixtureIds,
+    userId,
+    orgContext,
+    profileCache,
+  );
+  return { ok: true, simulated, round };
+}
+
+/**
+ * Sim every unplayed winners-bracket round through semifinal; leaves the
+ * championship fixture unresolved (WSM-000241).
+ */
+async function simulatePlayoffsThroughSemifinal(
   seasonId: string,
   userId: string,
   orgContext: OrgContext,
   profileCache: TeamSimProfileCache,
 ): Promise<number> {
   let playoffGames = 0;
-  for (let round = 0; round < MAX_PLAYOFF_ROUNDS; round++) {
-    const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
-    const pending = fixtures.filter(
-      (f) => f.stage === "playoff" && f.status === "scheduled",
+  for (let safety = 0; safety < MAX_PLAYOFF_ROUNDS; safety++) {
+    const bracket = await getPlayoffBracket(seasonId).catch(() => null);
+    if (!bracket || bracket.matchups.length === 0) break;
+    if (!supportsBulkPlayoffOps(bracket.format)) break;
+
+    const round = minimumUnresolvedRound(bracket.matchups, bracket.rounds);
+    if (round === null) break;
+    if (isChampionshipRound(round, bracket.rounds)) break;
+
+    const simulated = await simulatePlayoffFixtureIds(
+      seasonId,
+      fixtureIdsForRound(bracket.matchups, round),
+      userId,
+      orgContext,
+      profileCache,
     );
-    if (pending.length === 0) break;
-    for (const fixture of pending) {
-      await simulateAndPersistFixture({
-        fixture,
-        orgContext,
-        actorUserId: userId,
-        decisive: true,
-        profileCache,
-        bulkStats: true,
-      });
-      playoffGames += 1;
-    }
+    playoffGames += simulated;
+    if (simulated === 0) break;
   }
   return playoffGames;
 }
 
+/** Sim every unplayed playoff round through a champion (whole-season path). */
+async function simulateAllPlayoffRounds(
+  seasonId: string,
+  userId: string,
+  orgContext: OrgContext,
+  profileCache: TeamSimProfileCache,
+): Promise<number> {
+  let playoffGames = 0;
+  for (let safety = 0; safety < MAX_PLAYOFF_ROUNDS; safety++) {
+    const bracket = await getPlayoffBracket(seasonId).catch(() => null);
+    if (!bracket || bracket.matchups.length === 0) break;
+
+    const round = minimumUnresolvedRound(bracket.matchups, bracket.rounds);
+    if (round === null) break;
+
+    const simulated = await simulatePlayoffFixtureIds(
+      seasonId,
+      fixtureIdsForRound(bracket.matchups, round),
+      userId,
+      orgContext,
+      profileCache,
+    );
+    playoffGames += simulated;
+    if (simulated === 0) break;
+  }
+  return playoffGames;
+}
+
+/** Sim only the championship (final) matchup(s). */
+async function simulateChampionshipFixtures(
+  seasonId: string,
+  userId: string,
+  orgContext: OrgContext,
+  profileCache: TeamSimProfileCache,
+): Promise<
+  | { ok: true; simulated: number }
+  | { ok: false; error: string }
+> {
+  const bracket = await getPlayoffBracket(seasonId).catch(() => null);
+  if (!bracket || bracket.matchups.length === 0) {
+    return { ok: false, error: "no_playoffs" };
+  }
+  if (!supportsBulkPlayoffOps(bracket.format)) {
+    return { ok: false, error: "unsupported_format" };
+  }
+
+  const finalRound = bracket.rounds;
+  const fixtureIds = fixtureIdsForRound(bracket.matchups, finalRound);
+  if (fixtureIds.length === 0) {
+    return { ok: false, error: "no_championship_fixture" };
+  }
+
+  const simulated = await simulatePlayoffFixtureIds(
+    seasonId,
+    fixtureIds,
+    userId,
+    orgContext,
+    profileCache,
+  );
+  return { ok: true, simulated };
+}
+
 function championFromBracket(
-  bracket: { matchups: PlayoffMatchupDto[] } | null,
+  bracket: { matchups: PlayoffMatchupDto[]; format: string } | null,
 ): string | null {
   if (!bracket) return null;
-  const final = bracket.matchups.reduce<PlayoffMatchupDto | null>(
-    (best, m) => (m.round > (best?.round ?? -1) ? m : best),
-    null,
-  );
-  if (!final?.winnerTeamId) return null;
-  return final.winnerTeamId === final.homeTeamId
-    ? final.homeTeamName
-    : final.awayTeamName;
+  const champion = deriveChampion(bracket.matchups, bracket.format);
+  return champion?.teamName ?? null;
 }
 
 export async function simulateWeekAction(input: {
@@ -434,15 +590,25 @@ export async function simulatePlayoffsAction(input: {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
 
+  const orgContext = await resolveOrgContext(userId);
+  const seasonGuard = await assertSeasonBelongsToLeague(
+    input.seasonId,
+    input.leagueId,
+    orgContext,
+  );
+  if (!seasonGuard.ok) return seasonGuard;
+
   const bracket = await getPlayoffBracket(input.seasonId).catch(() => null);
   if (!bracket || bracket.matchups.length === 0) {
     return { ok: false, error: "no_playoffs" };
   }
+  if (!supportsBulkPlayoffOps(bracket.format)) {
+    return { ok: false, error: "unsupported_format" };
+  }
 
-  const orgContext = await resolveOrgContext(userId);
   const profileCache: TeamSimProfileCache = new Map();
   try {
-    const playoffGames = await simulateUnplayedPlayoffs(
+    const playoffGames = await simulatePlayoffsThroughSemifinal(
       input.seasonId,
       userId,
       orgContext,
@@ -460,12 +626,92 @@ export async function simulatePlayoffsAction(input: {
   }
 }
 
+/** Simulate unfinished games in the current single-elim round only (WSM-000241). */
+export async function advancePlayoffRoundAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<
+  | { ok: true; simulated: number; round: number | null }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const seasonGuard = await assertSeasonBelongsToLeague(
+    input.seasonId,
+    input.leagueId,
+    orgContext,
+  );
+  if (!seasonGuard.ok) return seasonGuard;
+
+  const profileCache: TeamSimProfileCache = new Map();
+  try {
+    const res = await simulateCurrentPlayoffRound(
+      input.seasonId,
+      userId,
+      orgContext,
+      profileCache,
+    );
+    if (!res.ok) return res;
+    revalidateSchedulePaths(input.leagueId, true);
+    return res;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/** Simulate only the championship (final) matchup (WSM-000241). */
+export async function simulateChampionshipAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<
+  | { ok: true; simulated: number; champion: string | null }
+  | { ok: false; error: string }
+> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const seasonGuard = await assertSeasonBelongsToLeague(
+    input.seasonId,
+    input.leagueId,
+    orgContext,
+  );
+  if (!seasonGuard.ok) return seasonGuard;
+
+  const profileCache: TeamSimProfileCache = new Map();
+  try {
+    const res = await simulateChampionshipFixtures(
+      input.seasonId,
+      userId,
+      orgContext,
+      profileCache,
+    );
+    if (!res.ok) return res;
+    const bracket = await getPlayoffBracket(input.seasonId).catch(() => null);
+    const champion = championFromBracket(bracket);
+    revalidateSchedulePaths(input.leagueId, true);
+    return { ok: true, simulated: res.simulated, champion };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
 /*
  * Simulate a whole season through to a champion (WSM-000185): sim every unplayed
  * regular-season game, then — if the season is configured for playoffs —
  * (re)generate the bracket from its config and sim each playoff round until a
- * winner emerges. Playoff games are simulated `decisive` so a bracket never
- * stalls on a tie. Bounded loop (≤ 8 rounds) as a safety net.
+ * winner emerges. Single-elim + standard 4/8/16 only (WSM-000241); double-elim
+ * and legacy sizes are rejected. Bounded loop (≤ 8 rounds) as a safety net.
  */
 export async function simulateSeasonThroughChampionAction(input: {
   leagueId: string;
@@ -486,6 +732,13 @@ export async function simulateSeasonThroughChampionAction(input: {
   if (!userId) return { ok: false, error: "unauthorized" };
 
   const orgContext = await resolveOrgContext(userId);
+  const seasonGuard = await assertSeasonBelongsToLeague(
+    input.seasonId,
+    input.leagueId,
+    orgContext,
+  );
+  if (!seasonGuard.ok) return seasonGuard;
+
   const profileCache: TeamSimProfileCache = new Map();
   try {
     const regularSimulated = await simulateUnplayedRegularSeason(
@@ -503,6 +756,13 @@ export async function simulateSeasonThroughChampionAction(input: {
       return { ok: true, regularSimulated, playoffGames: 0, champion: null };
     }
 
+    if (!isStandardPlayoffTeamCount(size)) {
+      return { ok: false, error: "invalid_playoff_size" };
+    }
+    if ((season.playoffFormat ?? "single") === "double") {
+      return { ok: false, error: "unsupported_format" };
+    }
+
     // Fresh bracket from the configured size + qualification rule.
     await generatePlayoffBracket({
       seasonId: input.seasonId,
@@ -512,7 +772,7 @@ export async function simulateSeasonThroughChampionAction(input: {
       divisionWinnersQualify: season.divisionWinnersQualify,
     });
 
-    const playoffGames = await simulateUnplayedPlayoffs(
+    const playoffGames = await simulateAllPlayoffRounds(
       input.seasonId,
       userId,
       orgContext,

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -289,6 +289,9 @@ export default async function LeagueSchedulePage({
               <SimulateScopeMenu
                 leagueId={leagueId}
                 seasonId={activeSeason.id}
+                playoffFormat={
+                  bracket?.format ?? activeSeason.playoffFormat ?? "single"
+                }
               />
             ) : null}
             {canGenerateRosters ? (

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -45,9 +45,8 @@ function nullableDate(value: string): string | null {
   return value.trim() === "" ? null : value;
 }
 
-/** Bye-friendly playoff team counts (any value ≥ 2 is supported; the bracket
- *  rounds up to the next power of two and gives top seeds first-round byes). */
-const PLAYOFF_TEAM_OPTIONS = [2, 4, 6, 8, 10, 12, 16] as const;
+/** Standard playoff field sizes for new seasons (WSM-000241). */
+const PLAYOFF_TEAM_OPTIONS = [4, 8, 16] as const;
 
 /** Playoff setup fields shared by the create + edit season forms (WSM-000184,
  *  WSM-flex-brackets: bye-friendly counts + single/double elimination). */

--- a/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
+++ b/apps/web/src/components/playoffs/AdvanceToPlayoffsButton.tsx
@@ -26,7 +26,8 @@ const ERROR_MESSAGES: Record<string, string> = {
     "Finish every regular-season game before advancing.",
   already_advanced: "Playoffs have already started for this season.",
   no_season: "No active season found.",
-  no_playoffs_configured: "This season is not configured for playoffs.",
+  invalid_playoff_team_count:
+    "Playoff team count must be 4, 8, or 16 for this season.",
   season_required: "No season selected — reload and try again.",
   season_not_found: "This season no longer exists.",
   season_completed: "This season is already completed.",

--- a/apps/web/src/components/playoffs/PlayoffRoundControls.tsx
+++ b/apps/web/src/components/playoffs/PlayoffRoundControls.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Dices, FastForward, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+import {
+  advancePlayoffRoundAction,
+  simulateChampionshipAction,
+  simulatePlayoffsAction,
+} from "@/app/dashboard/leagues/[id]/schedule/actions";
+import {
+  isChampionshipRound,
+  minimumUnresolvedRound,
+  roundLabel,
+  supportsBulkPlayoffOps,
+} from "@/lib/playoffs";
+import type { PlayoffBracketDto } from "@/lib/data-api";
+
+export default function PlayoffRoundControls({
+  leagueId,
+  seasonId,
+  bracket,
+  canManage,
+}: {
+  leagueId: string;
+  seasonId: string;
+  bracket: PlayoffBracketDto;
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<
+    "advance" | "simPlayoffs" | "championship" | null
+  >(null);
+
+  if (!canManage || !supportsBulkPlayoffOps(bracket.format)) {
+    return null;
+  }
+
+  const currentRound = minimumUnresolvedRound(
+    bracket.matchups,
+    bracket.rounds,
+  );
+  const atChampionship =
+    currentRound !== null &&
+    isChampionshipRound(currentRound, bracket.rounds);
+  const currentLabel =
+    currentRound !== null
+      ? roundLabel(currentRound, bracket.rounds)
+      : null;
+
+  function openConfirm(action: "advance" | "simPlayoffs" | "championship") {
+    setConfirmAction(action);
+    setConfirmOpen(true);
+  }
+
+  function runAdvance() {
+    start(async () => {
+      const res = await advancePlayoffRoundAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.simulated === 0
+            ? "No unplayed games in the current round."
+            : `Simulated ${res.simulated} game${res.simulated === 1 ? "" : "s"} in ${currentLabel ?? "this round"}.`,
+        );
+        router.refresh();
+        setConfirmOpen(false);
+      } else {
+        toast.error(playoffOpError(res.error));
+      }
+    });
+  }
+
+  function runSimPlayoffs() {
+    start(async () => {
+      const res = await simulatePlayoffsAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.champion
+            ? `${res.champion} wins — simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
+            : res.playoffGames > 0
+              ? `Simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"} through the semifinals.`
+              : "No unplayed playoff games through the semifinals.",
+        );
+        router.refresh();
+        setConfirmOpen(false);
+      } else {
+        toast.error(playoffOpError(res.error));
+      }
+    });
+  }
+
+  function runChampionship() {
+    start(async () => {
+      const res = await simulateChampionshipAction({ leagueId, seasonId });
+      if (res.ok) {
+        toast.success(
+          res.champion
+            ? `${res.champion} wins the championship!`
+            : res.simulated > 0
+              ? "Championship game simulated."
+              : "No championship game to simulate.",
+        );
+        router.refresh();
+        setConfirmOpen(false);
+      } else {
+        toast.error(playoffOpError(res.error));
+      }
+    });
+  }
+
+  const confirmCopy =
+    confirmAction === "advance"
+      ? {
+          title: `Advance ${currentLabel ?? "current round"}?`,
+          description: `Simulate every unplayed game in ${currentLabel ?? "the current round"}? Later rounds are left untouched.`,
+          onConfirm: runAdvance,
+        }
+      : confirmAction === "simPlayoffs"
+        ? {
+            title: "Simulate playoffs?",
+            description:
+              "Simulate every unplayed playoff game through the semifinals? The championship stays unresolved until you simulate it explicitly.",
+            onConfirm: runSimPlayoffs,
+          }
+        : confirmAction === "championship"
+          ? {
+              title: "Simulate championship?",
+              description:
+                "Simulate the final matchup to crown a champion? This is the only bulk action that completes the bracket.",
+              onConfirm: runChampionship,
+            }
+          : null;
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {currentRound !== null && !atChampionship ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => openConfirm("advance")}
+            className="gap-1.5"
+          >
+            <FastForward className="h-4 w-4" />
+            {pending ? "Simulating…" : `Advance ${currentLabel}`}
+          </Button>
+        ) : null}
+        {currentRound !== null && !atChampionship ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => openConfirm("simPlayoffs")}
+            className="gap-1.5"
+          >
+            <Dices className="h-4 w-4" />
+            {pending ? "Simulating…" : "Sim playoffs"}
+          </Button>
+        ) : null}
+        {atChampionship ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => openConfirm("championship")}
+            className="gap-1.5"
+          >
+            <Trophy className="h-4 w-4" />
+            {pending ? "Simulating…" : "Sim championship"}
+          </Button>
+        ) : null}
+      </div>
+      {confirmCopy ? (
+        <ActionConfirmDialog
+          open={confirmOpen}
+          onOpenChange={(open) => {
+            setConfirmOpen(open);
+            if (!open) setConfirmAction(null);
+          }}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          confirmLabel="Simulate"
+          pending={pending}
+          onConfirm={confirmCopy.onConfirm}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function playoffOpError(error: string): string {
+  switch (error) {
+    case "unsupported_format":
+      return "Bulk playoff simulation is not available for double elimination.";
+    case "championship_requires_explicit_sim":
+      return "Use Sim championship to play the final.";
+    case "no_championship_fixture":
+      return "The championship matchup is not ready yet.";
+    case "no_playoffs":
+      return "No playoff bracket found.";
+    case "not_authorized":
+      return "Only league admins/coaches can simulate playoff games.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/components/schedule/SimulateControls.tsx
+++ b/apps/web/src/components/schedule/SimulateControls.tsx
@@ -134,9 +134,12 @@ export function SimulateWeekButton({
 export function SimulateScopeMenu({
   leagueId,
   seasonId,
+  playoffFormat = "single",
 }: {
   leagueId: string;
   seasonId: string;
+  /** Season or live-bracket format — bulk playoff sims hidden for double elim. */
+  playoffFormat?: string;
 }) {
   const router = useRouter();
   const [pending, start] = useTransition();
@@ -175,8 +178,8 @@ export function SimulateScopeMenu({
           res.champion
             ? `${res.champion} wins — simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
             : res.playoffGames > 0
-              ? `Simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"}`
-              : "No unplayed playoff games to simulate.",
+              ? `Simulated ${res.playoffGames} playoff game${res.playoffGames === 1 ? "" : "s"} through the semifinals.`
+              : "No unplayed playoff games through the semifinals.",
         );
         router.refresh();
         setConfirmOpen(false);
@@ -225,7 +228,7 @@ export function SimulateScopeMenu({
         ? {
             title: "Simulate playoffs?",
             description:
-              "Simulate every unplayed playoff game round by round? Already-recorded games are left untouched.",
+              "Simulate every unplayed playoff game through the semifinals? The championship stays unresolved until you simulate it explicitly.",
             onConfirm: runPlayoffs,
           }
         : confirmAction === "champion"
@@ -236,6 +239,8 @@ export function SimulateScopeMenu({
               onConfirm: runToChampion,
             }
           : null;
+
+  const bulkPlayoffSimsEnabled = playoffFormat !== "double";
 
   return (
     <>
@@ -259,13 +264,23 @@ export function SimulateScopeMenu({
           <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("regular")}>
             Sim regular season
           </DropdownMenuItem>
-          <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("playoffs")}>
-            Sim playoffs
-          </DropdownMenuItem>
-          <DropdownMenuItem disabled={pending} onSelect={() => openConfirm("champion")}>
-            <Trophy className="h-4 w-4" />
-            Sim to champion
-          </DropdownMenuItem>
+          {bulkPlayoffSimsEnabled ? (
+            <>
+              <DropdownMenuItem
+                disabled={pending}
+                onSelect={() => openConfirm("playoffs")}
+              >
+                Sim playoffs
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={pending}
+                onSelect={() => openConfirm("champion")}
+              >
+                <Trophy className="h-4 w-4" />
+                Sim to champion
+              </DropdownMenuItem>
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
       {confirmCopy ? (
@@ -421,6 +436,14 @@ function simError(error: string): string {
       return "Game not found.";
     case "no_playoffs":
       return "No playoff bracket yet. Generate a bracket on the Playoffs page first.";
+    case "unsupported_format":
+      return "Bulk playoff simulation is not available for double elimination.";
+    case "invalid_playoff_size":
+      return "Playoff team count must be 4, 8, or 16 (set it in season settings).";
+    case "season_league_mismatch":
+      return "That season does not belong to this league.";
+    case "season_not_found":
+      return "Season not found.";
     default:
       if (error.includes("not_enough_teams")) {
         return "Not enough teams for the configured playoff bracket. Lower the playoff team count in season settings.";

--- a/apps/web/src/lib/__tests__/playoff-handoff.test.ts
+++ b/apps/web/src/lib/__tests__/playoff-handoff.test.ts
@@ -57,10 +57,11 @@ describe("resolvePlayoffHandoff", () => {
     ).toBe("hidden");
   });
 
-  it("hides the handoff when playoffs are not configured", () => {
+  it("hides the handoff when playoffs are not configured for a standard field", () => {
     expect(resolvePlayoffHandoff(input({ playoffTeams: null }))).toBe("hidden");
     expect(resolvePlayoffHandoff(input({ playoffTeams: 0 }))).toBe("hidden");
     expect(resolvePlayoffHandoff(input({ playoffTeams: 1 }))).toBe("hidden");
+    expect(resolvePlayoffHandoff(input({ playoffTeams: 6 }))).toBe("hidden");
   });
 
   it("hides the handoff while the regular season is incomplete", () => {

--- a/apps/web/src/lib/__tests__/playoffs.test.ts
+++ b/apps/web/src/lib/__tests__/playoffs.test.ts
@@ -7,6 +7,11 @@ import {
   deriveChampion,
   regularSeasonProgress,
   playoffPagePhase,
+  isStandardPlayoffTeamCount,
+  minimumUnresolvedRound,
+  fixtureIdsForRound,
+  isChampionshipRound,
+  supportsBulkPlayoffOps,
 } from "../playoffs";
 import type { PlayoffMatchupDto } from "@/lib/data-api";
 
@@ -219,5 +224,72 @@ describe("playoffPagePhase", () => {
         regularComplete: false,
       }),
     ).toBe("in_progress");
+  });
+
+  it("returns invalid_playoff_size for legacy team counts before bracket creation", () => {
+    expect(
+      playoffPagePhase({
+        playoffTeams: 6,
+        bracketExists: false,
+        regularComplete: true,
+      }),
+    ).toBe("invalid_playoff_size");
+  });
+
+  it("still shows bracket_live for legacy sizes when a bracket exists", () => {
+    expect(
+      playoffPagePhase({
+        playoffTeams: 6,
+        bracketExists: true,
+        regularComplete: true,
+      }),
+    ).toBe("bracket_live");
+  });
+});
+
+describe("isStandardPlayoffTeamCount (WSM-000241)", () => {
+  it("accepts 4, 8, and 16 only", () => {
+    expect(isStandardPlayoffTeamCount(4)).toBe(true);
+    expect(isStandardPlayoffTeamCount(8)).toBe(true);
+    expect(isStandardPlayoffTeamCount(16)).toBe(true);
+    expect(isStandardPlayoffTeamCount(6)).toBe(false);
+    expect(isStandardPlayoffTeamCount(2)).toBe(false);
+    expect(isStandardPlayoffTeamCount(null)).toBe(false);
+  });
+});
+
+describe("minimumUnresolvedRound (WSM-000241)", () => {
+  it("returns the lowest round with an undecided non-bye matchup", () => {
+    const matchups = [
+      m({ id: "s0", round: 1, slot: 0, winnerTeamId: "t1" }),
+      m({ id: "s1", round: 1, slot: 1 }),
+      m({ id: "f", round: 2, slot: 0 }),
+    ];
+    expect(minimumUnresolvedRound(matchups, 2)).toBe(1);
+  });
+
+  it("skips bye slots when finding the current round", () => {
+    const matchups = [
+      m({ id: "bye", round: 1, slot: 0, isBye: true, winnerTeamId: "t1" }),
+      m({ id: "f", round: 2, slot: 0, fixtureId: "fix1" }),
+    ];
+    expect(minimumUnresolvedRound(matchups, 2)).toBe(2);
+    expect(isChampionshipRound(2, 2)).toBe(true);
+  });
+
+  it("returns fixture ids only for playable matchups in a round", () => {
+    const matchups = [
+      m({ id: "s0", round: 1, slot: 0, fixtureId: "f1" }),
+      m({ id: "bye", round: 1, slot: 1, isBye: true }),
+      m({ id: "s1", round: 1, slot: 2, fixtureId: "f2", winnerTeamId: "t2" }),
+    ];
+    expect(fixtureIdsForRound(matchups, 1)).toEqual(["f1"]);
+  });
+});
+
+describe("supportsBulkPlayoffOps", () => {
+  it("allows single elimination and rejects double", () => {
+    expect(supportsBulkPlayoffOps("single")).toBe(true);
+    expect(supportsBulkPlayoffOps("double")).toBe(false);
   });
 });

--- a/apps/web/src/lib/playoff-handoff.ts
+++ b/apps/web/src/lib/playoff-handoff.ts
@@ -1,10 +1,12 @@
 /*
  * WSM-000239 — season-safe playoff handoff gating for the schedule page.
+ * WSM-000241 — start readiness requires a standard 4/8/16 playoff field.
  *
  * Pure so the read-only "waiting" branch has deterministic unit coverage (the
  * e2e environment has no viewer-role Clerk user, so this branch cannot be
  * driven end-to-end — see schedules e2e spec notes).
  */
+import { canStartPlayoffs } from "@/lib/playoffs";
 
 export type PlayoffHandoffState = "start" | "waiting" | "hidden";
 
@@ -43,7 +45,7 @@ export function resolvePlayoffHandoff(
   // Viewing a historical or upcoming season never surfaces the button.
   if (input.viewedSeasonId !== input.decidedSeasonId) return "hidden";
   if (input.viewedSeasonStatus !== "active") return "hidden";
-  if (!input.playoffTeams || input.playoffTeams < 2) return "hidden";
+  if (!canStartPlayoffs(input.playoffTeams)) return "hidden";
   if (input.regularTotal === 0 || !input.regularComplete) return "hidden";
   if (input.bracketExists) return "hidden";
   return input.canManage ? "start" : "waiting";

--- a/apps/web/src/lib/playoffs.ts
+++ b/apps/web/src/lib/playoffs.ts
@@ -192,8 +192,89 @@ export function regularSeasonProgress(
   };
 }
 
+/** Standard playoff field sizes for newly started brackets (WSM-000241). */
+export const STANDARD_PLAYOFF_TEAM_COUNTS = [4, 8, 16] as const;
+
+export function isStandardPlayoffTeamCount(
+  count: number | null | undefined,
+): boolean {
+  return (
+    count === 4 ||
+    count === 8 ||
+    count === 16
+  );
+}
+
+/** Single-elim winners-bracket matchups only — bulk round ops ignore losers/GF. */
+export function winnersBracketMatchups(
+  matchups: PlayoffMatchupDto[],
+): PlayoffMatchupDto[] {
+  return matchups.filter((m) => (m.bracketType ?? "winners") === "winners");
+}
+
+/** Lowest round that still has an unresolved non-bye matchup; null when decided. */
+export function minimumUnresolvedRound(
+  matchups: PlayoffMatchupDto[],
+  totalRounds: number,
+): number | null {
+  const winners = winnersBracketMatchups(matchups);
+  for (let round = 1; round <= totalRounds; round++) {
+    const roundMatchups = winners.filter((m) => m.round === round);
+    if (roundMatchups.some((m) => !m.isBye && !m.winnerTeamId)) {
+      return round;
+    }
+  }
+  return null;
+}
+
+export function championshipRound(totalRounds: number): number {
+  return totalRounds;
+}
+
+export function isChampionshipRound(
+  round: number,
+  totalRounds: number,
+): boolean {
+  return round === championshipRound(totalRounds);
+}
+
+/** Playable (non-bye, undecided) matchups in a single-elim round. */
+export function playableMatchupsInRound(
+  matchups: PlayoffMatchupDto[],
+  round: number,
+): PlayoffMatchupDto[] {
+  return winnersBracketMatchups(matchups).filter(
+    (m) =>
+      m.round === round &&
+      !m.isBye &&
+      !m.winnerTeamId &&
+      m.fixtureId != null,
+  );
+}
+
+export function fixtureIdsForRound(
+  matchups: PlayoffMatchupDto[],
+  round: number,
+): string[] {
+  return playableMatchupsInRound(matchups, round)
+    .map((m) => m.fixtureId)
+    .filter((id): id is string => id != null);
+}
+
+/** Bulk single-elim round simulation is unsupported for double elimination. */
+export function supportsBulkPlayoffOps(format: string): boolean {
+  return format !== "double";
+}
+
+export function canStartPlayoffs(
+  playoffTeams: number | null | undefined,
+): boolean {
+  return isStandardPlayoffTeamCount(playoffTeams);
+}
+
 export type PlayoffPagePhase =
   | "no_playoffs_config"
+  | "invalid_playoff_size"
   | "in_progress"
   | "ready"
   | "bracket_live";
@@ -203,8 +284,13 @@ export function playoffPagePhase(input: {
   bracketExists: boolean;
   regularComplete: boolean;
 }): PlayoffPagePhase {
-  if (!input.playoffTeams || input.playoffTeams < 2) return "no_playoffs_config";
+  if (!input.playoffTeams || input.playoffTeams < 2) {
+    return "no_playoffs_config";
+  }
   if (input.bracketExists) return "bracket_live";
+  if (!isStandardPlayoffTeamCount(input.playoffTeams)) {
+    return "invalid_playoff_size";
+  }
   if (input.regularComplete) return "ready";
   return "in_progress";
 }


### PR DESCRIPTION
## Summary

- Add pure round selectors and 4/8/16 start gating for single-elim playoffs
- Introduce current-round advance, semifinal-stop Sim playoffs, and explicit Sim championship actions/UI
- Hide/reject bulk playoff round controls for double elimination (`unsupported_format`)
- Require season↔league ownership on playoff mutate actions; cover viewer and mismatch rejection in unit tests

## Test plan

- [x] `pnpm --filter @sports-management/web exec vitest run` on playoffs helpers, handoff, simulate-actions, advance-playoffs-action
- [x] `pnpm --filter @sports-management/web type-check`
- [ ] Playwright: `playoffs-bracket.spec.ts` / `sim-scopes.spec.ts` (chromium) when org secrets available

## Related Issue

Closes #529
