### PR TITLE
feat(web): ranked teams table with team detail sheet (WSM-000248)

### DIFF
--- a/apps/web/e2e/tests/team-detail.spec.ts
+++ b/apps/web/e2e/tests/team-detail.spec.ts
@@ -10,6 +10,9 @@ test.describe("Team Detail Page", () => {
     // Navigate to Cowboys detail via the teams list
     await page.goto("/dashboard/teams");
     await page.locator("a", { hasText: TEAMS.COWBOYS.name }).click();
+    // The teams list is itself a table now — wait for the detail route so
+    // thead/table assertions don't race client-side navigation.
+    await expect(page).toHaveURL(/\/dashboard\/teams\/[^/]+$/);
   });
 
   test("shows team name as heading", async ({ page }) => {

--- a/apps/web/e2e/tests/teams-redesign.spec.ts
+++ b/apps/web/e2e/tests/teams-redesign.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import path from "node:path";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { TEAMS } from "../helpers/test-data";
+import {
+  acceptBrowserConfirms,
+  bootstrapFourTeamSimLeague,
+  simWeek,
+} from "../helpers/sim-league-setup";
+
+const STORAGE_STATE = path.resolve("e2e", ".auth", "user.json");
+
+test.describe("Teams table redesign — canonical league (WSM-000248)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    const canonical = readCanonicalFixture();
+    test.skip(!canonical, "canonical fixture not seeded");
+    await setActiveLeague(page, canonical!.leagueId);
+    await page.goto("/dashboard/teams");
+  });
+
+  test("renders ranked table with canonical teams", async ({ page }) => {
+    const main = page.locator("#main-content");
+    await expect(main.getByRole("heading", { name: "Teams" })).toBeVisible();
+    await expect(main.getByTestId("teams-table")).toBeVisible();
+    await expect(
+      main.getByRole("row", { name: new RegExp(TEAMS.COWBOYS.name) }),
+    ).toBeVisible();
+    await expect(
+      main.getByRole("row", { name: new RegExp(TEAMS.PATRIOTS.name) }),
+    ).toBeVisible();
+  });
+
+  test("row opens detail sheet with team name", async ({ page }) => {
+    const main = page.locator("#main-content");
+    const cowboysRow = main.getByRole("row", {
+      name: new RegExp(TEAMS.COWBOYS.name),
+    });
+    await expect(cowboysRow).toBeVisible();
+    await cowboysRow.click();
+    const sheet = page.getByTestId("team-detail-sheet");
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByText(TEAMS.COWBOYS.name)).toBeVisible();
+  });
+
+  test("team name link navigates to team detail page", async ({ page }) => {
+    const main = page.locator("#main-content");
+    await main.getByRole("link", { name: TEAMS.COWBOYS.name }).click();
+    await expect(
+      page.getByRole("heading", { name: TEAMS.COWBOYS.name }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Teams table redesign — fixture league records (WSM-000248)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "teams-table-redesign";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(300_000);
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E TT Home",
+      awayTeamName: "E2E TT Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    const context = await browser.newContext({ storageState: STORAGE_STATE });
+    const page = await context.newPage();
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+    await bootstrapFourTeamSimLeague(page, fixture.leagueId, LEAGUE_NAME, {
+      playoffTeams: 4,
+    });
+    await page.goto(`/dashboard/leagues/${fixture.leagueId}/schedule`);
+    await simWeek(page, 1);
+    await context.close();
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    if (!fixture) test.skip();
+    await setActiveLeague(page, fixture!.leagueId);
+  });
+
+  test("detail sheet shows record and form after week 1 is simulated", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/teams");
+    const main = page.locator("#main-content");
+    const homeRow = main.getByRole("row", { name: /E2E TT Home/ });
+    await expect(homeRow).toBeVisible();
+    await expect(homeRow).toContainText(/\d+-\d+/);
+    await homeRow.click();
+    const sheet = page.getByTestId("team-detail-sheet");
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByText("E2E TT Home")).toBeVisible();
+    await expect(sheet.getByText(/\d+-\d+/)).toBeVisible();
+    await expect(sheet.getByText("Form · last 5")).toBeVisible();
+    await expect(
+      sheet.locator("span").filter({ hasText: /^[WLT]$/ }).first(),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/teams.spec.ts
+++ b/apps/web/e2e/tests/teams.spec.ts
@@ -1,37 +1,45 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { readCanonicalFixture, setActiveLeague } from "../helpers/seed-canonical";
 import { TEAMS } from "../helpers/test-data";
 
 test.describe("Teams Page", () => {
   test.beforeEach(async ({ page }) => {
     await setupClerkTestingToken({ page });
+    const canonical = readCanonicalFixture();
+    if (canonical) {
+      await setActiveLeague(page, canonical.leagueId);
+    }
     await page.goto("/dashboard/teams");
   });
 
   test("shows Teams heading", async ({ page }) => {
-    await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
+    await expect(
+      page.locator("#main-content").getByRole("heading", { name: "Teams" }),
+    ).toBeVisible();
   });
 
-  test("renders at least 4 team cards", async ({ page }) => {
-    const cards = page.locator("main a[href^='/dashboard/teams/']");
-    await expect(cards.first()).toBeVisible();
-    expect(await cards.count()).toBeGreaterThanOrEqual(4);
+  test("renders at least 4 team rows", async ({ page }) => {
+    const rows = page.locator("#main-content").getByTestId("team-row");
+    await expect(rows.first()).toBeVisible();
+    expect(await rows.count()).toBeGreaterThanOrEqual(4);
   });
 
-  test("Cowboys card shows correct details", async ({ page }) => {
+  test("Cowboys row is present in the table", async ({ page }) => {
+    const main = page.locator("#main-content");
     const cowboys = TEAMS.COWBOYS;
-    const card = page.locator("a", { hasText: cowboys.name });
-    await expect(card).toBeVisible();
-    await expect(card).toContainText(cowboys.city);
-    await expect(card).toContainText(cowboys.stadium);
-    await expect(card).toContainText(String(cowboys.foundedYear));
+    const row = main.getByRole("row", { name: new RegExp(cowboys.name) });
+    await expect(row).toBeVisible();
+    await expect(row.getByRole("link", { name: cowboys.name })).toBeVisible();
   });
 
-  test("each team card is a link", async ({ page }) => {
-    const cards = page.locator("main a[href^='/dashboard/teams/']");
-    await expect(cards.first()).toBeVisible();
-    for (const card of await cards.all()) {
-      const href = await card.getAttribute("href");
+  test("each team name links to the team detail route", async ({ page }) => {
+    const links = page.locator(
+      "#main-content a[href^='/dashboard/teams/']",
+    );
+    await expect(links.first()).toBeVisible();
+    for (const link of await links.all()) {
+      const href = await link.getAttribute("href");
       expect(href).toBeTruthy();
     }
   });

--- a/apps/web/src/app/dashboard/teams/loading.tsx
+++ b/apps/web/src/app/dashboard/teams/loading.tsx
@@ -1,24 +1,29 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
 
 export default function TeamsLoading() {
   return (
     <div>
-      <div className="mb-6 h-6 w-24 animate-pulse rounded bg-muted" />
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, i) => (
+      <div className="mb-6 space-y-2">
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-4 w-48" />
+      </div>
+      <Card className="gap-0 overflow-hidden py-0">
+        <div className="space-y-0 border-b border-border px-4 py-3">
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </div>
+        {Array.from({ length: 8 }).map((_, index) => (
           <div
-            key={i}
-            className="rounded-lg border border-border bg-card p-6"
+            key={index}
+            className="flex items-center gap-4 border-b border-border px-4 py-3 last:border-b-0"
           >
-            <Skeleton className="h-5 w-32" />
-            <div className="mt-3 space-y-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-4 w-20" />
-            </div>
+            <Skeleton className="h-4 w-6" />
+            <Skeleton className="h-7 w-7 rounded-md" />
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="ml-auto h-4 w-16" />
           </div>
         ))}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/teams/page.tsx
+++ b/apps/web/src/app/dashboard/teams/page.tsx
@@ -1,55 +1,208 @@
-import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getTeams } from "@/lib/data-api";
+import type { PlayerDto, Standing, TeamDto } from "@sports-management/shared-types";
+import {
+  computeStandings,
+  getDivisions,
+  getPlayers,
+  getSeasons,
+  getTeamAttributeSnapshots,
+  getTeamMaddenOveralls,
+  getTeamRosterLimitStatus,
+  getTeams,
+  listFixturesBySeason,
+  listResultsBySeason,
+} from "@/lib/data-api";
 import { resolveActiveLeague } from "@/lib/active-league";
-import { PageHeader } from "../_components/page-header";
+import { resolveOrgContext } from "@/lib/org-context";
+import { playerAttributesV1, schedulesStandingsV1 } from "@/lib/flags";
+import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
+import {
+  computeTeamOvr,
+  divisionTeamCount,
+  formLast5,
+  mergeStandingsWithTeams,
+  pickKeyPlayers,
+  resultsMapFromSeasonLines,
+} from "@/lib/teams-table";
+import type { TeamsTableRow } from "./teams-table";
+import type { TeamDetailSheetData } from "./team-detail-sheet";
+import { TeamsView } from "./teams-view";
+
+function groupPlayersByTeam(players: PlayerDto[]): Map<string, PlayerDto[]> {
+  const map = new Map<string, PlayerDto[]>();
+  for (const player of players) {
+    const list = map.get(player.teamId) ?? [];
+    list.push(player);
+    map.set(player.teamId, list);
+  }
+  return map;
+}
+
+async function buildTeamsPageData(input: {
+  teams: TeamDto[];
+  standings: Standing[];
+  seasonId: string;
+  divisionNameById: Map<string, string>;
+  playersByTeam: Map<string, PlayerDto[]>;
+  attributesEnabled: boolean;
+  orgContext: Awaited<ReturnType<typeof resolveOrgContext>>;
+  fixtures: Awaited<ReturnType<typeof listFixturesBySeason>>;
+  results: Awaited<ReturnType<typeof listResultsBySeason>>;
+}) {
+  const resultsByFixtureId = resultsMapFromSeasonLines(input.results);
+  const mergedStandings = mergeStandingsWithTeams(input.standings, input.teams);
+  const teamById = new Map(input.teams.map((team) => [team.id, team]));
+
+  const rosterStatuses = await Promise.all(
+    input.teams.map(async (team) => {
+      const status = await getTeamRosterLimitStatus(
+        input.seasonId,
+        team.id,
+      ).catch(() => ({
+        activeCount: 0,
+        rosterLimit: team.rosterLimit,
+        remaining: null,
+      }));
+      return {
+        teamId: team.id,
+        activeCount: status.activeCount,
+        rosterLimit:
+          status.rosterLimit ?? team.rosterLimit ?? DEFAULT_TARGET_ROSTER_SIZE,
+      };
+    }),
+  );
+  const rosterByTeamId = new Map(
+    rosterStatuses.map((status) => [status.teamId, status]),
+  );
+
+  const ratingBundles = input.attributesEnabled
+    ? await Promise.all(
+        input.teams.map(async (team) => {
+          const [snapshots, madden] = await Promise.all([
+            getTeamAttributeSnapshots(team.id, input.orgContext).catch(
+              () => new Map(),
+            ),
+            getTeamMaddenOveralls(team.id, input.orgContext).catch(
+              () => new Map<string, number>(),
+            ),
+          ]);
+          return { teamId: team.id, snapshots, madden };
+        }),
+      )
+    : [];
+
+  const ratingsByTeamId = new Map(
+    ratingBundles.map((bundle) => [bundle.teamId, bundle]),
+  );
+
+  const rows: TeamsTableRow[] = [];
+  const sheetDataByTeamId: Record<string, TeamDetailSheetData> = {};
+
+  for (const standing of mergedStandings) {
+    const team = teamById.get(standing.teamId);
+    if (!team) continue;
+
+    const roster = rosterByTeamId.get(team.id) ?? {
+      activeCount: 0,
+      rosterLimit: team.rosterLimit ?? DEFAULT_TARGET_ROSTER_SIZE,
+    };
+    const divisionName = input.divisionNameById.get(team.divisionId) ?? null;
+    const ratings = ratingsByTeamId.get(team.id);
+    const teamPlayers = input.playersByTeam.get(team.id) ?? [];
+
+    rows.push({
+      team,
+      standing,
+      divisionName,
+      rosterCount: roster.activeCount,
+      rosterLimit: roster.rosterLimit,
+    });
+
+    sheetDataByTeamId[team.id] = {
+      team,
+      standing,
+      divisionName,
+      divisionRank: standing.divisionRank,
+      divisionTeamCount: divisionTeamCount(
+        mergedStandings,
+        team.divisionId,
+        input.teams,
+      ),
+      rosterCount: roster.activeCount,
+      rosterLimit: roster.rosterLimit,
+      form: formLast5(input.fixtures, resultsByFixtureId, team.id),
+      ovr: ratings
+        ? computeTeamOvr(ratings.snapshots, ratings.madden)
+        : null,
+      keyPlayers: ratings
+        ? pickKeyPlayers(teamPlayers, ratings.snapshots, ratings.madden)
+        : pickKeyPlayers(teamPlayers, new Map(), new Map()),
+    };
+  }
+
+  return { rows, sheetDataByTeamId };
+}
 
 export default async function TeamsPage() {
   const { userId } = await auth();
   if (!userId) redirect("/sign-in");
 
-  // Scoped to the active league (WSM-000103).
   const { activeLeagueId } = await resolveActiveLeague(userId);
-  const teams = activeLeagueId ? await getTeams([activeLeagueId]) : [];
+  const leagueScope = activeLeagueId ? [activeLeagueId] : [];
+  const orgContext = await resolveOrgContext(userId);
+
+  const [teams, seasons, divisions, players, scheduleLinksEnabled, attributesEnabled] =
+    await Promise.all([
+      getTeams(leagueScope),
+      getSeasons(leagueScope),
+      getDivisions(leagueScope),
+      getPlayers(leagueScope),
+      schedulesStandingsV1(),
+      playerAttributesV1(),
+    ]);
+
+  const activeSeason =
+    seasons.find((season) => season.status.toLowerCase() === "active") ?? null;
+  const divisionNameById = new Map(
+    divisions.map((division) => [division.id, division.name]),
+  );
+  const playersByTeam = groupPlayersByTeam(players);
+
+  let rows: TeamsTableRow[] = [];
+  let sheetDataByTeamId: Record<string, TeamDetailSheetData> = {};
+
+  if (activeSeason) {
+    const [standings, fixtures, results] = await Promise.all([
+      computeStandings(activeSeason.id).catch(() => [] as Standing[]),
+      listFixturesBySeason(activeSeason.id).catch(() => []),
+      listResultsBySeason(activeSeason.id).catch(() => []),
+    ]);
+
+    const built = await buildTeamsPageData({
+      teams,
+      standings,
+      seasonId: activeSeason.id,
+      divisionNameById,
+      playersByTeam,
+      attributesEnabled,
+      orgContext,
+      fixtures,
+      results,
+    });
+    rows = built.rows;
+    sheetDataByTeamId = built.sheetDataByTeamId;
+  }
 
   return (
-    <div>
-      <PageHeader title="Teams" description="Every team in the active league." />
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {teams.map((team) => (
-          <Link
-            key={team.id}
-            href={`/dashboard/teams/${team.id}`}
-            className="rounded-lg border border-border bg-card p-6 shadow-sm transition-shadow hover:shadow-md"
-          >
-            <h3 className="text-lg font-semibold text-foreground">{team.name}</h3>
-            <dl className="mt-3 space-y-1 text-sm text-muted-foreground">
-              {team.city && (
-                <div>
-                  <dt className="inline font-medium">City: </dt>
-                  <dd className="inline">{team.city}</dd>
-                </div>
-              )}
-              {team.stadium && (
-                <div>
-                  <dt className="inline font-medium">Stadium: </dt>
-                  <dd className="inline">{team.stadium}</dd>
-                </div>
-              )}
-              {team.foundedYear && (
-                <div>
-                  <dt className="inline font-medium">Founded: </dt>
-                  <dd className="inline">{team.foundedYear}</dd>
-                </div>
-              )}
-            </dl>
-          </Link>
-        ))}
-        {teams.length === 0 && (
-          <p className="text-muted-foreground">No teams found.</p>
-        )}
-      </div>
-    </div>
+    <TeamsView
+      teamCount={teams.length}
+      seasonName={activeSeason?.name ?? null}
+      rows={rows}
+      sheetDataByTeamId={sheetDataByTeamId}
+      leagueId={activeLeagueId}
+      scheduleLinksEnabled={scheduleLinksEnabled}
+      hasActiveSeason={activeSeason != null}
+    />
   );
 }

--- a/apps/web/src/app/dashboard/teams/team-detail-sheet.tsx
+++ b/apps/web/src/app/dashboard/teams/team-detail-sheet.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import Link from "next/link";
+import { Target } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TeamMark } from "@/components/team-mark";
+import { cn } from "@/lib/utils";
+import {
+  formatStandingRecord,
+  standingPointDifferential,
+  winPercentage,
+  type FormResult,
+  type KeyPlayerRow,
+} from "@/lib/teams-table";
+import type { Standing, TeamDto } from "@sports-management/shared-types";
+
+export interface TeamDetailSheetData {
+  team: TeamDto;
+  standing: Standing;
+  divisionName: string | null;
+  divisionRank: number;
+  divisionTeamCount: number;
+  rosterCount: number;
+  rosterLimit: number;
+  form: FormResult[];
+  ovr: number | null;
+  keyPlayers: KeyPlayerRow[];
+}
+
+export interface TeamDetailSheetProps {
+  data: TeamDetailSheetData | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  leagueId: string;
+  scheduleLinksEnabled: boolean;
+}
+
+function StatCell({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  tone?: "accent" | "muted" | "default";
+}) {
+  const valueClass =
+    tone === "accent"
+      ? "text-accent"
+      : tone === "muted"
+        ? "text-muted-foreground"
+        : "text-foreground";
+
+  return (
+    <div>
+      <p className="m-0 font-mono text-[10.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className={cn("m-0 mt-1.5 font-mono text-lg font-semibold tabular-nums", valueClass)}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function FormChip({ result }: { result: FormResult }) {
+  const className =
+    result === "W"
+      ? "bg-accent/15 text-accent"
+      : result === "L"
+        ? "bg-surface-3 text-muted-foreground"
+        : "bg-surface-3 text-muted-foreground/80";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex h-[22px] w-[22px] items-center justify-center rounded-[5px] font-mono text-[11px] font-semibold",
+        className,
+      )}
+    >
+      {result}
+    </span>
+  );
+}
+
+export function TeamDetailSheet({
+  data,
+  open,
+  onOpenChange,
+  leagueId,
+  scheduleLinksEnabled,
+}: TeamDetailSheetProps) {
+  const titleId = "team-detail-sheet-title";
+
+  if (!data) {
+    return (
+      <Sheet open={false} onOpenChange={onOpenChange}>
+        <SheetContent side="right" className="hidden" />
+      </Sheet>
+    );
+  }
+
+  const { team, standing } = data;
+  const diff = standingPointDifferential(standing);
+  const diffTone = diff > 0 ? "accent" : diff < 0 ? "muted" : "default";
+  const mascot = team.teamName?.trim() || "—";
+  const standingsHref = `/dashboard/leagues/${leagueId}/standings`;
+  const scheduleHref = `/dashboard/leagues/${leagueId}/schedule`;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        aria-labelledby={titleId}
+        data-testid="team-detail-sheet"
+        className="flex w-[min(100vw,35rem)] max-w-[100vw] flex-col gap-0 overflow-x-hidden overflow-y-auto overscroll-contain p-0"
+      >
+        <div className="sticky top-0 z-10 border-b border-border bg-background px-5 py-4">
+          <div className="flex items-center justify-between gap-2 pr-8">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              {data.divisionName ? (
+                <Badge variant="outline">{data.divisionName} Division</Badge>
+              ) : null}
+              {standing.leagueRank > 0 ? (
+                <span className="font-mono text-[11.5px] uppercase tracking-wide text-muted-foreground">
+                  #{standing.leagueRank} overall
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3.5 px-5 pb-1 pt-5">
+          <TeamMark
+            name={team.name}
+            primaryColor={team.primaryColor}
+            size="lg"
+          />
+          <div className="min-w-0">
+            <p
+              id={titleId}
+              className="m-0 text-[22px] font-extrabold leading-tight tracking-tight text-foreground"
+            >
+              {team.name}
+            </p>
+            <p className="m-0 mt-0.5 text-sm text-muted-foreground">
+              {mascot}
+              {data.ovr != null ? (
+                <>
+                  {" "}
+                  · OVR <span className="font-mono">{data.ovr}</span>
+                </>
+              ) : null}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 px-5 pb-6 pt-4">
+          <div className="grid grid-cols-3 gap-x-3 gap-y-4 rounded-xl border border-border bg-card p-4">
+            <StatCell label="Record" value={formatStandingRecord(standing)} />
+            <StatCell
+              label="Win %"
+              value={winPercentage(standing.wins, standing.losses, standing.ties)}
+            />
+            <StatCell
+              label="Diff"
+              value={`${diff > 0 ? "+" : ""}${diff}`}
+              tone={diffTone}
+            />
+            <StatCell label="Points for" value={standing.pointsFor} />
+            <StatCell label="Points against" value={standing.pointsAgainst} />
+            <StatCell
+              label="Roster"
+              value={`${data.rosterCount}/${data.rosterLimit}`}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-border p-3.5">
+              <p className="mb-2.5 font-mono text-[10.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Form · last 5
+              </p>
+              <div className="flex gap-1">
+                {data.form.length > 0 ? (
+                  data.form.map((result, index) => (
+                    <FormChip key={`${result}-${index}`} result={result} />
+                  ))
+                ) : (
+                  <span className="text-xs text-muted-foreground">No games</span>
+                )}
+              </div>
+            </div>
+
+            <Link
+              href="/dashboard/divisions"
+              className="rounded-xl border border-border bg-card p-3.5 text-left transition-colors hover:bg-muted/40"
+            >
+              <p className="mb-2.5 font-mono text-[10.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Division standing
+              </p>
+              <p className="m-0 text-sm text-foreground">
+                {data.divisionName ?? "—"} ·{" "}
+                <span className="font-mono font-semibold">
+                  #{data.divisionRank || "—"}
+                </span>{" "}
+                of {data.divisionTeamCount}{" "}
+                <span className="text-muted-foreground">→</span>
+              </p>
+            </Link>
+          </div>
+
+          <div className="rounded-xl border border-border p-3.5">
+            <div className="mb-1 flex items-center gap-2">
+              <Target className="h-4 w-4 text-accent" aria-hidden />
+              <span className="text-sm font-semibold text-foreground">Key players</span>
+            </div>
+            {data.keyPlayers.length > 0 ? (
+              <ul className="m-0 flex list-none flex-col p-0">
+                {data.keyPlayers.map((player) => (
+                  <li
+                    key={player.id}
+                    className="flex items-center justify-between gap-2 border-t border-border py-2 first:border-t-0"
+                  >
+                    <span className="inline-flex min-w-0 items-center gap-2.5">
+                      <span className="w-[26px] font-mono text-[11px] text-muted-foreground">
+                        {player.position}
+                      </span>
+                      <span className="truncate text-sm text-foreground">
+                        {player.name}
+                      </span>
+                    </span>
+                    <span className="font-mono text-sm font-semibold text-accent">
+                      {player.rating ?? "—"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="m-0 pt-2 text-xs text-muted-foreground">No players yet</p>
+            )}
+          </div>
+
+          {scheduleLinksEnabled ? (
+            <div className="flex flex-wrap gap-2">
+              <Button asChild>
+                <Link href={standingsHref}>View in standings</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href={scheduleHref}>Schedule</Link>
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/app/dashboard/teams/teams-table.tsx
+++ b/apps/web/src/app/dashboard/teams/teams-table.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import type { Standing, TeamDto } from "@sports-management/shared-types";
+import { TeamMark } from "@/components/team-mark";
+import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  formatStandingRecord,
+  standingPointDifferential,
+} from "@/lib/teams-table";
+import { cn } from "@/lib/utils";
+
+export interface TeamsTableRow {
+  team: TeamDto;
+  standing: Standing;
+  divisionName: string | null;
+  rosterCount: number;
+  rosterLimit: number;
+}
+
+export interface TeamsTableProps {
+  rows: TeamsTableRow[];
+  onRowClick: (teamId: string) => void;
+}
+
+export function TeamsTable({ rows, onRowClick }: TeamsTableProps) {
+  return (
+    <Card className="gap-0 overflow-hidden py-0" data-testid="teams-table">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="w-10 px-4">#</TableHead>
+            <TableHead className="px-4">Team</TableHead>
+            <TableHead className="px-4">Division</TableHead>
+            <TableHead className="px-4 text-right">Record</TableHead>
+            <TableHead className="px-4 text-right">PF</TableHead>
+            <TableHead className="px-4 text-right">Diff</TableHead>
+            <TableHead className="px-4 text-right">Roster</TableHead>
+            <TableHead className="w-8 px-2" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => {
+            const diff = standingPointDifferential(row.standing);
+            const mascot = row.team.teamName?.trim();
+
+            return (
+              <TableRow
+                key={row.team.id}
+                data-testid="team-row"
+                className="cursor-pointer"
+                onClick={() => onRowClick(row.team.id)}
+              >
+                <TableCell className="px-4 font-mono text-muted-foreground">
+                  {row.standing.leagueRank}
+                </TableCell>
+                <TableCell className="px-4">
+                  <span className="inline-flex items-center gap-2.5">
+                    <TeamMark
+                      name={row.team.name}
+                      primaryColor={row.team.primaryColor}
+                      size="sm"
+                    />
+                    <span className="min-w-0">
+                      <Link
+                        href={`/dashboard/teams/${row.team.id}`}
+                        className="block font-semibold text-foreground hover:underline"
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        {row.team.name}
+                      </Link>
+                      {mascot ? (
+                        <span className="block text-xs text-muted-foreground">
+                          {mascot}
+                        </span>
+                      ) : null}
+                    </span>
+                  </span>
+                </TableCell>
+                <TableCell className="px-4 text-muted-foreground">
+                  {row.divisionName ?? "—"}
+                </TableCell>
+                <TableCell className="px-4 text-right font-mono tabular-nums">
+                  {formatStandingRecord(row.standing)}
+                </TableCell>
+                <TableCell className="px-4 text-right font-mono tabular-nums">
+                  {row.standing.pointsFor}
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "px-4 text-right font-mono tabular-nums",
+                    diff > 0
+                      ? "text-accent"
+                      : diff < 0
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/80",
+                  )}
+                >
+                  {diff > 0 ? "+" : ""}
+                  {diff}
+                </TableCell>
+                <TableCell className="px-4 text-right font-mono tabular-nums">
+                  {row.rosterCount}/{row.rosterLimit}
+                </TableCell>
+                <TableCell className="px-2 text-muted-foreground/70">
+                  <ChevronRight className="h-4 w-4" aria-hidden />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+}

--- a/apps/web/src/app/dashboard/teams/teams-view.tsx
+++ b/apps/web/src/app/dashboard/teams/teams-view.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/empty-state";
+import { PageHeader } from "../_components/page-header";
+import { TeamsTable, type TeamsTableRow } from "./teams-table";
+import {
+  TeamDetailSheet,
+  type TeamDetailSheetData,
+} from "./team-detail-sheet";
+
+export interface TeamsViewProps {
+  teamCount: number;
+  seasonName: string | null;
+  rows: TeamsTableRow[];
+  sheetDataByTeamId: Record<string, TeamDetailSheetData>;
+  leagueId: string | null;
+  scheduleLinksEnabled: boolean;
+  hasActiveSeason: boolean;
+}
+
+export function TeamsView({
+  teamCount,
+  seasonName,
+  rows,
+  sheetDataByTeamId,
+  leagueId,
+  scheduleLinksEnabled,
+  hasActiveSeason,
+}: TeamsViewProps) {
+  const [selectedTeamId, setSelectedTeamId] = React.useState<string | null>(null);
+  const selectedData = selectedTeamId
+    ? (sheetDataByTeamId[selectedTeamId] ?? null)
+    : null;
+
+  const description =
+    seasonName != null
+      ? `${teamCount} teams · ${seasonName}`
+      : `${teamCount} teams`;
+
+  return (
+    <div>
+      <PageHeader
+        title="Teams"
+        description={description}
+        action={
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant="outline">{teamCount}</Badge>
+            <Link
+              href="/dashboard/divisions"
+              className="text-sm text-primary hover:underline"
+            >
+              Divisions →
+            </Link>
+            <Link
+              href="/dashboard/players"
+              className="text-sm text-primary hover:underline"
+            >
+              Players →
+            </Link>
+          </div>
+        }
+      />
+
+      {!hasActiveSeason ? (
+        <EmptyState
+          icon={Users}
+          title="No active season"
+          description="Activate or create a season to see team standings here."
+          action={
+            <Link
+              href="/dashboard/seasons"
+              className="text-sm text-primary hover:underline"
+            >
+              Go to Seasons →
+            </Link>
+          }
+        />
+      ) : rows.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="No teams found"
+          description="Teams will appear here once added to the league."
+        />
+      ) : (
+        <TeamsTable
+          rows={rows}
+          onRowClick={(teamId) => setSelectedTeamId(teamId)}
+        />
+      )}
+
+      {leagueId ? (
+        <TeamDetailSheet
+          data={selectedData}
+          open={selectedTeamId != null && selectedData != null}
+          onOpenChange={(open) => {
+            if (!open) setSelectedTeamId(null);
+          }}
+          leagueId={leagueId}
+          scheduleLinksEnabled={scheduleLinksEnabled}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/teams-table.test.ts
+++ b/apps/web/src/lib/__tests__/teams-table.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTeamOvr,
+  formLast5,
+  mergeStandingsWithTeams,
+  pickKeyPlayers,
+  resultsMapFromSeasonLines,
+  winPercentage,
+} from "../teams-table";
+import type { Standing } from "@sports-management/shared-types";
+
+const standing = (
+  teamId: string,
+  name: string,
+  rank: number,
+  wins = 0,
+  losses = 0,
+): Standing => ({
+  teamId,
+  teamName: name,
+  wins,
+  losses,
+  ties: 0,
+  pointsFor: wins * 7,
+  pointsAgainst: losses * 7,
+  divisionRank: rank,
+  leagueRank: rank,
+});
+
+describe("formLast5", () => {
+  const fixtures = [
+    {
+      id: "f1",
+      status: "final" as const,
+      homeTeamId: "t1",
+      awayTeamId: "t2",
+    },
+    {
+      id: "f2",
+      status: "final" as const,
+      homeTeamId: "t3",
+      awayTeamId: "t1",
+    },
+    {
+      id: "f3",
+      status: "scheduled" as const,
+      homeTeamId: "t1",
+      awayTeamId: "t4",
+    },
+    {
+      id: "f4",
+      status: "final" as const,
+      homeTeamId: "t1",
+      awayTeamId: "t5",
+    },
+  ];
+
+  const results = resultsMapFromSeasonLines([
+    { fixtureId: "f1", homeScore: 21, awayScore: 14 },
+    { fixtureId: "f2", homeScore: 10, awayScore: 17 },
+    { fixtureId: "f4", homeScore: 14, awayScore: 14 },
+  ]);
+
+  it("returns W/L/T for the last five final games with results", () => {
+    expect(formLast5(fixtures, results, "t1")).toEqual(["W", "W", "T"]);
+  });
+
+  it("returns an empty array when there are no final games", () => {
+    expect(formLast5(fixtures, new Map(), "t9")).toEqual([]);
+  });
+});
+
+describe("winPercentage", () => {
+  it("formats win pct with one decimal", () => {
+    expect(winPercentage(3, 1, 0)).toBe("75.0");
+    expect(winPercentage(1, 1, 1)).toBe("50.0");
+  });
+
+  it("returns em dash when no games played", () => {
+    expect(winPercentage(0, 0, 0)).toBe("—");
+  });
+});
+
+describe("mergeStandingsWithTeams", () => {
+  it("appends teams missing from standings and sorts by rank", () => {
+    const merged = mergeStandingsWithTeams(
+      [standing("t2", "Bravo", 1, 2, 0), standing("t1", "Alpha", 2, 1, 1)],
+      [
+        { id: "t1", name: "Alpha", divisionId: "d1" },
+        { id: "t2", name: "Bravo", divisionId: "d1" },
+        { id: "t3", name: "Charlie", divisionId: "d2" },
+      ],
+    );
+    expect(merged.map((row) => row.teamId)).toEqual(["t2", "t1", "t3"]);
+    expect(merged.find((row) => row.teamId === "t3")?.wins).toBe(0);
+  });
+});
+
+describe("pickKeyPlayers", () => {
+  it("returns top four players by rating", () => {
+    const players = [
+      { id: "p1", name: "Alice", position: "QB" },
+      { id: "p2", name: "Bob", position: "RB" },
+      { id: "p3", name: "Cara", position: "WR" },
+      { id: "p4", name: "Dan", position: "TE" },
+      { id: "p5", name: "Eve", position: "LB" },
+    ];
+    const snapshots = new Map([
+      ["p1", { weightedOverall: 88 }],
+      ["p2", { weightedOverall: 92 }],
+      ["p3", { weightedOverall: 81 }],
+      ["p4", { weightedOverall: 95 }],
+      ["p5", { weightedOverall: 77 }],
+    ]);
+    const key = pickKeyPlayers(players, snapshots, new Map());
+    expect(key.map((player) => player.id)).toEqual(["p4", "p2", "p1", "p3"]);
+  });
+});
+
+describe("computeTeamOvr", () => {
+  it("averages SPRT ratings when present", () => {
+    const snapshots = new Map([
+      ["p1", { weightedOverall: 80 }],
+      ["p2", { weightedOverall: 90 }],
+    ]);
+    expect(computeTeamOvr(snapshots, new Map())).toBe(85);
+  });
+});

--- a/apps/web/src/lib/teams-table.ts
+++ b/apps/web/src/lib/teams-table.ts
@@ -1,0 +1,158 @@
+import type { FixtureDto, PlayerDto, Standing } from "@sports-management/shared-types";
+import { formatSeasonRecord } from "@/lib/season-list";
+
+export type FormResult = "W" | "L" | "T";
+
+export interface ResultScores {
+  homeScore: number;
+  awayScore: number;
+}
+
+/** Last five W/L/T chips from final fixtures (prototype formLast5). */
+export function formLast5(
+  fixtures: ReadonlyArray<
+    Pick<FixtureDto, "id" | "status" | "homeTeamId" | "awayTeamId">
+  >,
+  resultsByFixtureId: ReadonlyMap<string, ResultScores>,
+  teamId: string,
+): FormResult[] {
+  const games = fixtures
+    .filter(
+      (fixture) =>
+        fixture.status === "final" &&
+        (fixture.homeTeamId === teamId || fixture.awayTeamId === teamId) &&
+        resultsByFixtureId.has(fixture.id),
+    )
+    .slice(-5);
+
+  return games.map((fixture) => {
+    const result = resultsByFixtureId.get(fixture.id)!;
+    const us =
+      fixture.homeTeamId === teamId ? result.homeScore : result.awayScore;
+    const them =
+      fixture.homeTeamId === teamId ? result.awayScore : result.homeScore;
+    if (us > them) return "W";
+    if (us < them) return "L";
+    return "T";
+  });
+}
+
+/** Win percentage for display (prototype: pct * 100, one decimal). */
+export function winPercentage(
+  wins: number,
+  losses: number,
+  ties: number,
+): string {
+  const gamesPlayed = wins + losses + ties;
+  if (gamesPlayed === 0) return "—";
+  const pct = (wins + ties * 0.5) / gamesPlayed;
+  return (pct * 100).toFixed(1);
+}
+
+export function standingPointDifferential(row: Standing): number {
+  return row.pointsFor - row.pointsAgainst;
+}
+
+export function formatStandingRecord(row: Standing): string {
+  return formatSeasonRecord(row.wins, row.losses, row.ties);
+}
+
+/**
+ * Merge standings rows with any league teams missing from standings (0-0 placeholders).
+ * Output is sorted by league rank ascending.
+ */
+export function mergeStandingsWithTeams(
+  standings: ReadonlyArray<Standing>,
+  teamIds: ReadonlyArray<{ id: string; name: string; divisionId: string }>,
+): Standing[] {
+  const byTeamId = new Map(standings.map((row) => [row.teamId, row]));
+  const merged: Standing[] = [...standings];
+
+  for (const team of teamIds) {
+    if (byTeamId.has(team.id)) continue;
+    merged.push({
+      teamId: team.id,
+      teamName: team.name,
+      wins: 0,
+      losses: 0,
+      ties: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      divisionRank: 0,
+      leagueRank: merged.length + 1,
+    });
+  }
+
+  return merged.sort((a, b) => a.leagueRank - b.leagueRank);
+}
+
+export interface KeyPlayerRow {
+  id: string;
+  name: string;
+  position: string;
+  rating: number | null;
+}
+
+/** Top-rated roster players for the detail sheet (prototype starPlayers). */
+export function pickKeyPlayers(
+  players: ReadonlyArray<Pick<PlayerDto, "id" | "name" | "position">>,
+  snapshots: ReadonlyMap<string, { weightedOverall: number | null }>,
+  madden: ReadonlyMap<string, number>,
+  limit = 4,
+): KeyPlayerRow[] {
+  return [...players]
+    .map((player) => ({
+      id: player.id,
+      name: player.name,
+      position: player.position,
+      rating:
+        snapshots.get(player.id)?.weightedOverall ??
+        madden.get(player.id) ??
+        null,
+    }))
+    .sort((a, b) => {
+      if (a.rating != null && b.rating != null) return b.rating - a.rating;
+      if (a.rating != null) return -1;
+      if (b.rating != null) return 1;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, limit);
+}
+
+/** Team-level OVR from attribute snapshots (prototype team.ovr). */
+export function computeTeamOvr(
+  snapshots: ReadonlyMap<string, { weightedOverall: number | null }>,
+  madden: ReadonlyMap<string, number>,
+): number | null {
+  const sprt = [...snapshots.values()]
+    .map((snap) => snap.weightedOverall)
+    .filter((value): value is number => value != null);
+  if (sprt.length > 0) {
+    return Math.round(sprt.reduce((sum, value) => sum + value, 0) / sprt.length);
+  }
+  if (madden.size > 0) {
+    const values = [...madden.values()];
+    return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+  }
+  return null;
+}
+
+export function resultsMapFromSeasonLines(
+  lines: ReadonlyArray<{ fixtureId: string; homeScore: number; awayScore: number }>,
+): Map<string, ResultScores> {
+  return new Map(
+    lines.map((line) => [
+      line.fixtureId,
+      { homeScore: line.homeScore, awayScore: line.awayScore },
+    ]),
+  );
+}
+
+export function divisionTeamCount(
+  standings: ReadonlyArray<Standing>,
+  divisionId: string | null | undefined,
+  teams: ReadonlyArray<{ divisionId: string }>,
+): number {
+  if (!divisionId) return teams.length;
+  return teams.filter((team) => team.divisionId === divisionId).length;
+}


### PR DESCRIPTION
## Summary
Teams surface per the leagues-seasons handoff (WSM-000248): `/dashboard/teams` becomes a standings-ranked table (rank, TeamMark + name, record, prototype columns) with a right-side team detail sheet (shadcn Sheet) showing record, recent form derived from final fixtures, and key players — all on existing `data-api.ts` wrappers, no Convex changes. Team-name links remain real `<a>` navigation to `/dashboard/teams/[id]`; row interaction opens the sheet.

## Tests
- Unit: new `teams-table` merge/derivation tests — 171 files / 1216 tests pass
- E2E: new `teams-redesign.spec.ts` (canonical presence-only + fixture-league record/form per the shared-league isolation rules); `teams.spec.ts` updated for the table UI — runs in CI
- Lint + type-check pass

## Notes
Known follow-up (not blocking): per-team roster-limit lookups are N+1 on SSR — fine at current league sizes, batch later if needed.

## Related Issue
Closes #550
