### PR TITLE
fix(web): stabilize offseason free-agency e2e release/sign flow

### DIFF
--- a/apps/web/e2e/tests/offseason-free-agency.spec.ts
+++ b/apps/web/e2e/tests/offseason-free-agency.spec.ts
@@ -105,13 +105,18 @@ test.describe("Offseason free agency", () => {
       page.getByRole("button", { name: `Release ${releasedName}` }),
     ).toHaveCount(0, { timeout: 60_000 });
 
-    await page.goto(upcomingSeasonUrl!);
-    const faPanel = page.getByTestId("free-agency-panel");
-    await expect(faPanel).toBeVisible({ timeout: 60_000 });
-    // The released player reached the pool (scoped to the panel).
-    await expect(faPanel.getByText(releasedName!).first()).toBeVisible({
-      timeout: 60_000,
-    });
+    // Soft-reload until the released player is visible in the pool.
+    // Inner timeouts stay short so toPass can retry within the budget
+    // (a single hard goto can race Convex pool propagation — Sig A).
+    // .first() avoids strict-mode on a transient double panel mount (Sig B).
+    await expect(async () => {
+      await page.goto(upcomingSeasonUrl!);
+      const faPanel = page.getByTestId("free-agency-panel").first();
+      await expect(faPanel).toBeVisible();
+      await expect(faPanel.getByText(releasedName!).first()).toBeVisible();
+    }).toPass({ timeout: 60_000 });
+
+    const faPanel = page.getByTestId("free-agency-panel").first();
 
     // Sign the first free agent; read its exact name from the row so every
     // post-sign assertion targets the SAME player (not the arbitrary released


### PR DESCRIPTION
## Summary
- Stabilize the flaky offseason free-agency e2e that releases a player then asserts them in the free-agent pool.
- Retry hard navigation with Playwright `toPass` until the released player is visible (Sig A: release→pool race).
- Scope `free-agency-panel` with `.first()` to avoid transient strict-mode double mounts (Sig B).

## Test plan
- [ ] CI Playwright run includes `offseason-free-agency.spec.ts`
- [ ] Confirm no remaining unscoped `getByTestId('free-agency-panel')` in the spec
- [ ] Sign flow still asserts panel-scoped name disappearance + destination team Release button

Closes #534
