### PR TITLE
feat(web): persist display density and season simulation settings (WSM-000244)

### DIFF
--- a/apps/web/convex/__tests__/seasonCrud.test.ts
+++ b/apps/web/convex/__tests__/seasonCrud.test.ts
@@ -101,6 +101,70 @@ describe("season CRUD (WSM-000126)", () => {
     expect(dto?.name).toBe("Fall 2026");
     expect(dto?.startDate).toBe("2026-09-01");
     expect(dto?.status).toBe("active");
+    expect(dto?.simulationFlavor).toBe("balanced");
+  });
+
+  it("rejects invalid playoff team counts on update", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "active");
+
+    await expect(
+      t.mutation(internal.sports.updateSeason, {
+        seasonId,
+        name: "2026",
+        startDate: null,
+        endDate: null,
+        playoffTeams: 6,
+      }),
+    ).rejects.toThrow("invalid_playoff_teams");
+  });
+
+  it("rejects playoff team count changes after a bracket exists", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seedLeagueWithSeason(t, "active");
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("playoffBrackets", {
+        seasonId,
+        leagueId,
+        size: 8,
+        rounds: 3,
+        createdAt: "2026-01-01",
+        createdBy: "actor",
+        format: "single",
+        teamCount: 8,
+      });
+      await ctx.db.patch(seasonId, { playoffTeams: 8 });
+    });
+
+    await expect(
+      t.mutation(internal.sports.updateSeason, {
+        seasonId,
+        name: "2026",
+        startDate: null,
+        endDate: null,
+        playoffTeams: 16,
+      }),
+    ).rejects.toThrow("playoff_teams_locked");
+  });
+
+  it("allows keeping a legacy playoff size when unchanged", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedLeagueWithSeason(t, "active");
+
+    await t.run((ctx) => ctx.db.patch(seasonId, { playoffTeams: 6 }));
+
+    const dto = await t.mutation(internal.sports.updateSeason, {
+      seasonId,
+      name: "Legacy size season",
+      startDate: null,
+      endDate: null,
+      playoffTeams: 6,
+      simulationFlavor: "upsets",
+    });
+
+    expect(dto?.playoffTeams).toBe(6);
+    expect(dto?.simulationFlavor).toBe("upsets");
   });
 
   it("claims exactly one upcoming rollover target for a completed source", async () => {

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -131,6 +131,7 @@ export default defineSchema({
     playoffTeams: v.optional(v.number()), // 0 = no playoffs; else 4 | 8 | 16
     playoffFormat: v.optional(v.string()), // "single" (double = future)
     divisionWinnersQualify: v.optional(v.boolean()),
+    simulationFlavor: v.optional(v.string()), // "chalk" | "balanced" | "upsets"
   })
     .index("by_leagueId", ["leagueId"])
     .index("by_leagueId_name", ["leagueId", "name"]),

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -199,6 +199,7 @@ function toSeasonDto(doc: {
   playoffTeams?: number;
   playoffFormat?: string;
   divisionWinnersQualify?: boolean;
+  simulationFlavor?: string;
 }) {
   return {
     id: doc._id,
@@ -211,7 +212,36 @@ function toSeasonDto(doc: {
     playoffTeams: doc.playoffTeams ?? null,
     playoffFormat: doc.playoffFormat ?? null,
     divisionWinnersQualify: doc.divisionWinnersQualify ?? false,
+    simulationFlavor: normalizeSimulationFlavor(doc.simulationFlavor),
   };
+}
+
+function normalizeSimulationFlavor(
+  value: string | undefined,
+): "chalk" | "balanced" | "upsets" {
+  if (value === "chalk" || value === "upsets") return value;
+  return "balanced";
+}
+
+function isAllowedNewPlayoffTeamCount(count: number): boolean {
+  return count === 0 || count === 4 || count === 8 || count === 16;
+}
+
+async function assertPlayoffTeamsChangeAllowed(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+  existing: number | undefined,
+  next: number | undefined,
+): Promise<void> {
+  if (next === undefined || next === existing) return;
+  const bracket = await ctx.db
+    .query("playoffBrackets")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .first();
+  if (bracket) throw new Error("playoff_teams_locked");
+  if (!isAllowedNewPlayoffTeamCount(next)) {
+    throw new Error("invalid_playoff_teams");
+  }
 }
 
 function toRosterAssignmentDto(doc: {
@@ -736,6 +766,7 @@ export const listSeasons = queryGeneric({
       playoffTeams: v.optional(v.union(v.number(), v.null())),
       playoffFormat: v.optional(v.union(v.string(), v.null())),
       divisionWinnersQualify: v.optional(v.boolean()),
+      simulationFlavor: v.string(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -765,6 +796,7 @@ export const getSeason = queryGeneric({
       playoffTeams: v.optional(v.union(v.number(), v.null())),
       playoffFormat: v.optional(v.union(v.string(), v.null())),
       divisionWinnersQualify: v.optional(v.boolean()),
+      simulationFlavor: v.string(),
     }),
     v.null(),
   ),
@@ -1920,6 +1952,7 @@ export const upsertSeason = internalMutationGeneric({
     playoffTeams: v.optional(v.number()),
     playoffFormat: v.optional(v.string()),
     divisionWinnersQualify: v.optional(v.boolean()),
+    simulationFlavor: v.optional(v.string()),
   },
   returns: v.object({
     dto: v.object({
@@ -1933,6 +1966,7 @@ export const upsertSeason = internalMutationGeneric({
       playoffTeams: v.optional(v.union(v.number(), v.null())),
       playoffFormat: v.optional(v.union(v.string(), v.null())),
       divisionWinnersQualify: v.optional(v.boolean()),
+      simulationFlavor: v.string(),
     }),
     created: v.boolean(),
   }),
@@ -1953,10 +1987,21 @@ export const upsertSeason = internalMutationGeneric({
         endDate: args.endDate,
         status: args.status,
       };
-      if (args.playoffTeams !== undefined) patch.playoffTeams = args.playoffTeams;
+      if (args.playoffTeams !== undefined) {
+        await assertPlayoffTeamsChangeAllowed(
+          ctx as MutationCtx,
+          existing._id,
+          existing.playoffTeams,
+          args.playoffTeams,
+        );
+        patch.playoffTeams = args.playoffTeams;
+      }
       if (args.playoffFormat !== undefined) patch.playoffFormat = args.playoffFormat;
       if (args.divisionWinnersQualify !== undefined) {
         patch.divisionWinnersQualify = args.divisionWinnersQualify;
+      }
+      if (args.simulationFlavor !== undefined) {
+        patch.simulationFlavor = normalizeSimulationFlavor(args.simulationFlavor);
       }
       await ctx.db.patch(existing._id, patch);
       return {
@@ -1969,13 +2014,23 @@ export const upsertSeason = internalMutationGeneric({
           playoffFormat: args.playoffFormat ?? existing.playoffFormat,
           divisionWinnersQualify:
             args.divisionWinnersQualify ?? existing.divisionWinnersQualify,
+          simulationFlavor:
+            args.simulationFlavor ?? existing.simulationFlavor,
         }),
         created: false,
       };
     }
 
+    if (
+      args.playoffTeams !== undefined &&
+      !isAllowedNewPlayoffTeamCount(args.playoffTeams)
+    ) {
+      throw new Error("invalid_playoff_teams");
+    }
+
     const seasonId = await ctx.db.insert("seasons", {
       ...args,
+      simulationFlavor: normalizeSimulationFlavor(args.simulationFlavor),
       rosterLocked: false,
     });
     return {
@@ -1990,6 +2045,7 @@ export const upsertSeason = internalMutationGeneric({
         playoffTeams: args.playoffTeams,
         playoffFormat: args.playoffFormat,
         divisionWinnersQualify: args.divisionWinnersQualify,
+        simulationFlavor: args.simulationFlavor,
       }),
       created: true,
     };
@@ -2009,6 +2065,7 @@ export const updateSeason = internalMutationGeneric({
     playoffTeams: v.optional(v.number()),
     playoffFormat: v.optional(v.string()),
     divisionWinnersQualify: v.optional(v.boolean()),
+    simulationFlavor: v.optional(v.string()),
   },
   returns: v.union(
     v.object({
@@ -2022,12 +2079,21 @@ export const updateSeason = internalMutationGeneric({
       playoffTeams: v.optional(v.union(v.number(), v.null())),
       playoffFormat: v.optional(v.union(v.string(), v.null())),
       divisionWinnersQualify: v.optional(v.boolean()),
+      simulationFlavor: v.string(),
     }),
     v.null(),
   ),
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.seasonId);
     if (!existing) return null;
+    if (args.playoffTeams !== undefined) {
+      await assertPlayoffTeamsChangeAllowed(
+        ctx as MutationCtx,
+        args.seasonId,
+        existing.playoffTeams,
+        args.playoffTeams,
+      );
+    }
     const patch: Record<string, unknown> = {
       name: args.name,
       startDate: args.startDate,
@@ -2037,6 +2103,9 @@ export const updateSeason = internalMutationGeneric({
     if (args.playoffFormat !== undefined) patch.playoffFormat = args.playoffFormat;
     if (args.divisionWinnersQualify !== undefined) {
       patch.divisionWinnersQualify = args.divisionWinnersQualify;
+    }
+    if (args.simulationFlavor !== undefined) {
+      patch.simulationFlavor = normalizeSimulationFlavor(args.simulationFlavor);
     }
     await ctx.db.patch(args.seasonId, patch);
     return toSeasonDto({
@@ -2048,6 +2117,7 @@ export const updateSeason = internalMutationGeneric({
       playoffFormat: args.playoffFormat ?? existing.playoffFormat,
       divisionWinnersQualify:
         args.divisionWinnersQualify ?? existing.divisionWinnersQualify,
+      simulationFlavor: args.simulationFlavor ?? existing.simulationFlavor,
     });
   },
 });
@@ -2217,6 +2287,7 @@ export const beginSeasonRollover = internalMutationGeneric({
       playoffTeams: source.playoffTeams,
       playoffFormat: source.playoffFormat,
       divisionWinnersQualify: source.divisionWinnersQualify,
+      simulationFlavor: source.simulationFlavor,
     });
     const startedAt = new Date().toISOString();
     const rolloverId = await ctx.db.insert("seasonRollovers", {

--- a/apps/web/e2e/tests/display-settings.spec.ts
+++ b/apps/web/e2e/tests/display-settings.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+const DENSITY_KEY = "sports-mgmt-density";
+const THEME_KEY = "theme";
+
+test.describe("display settings persistence (WSM-000244)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem("sports-mgmt-density");
+      localStorage.removeItem("theme");
+    });
+  });
+
+  test("theme and density survive reload without flash attributes", async ({
+    page,
+  }) => {
+    // /local renders both DensityToggle and ThemeToggle without auth
+    // (marketing `/` only exposes ThemeToggle).
+    await page.goto("/local");
+
+    const densityToggle = page.getByRole("button", {
+      name: /compact density/i,
+    });
+    await expect(densityToggle).toBeVisible();
+    await densityToggle.click();
+
+    const themeToggle = page.getByRole("button", { name: /toggle theme/i });
+    await themeToggle.click();
+
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.className))
+      .toMatch(/light/);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => document.documentElement.getAttribute("data-density")),
+      )
+      .toBe("compact");
+
+    await page.reload();
+
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.className))
+      .toMatch(/light/);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => document.documentElement.getAttribute("data-density")),
+      )
+      .toBe("compact");
+
+    const stored = await page.evaluate(
+      ([densityKey, themeKey]) => ({
+        density: localStorage.getItem(densityKey),
+        theme: localStorage.getItem(themeKey),
+      }),
+      [DENSITY_KEY, THEME_KEY],
+    );
+    expect(stored.density).toBe("compact");
+    expect(stored.theme).toBe("light");
+  });
+});

--- a/apps/web/e2e/tests/display-settings.spec.ts
+++ b/apps/web/e2e/tests/display-settings.spec.ts
@@ -4,9 +4,9 @@ const DENSITY_KEY = "sports-mgmt-density";
 const THEME_KEY = "theme";
 
 async function resolvedTheme(page: {
-  evaluate: (fn: () => string) => Promise<string>;
+  evaluate: <T>(fn: () => T) => Promise<T>;
 }): Promise<"dark" | "light"> {
-  return page.evaluate(() =>
+  return page.evaluate((): "dark" | "light" =>
     document.documentElement.classList.contains("dark") ? "dark" : "light",
   );
 }

--- a/apps/web/e2e/tests/display-settings.spec.ts
+++ b/apps/web/e2e/tests/display-settings.spec.ts
@@ -12,16 +12,18 @@ async function resolvedTheme(page: {
 }
 
 test.describe("display settings persistence (WSM-000244)", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.removeItem("sports-mgmt-density");
-      localStorage.removeItem("theme");
-    });
-  });
-
   test("theme and density survive reload without flash attributes", async ({
     page,
   }) => {
+    // Clear prefs once per tab. Do not use a bare addInitScript wipe — that
+    // also runs on reload and would erase the values this test asserts.
+    await page.addInitScript(() => {
+      if (sessionStorage.getItem("__wsm244_prefs_cleared") === "1") return;
+      localStorage.removeItem("sports-mgmt-density");
+      localStorage.removeItem("theme");
+      sessionStorage.setItem("__wsm244_prefs_cleared", "1");
+    });
+
     // /local renders both DensityToggle and ThemeToggle without auth
     // (marketing `/` only exposes ThemeToggle).
     await page.goto("/local");
@@ -46,6 +48,16 @@ test.describe("display settings persistence (WSM-000244)", () => {
         page.evaluate(() => document.documentElement.getAttribute("data-density")),
       )
       .toBe("compact");
+
+    const storedBeforeReload = await page.evaluate(
+      ([densityKey, themeKey]) => ({
+        density: localStorage.getItem(densityKey),
+        theme: localStorage.getItem(themeKey),
+      }),
+      [DENSITY_KEY, THEME_KEY],
+    );
+    expect(storedBeforeReload.density).toBe("compact");
+    expect(storedBeforeReload.theme).toBe(expectedTheme);
 
     await page.reload();
 

--- a/apps/web/e2e/tests/display-settings.spec.ts
+++ b/apps/web/e2e/tests/display-settings.spec.ts
@@ -3,6 +3,14 @@ import { test, expect } from "@playwright/test";
 const DENSITY_KEY = "sports-mgmt-density";
 const THEME_KEY = "theme";
 
+async function resolvedTheme(page: {
+  evaluate: (fn: () => string) => Promise<string>;
+}): Promise<"dark" | "light"> {
+  return page.evaluate(() =>
+    document.documentElement.classList.contains("dark") ? "dark" : "light",
+  );
+}
+
 test.describe("display settings persistence (WSM-000244)", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
@@ -24,12 +32,15 @@ test.describe("display settings persistence (WSM-000244)", () => {
     await expect(densityToggle).toBeVisible();
     await densityToggle.click();
 
+    // next-themes with attribute="class" only adds/removes `dark` (no `light`
+    // class). Toggle once from the system default, then assert that exact
+    // resolved theme persists across reload.
     const themeToggle = page.getByRole("button", { name: /toggle theme/i });
+    const beforeTheme = await resolvedTheme(page);
     await themeToggle.click();
+    const expectedTheme = beforeTheme === "dark" ? "light" : "dark";
 
-    await expect
-      .poll(async () => page.evaluate(() => document.documentElement.className))
-      .toMatch(/light/);
+    await expect.poll(async () => resolvedTheme(page)).toBe(expectedTheme);
     await expect
       .poll(async () =>
         page.evaluate(() => document.documentElement.getAttribute("data-density")),
@@ -38,9 +49,7 @@ test.describe("display settings persistence (WSM-000244)", () => {
 
     await page.reload();
 
-    await expect
-      .poll(async () => page.evaluate(() => document.documentElement.className))
-      .toMatch(/light/);
+    await expect.poll(async () => resolvedTheme(page)).toBe(expectedTheme);
     await expect
       .poll(async () =>
         page.evaluate(() => document.documentElement.getAttribute("data-density")),
@@ -55,6 +64,6 @@ test.describe("display settings persistence (WSM-000244)", () => {
       [DENSITY_KEY, THEME_KEY],
     );
     expect(stored.density).toBe("compact");
-    expect(stored.theme).toBe("light");
+    expect(stored.theme).toBe(expectedTheme);
   });
 });

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -79,6 +79,7 @@ const ACTIVE = {
   playoffTeams: 8,
   playoffFormat: "single",
   divisionWinnersQualify: false,
+  simulationFlavor: "balanced" as const,
 };
 const completedSummary = {
   sourceSeason: { id: ACTIVE.id, name: ACTIVE.name },

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -9,6 +9,7 @@ import Sidebar from "./sidebar";
 import { LeagueSwitcher } from "./league-switcher";
 import { CommandTrigger } from "./command-trigger";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { DensityToggle } from "@/components/density-toggle";
 
 interface LeagueOption {
   id: string;
@@ -43,6 +44,7 @@ export default function MobileHeader({
       )}
       <div className="flex items-center gap-1">
         <CommandTrigger variant="icon" />
+        <DensityToggle />
         <ThemeToggle />
         <UserButton />
       </div>

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from "./_components/command-palette";
 import { CommandTrigger } from "./_components/command-trigger";
 import { Breadcrumbs } from "./_components/breadcrumbs";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { DensityToggle } from "@/components/density-toggle";
 import { resolveActiveLeague } from "@/lib/active-league";
 
 export default async function DashboardLayout({
@@ -45,6 +46,7 @@ export default async function DashboardLayout({
             <CommandTrigger />
           </div>
           <div className="flex items-center gap-2">
+            <DensityToggle />
             <ThemeToggle />
             <UserButton />
           </div>

--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/__tests__/advance-playoffs-action.test.ts
@@ -56,6 +56,7 @@ const ACTIVE_SEASON = {
   playoffTeams: 8,
   playoffFormat: "single",
   divisionWinnersQualify: false,
+  simulationFlavor: "balanced" as const,
 };
 
 function authorize() {

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -124,6 +124,7 @@ function authorize() {
     playoffTeams: 4,
     playoffFormat: "single",
     divisionWinnersQualify: false,
+    simulationFlavor: "balanced" as const,
   });
   mockSimulateAndPersistFixture.mockResolvedValue({
     homeScore: 21,
@@ -154,6 +155,7 @@ describe("simulateGameAction (PBP Slice B)", () => {
       actorUserId: USER,
       decisive: false,
       profileCache: expect.any(Map),
+      simulationFlavor: "balanced",
     });
   });
 });
@@ -358,6 +360,7 @@ describe("simulatePlayoffsAction", () => {
       decisive: true,
       profileCache: expect.any(Map),
       bulkStats: true,
+      simulationFlavor: "balanced",
     });
   });
 
@@ -534,6 +537,7 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
       playoffTeams: 6,
       playoffFormat: "single",
       divisionWinnersQualify: false,
+    simulationFlavor: "balanced" as const,
     });
     mockListFixturesBySeason.mockResolvedValue([
       fixture({ id: "reg", stage: "regular" }),
@@ -556,6 +560,7 @@ describe("simulateSeasonThroughChampionAction (WSM-000241)", () => {
       playoffTeams: 4,
       playoffFormat: "double",
       divisionWinnersQualify: false,
+    simulationFlavor: "balanced" as const,
     });
     mockListFixturesBySeason.mockResolvedValue([
       fixture({ id: "reg", stage: "regular" }),

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -22,6 +22,7 @@ import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
 import { type TeamSimProfileCache } from "@/lib/build-team-sim-profile";
 import { simulateAndPersistFixture } from "@/lib/simulate-fixture";
+import { normalizeSimulationFlavor } from "@/lib/simulation-flavor";
 import {
   deriveChampion,
   fixtureIdsForRound,
@@ -253,6 +254,14 @@ export async function deleteFixtureAction(
  * + playoff advancement flow exactly as hand-entered results do.
  */
 
+async function resolveSeasonSimulationFlavor(
+  seasonId: string,
+  orgContext: OrgContext,
+) {
+  const season = await getSeason(seasonId, orgContext);
+  return normalizeSimulationFlavor(season.simulationFlavor);
+}
+
 export async function simulateGameAction(input: {
   leagueId: string;
   fixtureId: string;
@@ -273,12 +282,17 @@ export async function simulateGameAction(input: {
   const orgContext = await resolveOrgContext(userId);
 
   try {
+    const simulationFlavor = await resolveSeasonSimulationFlavor(
+      fixture.seasonId,
+      orgContext,
+    );
     const { homeScore, awayScore } = await simulateAndPersistFixture({
       fixture,
       orgContext,
       actorUserId: userId,
       decisive: fixture.stage === "playoff",
       profileCache: new Map(),
+      simulationFlavor,
     });
     revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
     revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
@@ -308,6 +322,7 @@ async function simulateUnplayedRegularSeason(
   orgContext: OrgContext,
   profileCache: TeamSimProfileCache,
 ): Promise<number> {
+  const simulationFlavor = await resolveSeasonSimulationFlavor(seasonId, orgContext);
   const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
   // Regular-season, unplayed games only — never overwrite real results, and
   // leave playoff games to the bracket flow.
@@ -322,6 +337,7 @@ async function simulateUnplayedRegularSeason(
       actorUserId: userId,
       profileCache,
       bulkStats: true,
+      simulationFlavor,
     });
     simulated += 1;
   }
@@ -337,6 +353,7 @@ async function simulatePlayoffFixtureIds(
   profileCache: TeamSimProfileCache,
 ): Promise<number> {
   if (fixtureIds.length === 0) return 0;
+  const simulationFlavor = await resolveSeasonSimulationFlavor(seasonId, orgContext);
   const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
   const byId = new Map(fixtures.map((f) => [f.id, f]));
   let simulated = 0;
@@ -356,6 +373,7 @@ async function simulatePlayoffFixtureIds(
       decisive: true,
       profileCache,
       bulkStats: true,
+      simulationFlavor,
     });
     simulated += 1;
   }
@@ -519,6 +537,10 @@ export async function simulateWeekAction(input: {
   const orgContext = await resolveOrgContext(userId);
   const profileCache: TeamSimProfileCache = new Map();
   try {
+    const simulationFlavor = await resolveSeasonSimulationFlavor(
+      input.seasonId,
+      orgContext,
+    );
     const fixtures = await listFixturesBySeason(input.seasonId).catch(() => []);
     const unplayed = fixtures.filter(
       (f) => f.status === "scheduled" && f.week === input.week,
@@ -532,6 +554,7 @@ export async function simulateWeekAction(input: {
         decisive: fixture.stage === "playoff",
         profileCache,
         bulkStats: true,
+        simulationFlavor,
       });
       simulated += 1;
     }

--- a/apps/web/src/app/dashboard/seasons/actions.ts
+++ b/apps/web/src/app/dashboard/seasons/actions.ts
@@ -39,6 +39,7 @@ export async function createSeasonAction(input: {
   playoffTeams?: number;
   playoffFormat?: string;
   divisionWinnersQualify?: boolean;
+  simulationFlavor?: string;
 }): Promise<Result<{ id: string }>> {
   const name = input.name.trim();
   if (!name) return { ok: false, error: "Season name is required." };
@@ -61,6 +62,7 @@ export async function createSeasonAction(input: {
       playoffTeams: input.playoffTeams,
       playoffFormat: input.playoffFormat ?? "single",
       divisionWinnersQualify: input.divisionWinnersQualify,
+      simulationFlavor: input.simulationFlavor,
     });
     revalidatePath("/dashboard/seasons");
     return { ok: true, id: dto.id };
@@ -80,6 +82,7 @@ export async function updateSeasonAction(input: {
   playoffTeams?: number;
   playoffFormat?: string;
   divisionWinnersQualify?: boolean;
+  simulationFlavor?: string;
 }): Promise<Result> {
   const name = input.name.trim();
   if (!name) return { ok: false, error: "Season name is required." };
@@ -96,13 +99,21 @@ export async function updateSeasonAction(input: {
       playoffTeams: input.playoffTeams,
       playoffFormat: input.playoffFormat,
       divisionWinnersQualify: input.divisionWinnersQualify,
+      simulationFlavor: input.simulationFlavor,
     });
     revalidatePath("/dashboard/seasons");
     return { ok: true };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("playoff_teams_locked")) {
+      return { ok: false, error: "playoff_teams_locked" };
+    }
+    if (message.includes("invalid_playoff_teams")) {
+      return { ok: false, error: "invalid_playoff_teams" };
+    }
     return {
       ok: false,
-      error: err instanceof Error ? err.message : "Could not update season.",
+      error: message || "Could not update season.",
     };
   }
 }

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { SeasonDto } from "@sports-management/shared-types";
+import type { SeasonDto, SimulationFlavor } from "@sports-management/shared-types";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -48,6 +48,23 @@ function nullableDate(value: string): string | null {
 /** Standard playoff field sizes for new seasons (WSM-000241). */
 const PLAYOFF_TEAM_OPTIONS = [4, 8, 16] as const;
 
+const SIMULATION_FLAVOR_OPTIONS: {
+  value: SimulationFlavor;
+  label: string;
+}[] = [
+  { value: "balanced", label: "Balanced" },
+  { value: "chalk", label: "Chalk (favorites)" },
+  { value: "upsets", label: "Upsets" },
+];
+
+function playoffTeamOptions(current: number): number[] {
+  const base = [0, ...PLAYOFF_TEAM_OPTIONS];
+  if (current > 0 && !PLAYOFF_TEAM_OPTIONS.includes(current as 4 | 8 | 16)) {
+    return [...base, current];
+  }
+  return base;
+}
+
 /** Playoff setup fields shared by the create + edit season forms (WSM-000184,
  *  WSM-flex-brackets: bye-friendly counts + single/double elimination). */
 function PlayoffConfigFields({
@@ -57,6 +74,9 @@ function PlayoffConfigFields({
   setPlayoffFormat,
   divisionWinnersQualify,
   setDivisionWinnersQualify,
+  simulationFlavor,
+  setSimulationFlavor,
+  playoffTeamChoices,
 }: {
   playoffTeams: number;
   setPlayoffTeams: (n: number) => void;
@@ -64,7 +84,12 @@ function PlayoffConfigFields({
   setPlayoffFormat: (f: string) => void;
   divisionWinnersQualify: boolean;
   setDivisionWinnersQualify: (b: boolean) => void;
+  simulationFlavor: SimulationFlavor;
+  setSimulationFlavor: (f: SimulationFlavor) => void;
+  playoffTeamChoices?: number[];
 }) {
+  const teamOptions = playoffTeamChoices ?? playoffTeamOptions(playoffTeams);
+
   return (
     <>
       <label className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -75,10 +100,9 @@ function PlayoffConfigFields({
           onChange={(e) => setPlayoffTeams(Number(e.target.value))}
           aria-label="Number of playoff teams"
         >
-          <option value={0}>None</option>
-          {PLAYOFF_TEAM_OPTIONS.map((n) => (
+          {teamOptions.map((n) => (
             <option key={n} value={n}>
-              {n} teams
+              {n === 0 ? "None" : `${n} teams`}
             </option>
           ))}
         </select>
@@ -94,6 +118,21 @@ function PlayoffConfigFields({
         >
           <option value="single">Single elimination</option>
           <option value="double">Double elimination</option>
+        </select>
+      </label>
+      <label className="flex items-center gap-1 text-xs text-muted-foreground">
+        Simulation
+        <select
+          className={inputClass}
+          value={simulationFlavor}
+          onChange={(e) => setSimulationFlavor(e.target.value as SimulationFlavor)}
+          aria-label="Simulation flavor"
+        >
+          {SIMULATION_FLAVOR_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
         </select>
       </label>
       <label className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -117,6 +156,8 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
   const [playoffTeams, setPlayoffTeams] = useState(8);
   const [playoffFormat, setPlayoffFormat] = useState("single");
   const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(false);
+  const [simulationFlavor, setSimulationFlavor] =
+    useState<SimulationFlavor>("balanced");
   const [busy, setBusy] = useState(false);
   /** Name of the season just created; non-null switches the dialog to its success state. */
   const [createdName, setCreatedName] = useState<string | null>(null);
@@ -128,6 +169,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
     setPlayoffTeams(8);
     setPlayoffFormat("single");
     setDivisionWinnersQualify(false);
+    setSimulationFlavor("balanced");
     setCreatedName(null);
   }
 
@@ -148,6 +190,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
       playoffTeams,
       playoffFormat,
       divisionWinnersQualify,
+      simulationFlavor,
     });
     setBusy(false);
     if (res.ok) {
@@ -248,6 +291,26 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
                     </SelectContent>
                   </Select>
                 </div>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="season-simulation-flavor">Simulation flavor</Label>
+                <Select
+                  value={simulationFlavor}
+                  onValueChange={(v) =>
+                    setSimulationFlavor(v as SimulationFlavor)
+                  }
+                >
+                  <SelectTrigger id="season-simulation-flavor">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SIMULATION_FLAVOR_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <label className="flex items-center gap-2 text-sm text-foreground">
                 <input
@@ -388,6 +451,9 @@ export function SeasonRowActions({
   const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(
     season.divisionWinnersQualify ?? false,
   );
+  const [simulationFlavor, setSimulationFlavor] = useState<SimulationFlavor>(
+    season.simulationFlavor ?? "balanced",
+  );
   const [busy, setBusy] = useState(false);
   const [activateWarningOpen, setActivateWarningOpen] = useState(false);
   const [completeStep, setCompleteStep] = useState<"complete" | "force" | null>(null);
@@ -462,12 +528,17 @@ export function SeasonRowActions({
       playoffTeams,
       playoffFormat,
       divisionWinnersQualify,
+      simulationFlavor,
     });
     setBusy(false);
     if (res.ok) {
       toast.success("Season updated.");
       setEditing(false);
       router.refresh();
+    } else if (res.error === "playoff_teams_locked") {
+      toast.error("Playoff team count can't change after a bracket exists.");
+    } else if (res.error === "invalid_playoff_teams") {
+      toast.error("Playoff team count must be none, 4, 8, or 16.");
     } else {
       toast.error(res.error === "not_admin" ? "Only league admins can edit seasons." : res.error);
     }
@@ -520,6 +591,9 @@ export function SeasonRowActions({
           setPlayoffFormat={setPlayoffFormat}
           divisionWinnersQualify={divisionWinnersQualify}
           setDivisionWinnersQualify={setDivisionWinnersQualify}
+          simulationFlavor={simulationFlavor}
+          setSimulationFlavor={setSimulationFlavor}
+          playoffTeamChoices={playoffTeamOptions(season.playoffTeams ?? 8)}
         />
         <Button size="sm" disabled={busy} onClick={save}>
           {busy ? "…" : "Save"}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -237,3 +237,52 @@ body[data-scroll-locked] {
     scroll-behavior: auto !important;
   }
 }
+
+/*
+ * Device-scoped compact density (WSM-000244). Applied via `data-density` on
+ * <html> (pre-hydration script + DensityProvider). Token-level tightening so
+ * pages inherit spacing without per-route overrides.
+ */
+html[data-density="compact"] {
+  --text-body-15: 14px;
+  --text-body-15--line-height: 21px;
+  --text-label-14: 13px;
+  --text-label-14--line-height: 18px;
+  --text-caption-12: 11px;
+  --text-caption-12--line-height: 15px;
+  --radius-control: 8px;
+  --radius-card: 12px;
+  --radius-md: 8px;
+  --radius-xl: 12px;
+}
+
+html[data-density="compact"] body {
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+html[data-density="compact"] .gap-4 {
+  gap: 0.75rem;
+}
+
+html[data-density="compact"] .gap-2 {
+  gap: 0.375rem;
+}
+
+html[data-density="compact"] .p-4 {
+  padding: 0.75rem;
+}
+
+html[data-density="compact"] .p-6 {
+  padding: 1rem;
+}
+
+html[data-density="compact"] .py-4 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+html[data-density="compact"] .px-8 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { AppToaster } from "@/components/app-toaster";
 import { ThemeProvider } from "@/components/theme-provider";
+import { DensityProvider } from "@/components/density-provider";
+import { DENSITY_STORAGE_KEY } from "@/components/density-provider";
 import "./globals.css";
 
 export const dynamic = "force-dynamic";
@@ -74,6 +76,13 @@ export default function RootLayout({
         suppressHydrationWarning
         className={`${hanken.variable} ${jetbrainsMono.variable}`}
       >
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(){try{var d=localStorage.getItem('${DENSITY_STORAGE_KEY}');document.documentElement.setAttribute('data-density',d==='compact'?'compact':'comfortable');}catch(e){document.documentElement.setAttribute('data-density','comfortable');}})();`,
+            }}
+          />
+        </head>
         <body className="bg-background text-foreground font-sans antialiased">
           <script
             type="application/ld+json"
@@ -85,8 +94,10 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            {children}
-            <AppToaster />
+            <DensityProvider>
+              {children}
+              <AppToaster />
+            </DensityProvider>
           </ThemeProvider>
           <Analytics />
           <SpeedInsights />

--- a/apps/web/src/app/local/layout.tsx
+++ b/apps/web/src/app/local/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { DensityToggle } from "@/components/density-toggle";
 import { LocalModeBanner } from "./_components/local-mode-banner";
 
 /**
@@ -21,6 +22,7 @@ export default function LocalLayout({
           sprtsmng <span className="text-muted-foreground">· local</span>
         </Link>
         <div className="flex items-center gap-2">
+          <DensityToggle />
           <ThemeToggle />
           <Button asChild size="sm">
             <Link href="/sign-up">Create a free account</Link>

--- a/apps/web/src/components/__tests__/density-provider.test.tsx
+++ b/apps/web/src/components/__tests__/density-provider.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import {
+  DENSITY_STORAGE_KEY,
+  DensityProvider,
+  DEFAULT_DENSITY,
+} from "../density-provider";
+import { DensityToggle } from "../density-toggle";
+
+describe("DensityProvider", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-density");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    localStorage.clear();
+    document.documentElement.setAttribute("data-density", DEFAULT_DENSITY);
+  });
+
+  it("defaults to comfortable and writes the storage key on toggle", () => {
+    act(() => {
+      root.render(
+        <DensityProvider>
+          <DensityToggle />
+        </DensityProvider>,
+      );
+    });
+
+    expect(document.documentElement.getAttribute("data-density")).toBe(
+      "comfortable",
+    );
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button?.click();
+    });
+
+    expect(document.documentElement.getAttribute("data-density")).toBe("compact");
+    expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe("compact");
+
+    act(() => {
+      button?.click();
+    });
+
+    expect(document.documentElement.getAttribute("data-density")).toBe(
+      "comfortable",
+    );
+    expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe("comfortable");
+  });
+
+  it("hydrates from localStorage on mount", () => {
+    localStorage.setItem(DENSITY_STORAGE_KEY, "compact");
+
+    act(() => {
+      root.render(
+        <DensityProvider>
+          <span>child</span>
+        </DensityProvider>,
+      );
+    });
+
+    expect(document.documentElement.getAttribute("data-density")).toBe("compact");
+  });
+});

--- a/apps/web/src/components/density-provider.tsx
+++ b/apps/web/src/components/density-provider.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export const DENSITY_STORAGE_KEY = "sports-mgmt-density";
+
+export type Density = "comfortable" | "compact";
+
+export const DEFAULT_DENSITY: Density = "comfortable";
+
+function readStoredDensity(): Density {
+  if (typeof window === "undefined") return DEFAULT_DENSITY;
+  try {
+    const stored = localStorage.getItem(DENSITY_STORAGE_KEY);
+    return stored === "compact" ? "compact" : DEFAULT_DENSITY;
+  } catch {
+    return DEFAULT_DENSITY;
+  }
+}
+
+function applyDensity(density: Density) {
+  document.documentElement.setAttribute("data-density", density);
+}
+
+interface DensityContextValue {
+  density: Density;
+  setDensity: (density: Density) => void;
+  toggleDensity: () => void;
+}
+
+const DensityContext = createContext<DensityContextValue | null>(null);
+
+/**
+ * Device-scoped UI density (WSM-000244). Pairs with a pre-hydration inline
+ * script on <html> so the first paint matches the stored preference.
+ */
+export function DensityProvider({ children }: { children: React.ReactNode }) {
+  const [density, setDensityState] = useState<Density>(readStoredDensity);
+
+  const setDensity = useCallback((next: Density) => {
+    setDensityState(next);
+    try {
+      localStorage.setItem(DENSITY_STORAGE_KEY, next);
+    } catch {
+      // Private browsing — still apply for the session.
+    }
+    applyDensity(next);
+  }, []);
+
+  const toggleDensity = useCallback(() => {
+    setDensity(density === "compact" ? "comfortable" : "compact");
+  }, [density, setDensity]);
+
+  useEffect(() => {
+    applyDensity(density);
+  }, [density]);
+
+  const value = useMemo(
+    () => ({ density, setDensity, toggleDensity }),
+    [density, setDensity, toggleDensity],
+  );
+
+  return (
+    <DensityContext.Provider value={value}>{children}</DensityContext.Provider>
+  );
+}
+
+export function useDensity(): DensityContextValue {
+  const ctx = useContext(DensityContext);
+  if (!ctx) {
+    throw new Error("useDensity must be used within DensityProvider");
+  }
+  return ctx;
+}

--- a/apps/web/src/components/density-toggle.tsx
+++ b/apps/web/src/components/density-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { LayoutGrid, Rows3 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useDensity } from "@/components/density-provider";
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Comfortable/compact density toggle (WSM-000244). Mirrors ThemeToggle's
+ * mounted guard so SSR and the first client render stay aligned.
+ */
+export function DensityToggle() {
+  const { density, toggleDensity } = useDensity();
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+
+  const isCompact = density === "compact";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={isCompact ? "Use comfortable density" : "Use compact density"}
+      title={isCompact ? "Comfortable density" : "Compact density"}
+      onClick={toggleDensity}
+    >
+      {mounted && isCompact ? (
+        <Rows3 className="h-4 w-4" />
+      ) : (
+        <LayoutGrid className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/lib/__tests__/season-view.test.ts
+++ b/apps/web/src/lib/__tests__/season-view.test.ts
@@ -14,6 +14,7 @@ function season(id: string, status: string): SeasonDto {
     playoffTeams: null,
     playoffFormat: null,
     divisionWinnersQualify: false,
+    simulationFlavor: "balanced",
   };
 }
 

--- a/apps/web/src/lib/__tests__/simulate-game.test.ts
+++ b/apps/web/src/lib/__tests__/simulate-game.test.ts
@@ -71,4 +71,11 @@ describe("simulateScore", () => {
     expect(seedFromString("fixture_1")).toBe(seedFromString("fixture_1"));
     expect(seedFromString("fixture_1")).not.toBe(seedFromString("fixture_2"));
   });
+
+  it("matches legacy output when flavor is omitted or balanced", () => {
+    const input = { homeStrength: 70, awayStrength: 60, seed: 42 };
+    const legacy = simulateScore(input);
+    const explicit = simulateScore({ ...input, flavor: "balanced" });
+    expect(explicit).toEqual(legacy);
+  });
 });

--- a/apps/web/src/lib/__tests__/simulation-flavor.test.ts
+++ b/apps/web/src/lib/__tests__/simulation-flavor.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeSimulationFlavor,
+  weightsForFlavor,
+  BASE_STRENGTH_WEIGHT,
+  BASE_VARIANCE,
+} from "../simulation-flavor";
+import { simulateScore } from "../simulate-game";
+import { simulateGameLog } from "../pbp";
+import type { TeamSimProfile } from "../pbp";
+
+const team = (id: string, strength: number): TeamSimProfile => ({
+  teamId: id,
+  strength,
+  players: [],
+});
+
+describe("simulation flavor weighting", () => {
+  it("defaults missing values to balanced", () => {
+    expect(normalizeSimulationFlavor(undefined)).toBe("balanced");
+    expect(normalizeSimulationFlavor("legacy")).toBe("balanced");
+  });
+
+  it("keeps balanced constants identical to the legacy engine", () => {
+    const weights = weightsForFlavor("balanced");
+    expect(weights.strengthWeight).toBe(BASE_STRENGTH_WEIGHT);
+    expect(weights.variance).toBe(BASE_VARIANCE);
+    expect(weights.edgeScale).toBe(1);
+  });
+
+  it("is deterministic per fixture seed and flavor", () => {
+    const input = { homeStrength: 68, awayStrength: 61, seed: 90210 };
+    const balancedA = simulateScore({ ...input, flavor: "balanced" });
+    const balancedB = simulateScore({ ...input, flavor: "balanced" });
+    expect(balancedA).toEqual(balancedB);
+  });
+
+  it("changes score weighting across chalk, balanced, and upsets", () => {
+    const seed = 4242;
+    const homeStrength = 78;
+    const awayStrength = 52;
+    const flavors = ["chalk", "balanced", "upsets"] as const;
+    const scores = flavors.map((flavor) =>
+      simulateScore({ homeStrength, awayStrength, seed, flavor }),
+    );
+    expect(new Set(scores.map((s) => `${s.homeScore}-${s.awayScore}`)).size).toBe(
+      3,
+    );
+  });
+
+  it("lets chalk favor the stronger team more often than upsets", () => {
+    let chalkStrongWins = 0;
+    let upsetStrongWins = 0;
+    const N = 300;
+    for (let seed = 0; seed < N; seed++) {
+      const chalk = simulateScore({
+        homeStrength: 74,
+        awayStrength: 54,
+        seed,
+        flavor: "chalk",
+      });
+      const upsets = simulateScore({
+        homeStrength: 74,
+        awayStrength: 54,
+        seed,
+        flavor: "upsets",
+      });
+      if (chalk.homeScore > chalk.awayScore) chalkStrongWins++;
+      if (upsets.homeScore > upsets.awayScore) upsetStrongWins++;
+    }
+    expect(chalkStrongWins).toBeGreaterThan(upsetStrongWins);
+  });
+
+  it("changes PBP logs for the same seed when flavor changes", () => {
+    const home = team("home", 70);
+    const away = team("away", 58);
+    const seed = 1337;
+    const balanced = simulateGameLog({ home, away, seed, flavor: "balanced" });
+    const chalk = simulateGameLog({ home, away, seed, flavor: "chalk" });
+    const upsets = simulateGameLog({ home, away, seed, flavor: "upsets" });
+    expect(chalk.homeScore).not.toBe(upsets.homeScore);
+    expect(balanced.drives.length).toBeGreaterThan(0);
+    expect(chalk).not.toEqual(upsets);
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -322,6 +322,7 @@ const refs = {
       playoffTeams?: number;
       playoffFormat?: string;
       divisionWinnersQualify?: boolean;
+      simulationFlavor?: string;
     },
     { dto: SeasonDto; created: boolean }
   >("sports:upsertSeason"),
@@ -334,6 +335,7 @@ const refs = {
       playoffTeams?: number;
       playoffFormat?: string;
       divisionWinnersQualify?: boolean;
+      simulationFlavor?: string;
     },
     SeasonDto | null
   >("sports:updateSeason"),
@@ -1511,6 +1513,7 @@ export async function upsertSeason(input: {
   playoffTeams?: number;
   playoffFormat?: string;
   divisionWinnersQualify?: boolean;
+  simulationFlavor?: string;
 }): Promise<{ dto: SeasonDto; created: boolean }> {
   return mutateConvex(refs.upsertSeason, input);
 }
@@ -1523,6 +1526,7 @@ export async function updateSeason(input: {
   playoffTeams?: number;
   playoffFormat?: string;
   divisionWinnersQualify?: boolean;
+  simulationFlavor?: string;
 }): Promise<SeasonDto> {
   const dto = await mutateConvex(refs.updateSeason, input);
   if (!dto) throw new Error("Season not found");

--- a/apps/web/src/lib/local/local-workspace-provider.ts
+++ b/apps/web/src/lib/local/local-workspace-provider.ts
@@ -278,6 +278,7 @@ export class LocalWorkspaceProvider implements WorkspaceDataProvider {
       playoffTeams: null,
       playoffFormat: null,
       divisionWinnersQualify: false,
+      simulationFlavor: "balanced",
     };
     await this.db.seasons.add(season);
     return season;

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -1,4 +1,9 @@
 import { mulberry32 } from "@/lib/simulate-game";
+import {
+  DEFAULT_SIMULATION_FLAVOR,
+  normalizeSimulationFlavor,
+  weightsForFlavor,
+} from "@/lib/simulation-flavor";
 import type {
   PbpDrive,
   PbpDriveEndReason,
@@ -16,7 +21,6 @@ import type {
 const QUARTER_SECONDS = 720;
 const OT_SECONDS = 300;
 const HOME_FIELD_EDGE = 2.5;
-const STRENGTH_WEIGHT = 0.26;
 const BASELINE_STRENGTH = 50;
 
 const POSITION_TO_GROUP: Record<string, SimPositionGroup> = {
@@ -49,6 +53,8 @@ interface GameState {
   rand: () => number;
   home: TeamSimProfile;
   away: TeamSimProfile;
+  strengthWeight: number;
+  edgeScale: number;
   decisive: boolean;
   quarter: number;
   clockSeconds: number;
@@ -97,8 +103,9 @@ function effectiveStrength(
   team: TeamSimProfile,
   isHome: boolean,
   oppStrength: number,
+  strengthWeight: number,
 ): number {
-  const homeEdge = isHome ? HOME_FIELD_EDGE / STRENGTH_WEIGHT : 0;
+  const homeEdge = isHome ? HOME_FIELD_EDGE / strengthWeight : 0;
   return team.strength + (team.strength - oppStrength) * 0.15 + homeEdge;
 }
 
@@ -110,13 +117,15 @@ function matchupEdge(state: GameState): number {
     off,
     offIsHome,
     def.strength,
+    state.strengthWeight,
   );
   const defEff = effectiveStrength(
     def,
     !offIsHome,
     off.strength,
+    state.strengthWeight,
   );
-  return (offEff - defEff) / 99;
+  return ((offEff - defEff) / 99) * state.edgeScale;
 }
 
 function clamp(n: number, min: number, max: number): number {
@@ -777,11 +786,16 @@ function runScrimmagePlay(state: GameState): void {
 }
 
 function simulateGameLog(input: PbpGameInput): PbpGameLog {
+  const weights = weightsForFlavor(
+    normalizeSimulationFlavor(input.flavor ?? DEFAULT_SIMULATION_FLAVOR),
+  );
   const rand = mulberry32(input.seed >>> 0);
   const state: GameState = {
     rand,
     home: input.home,
     away: input.away,
+    strengthWeight: weights.strengthWeight,
+    edgeScale: weights.edgeScale,
     decisive: input.decisive ?? false,
     quarter: 1,
     clockSeconds: QUARTER_SECONDS,

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -27,6 +27,8 @@ export interface TeamSimProfile {
   players: PlayerSimProfile[];
 }
 
+import type { SimulationFlavor } from "@/lib/simulation-flavor";
+
 export interface PbpGameInput {
   home: TeamSimProfile;
   away: TeamSimProfile;
@@ -34,6 +36,8 @@ export interface PbpGameInput {
   seed: number;
   /** Playoff: overtime until no tie. */
   decisive?: boolean;
+  /** Season simulation flavor; `balanced` preserves legacy weighting. */
+  flavor?: SimulationFlavor;
 }
 
 export type PbpPlayType =

--- a/apps/web/src/lib/simulate-fixture.ts
+++ b/apps/web/src/lib/simulate-fixture.ts
@@ -16,6 +16,10 @@ import {
   simulateGameLog,
 } from "@/lib/pbp";
 import { seedFromString, simulateScore } from "@/lib/simulate-game";
+import {
+  DEFAULT_SIMULATION_FLAVOR,
+  type SimulationFlavor,
+} from "@/lib/simulation-flavor";
 
 export interface SimulateFixtureInput {
   fixture: FixtureDto;
@@ -25,6 +29,8 @@ export interface SimulateFixtureInput {
   profileCache: TeamSimProfileCache;
   /** When true, stat lines are written in one bulk mutation (season sims). */
   bulkStats?: boolean;
+  /** Season simulation flavor (defaults to balanced). */
+  simulationFlavor?: SimulationFlavor;
 }
 
 export interface SimulateFixtureResult {
@@ -53,6 +59,7 @@ export async function simulateAndPersistFixture(
 ): Promise<SimulateFixtureResult> {
   const { fixture, orgContext, actorUserId, profileCache } = input;
   const decisive = input.decisive ?? fixture.stage === "playoff";
+  const flavor = input.simulationFlavor ?? DEFAULT_SIMULATION_FLAVOR;
   const seed = seedFromString(fixture.id);
 
   const [home, away] = await Promise.all([
@@ -68,6 +75,7 @@ export async function simulateAndPersistFixture(
       awayStrength: away.strength,
       seed,
       decisive,
+      flavor,
     });
     await recordGameResult({
       fixtureId: fixture.id,
@@ -78,7 +86,7 @@ export async function simulateAndPersistFixture(
     return { homeScore, awayScore, usedScoreFallback: true };
   }
 
-  const log = simulateGameLog({ home, away, seed, decisive });
+  const log = simulateGameLog({ home, away, seed, decisive, flavor });
   const homeScore = log.homeScore;
   const awayScore = log.awayScore;
 

--- a/apps/web/src/lib/simulate-game.ts
+++ b/apps/web/src/lib/simulate-game.ts
@@ -11,15 +11,17 @@
  * that a clearly stronger team usually (not always) wins.
  */
 import { seedFromString } from "@/lib/synthetic-roster";
+import {
+  DEFAULT_SIMULATION_FLAVOR,
+  normalizeSimulationFlavor,
+  weightsForFlavor,
+  type SimulationFlavor,
+} from "@/lib/simulation-flavor";
 
 /** Average points an average matchup yields per team. */
 const BASELINE_POINTS = 21;
-/** Points swing per point of strength differential (full 99-gap ≈ ±25). */
-const STRENGTH_WEIGHT = 0.26;
 /** Home-field edge, in points. */
 const HOME_FIELD = 2.5;
-/** Peak ± seeded swing applied to each team's expected points. */
-const VARIANCE = 13;
 
 /** mulberry32 — small deterministic PRNG (same family as synthetic-roster). */
 export function mulberry32(seed: number): () => number {
@@ -46,6 +48,8 @@ export interface SimulateScoreInput {
   seed: number;
   /** When true, never returns a tie — re-rolls to a clean winner (playoffs). */
   decisive?: boolean;
+  /** Season simulation flavor; `balanced` preserves legacy weighting. */
+  flavor?: SimulationFlavor;
 }
 
 export interface SimulatedScore {
@@ -58,10 +62,12 @@ function pointsFor(
   oppStrength: number,
   homeEdge: number,
   rand: () => number,
+  strengthWeight: number,
+  variance: number,
 ): number {
   const base =
-    BASELINE_POINTS + (strength - oppStrength) * STRENGTH_WEIGHT + homeEdge;
-  const swing = (rand() - 0.5) * 2 * VARIANCE;
+    BASELINE_POINTS + (strength - oppStrength) * strengthWeight + homeEdge;
+  const swing = (rand() - 0.5) * 2 * variance;
   return Math.max(0, Math.round(base + swing));
 }
 
@@ -75,10 +81,26 @@ export function simulateScore({
   awayStrength,
   seed,
   decisive = false,
+  flavor = DEFAULT_SIMULATION_FLAVOR,
 }: SimulateScoreInput): SimulatedScore {
+  const weights = weightsForFlavor(normalizeSimulationFlavor(flavor));
   const rand = rng(seed);
-  let homeScore = pointsFor(homeStrength, awayStrength, HOME_FIELD, rand);
-  let awayScore = pointsFor(awayStrength, homeStrength, 0, rand);
+  let homeScore = pointsFor(
+    homeStrength,
+    awayStrength,
+    HOME_FIELD,
+    rand,
+    weights.strengthWeight,
+    weights.variance,
+  );
+  let awayScore = pointsFor(
+    awayStrength,
+    homeStrength,
+    0,
+    rand,
+    weights.strengthWeight,
+    weights.variance,
+  );
 
   if (decisive && homeScore === awayScore) {
     // Overtime field goal for the favorite (home wins an exact-strength tie).

--- a/apps/web/src/lib/simulation-flavor.ts
+++ b/apps/web/src/lib/simulation-flavor.ts
@@ -1,0 +1,51 @@
+/** Season-scoped simulation tuning (WSM-000244). */
+export type SimulationFlavor = "chalk" | "balanced" | "upsets";
+
+export const SIMULATION_FLAVORS: SimulationFlavor[] = [
+  "chalk",
+  "balanced",
+  "upsets",
+];
+
+export const DEFAULT_SIMULATION_FLAVOR: SimulationFlavor = "balanced";
+
+/** Map legacy/missing rows to the neutral default at read time. */
+export function normalizeSimulationFlavor(
+  value: string | null | undefined,
+): SimulationFlavor {
+  if (value === "chalk" || value === "upsets") return value;
+  return DEFAULT_SIMULATION_FLAVOR;
+}
+
+export const BASE_STRENGTH_WEIGHT = 0.26;
+export const BASE_VARIANCE = 13;
+
+export interface SimulationWeights {
+  strengthWeight: number;
+  variance: number;
+  /** Scales PBP matchup-edge influence; 1 keeps balanced behavior unchanged. */
+  edgeScale: number;
+}
+
+export function weightsForFlavor(flavor: SimulationFlavor): SimulationWeights {
+  switch (flavor) {
+    case "chalk":
+      return {
+        strengthWeight: BASE_STRENGTH_WEIGHT * 1.35,
+        variance: BASE_VARIANCE * 0.7,
+        edgeScale: 1.25,
+      };
+    case "upsets":
+      return {
+        strengthWeight: BASE_STRENGTH_WEIGHT * 0.75,
+        variance: BASE_VARIANCE * 1.35,
+        edgeScale: 0.75,
+      };
+    default:
+      return {
+        strengthWeight: BASE_STRENGTH_WEIGHT,
+        variance: BASE_VARIANCE,
+        edgeScale: 1,
+      };
+  }
+}

--- a/docs/WSM-000235-progress.txt
+++ b/docs/WSM-000235-progress.txt
@@ -44,12 +44,12 @@ On completion, move this file and the plan to docs/archive/.
     [x] 8.3 - Resume persisted rollover stages and return truthful operation summaries
     [x] 8.4 - Verify concurrent starts and retries at every stage converge on one target
     [x] 8.5 - Verify complete → rollover → activate, offseason destination, and historical continuity
-[ ] 9.0 - WSM-000244 - Display and simulation settings
-    [ ] 9.1 - Add persistent device-scoped density preference
-    [ ] 9.2 - Add season-scoped simulation flavor schema and APIs
-    [ ] 9.3 - Integrate deterministic flavor weighting
-    [ ] 9.4 - Lock new 4/8/16 configuration while preserving persisted legacy bracket sizes
-    [ ] 9.5 - Verify theme hydration, keyboard use, settings scope, and no accent control
+[x] 9.0 - WSM-000244 - Display and simulation settings
+    [x] 9.1 - Add persistent device-scoped density preference
+    [x] 9.2 - Add season-scoped simulation flavor schema and APIs
+    [x] 9.3 - Integrate deterministic flavor weighting
+    [x] 9.4 - Lock new 4/8/16 configuration while preserving persisted legacy bracket sizes
+    [x] 9.5 - Verify theme hydration, keyboard use, settings scope, and no accent control
 [ ] 10.0 - Integration, review, and shipping
     [ ] 10.1 - Run type-check, lint, unit, focused E2E, and visual suites
     [ ] 10.2 - Run deterministic full dynasty lifecycle E2E

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -108,6 +108,8 @@ export const RosterAuditLogDtoSchema = z.object({
   createdAt: z.string(),
 }) satisfies z.ZodType<RosterAuditLogDto>;
 
+export const SimulationFlavorSchema = z.enum(["chalk", "balanced", "upsets"]);
+
 export const SeasonDtoSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -119,6 +121,7 @@ export const SeasonDtoSchema = z.object({
   playoffTeams: z.number().nullable(),
   playoffFormat: z.string().nullable(),
   divisionWinnersQualify: z.boolean(),
+  simulationFlavor: SimulationFlavorSchema,
 }) satisfies z.ZodType<SeasonDto>;
 
 // --- Mutation input schemas ---

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -73,6 +73,8 @@ export interface PlayerDto {
   hometown: string | null;
 }
 
+export type SimulationFlavor = "chalk" | "balanced" | "upsets";
+
 export interface SeasonDto {
   id: string;
   name: string;
@@ -85,6 +87,8 @@ export interface SeasonDto {
   playoffTeams: number | null; // 0/null = no playoffs; else 4 | 8 | 16
   playoffFormat: string | null; // "single"
   divisionWinnersQualify: boolean;
+  /** Simulation tuning (WSM-000244); missing rows default to balanced. */
+  simulationFlavor: SimulationFlavor;
 }
 
 export interface DepthChartEntryDto {


### PR DESCRIPTION
## Summary
- Add device-scoped comfortable/compact density (pre-hydration `data-density`, localStorage, dashboard/local toggles)
- Add season-scoped `simulationFlavor` (`chalk` | `balanced` | `upsets`) through Convex schema, DTOs, season forms, and deterministic sim weighting (`balanced` keeps prior engine constants)
- Lock playoff team-count changes after a bracket exists; validate new values to 0/4/8/16 while preserving legacy sizes on existing seasons
- No accent-color control

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`
- [x] `pnpm --filter @sports-management/web lint`
- [x] `pnpm --filter @sports-management/web test:unit` (1194 tests)
- [ ] CI Playwright including `e2e/tests/display-settings.spec.ts` (targets `/local`)
- [ ] Manual: create season → generate bracket → change playoff size → expect `playoff_teams_locked`
- [ ] Manual: chalk vs upsets same fixture seed → different weighting; balanced matches prior behavior

## Related Issue
Closes #532
