### PR TITLE
feat(web): manage league settings rows and danger zone (WSM-000251)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/league-claimable-toggle.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/league-claimable-toggle.tsx
@@ -39,36 +39,36 @@ export default function LeagueClaimableToggle({
   }
 
   return (
-    <div className="flex flex-col gap-2 border-2 border-border bg-card p-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-foreground">
-            Claimable by coaches
-          </p>
-          <p className="text-xs text-muted-foreground">
-            When on, a coach can find a team in this public template league and
-            claim it — forking a private, editable copy for their org (WSM-000109).
-            Use for curated leagues like GHSA.
-          </p>
-        </div>
-        <Button
-          className="shrink-0"
-          variant={claimable ? "destructive" : "default"}
-          onClick={handleToggle}
-          disabled={pending}
-        >
-          {pending ? "Saving…" : claimable ? "Disable claiming" : "Enable claiming"}
-        </Button>
-      </div>
-      <p className="font-mono text-xs text-muted-foreground">
-        Currently: {claimable ? "CLAIMABLE" : "NOT CLAIMABLE"}
-      </p>
-      {claimable && !isPublic && (
-        <p className="text-xs text-yellow-600 dark:text-yellow-500" role="alert">
-          Claiming only works while the league is also public — turn on “Public
-          viewer” above for coaches to claim.
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-label-14 text-foreground">Claimable by coaches</p>
+        <p className="text-caption-12 text-text-muted">
+          When on, a coach can find a team in this public template league and
+          claim it — forking a private, editable copy for their org (WSM-000109).
+          Use for curated leagues like GHSA.
         </p>
-      )}
+        <p className="mt-1 font-mono text-caption-12 text-text-subtle">
+          Currently: {claimable ? "CLAIMABLE" : "NOT CLAIMABLE"}
+        </p>
+        {claimable && !isPublic && (
+          <p
+            className="mt-1 text-caption-12 text-yellow-600 dark:text-yellow-500"
+            role="alert"
+          >
+            Claiming only works while the league is also public — set Visibility
+            to public above for coaches to claim.
+          </p>
+        )}
+      </div>
+      <Button
+        size="sm"
+        className="shrink-0"
+        variant={claimable ? "destructive" : "default"}
+        onClick={handleToggle}
+        disabled={pending}
+      >
+        {pending ? "Saving…" : claimable ? "Disable claiming" : "Enable claiming"}
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/league-public-toggle.tsx
@@ -32,29 +32,27 @@ export default function LeaguePublicToggle({
   }
 
   return (
-    <div className="flex flex-col gap-2 border-2 border-border bg-card p-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-foreground">
-            Public viewer
-          </p>
-          <p className="text-xs text-muted-foreground">
-            When on, anyone can view player development charts at{" "}
-            <code className="break-all font-mono">/leagues/{leagueId}/...</code>
-          </p>
-        </div>
-        <Button
-          className="shrink-0"
-          variant={isPublic ? "destructive" : "default"}
-          onClick={handleToggle}
-          disabled={pending}
-        >
-          {pending ? "Saving…" : isPublic ? "Make private" : "Make public"}
-        </Button>
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-label-14 text-foreground">Visibility</p>
+        <p className="text-caption-12 text-text-muted">
+          Public leagues appear in Discover. When public, anyone can view
+          player development charts at{" "}
+          <code className="break-all font-mono">/leagues/{leagueId}/...</code>
+        </p>
+        <p className="mt-1 font-mono text-caption-12 text-text-subtle">
+          Currently: {isPublic ? "PUBLIC" : "PRIVATE"}
+        </p>
       </div>
-      <p className="font-mono text-xs text-muted-foreground">
-        Currently: {isPublic ? "PUBLIC" : "PRIVATE"}
-      </p>
+      <Button
+        size="sm"
+        className="shrink-0"
+        variant={isPublic ? "destructive" : "default"}
+        onClick={handleToggle}
+        disabled={pending}
+      >
+        {pending ? "Saving…" : isPublic ? "Make private" : "Make public"}
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/leagues/[id]/manage/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/manage/page.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
@@ -36,9 +37,31 @@ import {
 import { DEFAULT_TARGET_ROSTER_SIZE } from "@/lib/offseason-activate";
 
 /**
- * League manage surface (WSM-000254): admin settings relocated from the league
- * info destination. Polish is scoped to WSM-000251 — preserve existing controls.
+ * League manage surface (WSM-000254), recomposed into the prototype's
+ * "Manage league" settings-row pattern (WSM-000251): one Settings card of
+ * label + description + control rows, ending in a Danger zone. Every control
+ * predates the polish and keeps its behavior.
  */
+function SettingsRow({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 py-4">
+      <div className="min-w-0">
+        <p className="text-label-14 text-foreground">{title}</p>
+        <p className="text-caption-12 text-text-muted">{description}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">{children}</div>
+    </div>
+  );
+}
+
 export default async function LeagueManagePage({
   params,
 }: {
@@ -92,45 +115,73 @@ export default async function LeagueManagePage({
         ]}
       />
       <BackLink href={`/dashboard/leagues/${id}`} label="Back to League" />
-      <WorkspaceHeader title={league.name} sub="Manage league settings" />
+      <WorkspaceHeader
+        title="Manage league"
+        sub="Settings, members, and roster tools."
+      />
 
       <Card data-testid="league-manage-settings">
         <CardContent className="pt-6">
-          <div className="space-y-6">
-            <div className="flex flex-wrap items-center gap-1">
+          <h2 className="text-lg font-bold tracking-[-0.3px] text-foreground">
+            Settings
+          </h2>
+          <div className="divide-y divide-border">
+            <SettingsRow title="League name" description="Rename this league.">
               <RenameLeagueForm leagueId={id} currentName={league.name} />
-              <DeleteLeagueButton leagueId={id} leagueName={league.name} />
-            </div>
-            <InviteForm orgId={league.orgId} />
-            <InvitationList orgId={league.orgId} />
-            <InviteLinkSection leagueId={id} />
-            <LeaguePublicToggle
-              leagueId={id}
-              initialIsPublic={visibility?.isPublic ?? false}
-            />
-            <LeagueClaimableToggle
-              leagueId={id}
-              initialClaimable={claimable}
-              isPublic={visibility?.isPublic ?? false}
-            />
-            <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
-              <div className="min-w-0">
-                <p className="text-label-14 text-foreground">Teams</p>
-                <p className="text-caption-12 text-text-muted">
-                  Add a team to this league.
-                </p>
+            </SettingsRow>
+
+            <div className="space-y-4 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-label-14 text-foreground">
+                    Members &amp; invites
+                  </p>
+                  <p className="text-caption-12 text-text-muted">
+                    Invite operators and coaches.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                  <Link
+                    href={`/dashboard/leagues/${id}/members`}
+                    className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                  >
+                    Manage Members &rarr;
+                  </Link>
+                  <Link
+                    href={`/dashboard/leagues/${id}/requests`}
+                    className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                  >
+                    Join Requests &rarr;
+                  </Link>
+                </div>
               </div>
-              <AddTeamForm leagueId={id} />
+              <InviteForm orgId={league.orgId} />
+              <InvitationList orgId={league.orgId} />
+              <InviteLinkSection leagueId={id} />
             </div>
+
+            <div className="py-4">
+              <LeaguePublicToggle
+                leagueId={id}
+                initialIsPublic={visibility?.isPublic ?? false}
+              />
+            </div>
+
+            <div className="py-4">
+              <LeagueClaimableToggle
+                leagueId={id}
+                initialClaimable={claimable}
+                isPublic={visibility?.isPublic ?? false}
+              />
+            </div>
+
+            <SettingsRow title="Teams" description="Add a team to this league.">
+              <AddTeamForm leagueId={id} />
+            </SettingsRow>
+
             {canGenerateRosters ? (
-              <div className="space-y-3 border-t border-border pt-4">
-                <UndersizedRosterPanel
-                  leagueId={id}
-                  target={rosterDeficit.target}
-                  undersizedTeams={rosterDeficit.teams}
-                  canAutoFill={!seasonStarted}
-                />
-                <div className="flex flex-wrap items-center gap-3">
+              <div className="space-y-3 py-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="min-w-0">
                     <p className="text-label-14 text-foreground">
                       Synthetic rosters
@@ -138,10 +189,10 @@ export default async function LeagueManagePage({
                     <p className="text-caption-12 text-text-muted">
                       {seasonStarted
                         ? "Season has started — roster and ratings generation is locked."
-                        : "Fill every team in this league with fake test players (~48 each) for demos. Not real people."}
+                        : "Fill every team with ~48 fake players for demos."}
                     </p>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <SyntheticRosterButton
                       kind="league"
                       id={id}
@@ -160,21 +211,16 @@ export default async function LeagueManagePage({
                     />
                   </div>
                 </div>
+                <UndersizedRosterPanel
+                  leagueId={id}
+                  target={rosterDeficit.target}
+                  undersizedTeams={rosterDeficit.teams}
+                  canAutoFill={!seasonStarted}
+                />
               </div>
             ) : null}
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
-              <Link
-                href={`/dashboard/leagues/${id}/members`}
-                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-              >
-                Manage Members &rarr;
-              </Link>
-              <Link
-                href={`/dashboard/leagues/${id}/requests`}
-                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-              >
-                Join Requests &rarr;
-              </Link>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-2 py-4">
               <Link
                 href={`/dashboard/leagues/${id}/schedule`}
                 className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
@@ -188,6 +234,17 @@ export default async function LeagueManagePage({
                 Standings &rarr;
               </Link>
             </div>
+
+            <SettingsRow
+              title="Danger zone"
+              description="Delete this league and all its data."
+            >
+              <DeleteLeagueButton
+                leagueId={id}
+                leagueName={league.name}
+                appearance="labeled"
+              />
+            </SettingsRow>
           </div>
         </CardContent>
       </Card>

--- a/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
+++ b/apps/web/src/app/dashboard/leagues/leagues-actions.tsx
@@ -89,9 +89,15 @@ export function CreateLeagueButton() {
 export function DeleteLeagueButton({
   leagueId,
   leagueName,
+  appearance = "icon",
 }: {
   leagueId: string;
   leagueName: string;
+  /**
+   * "icon" is the compact trash button used in the leagues list;
+   * "labeled" is the danger-zone button on the league manage page.
+   */
+  appearance?: "icon" | "labeled";
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -115,6 +121,20 @@ export function DeleteLeagueButton({
     }
   }
 
+  if (appearance === "labeled") {
+    return (
+      <Button
+        size="sm"
+        variant="destructive"
+        disabled={busy}
+        onClick={remove}
+        aria-label={`Delete ${leagueName}`}
+      >
+        <Trash2 className="mr-1 h-4 w-4" />
+        Delete league
+      </Button>
+    );
+  }
   return (
     <Button
       size="sm"


### PR DESCRIPTION
## Summary
Manage-league surface polish per the leagues-seasons handoff (WSM-000251): `/dashboard/leagues/[id]/manage` recomposed into the prototype's settings-row pattern (label + description + control per row, section headings) with a Danger zone for destructive actions. Prototype copy adopted verbatim where it exists ("Manage league" title, "Visibility" row with "Public leagues appear in Discover.", synthetic-roster description); every existing control keeps its behavior and accessible name — "Make public|Make private", "Add team"/"Team name"/"Add", invites, rename, roster tools — and `DeleteLeagueButton` gains a labeled appearance for the danger zone (icon form on the leagues list unchanged). `league-manage-settings` testid, non-admin `notFound()`, routes, and flags untouched. No Convex changes.

## Tests
- Unit: 170 files / 1209 tests pass; lint + type-check pass
- E2E: no spec changes needed — the league-info.spec manage assertions and sim-league-setup helper flows target control names that were deliberately preserved

## Related Issue
Closes #553
