### PR TITLE
feat(web): hub headers aligned to prototype (WSM-000247)

### DIFF
--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -39,6 +39,7 @@ import { Breadcrumbs } from "@/components/workspace/Breadcrumbs";
 import { BackLink } from "@/components/workspace/BackLink";
 import { WorkspaceHeader } from "@/components/workspace/WorkspaceHeader";
 import { WorkspaceNav } from "@/components/workspace/WorkspaceNav";
+import { buildLeagueSeasonNavLinks } from "@/components/workspace/build-league-nav-links";
 
 /**
  * Season hub (WSM-000213): one home per season. Progress, standings snapshot,
@@ -196,27 +197,16 @@ export default async function SeasonHubPage({
     : manageableTeams;
 
   const seasonQuery = `?season=${season.id}`;
-  const links = [
-    scheduleEnabled && {
-      href: `/dashboard/leagues/${league.id}/schedule${seasonQuery}`,
-      label: "Schedule",
-    },
-    scheduleEnabled && {
-      href: `/dashboard/leagues/${league.id}/standings${seasonQuery}`,
-      label: "Standings",
-    },
-    playoffsEnabled && {
-      href: `/dashboard/leagues/${league.id}/playoffs${seasonQuery}`,
-      label: "Playoffs",
-    },
-    statsEnabled && {
-      href: `/dashboard/leagues/${league.id}/stats${seasonQuery}`,
-      label: "Stat leaders",
-    },
-  ].filter((l): l is { href: string; label: string } => Boolean(l));
+  const links = buildLeagueSeasonNavLinks({
+    leagueId: league.id,
+    seasonId: season.id,
+    scheduleEnabled,
+    playoffsEnabled,
+    statsEnabled,
+  });
 
   return (
-    <div className="mx-auto max-w-4xl">
+    <div className="mx-auto max-w-[960px]">
       <Breadcrumbs
         items={[
           { label: "Dashboard", href: "/dashboard" },
@@ -241,8 +231,8 @@ export default async function SeasonHubPage({
             {formatDate(season.startDate)} &ndash; {formatDate(season.endDate)}
           </>
         }
+        nav={<WorkspaceNav links={links} />}
       />
-      <WorkspaceNav links={links} />
 
       {isUpcomingSeason && (
         <OffseasonHub

--- a/apps/web/src/app/dev/visual/workspace/page.tsx
+++ b/apps/web/src/app/dev/visual/workspace/page.tsx
@@ -84,22 +84,24 @@ export default function WorkspaceVisualHarness() {
               {SEASON.dateRange}
             </>
           }
-        />
-        <WorkspaceNav
-          links={[
-            {
-              href: `/dashboard/leagues/${LEAGUE.id}/schedule?season=${SEASON.id}`,
-              label: "Schedule",
-            },
-            {
-              href: `/dashboard/leagues/${LEAGUE.id}/standings?season=${SEASON.id}`,
-              label: "Standings",
-            },
-            {
-              href: `/dashboard/leagues/${LEAGUE.id}/playoffs?season=${SEASON.id}`,
-              label: "Playoffs",
-            },
-          ]}
+          nav={
+            <WorkspaceNav
+              links={[
+                {
+                  href: `/dashboard/leagues/${LEAGUE.id}/schedule?season=${SEASON.id}`,
+                  label: "Schedule",
+                },
+                {
+                  href: `/dashboard/leagues/${LEAGUE.id}/standings?season=${SEASON.id}`,
+                  label: "Standings",
+                },
+                {
+                  href: `/dashboard/leagues/${LEAGUE.id}/playoffs?season=${SEASON.id}`,
+                  label: "Playoffs",
+                },
+              ]}
+            />
+          }
         />
       </div>
     </div>

--- a/apps/web/src/components/workspace/BackLink.tsx
+++ b/apps/web/src/components/workspace/BackLink.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 
 /**
  * Destination-labeled back navigation for workspace sub-pages (WSM-000236).
@@ -9,7 +10,7 @@ export function BackLink({ href, label }: { href: string; label: string }) {
       href={href}
       className="mb-3.5 inline-flex items-center gap-1.5 text-[13.5px] text-text-muted hover:text-foreground"
     >
-      <span aria-hidden>&larr;</span>
+      <ArrowLeft className="h-[15px] w-[15px] shrink-0" aria-hidden />
       {label}
     </Link>
   );

--- a/apps/web/src/components/workspace/Breadcrumbs.tsx
+++ b/apps/web/src/components/workspace/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 
 export type BreadcrumbItem = {
   label: string;
@@ -22,9 +23,10 @@ export function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
         return (
           <span key={`${item.label}-${index}`} className="inline-flex items-center gap-2">
             {index > 0 ? (
-              <span className="text-text-subtle" aria-hidden>
-                ›
-              </span>
+              <ChevronRight
+                className="h-[13px] w-[13px] shrink-0 text-text-subtle"
+                aria-hidden
+              />
             ) : null}
             {isLast || !item.href ? (
               <span className="text-foreground">{item.label}</span>

--- a/apps/web/src/components/workspace/WorkspaceHeader.tsx
+++ b/apps/web/src/components/workspace/WorkspaceHeader.tsx
@@ -5,28 +5,35 @@ export type WorkspaceHeaderSize = "top-level" | "sub-hub";
 
 /**
  * Shared workspace page header: title, optional inline status, context line,
- * and right-aligned actions (WSM-000236).
+ * optional inline nav row, and right-aligned actions (WSM-000236, WSM-000247).
+ *
+ * Matches the prototype hub header (`PageHeader` / season-hub header in the
+ * leagues-seasons handoff): 800-weight title at 30px (28px for sub-hubs) with
+ * -1px letter spacing, 14.5px muted context line, and the peer-nav link row
+ * living inside the header block directly under the context line.
  */
 export function WorkspaceHeader({
   title,
   status,
   sub,
+  nav,
   actions,
   size = "top-level",
 }: {
   title: string;
   status?: ReactNode;
   sub?: ReactNode;
+  nav?: ReactNode;
   actions?: ReactNode;
   size?: WorkspaceHeaderSize;
 }) {
   return (
-    <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
+    <header className="mb-[22px] flex flex-wrap items-start justify-between gap-4">
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-3">
           <h1
             className={cn(
-              "font-extrabold tracking-[-0.06em] text-foreground",
+              "font-extrabold leading-[1.05] tracking-[-1px] text-foreground",
               size === "sub-hub" ? "text-[28px]" : "text-[30px]",
             )}
           >
@@ -37,6 +44,7 @@ export function WorkspaceHeader({
         {sub ? (
           <div className="mt-2 text-[14.5px] text-text-muted">{sub}</div>
         ) : null}
+        {nav}
       </div>
       {actions ? (
         <div className="flex flex-wrap items-center gap-2">{actions}</div>

--- a/apps/web/src/components/workspace/WorkspaceNav.tsx
+++ b/apps/web/src/components/workspace/WorkspaceNav.tsx
@@ -13,10 +13,7 @@ export function WorkspaceNav({ links }: { links: WorkspaceNavLink[] }) {
   if (links.length === 0) return null;
 
   return (
-    <nav
-      aria-label="Workspace"
-      className="mt-3 flex flex-wrap gap-3"
-    >
+    <nav aria-label="Workspace" className="mt-3 flex flex-wrap gap-4">
       {links.map((link) => (
         <Link
           key={link.href}

--- a/apps/web/src/components/workspace/__tests__/workspace.test.ts
+++ b/apps/web/src/components/workspace/__tests__/workspace.test.ts
@@ -23,7 +23,8 @@ describe("Breadcrumbs", () => {
     expect(html).toContain('href="/dashboard/leagues"');
     expect(html).toContain("NFL");
     expect(html).not.toContain('href="/dashboard/leagues/NFL"');
-    expect(html).toContain("›");
+    // Prototype separator: chevron-right icon, not a text glyph (WSM-000247).
+    expect(html).toContain("lucide-chevron-right");
   });
 
   it("renders nothing when items are empty", () => {
@@ -44,6 +45,8 @@ describe("BackLink", () => {
     );
     expect(html).toContain('href="/dashboard/leagues/league-1"');
     expect(html).toContain("Back to League");
+    // Prototype back affordance: arrow-left icon (WSM-000247).
+    expect(html).toContain("lucide-arrow-left");
   });
 });
 
@@ -72,6 +75,25 @@ describe("WorkspaceHeader", () => {
     expect(html).toContain("National Football League");
     expect(html).toContain("text-[30px]");
     expect(html).not.toContain("text-[28px]");
+  });
+
+  it("renders the nav slot inside the header block (WSM-000247)", () => {
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceHeader, {
+        title: "2025 Season",
+        size: "sub-hub",
+        sub: createElement("span", null, "League context"),
+        nav: createElement(WorkspaceNav, {
+          links: [{ href: "/dashboard/leagues/l1/schedule", label: "Schedule" }],
+        }),
+      }),
+    );
+    const headerClose = html.indexOf("</header>");
+    const navIndex = html.indexOf('aria-label="Workspace"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(headerClose);
+    // Nav sits after the context line, per the prototype hub header.
+    expect(navIndex).toBeGreaterThan(html.indexOf("League context"));
   });
 });
 


### PR DESCRIPTION
## Summary
Hub headers aligned to the prototype (WSM-000247): WorkspaceHeader/WorkspaceNav/Breadcrumbs/BackLink composition matched to the prototype's hub pattern (typography tracking/leading, spacing, icon breadcrumb separator and back arrow, nav gap), plus an optional `nav` slot so the season hub's peer nav sits inside the header block per the prototype. Season hub adopts the shared `buildLeagueSeasonNavLinks` (identical links/gating) and the prototype's 960px content constraint. The league info page (PR #561) picks up the shared-component alignment automatically.

Behavior preserved: "Back to League"/"Back to Seasons" accessible names, "Schedule · {season}" subtitle (three schedules-standings assertions), league-info.spec heading/badge/meta/testids, WorkspaceNav aria-label and link hrefs. No route/data/flag changes; no Convex changes.

## Tests
- Unit: workspace __tests__ updated; 170 files / 1210 tests pass; lint + type-check pass
- Visual regression (non-blocking check): `workspace-league.png` / `workspace-season.png` baselines will intentionally drift from this restyle; regeneration is scoped to WSM-000252 (#554) with the rest of the epic's baseline refresh

## Related Issue
Closes #549
