### PR TITLE
feat(web): blocking generation flows and roster auto-fill (WSM-000242)

### DIFF
--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -40,6 +40,23 @@ export async function confirmLifecycleDialog(
   }
 }
 
+/**
+ * Wait for a ProcessDialog to finish (pending unlocks Close) and dismiss it.
+ * Generation buttons relabel to "Generating…" while pending, so callers must
+ * await this instead of the original button name returning.
+ */
+export async function awaitProcessDialog(
+  page: Page,
+  opts: { timeout?: number } = {},
+): Promise<void> {
+  const dialog = page.getByTestId("process-dialog");
+  await expect(dialog).toBeVisible({ timeout: opts.timeout ?? 30_000 });
+  const close = dialog.getByTestId("process-dialog-close");
+  await expect(close).toBeEnabled({ timeout: opts.timeout ?? 180_000 });
+  await close.click();
+  await expect(dialog).toBeHidden();
+}
+
 export async function addTeamsToLeague(
   page: Page,
   leagueId: string,
@@ -82,11 +99,13 @@ export async function generateLeagueSyntheticData(
   const rostersBtn = page.getByRole("button", { name: "Generate rosters" });
   await rostersBtn.click();
   await confirmLifecycleDialog(page);
-  await expect(rostersBtn).toBeEnabled({ timeout: 120_000 });
+  await awaitProcessDialog(page, { timeout: 180_000 });
+  await expect(rostersBtn).toBeEnabled({ timeout: 30_000 });
   const ratingsBtn = page.getByRole("button", { name: "Generate ratings" });
   await ratingsBtn.click();
   await confirmLifecycleDialog(page);
-  await expect(ratingsBtn).toBeEnabled({ timeout: 120_000 });
+  await awaitProcessDialog(page, { timeout: 180_000 });
+  await expect(ratingsBtn).toBeEnabled({ timeout: 30_000 });
 }
 
 export async function generateRoundRobinSchedule(
@@ -96,8 +115,9 @@ export async function generateRoundRobinSchedule(
   await page.goto(`/dashboard/leagues/${leagueId}/schedule`);
   const generate = page.getByRole("button", { name: /Generate schedule/ });
   await expect(generate).toBeVisible();
-  // Fresh leagues have no fixtures — GenerateScheduleButton skips the dialog.
+  // Fresh leagues have no fixtures — skips ActionConfirmDialog, opens ProcessDialog.
   await generate.click();
+  await awaitProcessDialog(page, { timeout: 120_000 });
   await expect(page.getByText("Week 1", { exact: true })).toBeVisible({
     timeout: 60_000,
   });
@@ -205,4 +225,5 @@ export async function completeSeason(
 export async function startNextSeason(page: Page) {
   await page.getByRole("button", { name: "Start next season" }).click();
   await confirmLifecycleDialog(page);
+  await awaitProcessDialog(page, { timeout: 120_000 });
 }

--- a/apps/web/e2e/tests/dynasty.spec.ts
+++ b/apps/web/e2e/tests/dynasty.spec.ts
@@ -111,10 +111,9 @@ test.describe("Dynasty panel (dynasty rollover)", () => {
     await page.goto(`/dashboard/leagues/${leagueId}`);
     await expect(startBtn).toBeEnabled();
     await startNextSeason(page);
-    await expect(page.getByText("Next season started.")).toBeVisible({
+    await expect(page.getByText(/Offseason · upcoming/)).toBeVisible({
       timeout: 60_000,
     });
-    await expect(page.getByText(/Offseason · upcoming/)).toBeVisible();
     await expect(page.getByText(/View E2E Season/)).toBeVisible();
 
     await page.goto("/dashboard/seasons");

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -630,8 +630,13 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
     const drawer = page.getByTestId("game-context-drawer");
     await expect(drawer).toBeVisible();
     await expect(drawer.getByTestId("game-drawer-mode")).toHaveText(/^Final/);
-    await expect(drawer.getByText(String(ctx.expectedHome))).toBeVisible();
-    await expect(drawer.getByText(String(ctx.expectedAway))).toBeVisible();
+    // Use side-specific score testids — tied finals (e.g. 17–17) make getByText(score) ambiguous.
+    await expect(drawer.getByTestId("game-drawer-home-score")).toHaveText(
+      String(ctx.expectedHome),
+    );
+    await expect(drawer.getByTestId("game-drawer-away-score")).toHaveText(
+      String(ctx.expectedAway),
+    );
 
     await drawer.getByTestId("game-drawer-open-gamecast").click();
     await expect(page).toHaveURL(/\/dashboard\/games\/[^/]+\/gamecast$/);

--- a/apps/web/e2e/tests/offseason-draft.spec.ts
+++ b/apps/web/e2e/tests/offseason-draft.spec.ts
@@ -55,9 +55,6 @@ test.describe("Offseason draft", () => {
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });
     await startNextSeason(page);
-    await expect(page.getByText("Next season started.")).toBeVisible({
-      timeout: 60_000,
-    });
 
     const upcomingLink = page.getByRole("link", { name: /View E2E Season/ });
     await expect(upcomingLink).toBeVisible({ timeout: 60_000 });

--- a/apps/web/e2e/tests/offseason-free-agency.spec.ts
+++ b/apps/web/e2e/tests/offseason-free-agency.spec.ts
@@ -55,9 +55,6 @@ test.describe("Offseason free agency", () => {
     const startBtn = page.getByRole("button", { name: "Start next season" });
     await expect(startBtn).toBeEnabled({ timeout: 60_000 });
     await startNextSeason(page);
-    await expect(page.getByText("Next season started.")).toBeVisible({
-      timeout: 60_000,
-    });
 
     const upcomingLink = page.getByRole("link", { name: /View E2E Season/ });
     await expect(upcomingLink).toBeVisible({ timeout: 60_000 });

--- a/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
@@ -58,6 +58,8 @@ import {
   generateLeagueRostersAction,
   clearTeamSyntheticAction,
   clearLeagueSyntheticAction,
+  getLeagueRosterDeficitAction,
+  fillDeficientRostersAction,
 } from "../synthetic-rosters";
 
 const TEAM = "team_1";
@@ -201,5 +203,145 @@ describe("clearLeagueSyntheticAction", () => {
     const res = await clearLeagueSyntheticAction({ leagueId: LEAGUE });
     expect(res).toEqual({ ok: true, teams: 2, deleted: 20 });
     expect(mockClearSyntheticPlayers).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getLeagueRosterDeficitAction", () => {
+  beforeEach(() => {
+    mockGetTeamsByLeague.mockResolvedValue([
+      { id: "t1", name: "Alpha" },
+      { id: "t2", name: "Beta" },
+    ]);
+    mockGetPlayers.mockResolvedValue([
+      { id: "p1", teamId: "t1", status: "active" },
+      { id: "p2", teamId: "t2", status: "active" },
+    ]);
+  });
+
+  it("returns only deficient teams with target size", async () => {
+    const res = await getLeagueRosterDeficitAction({ leagueId: LEAGUE });
+    expect(res).toEqual({
+      ok: true,
+      target: 48,
+      teams: [
+        {
+          id: "t1",
+          name: "Alpha",
+          activeCount: 1,
+          target: 48,
+          deficit: 47,
+        },
+        {
+          id: "t2",
+          name: "Beta",
+          activeCount: 1,
+          target: 48,
+          deficit: 47,
+        },
+      ],
+    });
+  });
+
+  it("rejects viewers without visible league access", async () => {
+    mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [], orgIds: [] });
+    expect(await getLeagueRosterDeficitAction({ leagueId: LEAGUE })).toEqual({
+      ok: false,
+      error: "not_authorized",
+    });
+  });
+});
+
+describe("fillDeficientRostersAction", () => {
+  beforeEach(() => {
+    mockGetLeagueOrgId.mockResolvedValue(ORG);
+    mockResolveOrgRole.mockResolvedValue("admin");
+    mockGetTeamsByLeague.mockResolvedValue([
+      { id: "t1", name: "Alpha" },
+      { id: "t2", name: "Beta" },
+      { id: "t3", name: "Gamma" },
+    ]);
+    mockGetPlayers.mockResolvedValue([
+      { id: "p1", teamId: "t1", status: "active" },
+      { id: "p2", teamId: "t2", status: "active" },
+      { id: "p3", teamId: "t3", status: "active" },
+      ...Array.from({ length: 48 }, (_, index) => ({
+        id: `full-${index}`,
+        teamId: "t3",
+        status: "active",
+      })),
+    ]);
+    mockGetPlayersByTeam.mockImplementation(async (teamId: string) => {
+      if (teamId === "t3") {
+        return Array.from({ length: 48 }, (_, index) => ({
+          id: `full-${index}`,
+          jerseyNumber: index,
+        }));
+      }
+      return [{ id: `player-${teamId}`, jerseyNumber: 1 }];
+    });
+    mockBulkCreatePlayers.mockResolvedValue({ created: 47 });
+  });
+
+  it("fills all deficient teams for admins", async () => {
+    const res = await fillDeficientRostersAction({ leagueId: LEAGUE });
+    expect(res).toEqual({
+      ok: true,
+      teamsFilled: 2,
+      created: 94,
+      fullTeamsUnchanged: 1,
+    });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledTimes(2);
+    expect(mockBulkCreatePlayers.mock.calls.map(([teamId]) => teamId)).toEqual([
+      "t1",
+      "t2",
+    ]);
+  });
+
+  it("fills only managed deficient teams for coaches", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockImplementation(async (teamId: string) => teamId === "t1");
+
+    const res = await fillDeficientRostersAction({ leagueId: LEAGUE });
+    expect(res).toEqual({
+      ok: true,
+      teamsFilled: 1,
+      created: 47,
+      fullTeamsUnchanged: 1,
+    });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledTimes(1);
+    expect(mockBulkCreatePlayers.mock.calls[0]?.[0]).toBe("t1");
+  });
+
+  it("rejects coaches who cannot manage any deficient team", async () => {
+    mockResolveOrgRole.mockResolvedValue("coach");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    expect(await fillDeficientRostersAction({ leagueId: LEAGUE })).toEqual({
+      ok: false,
+      error: "not_authorized",
+    });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("rejects viewers", async () => {
+    mockResolveOrgRole.mockResolvedValue("viewer");
+    mockCanManageTeam.mockResolvedValue(false);
+
+    expect(await fillDeficientRostersAction({ leagueId: LEAGUE })).toEqual({
+      ok: false,
+      error: "not_authorized",
+    });
+    expect(mockBulkCreatePlayers).not.toHaveBeenCalled();
+  });
+
+  it("leaves full team player IDs unchanged", async () => {
+    await fillDeficientRostersAction({ leagueId: LEAGUE });
+    const fullTeamCalls = mockGetPlayersByTeam.mock.calls.filter(
+      ([teamId]) => teamId === "t3",
+    );
+    expect(fullTeamCalls.length).toBeGreaterThan(0);
+    expect(mockBulkCreatePlayers.mock.calls.some(([teamId]) => teamId === "t3")).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/synthetic-rosters.test.ts
@@ -344,4 +344,35 @@ describe("fillDeficientRostersAction", () => {
       false,
     );
   });
+
+  it("fills to active non-graduated target when graduated players remain on the roster", async () => {
+    mockGetTeamsByLeague.mockResolvedValue([{ id: "t1", name: "Alpha" }]);
+    mockGetPlayers.mockResolvedValue([
+      ...Array.from({ length: 47 }, (_, index) => ({
+        id: `active-${index}`,
+        teamId: "t1",
+        status: "active",
+      })),
+      { id: "grad-1", teamId: "t1", status: "graduated" },
+    ]);
+    mockGetPlayersByTeam.mockResolvedValue([
+      ...Array.from({ length: 47 }, (_, index) => ({
+        id: `active-${index}`,
+        jerseyNumber: index,
+        status: "active",
+      })),
+      { id: "grad-1", jerseyNumber: 99, status: "graduated" },
+    ]);
+    mockBulkCreatePlayers.mockResolvedValue({ created: 1 });
+
+    const res = await fillDeficientRostersAction({ leagueId: LEAGUE });
+    expect(res).toEqual({
+      ok: true,
+      teamsFilled: 1,
+      created: 1,
+      fullTeamsUnchanged: 0,
+    });
+    expect(mockBulkCreatePlayers).toHaveBeenCalledTimes(1);
+    expect(mockBulkCreatePlayers.mock.calls[0]?.[1]).toHaveLength(1);
+  });
 });

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -25,6 +25,12 @@ import {
 import { generateSyntheticAttributes } from "@/lib/synthetic-attributes";
 import { isSeasonStarted } from "@/lib/season-started";
 import { resolveLifecycleSeason } from "@/lib/season-view";
+import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
+import {
+  activeRosterCountByTeam,
+  buildLeagueRosterDeficitProjection,
+  type UndersizedTeamWithDeficit,
+} from "@/lib/roster-deficit";
 
 /*
  * Synthetic-roster generation (WSM-000173) — fills demo/test rosters with fake
@@ -34,8 +40,21 @@ import { resolveLifecycleSeason } from "@/lib/season-view";
  * (the generator never uses real data).
  */
 
-const DEFAULT_ROSTER_SIZE = 48;
+const DEFAULT_ROSTER_SIZE = DEFAULT_TARGET_ROSTER_SIZE;
 const MAX_ROSTER_SIZE = 60;
+
+type DeficitProjectionResult =
+  | { ok: true; target: number; teams: UndersizedTeamWithDeficit[] }
+  | { ok: false; error: string };
+
+type FillDeficientResult =
+  | {
+      ok: true;
+      teamsFilled: number;
+      created: number;
+      fullTeamsUnchanged: number;
+    }
+  | { ok: false; error: string };
 
 type TeamResult = { ok: true; created: number } | { ok: false; error: string };
 type LeagueResult =
@@ -106,6 +125,136 @@ function buildAttributeRows(
       weightedOverall: snapshot.weightedOverall,
     };
   });
+}
+
+/** Bounded league roster-deficit projection — deficient teams only (WSM-000242). */
+export async function getLeagueRosterDeficitAction(input: {
+  leagueId: string;
+}): Promise<DeficitProjectionResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(input.leagueId)) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+  const players = await getPlayers([input.leagueId]).catch(() => []);
+  const countByTeam = activeRosterCountByTeam(players);
+  return { ok: true, ...buildLeagueRosterDeficitProjection(teams, countByTeam) };
+}
+
+async function fillTeamsToTarget(
+  teamIds: string[],
+  leagueId: string,
+  orgContext: Awaited<ReturnType<typeof resolveOrgContext>>,
+  target: number,
+): Promise<{ teamsFilled: number; created: number }> {
+  const excludeNames = await leaguePlayerNames(leagueId, orgContext);
+  const usedNames = new Set(excludeNames);
+  let created = 0;
+  let teamsFilled = 0;
+
+  for (const teamId of teamIds) {
+    const existing = await getPlayersByTeam(teamId, orgContext).catch(() => []);
+    const toCreate = Math.max(0, target - existing.length);
+    if (toCreate === 0) continue;
+    const players = generateSyntheticRoster({
+      count: toCreate,
+      excludeJerseys: existingJerseys(existing),
+      excludeNames: Array.from(usedNames),
+      seed: seedFromString(teamId) + existing.length,
+    });
+    for (const player of players) usedNames.add(player.name);
+    const res = await bulkCreatePlayers(teamId, players);
+    created += res.created;
+    teamsFilled += 1;
+  }
+
+  return { teamsFilled, created };
+}
+
+/** Auto-fill only deficient teams — admin fills all; coach fills managed teams (WSM-000242). */
+export async function fillDeficientRostersAction(input: {
+  leagueId: string;
+}): Promise<FillDeficientResult> {
+  if (!(await syntheticRostersV1())) return { ok: false, error: "flag_disabled" };
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const seasonGuard = await assertSeasonNotStarted(input.leagueId);
+  if (!seasonGuard.ok) return seasonGuard;
+
+  const orgId = await getLeagueOrgId(input.leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  const isAdmin = canManageOrgSettings(role);
+
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(input.leagueId)) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  const teams = await getTeamsByLeague(input.leagueId, orgContext).catch(() => []);
+  const players = await getPlayers([input.leagueId]).catch(() => []);
+  const countByTeam = activeRosterCountByTeam(players);
+  const projection = buildLeagueRosterDeficitProjection(teams, countByTeam);
+  const fullTeamIds = teams
+    .filter((team) => (countByTeam.get(team.id) ?? 0) >= projection.target)
+    .map((team) => team.id);
+  const fullTeamPlayerIdsBefore = new Map<string, string[]>();
+  for (const teamId of fullTeamIds) {
+    const roster = await getPlayersByTeam(teamId, orgContext).catch(() => []);
+    fullTeamPlayerIdsBefore.set(
+      teamId,
+      roster.map((player) => player.id).sort(),
+    );
+  }
+
+  let teamIdsToFill: string[];
+  if (isAdmin) {
+    teamIdsToFill = projection.teams.map((team) => team.id);
+  } else {
+    const manageable: string[] = [];
+    for (const team of projection.teams) {
+      if (await canManageTeam(team.id, userId)) {
+        manageable.push(team.id);
+      }
+    }
+    if (manageable.length === 0) {
+      return { ok: false, error: "not_authorized" };
+    }
+    teamIdsToFill = manageable;
+  }
+
+  try {
+    const { teamsFilled, created } = await fillTeamsToTarget(
+      teamIdsToFill,
+      input.leagueId,
+      orgContext,
+      projection.target,
+    );
+
+    for (const teamId of fullTeamIds) {
+      const roster = await getPlayersByTeam(teamId, orgContext).catch(() => []);
+      const afterIds = roster.map((player) => player.id).sort();
+      const beforeIds = fullTeamPlayerIdsBefore.get(teamId) ?? [];
+      if (afterIds.join(",") !== beforeIds.join(",")) {
+        throw new Error("full_roster_mutated");
+      }
+    }
+
+    revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    return {
+      ok: true,
+      teamsFilled,
+      created,
+      fullTeamsUnchanged: fullTeamIds.length,
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 export async function generateTeamRosterAction(input: {

--- a/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
+++ b/apps/web/src/app/dashboard/_actions/synthetic-rosters.ts
@@ -159,7 +159,10 @@ async function fillTeamsToTarget(
 
   for (const teamId of teamIds) {
     const existing = await getPlayersByTeam(teamId, orgContext).catch(() => []);
-    const toCreate = Math.max(0, target - existing.length);
+    // Match deficit projection: count active (non-graduated) only for fill target.
+    // Still exclude jerseys/names from the full roster so graduated rows stay unique.
+    const activeCount = existing.filter((player) => player.status !== "graduated").length;
+    const toCreate = Math.max(0, target - activeCount);
     if (toCreate === 0) continue;
     const players = generateSyntheticRoster({
       count: toCreate,
@@ -275,7 +278,8 @@ export async function generateTeamRosterAction(input: {
   const target = Math.max(1, Math.min(input.count ?? DEFAULT_ROSTER_SIZE, MAX_ROSTER_SIZE));
   const orgContext = await resolveOrgContext(userId);
   const existing = await getPlayersByTeam(input.teamId, orgContext).catch(() => []);
-  const toCreate = Math.max(0, target - existing.length);
+  const activeCount = existing.filter((player) => player.status !== "graduated").length;
+  const toCreate = Math.max(0, target - activeCount);
   if (toCreate === 0) return { ok: true, created: 0 };
 
   const excludeNames = await leaguePlayerNames(leagueId, orgContext);
@@ -320,7 +324,8 @@ export async function generateLeagueRostersAction(input: {
   try {
     for (const team of teams) {
       const existing = await getPlayersByTeam(team.id, orgContext).catch(() => []);
-      const toCreate = Math.max(0, target - existing.length);
+      const activeCount = existing.filter((player) => player.status !== "graduated").length;
+      const toCreate = Math.max(0, target - activeCount);
       if (toCreate === 0) continue;
       const players = generateSyntheticRoster({
         count: toCreate,

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -37,6 +37,12 @@ import {
 } from "../leagues-actions";
 import { syntheticRostersV1 } from "@/lib/flags";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
+import { UndersizedRosterPanel } from "@/components/roster/UndersizedRosterPanel";
+import {
+  activeRosterCountByTeam,
+  buildLeagueRosterDeficitProjection,
+} from "@/lib/roster-deficit";
+import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
 
 export default async function LeagueDetailPage({
   params,
@@ -97,6 +103,13 @@ export default async function LeagueDetailPage({
     ? isSeasonStarted(activeSeason, fixtures)
     : false;
   const teamNameById = new Map(teams.map((t) => [t.id, t.name]));
+  const rosterDeficit =
+    isAdmin && league.orgId
+      ? buildLeagueRosterDeficitProjection(
+          teams,
+          activeRosterCountByTeam(leaguePlayers),
+        )
+      : { target: DEFAULT_TARGET_ROSTER_SIZE, teams: [] };
   const graduatedPlayers =
     isAdmin && league.orgId
       ? leaguePlayers
@@ -216,28 +229,36 @@ export default async function LeagueDetailPage({
                 />
               )}
               {canGenerateRosters && (
-                <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
-                  <div className="min-w-0">
-                    <p className="text-label-14 text-foreground">Synthetic rosters</p>
-                    <p className="text-caption-12 text-text-muted">
-                      {seasonStarted
-                        ? "Season has started — roster and ratings generation is locked."
-                        : "Fill every team in this league with fake test players (~48 each) for demos. Not real people."}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <SyntheticRosterButton
-                      kind="league"
-                      id={id}
-                      seasonStarted={seasonStarted}
-                    />
-                    <SyntheticRosterButton
-                      kind="league"
-                      id={id}
-                      action="attributes"
-                      seasonStarted={seasonStarted}
-                    />
-                    <SyntheticRosterButton kind="league" id={id} action="clear" />
+                <div className="space-y-3 border-t border-border pt-4">
+                  <UndersizedRosterPanel
+                    leagueId={id}
+                    target={rosterDeficit.target}
+                    undersizedTeams={rosterDeficit.teams}
+                    canAutoFill={!seasonStarted}
+                  />
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="min-w-0">
+                      <p className="text-label-14 text-foreground">Synthetic rosters</p>
+                      <p className="text-caption-12 text-text-muted">
+                        {seasonStarted
+                          ? "Season has started — roster and ratings generation is locked."
+                          : "Fill every team in this league with fake test players (~48 each) for demos. Not real people."}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <SyntheticRosterButton
+                        kind="league"
+                        id={id}
+                        seasonStarted={seasonStarted}
+                      />
+                      <SyntheticRosterButton
+                        kind="league"
+                        id={id}
+                        action="attributes"
+                        seasonStarted={seasonStarted}
+                      />
+                      <SyntheticRosterButton kind="league" id={id} action="clear" />
+                    </div>
                   </div>
                 </div>
               )}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -18,6 +18,7 @@ import {
   getGamePlayLog,
   getPlayoffBracket,
   getTeamsByLeague,
+  getPlayers,
   listFixturesBySeason,
   computeStandings,
   type PublicGameStream,
@@ -52,6 +53,12 @@ import ScheduleWeeks, {
 import { ScheduleFixtureRow } from "@/components/schedule/ScheduleFixtureRow";
 import AdvanceToPlayoffsButton from "@/components/playoffs/AdvanceToPlayoffsButton";
 import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
+import { UndersizedRosterPanel } from "@/components/roster/UndersizedRosterPanel";
+import {
+  activeRosterCountByTeam,
+  buildLeagueRosterDeficitProjection,
+} from "@/lib/roster-deficit";
+import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
 import { Button } from "@/components/ui/button";
 import SeasonSwitcher from "@/components/schedule/SeasonSwitcher";
 import { resolveLifecycleSeason, resolveViewedSeason } from "@/lib/season-view";
@@ -123,6 +130,15 @@ export default async function LeagueSchedulePage({
   const canGenerateRosters = rosterGenEnabled && !seasonCompleted;
 
   const teams = await getTeamsByLeague(leagueId, orgContext);
+  const leaguePlayers = canGenerateRosters
+    ? await getPlayers([leagueId]).catch(() => [])
+    : [];
+  const rosterDeficit = canGenerateRosters
+    ? buildLeagueRosterDeficitProjection(
+        teams,
+        activeRosterCountByTeam(leaguePlayers),
+      )
+    : { target: DEFAULT_TARGET_ROSTER_SIZE, teams: [] };
 
   const fixtures = activeSeason
     ? await listFixturesBySeason(activeSeason.id)
@@ -320,6 +336,17 @@ export default async function LeagueSchedulePage({
         }
       />
       <WorkspaceNav links={peerNavLinks} />
+
+      {canGenerateRosters && rosterDeficit.teams.length > 0 ? (
+        <div className="mb-6">
+          <UndersizedRosterPanel
+            leagueId={leagueId}
+            target={rosterDeficit.target}
+            undersizedTeams={rosterDeficit.teams}
+            canAutoFill={!seasonStarted}
+          />
+        </div>
+      ) : null}
 
       {handoff !== "hidden" && activeSeason ? (
         <Card className="mb-6" data-testid="playoff-handoff">

--- a/apps/web/src/components/dynasty/DynastyPanel.tsx
+++ b/apps/web/src/components/dynasty/DynastyPanel.tsx
@@ -3,12 +3,10 @@
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { CalendarClock, GraduationCap, Users } from "lucide-react";
 import { startNextSeasonAction } from "@/app/dashboard/_actions/dynasty";
 import {
   evaluateStartNextSeason,
-  formatRolloverSuccessSummary,
   startNextSeasonErrorMessage,
   type DynastySeasonState,
 } from "@/lib/dynasty-panel";
@@ -16,6 +14,8 @@ import type { ClassDistribution } from "@/lib/class-year";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+import { ProcessDialog } from "@/components/lifecycle/ProcessDialog";
+import { dynastyRolloverProcessStages } from "@/lib/process-stages";
 import {
   Accordion,
   AccordionContent,
@@ -63,16 +63,24 @@ export function DynastyPanel({
 }: DynastyPanelProps) {
   const router = useRouter();
   const [pending, start] = useTransition();
-  const [lastSuccess, setLastSuccess] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [processOpen, setProcessOpen] = useState(false);
+  const [processError, setProcessError] = useState<string | null>(null);
+  const [stages, setStages] = useState(dynastyRolloverProcessStages("pending"));
 
   function runStartNextSeason() {
     if (!gate.canStart) return;
 
+    setConfirmOpen(false);
+    setProcessOpen(true);
+    setProcessError(null);
+    setStages(dynastyRolloverProcessStages("pending"));
+
     start(async () => {
       const res = await startNextSeasonAction({ leagueId });
       if (!res.ok) {
-        toast.error(
+        setStages(dynastyRolloverProcessStages("error"));
+        setProcessError(
           startNextSeasonErrorMessage(res.error, {
             unplayedGames,
             playoffsUndecided,
@@ -81,16 +89,15 @@ export function DynastyPanel({
         );
         return;
       }
-      const summary = formatRolloverSuccessSummary({
-        graduated: res.graduated,
-        advanced: res.advanced,
-        freshmen: res.freshmen,
-        progressed: res.progressed,
-      });
-      setLastSuccess(summary);
-      toast.success("Next season started.");
+      setStages(
+        dynastyRolloverProcessStages("success", {
+          graduated: res.graduated,
+          advanced: res.advanced,
+          freshmen: res.freshmen,
+          progressed: res.progressed,
+        }),
+      );
       router.refresh();
-      setConfirmOpen(false);
     });
   }
 
@@ -150,12 +157,6 @@ export function DynastyPanel({
             >
               View {upcomingSeason.name} →
             </Link>
-          </p>
-        )}
-
-        {lastSuccess && (
-          <p className="mt-3 rounded-sm border border-border bg-muted/50 px-3 py-2 text-caption-12 text-foreground">
-            {lastSuccess}
           </p>
         )}
       </div>
@@ -230,6 +231,16 @@ export function DynastyPanel({
       confirmLabel="Start season"
       pending={pending}
       onConfirm={runStartNextSeason}
+    />
+    <ProcessDialog
+      open={processOpen}
+      onOpenChange={setProcessOpen}
+      title="Start next season"
+      description="Rolling over the dynasty — graduating seniors, advancing classes, and generating freshmen."
+      stages={stages}
+      pending={pending}
+      error={processError}
+      onRetry={runStartNextSeason}
     />
     </>
   );

--- a/apps/web/src/components/games/GameContextDrawer.tsx
+++ b/apps/web/src/components/games/GameContextDrawer.tsx
@@ -30,12 +30,14 @@ export interface GameContextDrawerProps {
 function TeamBlock({
   team,
   score,
+  scoreTestId,
   won,
   dim,
   align,
 }: {
   team: GameDrawerProjection["home"];
   score: number | null;
+  scoreTestId?: string;
   won: boolean;
   dim: boolean;
   align: "left" | "right";
@@ -71,7 +73,10 @@ function TeamBlock({
         <span className="text-xs text-muted-foreground">{meta}</span>
       ) : null}
       {score != null ? (
-        <span className="font-mono text-2xl tabular-nums text-foreground">
+        <span
+          className="font-mono text-2xl tabular-nums text-foreground"
+          data-testid={scoreTestId}
+        >
           {score}
         </span>
       ) : null}
@@ -130,6 +135,7 @@ export function GameContextDrawer({
               <TeamBlock
                 team={projection.home}
                 score={isFinal ? projection.homeScore : null}
+                scoreTestId="game-drawer-home-score"
                 won={
                   isFinal &&
                   projection.homeScore != null &&
@@ -145,6 +151,7 @@ export function GameContextDrawer({
               <TeamBlock
                 team={projection.away}
                 score={isFinal ? projection.awayScore : null}
+                scoreTestId="game-drawer-away-score"
                 won={
                   isFinal &&
                   projection.homeScore != null &&

--- a/apps/web/src/components/roster/SyntheticRosterButton.tsx
+++ b/apps/web/src/components/roster/SyntheticRosterButton.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { Sparkles, Trash2, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+import { ProcessDialog } from "@/components/lifecycle/ProcessDialog";
 import {
   generateTeamRosterAction,
   generateLeagueRostersAction,
@@ -14,6 +14,12 @@ import {
   generateTeamAttributesAction,
   generateLeagueAttributesAction,
 } from "@/app/dashboard/_actions/synthetic-rosters";
+import {
+  rosterAttributesProcessStages,
+  rosterClearProcessStages,
+  rosterGenerateProcessStages,
+} from "@/lib/process-stages";
+import type { ProcessStage } from "@/components/lifecycle/ProcessDialog";
 
 /*
  * Generate or clear synthetic (fake) players for testing/demos (WSM-000173).
@@ -39,78 +45,93 @@ export function SyntheticRosterButton({
   const router = useRouter();
   const [pending, start] = useTransition();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [processOpen, setProcessOpen] = useState(false);
+  const [processError, setProcessError] = useState<string | null>(null);
+  const [stages, setStages] = useState<ProcessStage[]>(
+    initialStages(action, kind),
+  );
+
+  function beginProcess() {
+    setConfirmOpen(false);
+    setProcessOpen(true);
+    setProcessError(null);
+    setStages(initialStages(action, kind));
+  }
 
   function run() {
+    beginProcess();
     start(async () => {
       if (action === "attributes" && kind === "team") {
         const res = await generateTeamAttributesAction({ teamId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterAttributesProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.rated === 0
-            ? "No players to rate yet — generate a roster first."
-            : `Generated ratings for ${res.rated} player${res.rated === 1 ? "" : "s"}.`,
+        setStages(
+          rosterAttributesProcessStages("success", kind, { rated: res.rated }),
         );
       } else if (action === "attributes") {
         const res = await generateLeagueAttributesAction({ leagueId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterAttributesProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.rated === 0
-            ? "No players to rate yet — generate rosters first."
-            : `Generated ratings for ${res.rated} player${res.rated === 1 ? "" : "s"} across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        setStages(
+          rosterAttributesProcessStages("success", kind, {
+            rated: res.rated,
+            teams: res.teams,
+          }),
         );
       } else if (action === "generate" && kind === "team") {
         const res = await generateTeamRosterAction({ teamId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterGenerateProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.created === 0
-            ? "Roster already full — nothing to add."
-            : `Added ${res.created} synthetic player${res.created === 1 ? "" : "s"}.`,
+        setStages(
+          rosterGenerateProcessStages("success", kind, { created: res.created }),
         );
       } else if (action === "generate") {
         const res = await generateLeagueRostersAction({ leagueId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterGenerateProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.created === 0
-            ? "All rosters already full — nothing to add."
-            : `Added ${res.created} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        setStages(
+          rosterGenerateProcessStages("success", kind, {
+            created: res.created,
+            teams: res.teams,
+          }),
         );
       } else if (kind === "team") {
         const res = await clearTeamSyntheticAction({ teamId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterClearProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.deleted === 0
-            ? "No synthetic players to remove."
-            : `Removed ${res.deleted} synthetic player${res.deleted === 1 ? "" : "s"}.`,
+        setStages(
+          rosterClearProcessStages("success", kind, { deleted: res.deleted }),
         );
       } else {
         const res = await clearLeagueSyntheticAction({ leagueId: id });
         if (!res.ok) {
-          toast.error(errorLabel(res.error));
+          setStages(rosterClearProcessStages("error", kind));
+          setProcessError(errorLabel(res.error));
           return;
         }
-        toast.success(
-          res.deleted === 0
-            ? "No synthetic players to remove."
-            : `Removed ${res.deleted} players across ${res.teams} team${res.teams === 1 ? "" : "s"}.`,
+        setStages(
+          rosterClearProcessStages("success", kind, {
+            deleted: res.deleted,
+            teams: res.teams,
+          }),
         );
       }
       router.refresh();
-      setConfirmOpen(false);
     });
   }
 
@@ -131,6 +152,13 @@ export function SyntheticRosterButton({
         : kind === "team"
           ? "Generate roster"
           : "Generate rosters";
+
+  const processTitle = isClear
+    ? "Clear synthetic players"
+    : isAttributes
+      ? "Generate ratings"
+      : "Generate synthetic roster";
+  const processDescription = CONFIRM[action][kind];
 
   return (
     <>
@@ -164,8 +192,27 @@ export function SyntheticRosterButton({
         pending={pending}
         onConfirm={run}
       />
+      <ProcessDialog
+        open={processOpen}
+        onOpenChange={setProcessOpen}
+        title={processTitle}
+        description={processDescription}
+        stages={stages}
+        pending={pending}
+        error={processError}
+        onRetry={run}
+      />
     </>
   );
+}
+
+function initialStages(
+  action: "generate" | "clear" | "attributes",
+  kind: "team" | "league",
+): ProcessStage[] {
+  if (action === "clear") return rosterClearProcessStages("pending", kind);
+  if (action === "attributes") return rosterAttributesProcessStages("pending", kind);
+  return rosterGenerateProcessStages("pending", kind);
 }
 
 const CONFIRM: Record<

--- a/apps/web/src/components/roster/UndersizedRosterPanel.tsx
+++ b/apps/web/src/components/roster/UndersizedRosterPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ProcessDialog } from "@/components/lifecycle/ProcessDialog";
+import { fillDeficientRostersAction } from "@/app/dashboard/_actions/synthetic-rosters";
+import { rosterAutoFillProcessStages } from "@/lib/process-stages";
+import {
+  undersizedRosterSummaryMessage,
+  type UndersizedTeamWithDeficit,
+} from "@/lib/roster-deficit";
+
+export interface UndersizedRosterPanelProps {
+  leagueId: string;
+  target: number;
+  undersizedTeams: UndersizedTeamWithDeficit[];
+  canAutoFill: boolean;
+}
+
+export function UndersizedRosterPanel({
+  leagueId,
+  target,
+  undersizedTeams,
+  canAutoFill,
+}: UndersizedRosterPanelProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [processOpen, setProcessOpen] = useState(false);
+  const [processError, setProcessError] = useState<string | null>(null);
+  const [stages, setStages] = useState(
+    rosterAutoFillProcessStages("pending"),
+  );
+
+  if (undersizedTeams.length === 0) return null;
+
+  function runAutoFill() {
+    setProcessOpen(true);
+    setProcessError(null);
+    setStages(rosterAutoFillProcessStages("pending"));
+
+    start(async () => {
+      const res = await fillDeficientRostersAction({ leagueId });
+      if (!res.ok) {
+        setStages(rosterAutoFillProcessStages("error"));
+        setProcessError(errorLabel(res.error));
+        return;
+      }
+      setStages(
+        rosterAutoFillProcessStages("success", {
+          created: res.created,
+          teamsFilled: res.teamsFilled,
+        }),
+      );
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <div
+        className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3"
+        data-testid="undersized-roster-panel"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 space-y-2">
+            <p className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+              <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600" aria-hidden="true" />
+              Undersized rosters
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {undersizedRosterSummaryMessage(undersizedTeams, target)}
+            </p>
+            <ul className="text-sm text-foreground" data-testid="undersized-roster-list">
+              {undersizedTeams.map((team) => (
+                <li key={team.id}>
+                  {team.name}{" "}
+                  <span className="text-muted-foreground">
+                    ({team.activeCount}/{target})
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {canAutoFill ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={pending}
+              onClick={runAutoFill}
+              data-testid="undersized-roster-autofill"
+            >
+              {pending ? "Auto-filling…" : "Auto-fill rosters"}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <ProcessDialog
+        open={processOpen}
+        onOpenChange={setProcessOpen}
+        title="Auto-fill rosters"
+        description="Filling only teams below the roster target."
+        stages={stages}
+        pending={pending}
+        error={processError}
+        onRetry={runAutoFill}
+      />
+    </>
+  );
+}
+
+function errorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Synthetic rosters aren't enabled.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "You don't have permission to auto-fill rosters.";
+    case "season_started":
+      return "Season has started — roster generation is locked.";
+    default:
+      return error;
+  }
+}

--- a/apps/web/src/components/roster/__tests__/SyntheticRosterButton.test.ts
+++ b/apps/web/src/components/roster/__tests__/SyntheticRosterButton.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGenerateLeagueRostersAction,
+  mockRefresh,
+} = vi.hoisted(() => ({
+  mockGenerateLeagueRostersAction: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock("@/app/dashboard/_actions/synthetic-rosters", () => ({
+  generateTeamRosterAction: vi.fn(),
+  generateLeagueRostersAction: mockGenerateLeagueRostersAction,
+  clearTeamSyntheticAction: vi.fn(),
+  clearLeagueSyntheticAction: vi.fn(),
+  generateTeamAttributesAction: vi.fn(),
+  generateLeagueAttributesAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? createElement("div", { "data-testid": "dialog-root" }, children) : null,
+  DialogContent: ({
+    children,
+    role,
+  }: {
+    children?: React.ReactNode;
+    role?: string;
+  }) =>
+    createElement(
+      "div",
+      { role, "data-testid": "process-dialog" },
+      children,
+    ),
+  DialogHeader: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogFooter: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogTitle: ({ children }: { children?: React.ReactNode }) =>
+    createElement("h2", null, children),
+  DialogDescription: ({ children }: { children?: React.ReactNode }) =>
+    createElement("p", null, children),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? createElement("div", { "data-testid": "action-confirm-dialog" }, children) : null,
+  AlertDialogContent: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogHeader: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogFooter: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogTitle: ({ children }: { children?: React.ReactNode }) =>
+    createElement("h2", null, children),
+  AlertDialogDescription: ({ children }: { children?: React.ReactNode }) =>
+    createElement("p", null, children),
+  AlertDialogCancel: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+  }) =>
+    createElement("button", { type: "button", onClick }, children),
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: (event: { preventDefault: () => void }) => void;
+  }) =>
+    createElement(
+      "button",
+      {
+        type: "button",
+        "data-testid": "action-confirm-submit",
+        onClick: (event: { preventDefault: () => void }) => onClick?.(event),
+      },
+      children,
+    ),
+}));
+
+import { SyntheticRosterButton } from "@/components/roster/SyntheticRosterButton";
+
+function renderButton() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root | null = null;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      createElement(SyntheticRosterButton, {
+        kind: "league",
+        id: "league-1",
+        action: "generate",
+      }),
+    );
+  });
+
+  return {
+    unmount() {
+      act(() => {
+        root?.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SyntheticRosterButton ProcessDialog wiring", () => {
+  it("confirms then shows roster fill stages from action results", async () => {
+    mockGenerateLeagueRostersAction.mockResolvedValue({
+      ok: true,
+      teams: 2,
+      created: 96,
+    });
+
+    renderButton();
+    const trigger = document.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      trigger.click();
+    });
+
+    const confirm = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      confirm.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const stage = document.querySelector('[data-stage-id="fill"]');
+    expect(stage?.getAttribute("data-stage-status")).toBe("complete");
+    expect(document.body.textContent).toContain("96 players across 2 teams");
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("marks roster generation failed when the action rejects", async () => {
+    mockGenerateLeagueRostersAction.mockResolvedValue({
+      ok: false,
+      error: "not_authorized",
+    });
+
+    renderButton();
+    const trigger = document.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      trigger.click();
+    });
+    const confirm = document.querySelector(
+      '[data-testid="action-confirm-submit"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      confirm.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const stage = document.querySelector('[data-stage-id="fill"]');
+    expect(stage?.getAttribute("data-stage-status")).toBe("error");
+    expect(document.body.textContent).toContain("You don't have permission");
+  });
+});

--- a/apps/web/src/components/schedule/GenerateScheduleButton.tsx
+++ b/apps/web/src/components/schedule/GenerateScheduleButton.tsx
@@ -41,11 +41,13 @@ export default function GenerateScheduleButton({
   const [format, setFormat] = useState<ScheduleFormat>("single");
   const [pending, startTransition] = useTransition();
   const [confirmStep, setConfirmStep] = useState<ConfirmStep>(null);
+  const [lastConfirm, setLastConfirm] = useState(false);
   const [processOpen, setProcessOpen] = useState(false);
   const [processError, setProcessError] = useState<string | null>(null);
   const [stages, setStages] = useState(scheduleProcessStages("pending"));
 
-  function beginProcess() {
+  function beginProcess(confirm: boolean) {
+    setLastConfirm(confirm);
     setConfirmStep(null);
     setProcessOpen(true);
     setProcessError(null);
@@ -53,7 +55,7 @@ export default function GenerateScheduleButton({
   }
 
   function run(confirm: boolean) {
-    beginProcess();
+    beginProcess(confirm);
     startTransition(async () => {
       const res = await generateScheduleAction({
         leagueId,
@@ -104,7 +106,7 @@ export default function GenerateScheduleButton({
   }
 
   function retryProcess() {
-    run(confirmStep === "destructive");
+    run(lastConfirm);
   }
 
   const confirmCopy =

--- a/apps/web/src/components/schedule/GenerateScheduleButton.tsx
+++ b/apps/web/src/components/schedule/GenerateScheduleButton.tsx
@@ -2,11 +2,12 @@
 
 import { useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { CalendarPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
+import { ProcessDialog } from "@/components/lifecycle/ProcessDialog";
 import { generateScheduleAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+import { scheduleProcessStages } from "@/lib/process-stages";
 
 export interface GenerateScheduleButtonProps {
   leagueId: string;
@@ -40,8 +41,19 @@ export default function GenerateScheduleButton({
   const [format, setFormat] = useState<ScheduleFormat>("single");
   const [pending, startTransition] = useTransition();
   const [confirmStep, setConfirmStep] = useState<ConfirmStep>(null);
+  const [processOpen, setProcessOpen] = useState(false);
+  const [processError, setProcessError] = useState<string | null>(null);
+  const [stages, setStages] = useState(scheduleProcessStages("pending"));
+
+  function beginProcess() {
+    setConfirmStep(null);
+    setProcessOpen(true);
+    setProcessError(null);
+    setStages(scheduleProcessStages("pending"));
+  }
 
   function run(confirm: boolean) {
+    beginProcess();
     startTransition(async () => {
       const res = await generateScheduleAction({
         leagueId,
@@ -51,22 +63,25 @@ export default function GenerateScheduleButton({
       });
 
       if (res.ok) {
-        toast.success(
-          `Generated ${res.created} ${
-            format === "double" ? "home-and-away " : ""
-          }games across ${res.weeks} weeks for ${res.teamCount} teams.`,
+        setStages(
+          scheduleProcessStages("success", {
+            created: res.created,
+            weeks: res.weeks,
+            teamCount: res.teamCount,
+          }),
         );
         router.refresh();
-        setConfirmStep(null);
         return;
       }
 
       if ("needsConfirm" in res) {
+        setProcessOpen(false);
         setConfirmStep("destructive");
         return;
       }
 
-      toast.error(friendlyError(res.error));
+      setStages(scheduleProcessStages("error"));
+      setProcessError(friendlyError(res.error));
     });
   }
 
@@ -86,6 +101,10 @@ export default function GenerateScheduleButton({
     if (confirmStep === "destructive") {
       run(true);
     }
+  }
+
+  function retryProcess() {
+    run(confirmStep === "destructive");
   }
 
   const confirmCopy =
@@ -138,6 +157,16 @@ export default function GenerateScheduleButton({
           onConfirm={handleConfirm}
         />
       ) : null}
+      <ProcessDialog
+        open={processOpen}
+        onOpenChange={setProcessOpen}
+        title="Generate schedule"
+        description={`Building the ${format === "double" ? "home-and-away" : "round-robin"} schedule for ${seasonName}.`}
+        stages={stages}
+        pending={pending}
+        error={processError}
+        onRetry={retryProcess}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/schedule/__tests__/GenerateScheduleButton.test.ts
+++ b/apps/web/src/components/schedule/__tests__/GenerateScheduleButton.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGenerateScheduleAction,
+  mockRefresh,
+} = vi.hoisted(() => ({
+  mockGenerateScheduleAction: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock("@/app/dashboard/leagues/[id]/schedule/actions", () => ({
+  generateScheduleAction: mockGenerateScheduleAction,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? createElement("div", { "data-testid": "dialog-root" }, children) : null,
+  DialogContent: ({
+    children,
+    role,
+  }: {
+    children?: React.ReactNode;
+    role?: string;
+  }) =>
+    createElement(
+      "div",
+      { role, "data-testid": "process-dialog" },
+      children,
+    ),
+  DialogHeader: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogFooter: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogTitle: ({ children }: { children?: React.ReactNode }) =>
+    createElement("h2", null, children),
+  DialogDescription: ({ children }: { children?: React.ReactNode }) =>
+    createElement("p", null, children),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    open ? createElement("div", { "data-testid": "action-confirm-dialog" }, children) : null,
+  AlertDialogContent: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogHeader: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogFooter: ({ children }: { children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  AlertDialogTitle: ({ children }: { children?: React.ReactNode }) =>
+    createElement("h2", null, children),
+  AlertDialogDescription: ({ children }: { children?: React.ReactNode }) =>
+    createElement("p", null, children),
+  AlertDialogCancel: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+  }) =>
+    createElement("button", { type: "button", onClick }, children),
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: (event: { preventDefault: () => void }) => void;
+  }) =>
+    createElement(
+      "button",
+      {
+        type: "button",
+        "data-testid": "action-confirm-submit",
+        onClick: (event: { preventDefault: () => void }) => onClick?.(event),
+      },
+      children,
+    ),
+}));
+
+import GenerateScheduleButton from "@/components/schedule/GenerateScheduleButton";
+
+function renderButton() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root | null = null;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      createElement(GenerateScheduleButton, {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        seasonName: "2026",
+        hasFixtures: false,
+      }),
+    );
+  });
+
+  return {
+    container,
+    unmount() {
+      act(() => {
+        root?.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("GenerateScheduleButton ProcessDialog wiring", () => {
+  it("shows schedule-specific stages after a successful generation", async () => {
+    mockGenerateScheduleAction.mockResolvedValue({
+      ok: true,
+      created: 28,
+      weeks: 7,
+      teamCount: 8,
+    });
+
+    renderButton();
+    const button = document.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const stage = document.querySelector('[data-stage-id="generate"]');
+    expect(stage?.getAttribute("data-stage-status")).toBe("complete");
+    expect(document.body.textContent).toContain("28 games · 7 weeks · 8 teams");
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("marks the schedule stage failed on action error", async () => {
+    mockGenerateScheduleAction.mockResolvedValue({
+      ok: false,
+      error: "season_not_found",
+    });
+
+    renderButton();
+    const button = document.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const stage = document.querySelector('[data-stage-id="generate"]');
+    expect(stage?.getAttribute("data-stage-status")).toBe("error");
+    expect(document.body.textContent).toContain("This season no longer exists.");
+  });
+});

--- a/apps/web/src/lib/__tests__/process-stages.test.ts
+++ b/apps/web/src/lib/__tests__/process-stages.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  dynastyRolloverProcessStages,
+  rosterAutoFillProcessStages,
+  rosterGenerateProcessStages,
+  scheduleProcessStages,
+} from "@/lib/process-stages";
+
+describe("process stage builders", () => {
+  it("builds schedule stages from action results", () => {
+    const pending = scheduleProcessStages("pending");
+    expect(pending[0]).toMatchObject({
+      id: "generate",
+      status: "in_progress",
+    });
+
+    const success = scheduleProcessStages("success", {
+      created: 28,
+      weeks: 7,
+      teamCount: 8,
+    });
+    expect(success[0]).toMatchObject({
+      id: "generate",
+      status: "complete",
+      detail: "28 games · 7 weeks · 8 teams",
+    });
+  });
+
+  it("builds roster generation stages for league scope", () => {
+    const success = rosterGenerateProcessStages("success", "league", {
+      created: 96,
+      teams: 2,
+    });
+    expect(success[0]).toMatchObject({
+      id: "fill",
+      status: "complete",
+      detail: "96 players across 2 teams",
+    });
+  });
+
+  it("builds auto-fill stages from created totals", () => {
+    const success = rosterAutoFillProcessStages("success", {
+      created: 38,
+      teamsFilled: 1,
+    });
+    expect(success[0]).toMatchObject({
+      id: "autofill",
+      status: "complete",
+      detail: "38 players across 1 team",
+    });
+  });
+
+  it("builds dynasty rollover stages from server counts", () => {
+    const pending = dynastyRolloverProcessStages("pending");
+    expect(pending.map((stage) => stage.id)).toEqual([
+      "rollover",
+      "graduate",
+      "advance",
+      "freshmen",
+    ]);
+    expect(pending[0]?.status).toBe("in_progress");
+
+    const success = dynastyRolloverProcessStages("success", {
+      graduated: 12,
+      advanced: 120,
+      freshmen: 48,
+      progressed: 120,
+    });
+    expect(success.find((stage) => stage.id === "graduate")?.detail).toBe(
+      "12 players",
+    );
+    expect(success.find((stage) => stage.id === "freshmen")?.detail).toBe(
+      "48 players",
+    );
+    expect(success.find((stage) => stage.id === "progress")?.detail).toBe(
+      "120 snapshots",
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/roster-deficit.test.ts
+++ b/apps/web/src/lib/__tests__/roster-deficit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  activeRosterCountByTeam,
+  buildLeagueRosterDeficitProjection,
+  undersizedRosterSummaryMessage,
+  withRosterDeficit,
+} from "@/lib/roster-deficit";
+
+describe("roster-deficit helpers", () => {
+  it("counts only active non-graduated players per team", () => {
+    const counts = activeRosterCountByTeam([
+      { teamId: "t1", status: "active" },
+      { teamId: "t1", status: "active" },
+      { teamId: "t1", status: "graduated" },
+      { teamId: "t2", status: "active" },
+    ]);
+    expect(counts.get("t1")).toBe(2);
+    expect(counts.get("t2")).toBe(1);
+  });
+
+  it("projects only deficient teams with deficit counts", () => {
+    const projection = buildLeagueRosterDeficitProjection(
+      [
+        { id: "t1", name: "Alpha" },
+        { id: "t2", name: "Beta" },
+        { id: "t3", name: "Gamma" },
+      ],
+      new Map([
+        ["t1", 48],
+        ["t2", 10],
+        ["t3", 47],
+      ]),
+      48,
+    );
+    expect(projection.target).toBe(48);
+    expect(projection.teams).toEqual([
+      { id: "t2", name: "Beta", activeCount: 10, target: 48, deficit: 38 },
+      { id: "t3", name: "Gamma", activeCount: 47, target: 48, deficit: 1 },
+    ]);
+  });
+
+  it("adds deficit to undersized teams", () => {
+    expect(
+      withRosterDeficit({ id: "t1", name: "Beta", activeCount: 10, target: 48 }),
+    ).toEqual({
+      id: "t1",
+      name: "Beta",
+      activeCount: 10,
+      target: 48,
+      deficit: 38,
+    });
+  });
+
+  it("builds a summary message for undersized teams", () => {
+    const message = undersizedRosterSummaryMessage(
+      [{ id: "t2", name: "Beta", activeCount: 10, target: 48, deficit: 38 }],
+      48,
+    );
+    expect(message).toContain("target roster size of 48");
+    expect(message).toContain("Beta (10/48)");
+  });
+});

--- a/apps/web/src/lib/process-stages.ts
+++ b/apps/web/src/lib/process-stages.ts
@@ -1,0 +1,210 @@
+/**
+ * ProcessDialog stage builders for generation flows (WSM-000242).
+ * Stages reflect real action boundaries — no simulated progress.
+ */
+import type { ProcessStage } from "@/components/lifecycle/ProcessDialog";
+
+export type ProcessOutcome = "pending" | "success" | "error";
+
+function stage(
+  id: string,
+  label: string,
+  outcome: ProcessOutcome,
+  detail?: string,
+): ProcessStage {
+  return {
+    id,
+    label,
+    status:
+      outcome === "pending"
+        ? "in_progress"
+        : outcome === "success"
+          ? "complete"
+          : "error",
+    detail,
+  };
+}
+
+function terminalStage(
+  id: string,
+  label: string,
+  outcome: ProcessOutcome,
+  detail?: string,
+): ProcessStage {
+  return {
+    id,
+    label,
+    status:
+      outcome === "pending"
+        ? "pending"
+        : outcome === "success"
+          ? "complete"
+          : outcome === "error"
+            ? "error"
+            : "pending",
+    detail,
+  };
+}
+
+export function scheduleProcessStages(
+  outcome: ProcessOutcome,
+  result?: { created: number; weeks: number; teamCount: number },
+): ProcessStage[] {
+  const detail =
+    outcome === "success" && result
+      ? `${result.created} games · ${result.weeks} weeks · ${result.teamCount} teams`
+      : undefined;
+  return [stage("generate", "Generate round-robin schedule", outcome, detail)];
+}
+
+export function rosterGenerateProcessStages(
+  outcome: ProcessOutcome,
+  scope: "team" | "league",
+  result?: { created: number; teams?: number },
+): ProcessStage[] {
+  const detail =
+    outcome === "success" && result
+      ? result.teams != null
+        ? `${result.created} players across ${result.teams} team${result.teams === 1 ? "" : "s"}`
+        : result.created === 0
+          ? "Roster already full"
+          : `${result.created} player${result.created === 1 ? "" : "s"} added`
+      : undefined;
+  return [
+    stage(
+      "fill",
+      scope === "league" ? "Fill league rosters" : "Fill team roster",
+      outcome,
+      detail,
+    ),
+  ];
+}
+
+export function rosterClearProcessStages(
+  outcome: ProcessOutcome,
+  scope: "team" | "league",
+  result?: { deleted: number; teams?: number },
+): ProcessStage[] {
+  const detail =
+    outcome === "success" && result
+      ? result.teams != null
+        ? `${result.deleted} players removed across ${result.teams} team${result.teams === 1 ? "" : "s"}`
+        : result.deleted === 0
+          ? "No synthetic players to remove"
+          : `${result.deleted} player${result.deleted === 1 ? "" : "s"} removed`
+      : undefined;
+  return [
+    stage(
+      "clear",
+      scope === "league" ? "Clear league synthetic players" : "Clear synthetic players",
+      outcome,
+      detail,
+    ),
+  ];
+}
+
+export function rosterAttributesProcessStages(
+  outcome: ProcessOutcome,
+  scope: "team" | "league",
+  result?: { rated: number; teams?: number },
+): ProcessStage[] {
+  const detail =
+    outcome === "success" && result
+      ? result.teams != null
+        ? `${result.rated} ratings across ${result.teams} team${result.teams === 1 ? "" : "s"}`
+        : result.rated === 0
+          ? "No players to rate"
+          : `${result.rated} player${result.rated === 1 ? "" : "s"} rated`
+      : undefined;
+  return [
+    stage(
+      "rate",
+      scope === "league" ? "Generate league ratings" : "Generate team ratings",
+      outcome,
+      detail,
+    ),
+  ];
+}
+
+export function rosterAutoFillProcessStages(
+  outcome: ProcessOutcome,
+  result?: { created: number; teamsFilled: number },
+): ProcessStage[] {
+  const detail =
+    outcome === "success" && result
+      ? result.created === 0
+        ? "All targeted rosters already full"
+        : `${result.created} players across ${result.teamsFilled} team${result.teamsFilled === 1 ? "" : "s"}`
+      : undefined;
+  return [stage("autofill", "Auto-fill undersized rosters", outcome, detail)];
+}
+
+export function dynastyRolloverProcessStages(
+  outcome: ProcessOutcome,
+  result?: {
+    graduated: number;
+    advanced: number;
+    freshmen: number;
+    progressed?: number;
+  },
+): ProcessStage[] {
+  const graduateDetail =
+    outcome === "success" && result
+      ? `${result.graduated} player${result.graduated === 1 ? "" : "s"}`
+      : undefined;
+  const advanceDetail =
+    outcome === "success" && result
+      ? `${result.advanced} player${result.advanced === 1 ? "" : "s"}`
+      : undefined;
+  const freshmanDetail =
+    outcome === "success" && result
+      ? `${result.freshmen} player${result.freshmen === 1 ? "" : "s"}`
+      : undefined;
+  const progressDetail =
+    outcome === "success" && result && (result.progressed ?? 0) > 0
+      ? `${result.progressed} snapshot${result.progressed === 1 ? "" : "s"}`
+      : undefined;
+
+  const graduate = terminalStage(
+    "graduate",
+    "Graduate seniors",
+    outcome === "pending" ? "pending" : outcome,
+    graduateDetail,
+  );
+  const advance = terminalStage(
+    "advance",
+    "Advance class years",
+    outcome === "pending" ? "pending" : outcome,
+    advanceDetail,
+  );
+  const freshmen = terminalStage(
+    "freshmen",
+    "Generate freshmen",
+    outcome === "pending" ? "pending" : outcome,
+    freshmanDetail,
+  );
+
+  if (outcome === "pending") {
+    return [
+      stage("rollover", "Start next season", "pending"),
+      graduate,
+      advance,
+      freshmen,
+    ];
+  }
+
+  const stages: ProcessStage[] = [
+    stage("rollover", "Start next season", outcome),
+    graduate,
+    advance,
+    freshmen,
+  ];
+
+  if (progressDetail) {
+    stages.push(
+      terminalStage("progress", "Write attribute progression", outcome, progressDetail),
+    );
+  }
+
+  return stages;
+}

--- a/apps/web/src/lib/roster-deficit.ts
+++ b/apps/web/src/lib/roster-deficit.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded league roster-deficit projection (WSM-000242).
+ * Reuses DEFAULT_TARGET_ROSTER_SIZE from offseason-activate.
+ */
+import {
+  DEFAULT_TARGET_ROSTER_SIZE,
+  type TeamRosterSize,
+  type UndersizedTeam,
+} from "@/lib/offseason-activate";
+
+export interface UndersizedTeamWithDeficit extends UndersizedTeam {
+  deficit: number;
+}
+
+export function withRosterDeficit(team: UndersizedTeam): UndersizedTeamWithDeficit {
+  return {
+    ...team,
+    deficit: team.target - team.activeCount,
+  };
+}
+
+/** Count active (non-graduated) players per team from a league player list. */
+export function activeRosterCountByTeam(
+  players: ReadonlyArray<{ teamId: string; status: string }>,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const player of players) {
+    if (player.status === "graduated") continue;
+    counts.set(player.teamId, (counts.get(player.teamId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function buildLeagueRosterDeficitProjection(
+  teams: ReadonlyArray<{ id: string; name: string }>,
+  countByTeam: ReadonlyMap<string, number>,
+  target: number = DEFAULT_TARGET_ROSTER_SIZE,
+): { target: number; teams: UndersizedTeamWithDeficit[] } {
+  const rosterSizes: TeamRosterSize[] = teams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    activeCount: countByTeam.get(team.id) ?? 0,
+  }));
+  const undersized = rosterSizes
+    .filter((team) => team.activeCount < target)
+    .map((team) =>
+      withRosterDeficit({
+        id: team.id,
+        name: team.name,
+        activeCount: team.activeCount,
+        target,
+      }),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return { target, teams: undersized };
+}
+
+export function undersizedRosterSummaryMessage(
+  undersized: ReadonlyArray<UndersizedTeamWithDeficit>,
+  target: number,
+): string {
+  if (undersized.length === 0) return "";
+  const teamLines = undersized
+    .map((team) => `${team.name} (${team.activeCount}/${target})`)
+    .join(", ");
+  return `Some teams are below the target roster size of ${target}: ${teamLines}.`;
+}


### PR DESCRIPTION
## Summary
- Wire `ProcessDialog` into schedule generation, synthetic roster/attributes/clear, and dynasty rollover with truthful server-confirmed stages
- Add bounded league roster-deficit projection and role-gated `fillDeficientRostersAction` (admin: all short teams; coach: managed short teams only)
- Surface `UndersizedRosterPanel` on league and schedule pages with explicit auto-fill

## Related Issue
Closes #530

## Test plan
- [x] Focused unit tests: roster-deficit, process-stages, synthetic-rosters (incl. auth matrix), GenerateScheduleButton, SyntheticRosterButton (33 passed)
- [x] `pnpm --filter @sports-management/web type-check`
- [ ] Manual: undersized warning → auto-fill → verify only short teams change
- [ ] CI unit/build on PR
