### PR TITLE
feat(web): dashboard overview league at a glance (WSM-000253)

### DIFF
--- a/apps/web/e2e/tests/dashboard-overview.spec.ts
+++ b/apps/web/e2e/tests/dashboard-overview.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
+import { LEAGUES, SEASONS } from "../helpers/test-data";
 
 test.describe("Dashboard Overview", () => {
   test.beforeEach(async ({ page }) => {
@@ -17,8 +18,9 @@ test.describe("Dashboard Overview", () => {
   // Stat cards carry the active-league count in <p class="text-stat-30 ...">.
   const countSelector = "p.text-stat-30";
 
-  test("shows Overview heading", async ({ page }) => {
+  test("shows Overview heading and subtitle", async ({ page }) => {
     await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
+    await expect(page.getByText("Your league at a glance.")).toBeVisible();
   });
 
   test("displays 5 stat cards with correct labels", async ({ page }) => {
@@ -82,5 +84,63 @@ test.describe("Dashboard Overview", () => {
       const innerCard = card.locator("[class*='hover\\:border-primary']");
       await expect(innerCard).toHaveCount(1);
     }
+  });
+});
+
+test.describe("Dashboard Overview — league at a glance (WSM-000253)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    const fixture = readCanonicalFixture();
+    await setActiveLeague(page, fixture.leagueId);
+    await page.goto("/dashboard");
+  });
+
+  test("shows league summary and standings cards for the active season", async ({
+    page,
+  }) => {
+    const overview = page.getByTestId("dashboard-overview");
+    await expect(overview).toBeVisible();
+
+    const summary = page.getByTestId("league-summary-card");
+    await expect(summary.getByText(LEAGUES.NFL, { exact: true })).toBeVisible();
+    await expect(summary.getByTestId("overview-active-season")).toHaveText(
+      SEASONS.NFL_2025.name,
+    );
+    await expect(summary.getByTestId("overview-season-progress")).toHaveText(
+      /\d+ \/ \d+ played/,
+    );
+    await expect(summary.getByTestId("overview-team-count")).toHaveText("4");
+
+    const standings = page.getByTestId("standings-card");
+    await expect(standings.getByText("Standings", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("overview-standings-rows").locator("li")).toHaveCount(4);
+    await expect(page.getByTestId("overview-full-standings-link")).toBeVisible();
+    await expect(page.getByTestId("overview-full-standings-link")).toHaveText(
+      "Full standings →",
+    );
+  });
+
+  test("Open league navigates to the league hub", async ({ page }) => {
+    const fixture = readCanonicalFixture();
+    await page.getByRole("link", { name: "Open league" }).click();
+    await expect(page).toHaveURL(`/dashboard/leagues/${fixture.leagueId}`);
+  });
+
+  test("Seasons button navigates to the seasons list", async ({ page }) => {
+    await page
+      .getByTestId("league-summary-card")
+      .getByRole("link", { name: "Seasons" })
+      .click();
+    await expect(page).toHaveURL("/dashboard/seasons");
+    await expect(page.getByRole("heading", { name: "Seasons" })).toBeVisible();
+  });
+
+  // AC #3 (no active season → EmptyState): canonical seed always has an Active
+  // season, so behavior is asserted in dashboard-overview unit tests.
+  test("active-season overview does not show the no-active-season empty state", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("dashboard-overview")).toBeVisible();
+    await expect(page.getByTestId("overview-no-active-season")).toHaveCount(0);
   });
 });

--- a/apps/web/src/app/dashboard/_components/overview/__tests__/dashboard-overview.test.ts
+++ b/apps/web/src/app/dashboard/_components/overview/__tests__/dashboard-overview.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { LeagueDto, SeasonDto } from "@sports-management/shared-types";
+import { DashboardOverview, findActiveSeason } from "../dashboard-overview";
+
+function season(status: string): SeasonDto {
+  return {
+    id: `season-${status}`,
+    name: `Season ${status}`,
+    leagueId: "league-1",
+    startDate: null,
+    endDate: null,
+    status,
+    rosterLocked: false,
+    playoffTeams: null,
+    playoffFormat: null,
+    divisionWinnersQualify: false,
+    simulationFlavor: "balanced",
+  };
+}
+
+describe("findActiveSeason", () => {
+  it("returns the season whose status is active (case-insensitive)", () => {
+    const seasons = [season("Completed"), season("Active"), season("Upcoming")];
+    expect(findActiveSeason(seasons)?.id).toBe("season-Active");
+  });
+
+  it("returns null when no season is active", () => {
+    const seasons = [season("Completed"), season("Upcoming")];
+    expect(findActiveSeason(seasons)).toBeNull();
+  });
+
+  it("returns null for an empty season list", () => {
+    expect(findActiveSeason([])).toBeNull();
+  });
+});
+
+const league: LeagueDto = {
+  id: "league-1",
+  name: "Test League",
+  orgId: "org-1",
+};
+
+describe("DashboardOverview", () => {
+  it("renders spec copy and stat rows when an active season exists", () => {
+    const html = renderToStaticMarkup(
+      createElement(DashboardOverview, {
+        league,
+        activeSeason: season("Active"),
+        teamCount: 16,
+        progress: { total: 11, final: 8, complete: false },
+        standings: [],
+        standingsLinkEnabled: true,
+      }),
+    );
+    expect(html).toContain("Active season");
+    expect(html).toContain("Regular season");
+    expect(html).toContain("8 / 11 played");
+    expect(html).toContain("Open league");
+    expect(html).toContain("Seasons");
+    expect(html).toContain("Standings");
+    expect(html).toContain("Full standings →");
+  });
+
+  it("renders EmptyState with guidance when there is no active season", () => {
+    const html = renderToStaticMarkup(
+      createElement(DashboardOverview, {
+        league,
+        activeSeason: null,
+        teamCount: 4,
+        progress: { total: 0, final: 0, complete: true },
+        standings: [],
+        standingsLinkEnabled: false,
+      }),
+    );
+    expect(html).toContain('data-testid="overview-no-active-season"');
+    expect(html).toContain("No active season");
+    expect(html).toContain("Activate or create a season");
+    expect(html).toContain('href="/dashboard/seasons"');
+    expect(html).not.toContain('data-testid="dashboard-overview"');
+    expect(html).not.toContain('data-testid="overview-season-progress"');
+  });
+});

--- a/apps/web/src/app/dashboard/_components/overview/dashboard-overview.tsx
+++ b/apps/web/src/app/dashboard/_components/overview/dashboard-overview.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { Calendar, Trophy } from "lucide-react";
+import type { LeagueDto, SeasonDto, Standing } from "@sports-management/shared-types";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/empty-state";
+import { TeamMark } from "@/components/team-mark";
+import type { RegularSeasonProgress } from "@/lib/playoffs";
+
+export function findActiveSeason(seasons: SeasonDto[]): SeasonDto | null {
+  return seasons.find((s) => s.status.toLowerCase() === "active") ?? null;
+}
+
+function formatRecord(wins: number, losses: number, ties: number): string {
+  return `${wins}-${losses}${ties > 0 ? `-${ties}` : ""}`;
+}
+
+interface DashboardOverviewProps {
+  league: LeagueDto;
+  activeSeason: SeasonDto | null;
+  teamCount: number;
+  progress: RegularSeasonProgress;
+  standings: Standing[];
+  standingsLinkEnabled: boolean;
+}
+
+export function DashboardOverview({
+  league,
+  activeSeason,
+  teamCount,
+  progress,
+  standings,
+  standingsLinkEnabled,
+}: DashboardOverviewProps) {
+  if (!activeSeason) {
+    return (
+      <div data-testid="overview-no-active-season">
+        <EmptyState
+          icon={Calendar}
+          title="No active season"
+          description="Activate or create a season to see progress and standings here."
+          action={
+            <Button asChild variant="outline" size="sm">
+              <Link href="/dashboard/seasons">Go to Seasons</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const topFive = standings.slice(0, 5);
+  const standingsHref = activeSeason
+    ? `/dashboard/leagues/${league.id}/standings`
+    : null;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2" data-testid="dashboard-overview">
+      <Card data-testid="league-summary-card">
+        <CardContent className="space-y-0">
+          <div className="mb-3.5 flex items-center gap-2.5">
+            <Trophy className="h-4 w-4 shrink-0 text-accent" aria-hidden />
+            <h3 className="text-title-22 font-semibold text-foreground">
+              {league.name}
+            </h3>
+          </div>
+
+          <dl className="space-y-2 text-sm">
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-muted-foreground">Active season</dt>
+              <dd className="text-foreground" data-testid="overview-active-season">
+                {activeSeason?.name ?? "—"}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-muted-foreground">Regular season</dt>
+              <dd
+                className="font-mono tabular-nums text-foreground"
+                data-testid="overview-season-progress"
+              >
+                {progress.final} / {progress.total} played
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <dt className="text-muted-foreground">Teams</dt>
+              <dd
+                className="font-mono tabular-nums text-foreground"
+                data-testid="overview-team-count"
+              >
+                {teamCount}
+              </dd>
+            </div>
+          </dl>
+
+          <div className="mt-3.5 flex flex-wrap gap-2">
+            <Button asChild variant="default" size="sm">
+              <Link href={`/dashboard/leagues/${league.id}`}>Open league</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/dashboard/seasons">Seasons</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="standings-card">
+        <CardContent>
+          <h3 className="mb-3.5 text-title-22 font-semibold text-foreground">
+            Standings
+          </h3>
+          <ol
+            className="space-y-2 text-sm"
+            data-testid="overview-standings-rows"
+          >
+            {topFive.map((row) => (
+              <li
+                key={row.teamId}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="w-4 shrink-0 font-mono text-xs text-muted-foreground">
+                    {row.leagueRank}
+                  </span>
+                  <TeamMark name={row.teamName} size="sm" />
+                  {standingsHref ? (
+                    <Link
+                      href={standingsHref}
+                      className="truncate text-foreground hover:underline"
+                    >
+                      {row.teamName}
+                    </Link>
+                  ) : (
+                    <span className="truncate text-foreground">{row.teamName}</span>
+                  )}
+                </span>
+                <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
+                  {formatRecord(row.wins, row.losses, row.ties)}
+                </span>
+              </li>
+            ))}
+          </ol>
+          {standingsLinkEnabled && standingsHref && (
+            <Link
+              href={standingsHref}
+              className="mt-3.5 inline-block text-sm text-primary hover:underline"
+              data-testid="overview-full-standings-link"
+            >
+              Full standings →
+            </Link>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -14,7 +14,9 @@ import {
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveBestOrgRole } from "@/lib/org-context";
 import { resolveActiveLeague } from "@/lib/active-league";
-import { canManageOrgSettings, roleLabel } from "@/lib/permissions";
+import { canManageOrgSettings } from "@/lib/permissions";
+import { regularSeasonProgress } from "@/lib/playoffs";
+import { schedulesStandingsV1 } from "@/lib/flags";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -23,7 +25,6 @@ import {
   UserCircle,
   Calendar,
   Layers,
-  CalendarClock,
   ShieldCheck,
   ArrowRight,
 } from "lucide-react";
@@ -34,6 +35,10 @@ import {
   WeekHeatmap,
 } from "./_components/bento/bento-widgets";
 import { LeagueMap } from "./_components/bento/league-map";
+import {
+  DashboardOverview,
+  findActiveSeason,
+} from "./_components/overview/dashboard-overview";
 
 const statCards = [
   { label: "Leagues", href: "/dashboard/leagues", key: "leagues", icon: Trophy },
@@ -42,13 +47,6 @@ const statCards = [
   { label: "Seasons", href: "/dashboard/seasons", key: "seasons", icon: Calendar },
   { label: "Divisions", href: "/dashboard/divisions", key: "divisions", icon: Layers },
 ] as const;
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export default async function DashboardPage() {
   const { userId } = await auth();
@@ -102,8 +100,9 @@ export default async function DashboardPage() {
   const leagueSeasons = activeLeague
     ? seasons.filter((s) => s.leagueId === activeLeague.id)
     : [];
+  const overviewActiveSeason = findActiveSeason(leagueSeasons);
   const activeSeason =
-    leagueSeasons.find((s) => s.status === "active") ?? leagueSeasons[0] ?? null;
+    overviewActiveSeason ?? leagueSeasons[0] ?? null;
 
   const leagueDivisions = activeLeague
     ? divisions.filter((d) => d.leagueId === activeLeague.id)
@@ -126,8 +125,9 @@ export default async function DashboardPage() {
   let fixturesFinal = 0;
   let perWeekGames: number[] = [];
   let perWeekPoints: number[] = [];
-  let nextKickoff: { label: string; date: string } | null = null;
-  let standings: Awaited<ReturnType<typeof computeStandings>> = [];
+  let overviewStandings: Awaited<ReturnType<typeof computeStandings>> = [];
+  let overviewProgress = { total: 0, final: 0, complete: true };
+  let standingsLinkEnabled = false;
   let feed: {
     week: number | null;
     home: string;
@@ -137,6 +137,20 @@ export default async function DashboardPage() {
     homeScore: number;
     awayScore: number;
   }[] = [];
+
+  if (overviewActiveSeason) {
+    standingsLinkEnabled = await schedulesStandingsV1();
+    try {
+      const [fixtures, seasonStandings] = await Promise.all([
+        listFixturesBySeason(overviewActiveSeason.id),
+        computeStandings(overviewActiveSeason.id),
+      ]);
+      overviewProgress = regularSeasonProgress(fixtures);
+      overviewStandings = seasonStandings;
+    } catch (err) {
+      console.error("dashboard: overview failed to load", err);
+    }
+  }
 
   if (activeSeason) {
     // Incident hardening: a single failing season-data read must not crash the
@@ -170,18 +184,6 @@ export default async function DashboardPage() {
         }, 0),
     );
 
-    const upcoming = fixtures
-      .filter((f) => f.status === "scheduled" && f.scheduledAt)
-      .sort((a, b) => (a.scheduledAt! < b.scheduledAt! ? -1 : 1))[0];
-    if (upcoming) {
-      nextKickoff = {
-        label: `${upcoming.homeTeamName} vs ${upcoming.awayTeamName}`,
-        date: formatDate(upcoming.scheduledAt!),
-      };
-    }
-
-    standings = (await computeStandings(activeSeason.id)).slice(0, 5);
-
     feed = fixtures
       .filter((f) => f.status === "final")
       .map((f) => ({ f, r: resultByFixture.get(f.id) }))
@@ -204,18 +206,9 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div>
         <h2 className="text-lg font-semibold text-foreground">Overview</h2>
-        {activeLeague && (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Trophy className="h-4 w-4" />
-            <span className="font-medium text-foreground">
-              {activeLeague.name}
-            </span>
-            {activeSeason && <Badge variant="secondary">{activeSeason.name}</Badge>}
-            {role && <Badge variant="outline">{roleLabel(role)}</Badge>}
-          </div>
-        )}
+        <p className="text-sm text-muted-foreground">Your league at a glance.</p>
       </div>
 
       {/* Quick-nav stat strip */}
@@ -257,45 +250,17 @@ export default async function DashboardPage() {
           </p>
         </BentoCard>
       ) : (
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
-          {/* Hero */}
-          <BentoCard title="This league" className="lg:col-span-2">
-            <div className="flex flex-1 flex-col justify-between gap-4">
-              <div>
-                <p className="text-title-22 text-foreground">
-                  <Link
-                    href={`/dashboard/leagues/${activeLeague!.id}`}
-                    className="hover:underline"
-                  >
-                    {activeLeague!.name}
-                  </Link>
-                </p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {leagueTeams.length} team{leagueTeams.length === 1 ? "" : "s"} ·{" "}
-                  {leaguePlayers.length} player
-                  {leaguePlayers.length === 1 ? "" : "s"} ·{" "}
-                  {activeSeason ? activeSeason.name : "no active season"}
-                </p>
-              </div>
-              {nextKickoff ? (
-                <div className="flex items-center gap-2 rounded-lg border border-border p-3 text-sm">
-                  <CalendarClock className="h-4 w-4 text-muted-foreground" />
-                  <span className="text-muted-foreground">Next:</span>
-                  <span className="font-medium text-foreground">
-                    {nextKickoff.label}
-                  </span>
-                  <span className="ml-auto font-mono text-muted-foreground">
-                    {nextKickoff.date}
-                  </span>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  No upcoming games scheduled.
-                </p>
-              )}
-            </div>
-          </BentoCard>
+        <>
+          <DashboardOverview
+            league={activeLeague!}
+            activeSeason={overviewActiveSeason}
+            teamCount={leagueTeams.length}
+            progress={overviewProgress}
+            standings={overviewStandings}
+            standingsLinkEnabled={standingsLinkEnabled}
+          />
 
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
           {/* Season health gauges */}
           <BentoCard title="Season health" className="lg:col-span-2">
             <div className="flex flex-1 items-center justify-around gap-4">
@@ -350,51 +315,6 @@ export default async function DashboardPage() {
               </div>
             </BentoCard>
           )}
-
-          {/* Standings */}
-          <BentoCard
-            title="Standings"
-            className="lg:col-span-2"
-            action={
-              activeSeason ? (
-                <Link
-                  href={`/dashboard/leagues/${activeLeague!.id}/standings`}
-                  className="text-xs text-primary hover:underline"
-                >
-                  View all
-                </Link>
-              ) : undefined
-            }
-          >
-            {standings.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No standings yet — record some game results.
-              </p>
-            ) : (
-              <ul className="space-y-1.5">
-                {standings.map((s) => (
-                  <li
-                    key={s.teamId}
-                    className="flex items-center gap-3 text-sm"
-                  >
-                    <span className="w-5 text-right font-mono text-muted-foreground">
-                      {s.leagueRank}
-                    </span>
-                    <Link
-                      href={`/dashboard/teams/${s.teamId}`}
-                      className="flex-1 truncate font-medium text-foreground hover:underline"
-                    >
-                      {s.teamName}
-                    </Link>
-                    <span className="font-mono text-muted-foreground">
-                      {s.wins}-{s.losses}
-                      {s.ties ? `-${s.ties}` : ""}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </BentoCard>
 
           {/* Activity feed */}
           <BentoCard title="Recent results" className="lg:col-span-2">
@@ -462,6 +382,7 @@ export default async function DashboardPage() {
             <LeagueMap teams={leagueTeams} />
           </BentoCard>
         </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/__tests__/team-mark.test.ts
+++ b/apps/web/src/components/__tests__/team-mark.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TeamMark } from "../team-mark";
+
+describe("TeamMark", () => {
+  it("renders two-letter initials from a multi-word team name", () => {
+    const html = renderToStaticMarkup(createElement(TeamMark, { name: "Dallas Cowboys" }));
+    expect(html).toContain("DC");
+  });
+
+  it("renders initials for a single-word team name", () => {
+    const html = renderToStaticMarkup(createElement(TeamMark, { name: "Cowboys" }));
+    expect(html).toContain("CO");
+  });
+});

--- a/apps/web/src/components/team-mark.tsx
+++ b/apps/web/src/components/team-mark.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+
+export type TeamMarkSize = "sm" | "md" | "lg";
+
+const SIZE_CLASSES: Record<TeamMarkSize, string> = {
+  sm: "h-6 w-6 text-[10px]",
+  md: "h-7 w-7 text-[11px]",
+  lg: "h-10 w-10 text-xs",
+};
+
+/** Derive two-letter initials from a team name (prototype SL.initials). */
+export function teamInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return `${words[0]![0] ?? ""}${words[words.length - 1]![0] ?? ""}`.toUpperCase();
+}
+
+/** Fallback brand color derived from the team name (prototype SL.teamColor). */
+export function teamMarkColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `oklch(0.62 0.14 ${hue})`;
+}
+
+export interface TeamMarkProps {
+  name: string;
+  /** Team brand color from data; falls back to a name-derived hue. */
+  primaryColor?: string | null;
+  size?: TeamMarkSize;
+  className?: string;
+}
+
+/**
+ * Initials-on-color team mark (leagues-seasons prototype TeamMark): tinted
+ * square with the team color as text and border, mono initials.
+ */
+export function TeamMark({
+  name,
+  primaryColor,
+  size = "md",
+  className,
+}: TeamMarkProps) {
+  const color = primaryColor || teamMarkColor(name);
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-md border font-mono font-bold leading-none",
+        SIZE_CLASSES[size],
+        className,
+      )}
+      style={{
+        color,
+        borderColor: `color-mix(in oklab, ${color} 35%, transparent)`,
+        backgroundColor: `color-mix(in oklab, ${color} 18%, transparent)`,
+      }}
+    >
+      {teamInitials(name)}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
Dashboard Overview per the leagues-seasons handoff (WSM-000253): league summary card (trophy header, active-season row, regular-season progress "X / Y played", team count) and a top-5 Standings card with TeamMark rows and a verbatim "Full standings →" link. "Open league" / "Seasons" actions navigate to the league hub and seasons list. With no active season, an EmptyState with guidance replaces the progress content (per AC #3). Adds the canonical `TeamMark` component (prototype visual: tinted square, team color, mono initials).

Read-only: no Convex changes; all data via existing `data-api.ts` wrappers. Spec: `docs/design_handoff/leagues-seasons/README.md` (lands via #558).

## Tests
- Unit: dashboard-overview (active + no-active-season EmptyState), team-mark initials — pass (1201 tests)
- E2E: new `dashboard-overview.spec.ts` (cards, progress, standings rows, navigation) — runs in CI
- Lint + type-check pass

## Related Issue
Closes #555
