### PR TITLE
feat(web): seasons list redesign and two-step season dialog (WSM-000255)

### DIFF
--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -206,15 +206,8 @@ export async function completeSeason(
   });
   await seasonRow.getByRole("button", { name: /^Complete / }).click();
   if (opts.forceWithoutChampion) {
-    // No playoff champion: confirming "Complete <season>?" opens a second
-    // "Complete without a champion?" force-completion dialog instead of
-    // closing. Name-scope both confirms (both dialogs share the testid).
     await confirmLifecycleDialog(page, {
-      name: /^Complete (?!without a champion\?)/,
-      expectClose: false,
-    });
-    await confirmLifecycleDialog(page, {
-      name: "Complete without a champion?",
+      name: "Complete season anyway?",
     });
   } else {
     await confirmLifecycleDialog(page);

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -349,8 +349,8 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
 
     // Complete the season (WSM-000238 lifecycle), then re-open the schedule:
     // read-only history — every mutation control is gone. This league never
-    // ran playoffs, so completion chains into the "Complete without a
-    // champion?" force-confirmation.
+    // ran playoffs, so no champion is decided and completing opens the
+    // "Complete season anyway?" force-confirmation directly (WSM-000255).
     await completeSeason(page, fixture!.seasonId, {
       forceWithoutChampion: true,
     });

--- a/apps/web/e2e/tests/seasons-list-redesign.spec.ts
+++ b/apps/web/e2e/tests/seasons-list-redesign.spec.ts
@@ -34,12 +34,17 @@ test.describe("Seasons list redesign — canonical rows (WSM-000255)", () => {
       has: page.getByText(LEAGUES.NFL),
     });
     const rows = nflCard.locator('[data-testid="season-row"]');
-    const names = await rows
-      .locator('a[href^="/dashboard/seasons/"]')
-      .allTextContents();
+    const nameLinks = rows.locator('a[href^="/dashboard/seasons/"]');
+    // allTextContents() does not auto-wait — anchor on the seeded rows first.
+    await expect(nameLinks.filter({ hasText: SEASONS.NFL_2024.name })).toBeVisible();
+    const names = await nameLinks.allTextContents();
 
-    expect(names[0]).toContain(SEASONS.NFL_2025.name);
-    expect(names[1]).toContain(SEASONS.NFL_2024.name);
+    // Other specs may leave extra upcoming seasons in the canonical league;
+    // assert the active season leads and precedes the completed one.
+    const active = names.findIndex((n) => n.includes(SEASONS.NFL_2025.name));
+    const completed = names.findIndex((n) => n.includes(SEASONS.NFL_2024.name));
+    expect(active).toBe(0);
+    expect(completed).toBeGreaterThan(active);
 
     const activeRow = rows.filter({ hasText: SEASONS.NFL_2025.name });
     await expect(activeRow.getByText(SEASONS.NFL_2025.status, { exact: true })).toBeVisible();
@@ -116,7 +121,12 @@ test.describe("Seasons list redesign — lifecycle actions (WSM-000255)", () => 
     await startNextSeason(page);
     const upcomingLink = page.getByRole("link", { name: /View E2E Season/ });
     await expect(upcomingLink).toBeVisible({ timeout: 60_000 });
-    upcomingSeasonName = (await upcomingLink.textContent())?.replace(/^View /, "") ?? null;
+    // Link text is "View {name} →" — strip both the prefix and the arrow.
+    upcomingSeasonName =
+      (await upcomingLink.textContent())
+        ?.replace(/^View /, "")
+        .replace(/\s*→\s*$/, "")
+        .trim() ?? null;
     await context.close();
   });
 

--- a/apps/web/e2e/tests/seasons-list-redesign.spec.ts
+++ b/apps/web/e2e/tests/seasons-list-redesign.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import path from "node:path";
-import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
-import { SEASONS, LEAGUES } from "../helpers/test-data";
 import {
   withScheduleFixture,
   type ScheduleFixtureResult,
@@ -10,7 +8,6 @@ import {
 import { getTestOrgId } from "../helpers/seed-roster";
 import {
   acceptBrowserConfirms,
-  awaitProcessDialog,
   bootstrapFourTeamSimLeague,
   completeSeason,
   confirmLifecycleDialog,
@@ -20,71 +17,11 @@ import {
 
 const STORAGE_STATE = path.resolve("e2e", ".auth", "user.json");
 
-test.describe("Seasons list redesign — canonical rows (WSM-000255)", () => {
-  test.beforeEach(async ({ page }) => {
-    await setupClerkTestingToken({ page });
-    await setActiveLeague(page, readCanonicalFixture().leagueId);
-    await page.goto("/dashboard/seasons");
-  });
-
-  test("sorts active season before completed and shows archive meta", async ({
-    page,
-  }) => {
-    const nflCard = page.locator('[data-slot="card"]', {
-      has: page.getByText(LEAGUES.NFL),
-    });
-    const rows = nflCard.locator('[data-testid="season-row"]');
-    const nameLinks = rows.locator('a[href^="/dashboard/seasons/"]');
-    // allTextContents() does not auto-wait — anchor on the seeded rows first.
-    await expect(nameLinks.filter({ hasText: SEASONS.NFL_2024.name })).toBeVisible();
-    const names = await nameLinks.allTextContents();
-
-    // Other specs may leave extra upcoming seasons in the canonical league;
-    // assert the active season leads and precedes the completed one.
-    const active = names.findIndex((n) => n.includes(SEASONS.NFL_2025.name));
-    const completed = names.findIndex((n) => n.includes(SEASONS.NFL_2024.name));
-    expect(active).toBe(0);
-    expect(completed).toBeGreaterThan(active);
-
-    const activeRow = rows.filter({ hasText: SEASONS.NFL_2025.name });
-    await expect(activeRow.getByText(SEASONS.NFL_2025.status, { exact: true })).toBeVisible();
-    await expect(activeRow.getByText("No games yet")).toBeVisible();
-
-    const completedRow = rows.filter({ hasText: SEASONS.NFL_2024.name });
-    await expect(
-      completedRow.getByText(SEASONS.NFL_2024.status, { exact: true }),
-    ).toBeVisible();
-    await expect(completedRow.getByText("No games yet")).toBeVisible();
-  });
-
-  test("new season dialog requires a name then offers schedule shortcut", async ({
-    page,
-  }) => {
-    const nflCard = page.locator('[data-slot="card"]', {
-      has: page.getByText(LEAGUES.NFL),
-    });
-    await nflCard.getByRole("button", { name: "New season" }).click();
-
-    const dialog = page.getByRole("dialog", { name: "New season" });
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByTestId("create-season-submit")).toBeDisabled();
-
-    const seasonName = `E2E Season ${Date.now()}`;
-    await dialog.getByLabel("Season name").fill(seasonName);
-    await expect(dialog.getByTestId("create-season-submit")).toBeEnabled();
-    await dialog.getByTestId("create-season-submit").click();
-
-    const success = page.getByRole("dialog", { name: "Season created" });
-    await expect(success).toBeVisible({ timeout: 30_000 });
-    await expect(success.getByText(
-      `Created ${seasonName}. Rosters start empty (0/48).`,
-    )).toBeVisible();
-
-    await success.getByTestId("create-season-generate-schedule").click();
-    await expect(page).toHaveURL(/\/dashboard\/leagues\/[^/]+\/schedule/);
-  });
-});
-
+// All assertions run against this suite's own fixture league. The canonical
+// shared league is mutated by other specs and earlier CI runs (stray seasons,
+// active-season churn on the shared dev backend), so row-order and status
+// assertions there are inherently flaky. Sorting logic itself is unit-tested
+// in src/lib/__tests__/season-list.test.ts; this suite verifies the wiring.
 test.describe("Seasons list redesign — lifecycle actions (WSM-000255)", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -173,11 +110,20 @@ test.describe("Seasons list redesign — lifecycle actions (WSM-000255)", () => 
     await expect(warning.getByText(/\(0\/48\)/)).toBeVisible();
     await expect(warning.getByTestId("activate-season-autofill")).toBeVisible();
 
+    // On success the ProcessDialog closes itself and chains into activation,
+    // so wait for it to appear then disappear rather than for a Close button.
     await warning.getByTestId("activate-season-autofill").click();
-    await awaitProcessDialog(page, { timeout: 180_000 });
+    const process = page.getByTestId("process-dialog");
+    await expect(process).toBeVisible({ timeout: 30_000 });
+    await expect(process).toBeHidden({ timeout: 180_000 });
     await expect(page.getByText(/is now the active season\./)).toBeVisible({
       timeout: 60_000,
     });
+
+    // Active-first sort wiring: the newly activated season leads its card.
+    await expect(
+      card.locator('[data-testid="season-row"]').first(),
+    ).toContainText(upcomingSeasonName!, { timeout: 30_000 });
   });
 
   test("complete season opens confirmation dialogs", async ({ page }) => {
@@ -193,5 +139,32 @@ test.describe("Seasons list redesign — lifecycle actions (WSM-000255)", () => 
 
     await confirmLifecycleDialog(page, { name: "Complete season anyway?" });
     await expect(page.getByText(/completed\./)).toBeVisible({ timeout: 60_000 });
+  });
+
+  test("new season dialog requires a name then offers schedule shortcut", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId("create-season-submit")).toBeDisabled();
+
+    const seasonName = `E2E Season ${Date.now()}`;
+    await dialog.getByLabel("Season name").fill(seasonName);
+    await expect(dialog.getByTestId("create-season-submit")).toBeEnabled();
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    await expect(success.getByText(
+      `Created ${seasonName}. Rosters start empty (0/48).`,
+    )).toBeVisible();
+
+    await success.getByTestId("create-season-generate-schedule").click();
+    await expect(page).toHaveURL(/\/dashboard\/leagues\/[^/]+\/schedule/);
   });
 });

--- a/apps/web/e2e/tests/seasons-list-redesign.spec.ts
+++ b/apps/web/e2e/tests/seasons-list-redesign.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import path from "node:path";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
+import { SEASONS, LEAGUES } from "../helpers/test-data";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import {
+  acceptBrowserConfirms,
+  awaitProcessDialog,
+  bootstrapFourTeamSimLeague,
+  completeSeason,
+  confirmLifecycleDialog,
+  simToChampion,
+  startNextSeason,
+} from "../helpers/sim-league-setup";
+
+const STORAGE_STATE = path.resolve("e2e", ".auth", "user.json");
+
+test.describe("Seasons list redesign — canonical rows (WSM-000255)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    await setActiveLeague(page, readCanonicalFixture().leagueId);
+    await page.goto("/dashboard/seasons");
+  });
+
+  test("sorts active season before completed and shows archive meta", async ({
+    page,
+  }) => {
+    const nflCard = page.locator('[data-slot="card"]', {
+      has: page.getByText(LEAGUES.NFL),
+    });
+    const rows = nflCard.locator('[data-testid="season-row"]');
+    const names = await rows
+      .locator('a[href^="/dashboard/seasons/"]')
+      .allTextContents();
+
+    expect(names[0]).toContain(SEASONS.NFL_2025.name);
+    expect(names[1]).toContain(SEASONS.NFL_2024.name);
+
+    const activeRow = rows.filter({ hasText: SEASONS.NFL_2025.name });
+    await expect(activeRow.getByText(SEASONS.NFL_2025.status, { exact: true })).toBeVisible();
+    await expect(activeRow.getByText("No games yet")).toBeVisible();
+
+    const completedRow = rows.filter({ hasText: SEASONS.NFL_2024.name });
+    await expect(
+      completedRow.getByText(SEASONS.NFL_2024.status, { exact: true }),
+    ).toBeVisible();
+    await expect(completedRow.getByText("No games yet")).toBeVisible();
+  });
+
+  test("new season dialog requires a name then offers schedule shortcut", async ({
+    page,
+  }) => {
+    const nflCard = page.locator('[data-slot="card"]', {
+      has: page.getByText(LEAGUES.NFL),
+    });
+    await nflCard.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId("create-season-submit")).toBeDisabled();
+
+    const seasonName = `E2E Season ${Date.now()}`;
+    await dialog.getByLabel("Season name").fill(seasonName);
+    await expect(dialog.getByTestId("create-season-submit")).toBeEnabled();
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    await expect(success.getByText(
+      `Created ${seasonName}. Rosters start empty (0/48).`,
+    )).toBeVisible();
+
+    await success.getByTestId("create-season-generate-schedule").click();
+    await expect(page).toHaveURL(/\/dashboard\/leagues\/[^/]+\/schedule/);
+  });
+});
+
+test.describe("Seasons list redesign — lifecycle actions (WSM-000255)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "seasons-list-redesign";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let upcomingSeasonName: string | null = null;
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(300_000);
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E SL Home",
+      awayTeamName: "E2E SL Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    const context = await browser.newContext({ storageState: STORAGE_STATE });
+    const page = await context.newPage();
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+    await bootstrapFourTeamSimLeague(page, fixture.leagueId, LEAGUE_NAME, {
+      playoffTeams: 4,
+    });
+    await simToChampion(page);
+    await completeSeason(page, fixture.seasonId);
+    await page.goto(`/dashboard/leagues/${fixture.leagueId}`);
+    await startNextSeason(page);
+    const upcomingLink = page.getByRole("link", { name: /View E2E Season/ });
+    await expect(upcomingLink).toBeVisible({ timeout: 60_000 });
+    upcomingSeasonName = (await upcomingLink.textContent())?.replace(/^View /, "") ?? null;
+    await context.close();
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(300_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("completed season row shows games progress and champion trophy", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    const completedRow = card.locator('[data-testid="season-row"]').filter({
+      hasText: "E2E Season",
+      has: page.getByText("Completed", { exact: true }),
+    });
+    await expect(completedRow).toBeVisible();
+    await expect(completedRow.getByText(/\d+ \/ \d+ games/)).toBeVisible();
+    await expect(completedRow.locator("svg.lucide-trophy")).toBeVisible();
+  });
+
+  test("make active shows undersized roster dialog and auto-fill path", async ({
+    page,
+  }) => {
+    if (!fixture || !upcomingSeasonName) test.skip();
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    const upcomingRow = card.locator('[data-testid="season-row"]').filter({
+      hasText: upcomingSeasonName!,
+    });
+    await upcomingRow
+      .getByRole("button", { name: `Make ${upcomingSeasonName} active` })
+      .click();
+
+    const warning = page.getByTestId("activate-season-warning-dialog");
+    await expect(warning).toBeVisible();
+    await expect(warning.getByText(/\(0\/48\)/)).toBeVisible();
+    await expect(warning.getByTestId("activate-season-autofill")).toBeVisible();
+
+    await warning.getByTestId("activate-season-autofill").click();
+    await awaitProcessDialog(page, { timeout: 180_000 });
+    await expect(page.getByText(/is now the active season\./)).toBeVisible({
+      timeout: 60_000,
+    });
+  });
+
+  test("complete season opens confirmation dialogs", async ({ page }) => {
+    if (!fixture || !upcomingSeasonName) test.skip();
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    const activeRow = card.locator('[data-testid="season-row"]').filter({
+      hasText: upcomingSeasonName!,
+    });
+    await activeRow
+      .getByRole("button", { name: `Complete ${upcomingSeasonName}` })
+      .click();
+
+    await confirmLifecycleDialog(page, { name: "Complete season anyway?" });
+    await expect(page.getByText(/completed\./)).toBeVisible({ timeout: 60_000 });
+  });
+});

--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -21,7 +21,7 @@ import { StatusBadge } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { Calendar, Trophy } from "lucide-react";
 import { formatDate } from "@/lib/format";
-import { isSeasonDecided } from "@/lib/dynasty";
+import { isChampionDecided } from "@/lib/dynasty";
 import {
   formatSeasonRecord,
   sortSeasons,
@@ -47,7 +47,7 @@ async function fetchSeasonArchive(seasonId: string): Promise<SeasonArchiveMeta> 
   return {
     gamesFinal,
     gamesTotal,
-    seasonDecided: isSeasonDecided(fixtures, bracket),
+    championDecided: isChampionDecided(bracket),
     leader: leaderRow
       ? {
           teamName: leaderRow.teamName,
@@ -229,8 +229,9 @@ export default async function SeasonsPage() {
                           </div>
                           <SeasonRowActions
                             season={season}
-                            seasonDecided={
-                              seasonArchives.get(season.id)?.seasonDecided ?? false
+                            championDecided={
+                              seasonArchives.get(season.id)?.championDecided ??
+                              false
                             }
                             undersizedTeams={undersizedBySeason.get(season.id) ?? []}
                           />

--- a/apps/web/src/app/dashboard/seasons/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/page.tsx
@@ -21,22 +21,16 @@ import { StatusBadge } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { Calendar, Trophy } from "lucide-react";
 import { formatDate } from "@/lib/format";
+import { isSeasonDecided } from "@/lib/dynasty";
+import {
+  formatSeasonRecord,
+  sortSeasons,
+  type SeasonArchiveMeta,
+} from "@/lib/season-list";
 import { CreateSeasonButton, SeasonRowActions } from "./season-actions";
 import { PageHeader } from "../_components/page-header";
 
-interface SeasonArchive {
-  gamesFinal: number;
-  gamesTotal: number;
-  leader: {
-    teamName: string;
-    wins: number;
-    losses: number;
-    ties: number;
-  } | null;
-  champion: { teamName: string | null } | null;
-}
-
-async function fetchSeasonArchive(seasonId: string): Promise<SeasonArchive> {
+async function fetchSeasonArchive(seasonId: string): Promise<SeasonArchiveMeta> {
   const [fixtures, standings, bracket] = await Promise.all([
     listFixturesBySeason(seasonId).catch(() => []),
     computeStandings(seasonId).catch(() => []),
@@ -53,6 +47,7 @@ async function fetchSeasonArchive(seasonId: string): Promise<SeasonArchive> {
   return {
     gamesFinal,
     gamesTotal,
+    seasonDecided: isSeasonDecided(fixtures, bracket),
     leader: leaderRow
       ? {
           teamName: leaderRow.teamName,
@@ -65,11 +60,7 @@ async function fetchSeasonArchive(seasonId: string): Promise<SeasonArchive> {
   };
 }
 
-function formatRecord(wins: number, losses: number, ties: number) {
-  return `${wins}-${losses}${ties ? `-${ties}` : ""}`;
-}
-
-function SeasonArchiveSummary({ archive }: { archive: SeasonArchive | undefined }) {
+function SeasonArchiveSummary({ archive }: { archive: SeasonArchiveMeta | undefined }) {
   if (!archive || archive.gamesTotal === 0) {
     return <p className="text-xs text-muted-foreground">No games yet</p>;
   }
@@ -86,7 +77,7 @@ function SeasonArchiveSummary({ archive }: { archive: SeasonArchive | undefined 
             {archive.leader.teamName}{" "}
             <span className="font-mono">
               (
-              {formatRecord(
+              {formatSeasonRecord(
                 archive.leader.wins,
                 archive.leader.losses,
                 archive.leader.ties,
@@ -188,7 +179,7 @@ export default async function SeasonsPage() {
       ) : (
         <div className="space-y-6">
           {leagues.map((league) => {
-            const leagueSeasons = seasonsByLeague.get(league.id) ?? [];
+            const leagueSeasons = sortSeasons(seasonsByLeague.get(league.id) ?? []);
             return (
               <Card key={league.id}>
                 <CardHeader>
@@ -215,7 +206,8 @@ export default async function SeasonsPage() {
                       {leagueSeasons.map((season) => (
                         <li
                           key={season.id}
-                          className="flex flex-wrap items-center justify-between gap-3 px-3 py-2"
+                          className="flex flex-wrap items-center justify-between gap-3 px-1 py-4"
+                          data-testid="season-row"
                         >
                           <div className="min-w-0 flex-1 space-y-1">
                             <div className="flex min-w-0 flex-wrap items-center gap-3">
@@ -237,6 +229,9 @@ export default async function SeasonsPage() {
                           </div>
                           <SeasonRowActions
                             season={season}
+                            seasonDecided={
+                              seasonArchives.get(season.id)?.seasonDecided ?? false
+                            }
                             undersizedTeams={undersizedBySeason.get(season.id) ?? []}
                           />
                         </li>

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -26,6 +26,7 @@ import {
 import { toast } from "sonner";
 import { Plus, Trash2, Pencil, CheckCircle2, Users, Trophy } from "lucide-react";
 import type { UndersizedTeam } from "@/lib/offseason-activate";
+import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
 import { ActivateSeasonWarningDialog } from "@/components/offseason/ActivateSeasonWarningDialog";
 import { ActionConfirmDialog } from "@/components/lifecycle/ActionConfirmDialog";
 import {
@@ -56,6 +57,9 @@ const SIMULATION_FLAVOR_OPTIONS: {
   { value: "chalk", label: "Chalk (favorites)" },
   { value: "upsets", label: "Upsets" },
 ];
+
+/** Defaults for create — hidden from the two-step dialog (WSM-000255). */
+const DEFAULT_CREATE_SIMULATION_FLAVOR: SimulationFlavor = "balanced";
 
 function playoffTeamOptions(current: number): number[] {
   const base = [0, ...PLAYOFF_TEAM_OPTIONS];
@@ -155,12 +159,10 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
   const [endDate, setEndDate] = useState("");
   const [playoffTeams, setPlayoffTeams] = useState(8);
   const [playoffFormat, setPlayoffFormat] = useState("single");
-  const [divisionWinnersQualify, setDivisionWinnersQualify] = useState(false);
-  const [simulationFlavor, setSimulationFlavor] =
-    useState<SimulationFlavor>("balanced");
   const [busy, setBusy] = useState(false);
   /** Name of the season just created; non-null switches the dialog to its success state. */
   const [createdName, setCreatedName] = useState<string | null>(null);
+  const [createdId, setCreatedId] = useState<string | null>(null);
 
   function resetForm() {
     setName("");
@@ -168,9 +170,8 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
     setEndDate("");
     setPlayoffTeams(8);
     setPlayoffFormat("single");
-    setDivisionWinnersQualify(false);
-    setSimulationFlavor("balanced");
     setCreatedName(null);
+    setCreatedId(null);
   }
 
   function handleOpenChange(next: boolean) {
@@ -189,12 +190,13 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
       endDate: nullableDate(endDate),
       playoffTeams,
       playoffFormat,
-      divisionWinnersQualify,
-      simulationFlavor,
+      divisionWinnersQualify: false,
+      simulationFlavor: DEFAULT_CREATE_SIMULATION_FLAVOR,
     });
     setBusy(false);
     if (res.ok) {
       setCreatedName(trimmed);
+      setCreatedId(res.id);
       router.refresh();
     } else {
       toast.error(res.error === "not_admin" ? "Only league admins can add seasons." : res.error);
@@ -215,8 +217,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
             <DialogHeader>
               <DialogTitle>New season</DialogTitle>
               <DialogDescription>
-                Add a season to this league to unlock rosters, schedules, and
-                player attributes.
+                Add a season to unlock rosters, schedules, and player attributes.
               </DialogDescription>
             </DialogHeader>
             <form
@@ -232,7 +233,7 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
                   id="season-name"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. 2026"
+                  placeholder="e.g. Cobb Football 2028"
                 />
               </div>
               <div className="grid grid-cols-2 gap-4">
@@ -292,34 +293,6 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
                   </Select>
                 </div>
               </div>
-              <div className="grid gap-2">
-                <Label htmlFor="season-simulation-flavor">Simulation flavor</Label>
-                <Select
-                  value={simulationFlavor}
-                  onValueChange={(v) =>
-                    setSimulationFlavor(v as SimulationFlavor)
-                  }
-                >
-                  <SelectTrigger id="season-simulation-flavor">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SIMULATION_FLAVOR_OPTIONS.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <label className="flex items-center gap-2 text-sm text-foreground">
-                <input
-                  type="checkbox"
-                  checked={divisionWinnersQualify}
-                  onChange={(e) => setDivisionWinnersQualify(e.target.checked)}
-                />
-                Division winners automatically qualify for playoffs
-              </label>
               <DialogFooter className="pt-2">
                 <Button
                   type="button"
@@ -329,7 +302,11 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
                 >
                   Cancel
                 </Button>
-                <Button type="submit" disabled={busy || name.trim() === ""}>
+                <Button
+                  type="submit"
+                  disabled={busy || name.trim() === ""}
+                  data-testid="create-season-submit"
+                >
                   {busy ? "Creating…" : "Create season"}
                 </Button>
               </DialogFooter>
@@ -346,14 +323,19 @@ export function CreateSeasonButton({ leagueId }: { leagueId: string }) {
             </DialogHeader>
             <div className="flex items-center gap-2 text-sm text-foreground">
               <CheckCircle2 className="h-5 w-5 shrink-0 text-primary" />
-              <span>Created {createdName}.</span>
+              <span>
+                Created {createdName}. Rosters start empty (0/
+                {DEFAULT_TARGET_ROSTER_SIZE}).
+              </span>
             </div>
             <DialogFooter className="pt-2">
               <Button variant="ghost" onClick={() => handleOpenChange(false)}>
                 Done
               </Button>
-              <Button asChild>
-                <Link href={`/dashboard/leagues/${leagueId}/schedule`}>
+              <Button asChild data-testid="create-season-generate-schedule">
+                <Link
+                  href={`/dashboard/leagues/${leagueId}/schedule${createdId ? `?seasonId=${createdId}` : ""}`}
+                >
                   Generate schedule
                 </Link>
               </Button>
@@ -421,9 +403,9 @@ export function CopyRostersButton({ season }: { season: SeasonDto }) {
       <ActionConfirmDialog
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
-        title="Replace existing rosters?"
-        description={`${season.name} already has rosters. Copying replaces them with last season's rosters. This can't be undone. Continue?`}
-        confirmLabel="Continue"
+        title="Replace rosters?"
+        description={`${season.name} already has rosters. Copying replaces them with the most recent prior season's rosters. This can't be undone.`}
+        confirmLabel="Copy & replace"
         destructive
         pending={busy}
         onConfirm={() => void run(true)}
@@ -434,9 +416,11 @@ export function CopyRostersButton({ season }: { season: SeasonDto }) {
 
 export function SeasonRowActions({
   season,
+  seasonDecided = false,
   undersizedTeams = [],
 }: {
   season: SeasonDto;
+  seasonDecided?: boolean;
   undersizedTeams?: UndersizedTeam[];
 }) {
   const router = useRouter();
@@ -496,7 +480,7 @@ export function SeasonRowActions({
     setBusy(false);
     if (res.ok) {
       toast.success(`${season.name} completed.`, {
-        description: "Run the dynasty rollover from the league page next.",
+        description: "Start the next season from the league page.",
         action: {
           label: "League page",
           onClick: () =>
@@ -513,7 +497,7 @@ export function SeasonRowActions({
   }
 
   function complete() {
-    setCompleteStep("complete");
+    setCompleteStep(seasonDecided ? "complete" : "force");
   }
 
   async function save() {
@@ -654,6 +638,7 @@ export function SeasonRowActions({
       <ActivateSeasonWarningDialog
         open={activateWarningOpen}
         seasonName={season.name}
+        leagueId={season.leagueId}
         undersizedTeams={undersizedTeams}
         busy={busy}
         onCancel={() => setActivateWarningOpen(false)}
@@ -665,8 +650,8 @@ export function SeasonRowActions({
           if (!open && !busy) setCompleteStep(null);
         }}
         title={`Complete ${season.name}?`}
-        description="Schedule generation, result recording, and simulations will be locked for it."
-        confirmLabel="Complete"
+        description="Schedule generation, result recording, and simulation will be locked for it."
+        confirmLabel="Complete season"
         pending={busy}
         onConfirm={() => void runComplete(false)}
       />
@@ -675,8 +660,8 @@ export function SeasonRowActions({
         onOpenChange={(open) => {
           if (!open && !busy) setCompleteStep(null);
         }}
-        title="Complete without a champion?"
-        description="No playoff champion has been decided for this season. Complete it anyway?"
+        title="Complete season anyway?"
+        description={`No champion has been decided for ${season.name}. Completing locks schedule generation, result recording, and simulation. Complete anyway?`}
         confirmLabel="Complete anyway"
         destructive
         pending={busy}
@@ -686,8 +671,8 @@ export function SeasonRowActions({
         open={deleteConfirmOpen}
         onOpenChange={setDeleteConfirmOpen}
         title={`Delete ${season.name}?`}
-        description="This deletes its schedule, results, and attributes. This can't be undone."
-        confirmLabel="Delete"
+        description="Delete this season and its schedule, results, and attributes? This can't be undone."
+        confirmLabel="Delete season"
         destructive
         pending={busy}
         onConfirm={() => void remove()}

--- a/apps/web/src/app/dashboard/seasons/season-actions.tsx
+++ b/apps/web/src/app/dashboard/seasons/season-actions.tsx
@@ -416,11 +416,11 @@ export function CopyRostersButton({ season }: { season: SeasonDto }) {
 
 export function SeasonRowActions({
   season,
-  seasonDecided = false,
+  championDecided = false,
   undersizedTeams = [],
 }: {
   season: SeasonDto;
-  seasonDecided?: boolean;
+  championDecided?: boolean;
   undersizedTeams?: UndersizedTeam[];
 }) {
   const router = useRouter();
@@ -497,7 +497,7 @@ export function SeasonRowActions({
   }
 
   function complete() {
-    setCompleteStep(seasonDecided ? "complete" : "force");
+    setCompleteStep(championDecided ? "complete" : "force");
   }
 
   async function save() {

--- a/apps/web/src/components/offseason/ActivateSeasonWarningDialog.tsx
+++ b/apps/web/src/components/offseason/ActivateSeasonWarningDialog.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import type { UndersizedTeam } from "@/lib/offseason-activate";
 import { activateSeasonWarningMessage } from "@/lib/offseason-activate";
+import { fillDeficientRostersAction } from "@/app/dashboard/_actions/synthetic-rosters";
+import { rosterAutoFillProcessStages } from "@/lib/process-stages";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,51 +15,126 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ProcessDialog } from "@/components/lifecycle/ProcessDialog";
 
 export interface ActivateSeasonWarningDialogProps {
   open: boolean;
   seasonName: string;
+  leagueId: string;
   undersizedTeams: UndersizedTeam[];
   busy: boolean;
   onCancel: () => void;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
 }
 
 export function ActivateSeasonWarningDialog({
   open,
   seasonName,
+  leagueId,
   undersizedTeams,
   busy,
   onCancel,
   onConfirm,
 }: ActivateSeasonWarningDialogProps) {
+  const router = useRouter();
+  const [autoFillPending, startAutoFill] = useTransition();
+  const [processOpen, setProcessOpen] = useState(false);
+  const [processError, setProcessError] = useState<string | null>(null);
+  const [stages, setStages] = useState(rosterAutoFillProcessStages("pending"));
+
+  const pending = busy || autoFillPending;
+
+  function runAutoFill() {
+    setProcessOpen(true);
+    setProcessError(null);
+    setStages(rosterAutoFillProcessStages("pending"));
+
+    startAutoFill(async () => {
+      const res = await fillDeficientRostersAction({ leagueId });
+      if (!res.ok) {
+        setStages(rosterAutoFillProcessStages("error"));
+        setProcessError(autoFillErrorLabel(res.error));
+        return;
+      }
+      setStages(
+        rosterAutoFillProcessStages("success", {
+          created: res.created,
+          teamsFilled: res.teamsFilled,
+        }),
+      );
+      router.refresh();
+      setProcessOpen(false);
+      await onConfirm();
+    });
+  }
+
   return (
-    <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
-      <DialogContent data-testid="activate-season-warning-dialog">
-        <DialogHeader>
-          <DialogTitle>Activate with undersized rosters?</DialogTitle>
-          <DialogDescription>
-            {activateSeasonWarningMessage(undersizedTeams)}
-          </DialogDescription>
-        </DialogHeader>
-        <p className="text-sm text-muted-foreground">
-          Proceed to make <span className="font-medium text-foreground">{seasonName}</span> the
-          active season anyway?
-        </p>
-        <DialogFooter>
-          <Button type="button" variant="outline" disabled={busy} onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={busy}
-            onClick={onConfirm}
-            data-testid="activate-season-warning-confirm"
-          >
-            {busy ? "Activating…" : "Proceed anyway"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog open={open} onOpenChange={(next) => !next && !pending && onCancel()}>
+        <DialogContent data-testid="activate-season-warning-dialog">
+          <DialogHeader>
+            <DialogTitle>Activate with undersized rosters?</DialogTitle>
+            <DialogDescription>
+              {activateSeasonWarningMessage(undersizedTeams)}
+            </DialogDescription>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Proceed to make{" "}
+            <span className="font-medium text-foreground">{seasonName}</span> the
+            active season anyway?
+          </p>
+          <DialogFooter className="gap-2 sm:justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={pending}
+              onClick={runAutoFill}
+              data-testid="activate-season-autofill"
+            >
+              {autoFillPending ? "Auto-filling…" : "Auto-fill rosters"}
+            </Button>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" disabled={pending} onClick={onCancel}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={pending}
+                onClick={() => void onConfirm()}
+                data-testid="activate-season-warning-confirm"
+              >
+                {busy ? "Activating…" : "Proceed anyway"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ProcessDialog
+        open={processOpen}
+        onOpenChange={setProcessOpen}
+        title="Auto-fill rosters"
+        description="Filling only teams below the roster target."
+        stages={stages}
+        pending={autoFillPending}
+        error={processError}
+        onRetry={runAutoFill}
+      />
+    </>
   );
+}
+
+function autoFillErrorLabel(error: string): string {
+  switch (error) {
+    case "flag_disabled":
+      return "Synthetic rosters aren't enabled.";
+    case "unauthorized":
+      return "Please sign in.";
+    case "not_authorized":
+      return "You don't have permission to auto-fill rosters.";
+    case "season_started":
+      return "Season has started — roster generation is locked.";
+    default:
+      return error;
+  }
 }

--- a/apps/web/src/lib/__tests__/season-list.test.ts
+++ b/apps/web/src/lib/__tests__/season-list.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatSeasonRecord, seasonSortYear, sortSeasons } from "../season-list";
+
+describe("season-list helpers", () => {
+  it("sorts active seasons first then year descending", () => {
+    const seasons = [
+      { id: "1", name: "2024 Season", startDate: "2024-09-01", status: "completed" },
+      { id: "2", name: "2026 Season", startDate: "2026-09-01", status: "upcoming" },
+      { id: "3", name: "2025 Season", startDate: "2025-09-01", status: "active" },
+    ];
+    expect(sortSeasons(seasons).map((s) => s.id)).toEqual(["3", "2", "1"]);
+  });
+
+  it("derives year from season name when start date is missing", () => {
+    expect(seasonSortYear({ name: "Cobb Football 2028", startDate: null })).toBe(2028);
+  });
+
+  it("formats W-L-T records", () => {
+    expect(formatSeasonRecord(10, 2, 0)).toBe("10-2");
+    expect(formatSeasonRecord(8, 3, 1)).toBe("8-3-1");
+  });
+});

--- a/apps/web/src/lib/dynasty.ts
+++ b/apps/web/src/lib/dynasty.ts
@@ -21,6 +21,13 @@ export function incrementSeasonName(name: string): string {
   return `${name} ${new Date().getFullYear() + 1}`;
 }
 
+/** True when a playoff champion exists or is derivable from the bracket. */
+export function isChampionDecided(bracket: PlayoffBracketDto | null): boolean {
+  if (!bracket || bracket.matchups.length === 0) return false;
+  if (bracket.champion) return true;
+  return deriveChampion(bracket.matchups, bracket.format ?? "single") !== null;
+}
+
 /**
  * A season is decided when a playoff champion exists (bracket present), else
  * when every regular-season fixture is final/cancelled.
@@ -30,9 +37,7 @@ export function isSeasonDecided(
   bracket: PlayoffBracketDto | null,
 ): boolean {
   if (bracket && bracket.matchups.length > 0) {
-    if (bracket.champion) return true;
-    const format = bracket.format ?? "single";
-    return deriveChampion(bracket.matchups, format) !== null;
+    return isChampionDecided(bracket);
   }
   return regularSeasonProgress(fixtures).complete;
 }

--- a/apps/web/src/lib/season-list.ts
+++ b/apps/web/src/lib/season-list.ts
@@ -27,7 +27,7 @@ export function sortSeasons<T extends Pick<SeasonDto, "status" | "name" | "start
 export interface SeasonArchiveMeta {
   gamesFinal: number;
   gamesTotal: number;
-  seasonDecided: boolean;
+  championDecided: boolean;
   leader: {
     teamName: string;
     wins: number;

--- a/apps/web/src/lib/season-list.ts
+++ b/apps/web/src/lib/season-list.ts
@@ -1,0 +1,42 @@
+import type { SeasonDto } from "@sports-management/shared-types";
+
+/** Extract a sortable year from season metadata (start date preferred). */
+export function seasonSortYear(season: Pick<SeasonDto, "name" | "startDate">): number {
+  if (season.startDate) {
+    const year = new Date(season.startDate).getFullYear();
+    if (!Number.isNaN(year)) return year;
+  }
+  const match = season.name.match(/\b(19|20)\d{2}\b/);
+  return match ? Number.parseInt(match[0], 10) : 0;
+}
+
+/**
+ * Active season first, then descending year (WSM-000255 / prototype SeasonsScreen).
+ */
+export function sortSeasons<T extends Pick<SeasonDto, "status" | "name" | "startDate">>(
+  seasons: ReadonlyArray<T>,
+): T[] {
+  return [...seasons].sort((a, b) => {
+    const aActive = a.status === "active";
+    const bActive = b.status === "active";
+    if (aActive !== bActive) return aActive ? -1 : 1;
+    return seasonSortYear(b) - seasonSortYear(a);
+  });
+}
+
+export interface SeasonArchiveMeta {
+  gamesFinal: number;
+  gamesTotal: number;
+  seasonDecided: boolean;
+  leader: {
+    teamName: string;
+    wins: number;
+    losses: number;
+    ties: number;
+  } | null;
+  champion: { teamName: string | null } | null;
+}
+
+export function formatSeasonRecord(wins: number, losses: number, ties: number): string {
+  return `${wins}-${losses}${ties ? `-${ties}` : ""}`;
+}


### PR DESCRIPTION
## Summary
Seasons list redesign + two-step New season dialog per the leagues-seasons handoff (WSM-000255): rows sorted active-first then year descending with status badge, date range, and archive meta ("X / Y games" / "No games yet" · leader record · champion with trophy); row actions (Make active / Complete / Copy rosters / rename / delete) use the handoff confirmation copy verbatim, including the stronger "Complete season anyway?" copy when no champion is decided and the danger confirm for populated-roster copies. New season dialog: step 1 (name required, dates, playoff teams None/4/8/16 default 8, single/double elimination), step 2 success with "Generate schedule" shortcut. Activating with undersized rosters lists "{team} (n/48)" with "Proceed anyway" and "Auto-fill rosters" wired to the existing synthetic-roster flow (WSM-000242).

No Convex changes; existing `setActiveSeason`/`completeSeason`/`upsertSeason` via `data-api.ts`. Spec: `docs/design_handoff/leagues-seasons/README.md` (lands via #558).

## Tests
- Unit: new season-list sort/format tests — pass (1197 tests)
- E2E: new `seasons-list-redesign.spec.ts` (sort/meta, two-step create, lifecycle confirms, auto-fill) — runs in CI
- Lint + type-check pass

## Related Issue
Closes #557
