### PR TITLE
feat(web): schedule standings playoffs surface polish (WSM-000250)

### DIFF
--- a/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/playoffs/page.tsx
@@ -1,12 +1,14 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
+import { Trophy } from "lucide-react";
 import { playoffsV1, schedulesStandingsV1, statKeepingV1 } from "@/lib/flags";
 import {
   getLeague,
   getLeagueOrgId,
   getSeasons,
   getPlayoffBracket,
+  getTeamsByLeague,
   listFixturesBySeason,
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
@@ -66,6 +68,14 @@ export default async function LeaguePlayoffsPage({
   const bracket = activeSeason
     ? await getPlayoffBracket(activeSeason.id)
     : null;
+
+  // Visual polish (WSM-000250): TeamMark brand colors for bracket cards.
+  const teams = bracket
+    ? await getTeamsByLeague(leagueId, orgContext).catch(() => [])
+    : [];
+  const teamColors = Object.fromEntries(
+    teams.map((team) => [team.id, team.primaryColor ?? null]),
+  );
 
   const phase = activeSeason
     ? playoffPagePhase({
@@ -154,12 +164,13 @@ export default async function LeaguePlayoffsPage({
               canManage={isAdmin}
             />
           ) : null}
-          <PlayoffBracket bracket={bracket} />
+          <PlayoffBracket bracket={bracket} teamColors={teamColors} />
         </div>
       ) : phase === "ready" ? (
         <Card>
-          <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
-            <p className="text-sm text-muted-foreground">
+          <CardContent className="flex flex-col items-center gap-4 p-10 text-center">
+            <Trophy className="h-8 w-8 text-accent" aria-hidden="true" />
+            <p className="max-w-md text-sm text-muted-foreground">
               Regular season complete ({progress.final} of {progress.total} games
               final). Ready to seed the bracket from current standings.
             </p>
@@ -181,18 +192,25 @@ export default async function LeaguePlayoffsPage({
         </Card>
       ) : (
         <Card>
-          <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
-            <p className="text-sm text-muted-foreground">
+          <CardContent className="flex flex-col items-center gap-4 p-10 text-center">
+            <p className="max-w-md text-sm text-muted-foreground">
               Regular season in progress — {progress.final} of {progress.total}{" "}
-              games final.
+              games final. Finish the schedule to seed the bracket.
             </p>
-            {isAdmin && !seasonCompleted ? (
-              <AdvanceToPlayoffsButton
-                leagueId={leagueId}
-                seasonId={activeSeason.id}
-                disabled
-              />
-            ) : null}
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {isAdmin && !seasonCompleted ? (
+                <AdvanceToPlayoffsButton
+                  leagueId={leagueId}
+                  seasonId={activeSeason.id}
+                  disabled
+                />
+              ) : null}
+              <Button asChild size="sm" variant="outline">
+                <Link href={`/dashboard/leagues/${leagueId}/schedule`}>
+                  Go to schedule
+                </Link>
+              </Button>
+            </div>
           </CardContent>
         </Card>
       )}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
+import { Trophy } from "lucide-react";
 import {
   schedulesStandingsV1,
   liveStreamingV1,
@@ -231,8 +232,10 @@ export default async function LeagueSchedulePage({
     key: group.key,
     label: group.label,
     status: group.status,
+    summary: `${group.rows.length} ${group.rows.length === 1 ? "game" : "games"}`,
+    totalCount: group.rows.length,
     // "completed", not "final" — completedRows also counts cancelled games.
-    summary: `${group.completedRows.length} of ${group.rows.length} completed`,
+    completedCount: group.completedRows.length,
     actions:
       canMutate &&
       activeSeason &&
@@ -250,7 +253,6 @@ export default async function LeagueSchedulePage({
         : fixtureTable(group.rows),
     completedContent:
       group.status === "mixed" ? fixtureTable(group.completedRows) : undefined,
-    completedCount: group.completedRows.length,
   }));
   const initialOpenKeys = initialOpenWeekKeys(weekGroups);
 
@@ -349,12 +351,26 @@ export default async function LeagueSchedulePage({
       ) : null}
 
       {handoff !== "hidden" && activeSeason ? (
-        <Card className="mb-6" data-testid="playoff-handoff">
-          <CardContent className="flex flex-col items-center gap-3 p-6 text-center">
-            <p className="text-sm text-muted-foreground">
-              Regular season complete ({progress.final} of {progress.total}{" "}
-              games final).
-            </p>
+        // Prototype "banner-cta--accent" treatment: trophy + title/sub left,
+        // the Start-playoffs CTA right. Exactly one element may contain the
+        // phrase "Regular season complete" (e2e regex, strict mode).
+        <Card
+          className="mb-6 border-accent/40 bg-accent/5"
+          data-testid="playoff-handoff"
+        >
+          <CardContent className="flex flex-wrap items-center justify-between gap-4 p-5">
+            <div className="flex items-center gap-3.5">
+              <Trophy className="h-6 w-6 shrink-0 text-accent" aria-hidden="true" />
+              <div>
+                <p className="font-bold text-foreground">
+                  Regular season complete
+                </p>
+                <p className="mt-0.5 text-[13px] text-muted-foreground">
+                  All {progress.total} games are final — seed the bracket to
+                  begin the playoffs.
+                </p>
+              </div>
+            </div>
             {handoff === "start" ? (
               <AdvanceToPlayoffsButton
                 leagueId={leagueId}
@@ -363,7 +379,7 @@ export default async function LeagueSchedulePage({
               />
             ) : (
               <p className="text-sm text-foreground">
-                Regular season complete — waiting for playoffs to start.
+                Waiting for playoffs to start.
               </p>
             )}
           </CardContent>
@@ -389,7 +405,11 @@ export default async function LeagueSchedulePage({
           </CardContent>
         </Card>
       ) : (
-        <ScheduleWeeks weeks={weekViews} initialOpenKeys={initialOpenKeys} />
+        <ScheduleWeeks
+          weeks={weekViews}
+          initialOpenKeys={initialOpenKeys}
+          progress={progress}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/standings/page.tsx
@@ -7,6 +7,7 @@ import {
   getDivisions,
   getLeague,
   getSeasons,
+  getTeamsByLeague,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -72,6 +73,15 @@ export default async function LeagueStandingsPage({
 
   const standings = await computeStandings(activeSeason.id);
   const divisions = await getDivisions([leagueId]);
+
+  // Visual polish (WSM-000250): TeamMark brand colors + the playoff-cut
+  // treatment. The cut divider only renders on the flat league-ranked table;
+  // division tables (division-rank ordered) show Clinched badges alone.
+  const teams = await getTeamsByLeague(leagueId, orgContext).catch(() => []);
+  const teamColors = Object.fromEntries(
+    teams.map((team) => [team.id, team.primaryColor ?? null]),
+  );
+  const playoffCut = activeSeason.playoffTeams ?? 0;
 
   const divisionStandings =
     divisions.length > 0
@@ -142,12 +152,21 @@ export default async function LeagueStandingsPage({
                     key={division.id}
                     divisionName={division.name}
                     rows={rows}
+                    playoffCut={playoffCut}
+                    withTeamMarks
+                    teamColors={teamColors}
                   />
                 ) : null,
               )}
             </div>
           ) : (
-            <StandingsTable rows={standings} />
+            <StandingsTable
+              rows={standings}
+              playoffCut={playoffCut}
+              showPlayoffCutDivider
+              withTeamMarks
+              teamColors={teamColors}
+            />
           )}
         </CardContent>
       </Card>

--- a/apps/web/src/components/playoffs/PlayoffBracket.tsx
+++ b/apps/web/src/components/playoffs/PlayoffBracket.tsx
@@ -2,7 +2,9 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { Trophy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TeamMark } from "@/components/team-mark";
 import type { PlayoffMatchupDto } from "@/lib/data-api";
 import { bracketSections, winnerSide } from "@/lib/playoffs";
 import type { PlayoffBracketDto } from "@/lib/data-api";
@@ -50,6 +52,7 @@ function Side({
   won,
   dim,
   linkable,
+  teamColors,
 }: {
   teamId: string | null;
   seed: number | null;
@@ -58,19 +61,28 @@ function Side({
   won: boolean;
   dim: boolean;
   linkable: boolean;
+  teamColors?: Record<string, string | null>;
 }) {
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-2 px-2 py-1 text-sm",
-        won && "bg-muted/50",
+        "flex items-center justify-between gap-2 px-3 py-2 text-sm",
+        won && "bg-muted",
       )}
     >
-      <span className="flex min-w-0 items-center gap-1.5">
-        {seed != null ? (
-          <span className="shrink-0 rounded bg-muted px-1 font-mono text-caption-12 tabular-nums text-muted-foreground">
-            {seed}
-          </span>
+      <span className="flex min-w-0 items-center gap-2">
+        {/* Prototype seed slot: fixed-width plain mono digit, kept even when
+            empty so team names align across TBD and seeded cards. */}
+        <span className="w-4 shrink-0 text-center font-mono text-caption-12 tabular-nums text-muted-foreground">
+          {seed ?? ""}
+        </span>
+        {name ? (
+          <TeamMark
+            name={name}
+            primaryColor={teamId ? teamColors?.[teamId] : null}
+            size="sm"
+            className="h-5 w-5 text-[9px]"
+          />
         ) : null}
         <TeamName
           teamId={teamId}
@@ -90,9 +102,11 @@ function Side({
 function MatchupCard({
   m,
   roundLabel,
+  teamColors,
 }: {
   m: PlayoffMatchupDto;
   roundLabel: string;
+  teamColors?: Record<string, string | null>;
 }) {
   const side = winnerSide(m);
   const decided = side !== null;
@@ -101,7 +115,7 @@ function MatchupCard({
   const restoreFocusRef = React.useRef<HTMLButtonElement | null>(null);
 
   const card = m.isBye ? (
-    <div className="overflow-hidden rounded-md border border-dashed border-border bg-card">
+    <div className="overflow-hidden rounded-lg border border-dashed border-border bg-card">
       <Side
         teamId={m.homeTeamId}
         seed={m.homeSeed}
@@ -110,14 +124,15 @@ function MatchupCard({
         won={true}
         dim={false}
         linkable={false}
+        teamColors={teamColors}
       />
       <div className="border-t border-border" />
-      <div className="px-2 py-1 text-xs italic text-muted-foreground">
+      <div className="px-3 py-1.5 text-xs italic text-muted-foreground">
         Bye — advances
       </div>
     </div>
   ) : (
-    <div className="overflow-hidden rounded-md border border-border bg-card">
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
       <Side
         teamId={m.homeTeamId}
         seed={m.homeSeed}
@@ -126,6 +141,7 @@ function MatchupCard({
         won={side === "home"}
         dim={decided}
         linkable={false}
+        teamColors={teamColors}
       />
       <div className="border-t border-border" />
       <Side
@@ -136,6 +152,7 @@ function MatchupCard({
         won={side === "away"}
         dim={decided}
         linkable={false}
+        teamColors={teamColors}
       />
     </div>
   );
@@ -155,7 +172,7 @@ function MatchupCard({
         aria-haspopup="dialog"
         data-testid={`playoff-drawer-trigger-${m.id}`}
         onClick={() => setOpen(true)}
-        className="block w-full rounded-md text-left transition-colors hover:ring-2 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="block w-full rounded-lg text-left transition-colors hover:ring-2 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {card}
       </button>
@@ -178,8 +195,11 @@ function MatchupCard({
  */
 export default function PlayoffBracket({
   bracket,
+  teamColors,
 }: {
   bracket: PlayoffBracketDto;
+  /** Team brand colors by team id, for TeamMark (name-derived fallback). */
+  teamColors?: Record<string, string | null>;
 }) {
   const sections = bracketSections(
     bracket.matchups,
@@ -190,22 +210,25 @@ export default function PlayoffBracket({
   return (
     <div className="flex flex-col gap-6">
       {bracket.champion ? (
-        <div className="rounded-lg border border-primary/30 bg-primary/10 px-4 py-3">
-          <p className="font-mono text-caption-12 uppercase tracking-wide text-primary">
-            Champion
-          </p>
-          <p className="mt-1 text-lg font-semibold text-foreground">
-            {bracket.champion.teamId ? (
-              <Link
-                href={`/dashboard/teams/${bracket.champion.teamId}`}
-                className="hover:underline"
-              >
-                {bracket.champion.teamName ?? "Champion"}
-              </Link>
-            ) : (
-              (bracket.champion.teamName ?? "Champion")
-            )}
-          </p>
+        <div className="flex flex-wrap items-center gap-3.5 rounded-lg border border-primary/30 bg-primary/10 px-5 py-4">
+          <Trophy className="h-6 w-6 shrink-0 text-primary" aria-hidden="true" />
+          <div>
+            <p className="font-mono text-caption-12 uppercase tracking-wide text-primary">
+              Champion
+            </p>
+            <p className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+              {bracket.champion.teamId ? (
+                <Link
+                  href={`/dashboard/teams/${bracket.champion.teamId}`}
+                  className="hover:underline"
+                >
+                  {bracket.champion.teamName ?? "Champion"}
+                </Link>
+              ) : (
+                (bracket.champion.teamName ?? "Champion")
+              )}
+            </p>
+          </div>
         </div>
       ) : null}
 
@@ -218,27 +241,67 @@ export default function PlayoffBracket({
               </h3>
             ) : null}
             <div className="overflow-x-auto">
-              <div className="flex min-w-max gap-6 pb-2">
-                {section.rounds.map((r) => (
-                  <div
-                    key={`${section.type}-${r.round}`}
-                    className="flex w-56 shrink-0 flex-col"
-                  >
-                    <h4 className="mb-3 font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
-                      {r.label}
-                    </h4>
-                    <div className="flex flex-1 flex-col justify-around gap-4">
-                      {r.matchups.map((m) => (
-                        <MatchupCard key={m.id} m={m} roundLabel={r.label} />
-                      ))}
+              <div className="flex min-w-max gap-8 pb-2">
+                {section.rounds.map((r) => {
+                  // Prototype phase treatment: rounds that have not been
+                  // built yet still render their column with dimmed TBD
+                  // placeholder cards (winners-bracket geometry only).
+                  const placeholderCount =
+                    section.type === "winners" && r.matchups.length === 0
+                      ? Math.max(1, 2 ** (bracket.rounds - r.round))
+                      : 0;
+                  return (
+                    <div
+                      key={`${section.type}-${r.round}`}
+                      className="flex w-56 shrink-0 flex-col"
+                    >
+                      <h4 className="mb-3 font-mono text-caption-12 uppercase tracking-wide text-muted-foreground">
+                        {r.label}
+                      </h4>
+                      <div className="flex flex-1 flex-col justify-around gap-5">
+                        {r.matchups.length > 0
+                          ? r.matchups.map((m) => (
+                              <MatchupCard
+                                key={m.id}
+                                m={m}
+                                roundLabel={r.label}
+                                teamColors={teamColors}
+                              />
+                            ))
+                          : Array.from({ length: placeholderCount }).map(
+                              (_, slot) => (
+                                <PlaceholderMatchup key={slot} />
+                              ),
+                            )}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           </section>
         ))}
       </div>
+    </div>
+  );
+}
+
+/** Dimmed two-side TBD card for rounds the bracket has not reached yet. */
+function PlaceholderMatchup() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-dashed border-border bg-card opacity-60">
+      <PlaceholderSide />
+      <div className="border-t border-border" />
+      <PlaceholderSide />
+    </div>
+  );
+}
+
+function PlaceholderSide() {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 text-sm">
+      <span className="w-4 shrink-0" />
+      <span className="text-muted-foreground">TBD</span>
     </div>
   );
 }

--- a/apps/web/src/components/schedule/ScheduleWeeks.tsx
+++ b/apps/web/src/components/schedule/ScheduleWeeks.tsx
@@ -2,6 +2,10 @@
 
 /*
  * WSM-000239 — lifecycle-aware accordion timeline for the schedule page.
+ * WSM-000250 — visual polish to the leagues-seasons prototype treatment:
+ * left-chevron accordion weeks with a games-count subtitle and a played
+ * status chip, full-bleed fixture tables, and a regular-season progress
+ * line beside Expand/Collapse all.
  *
  * Presentation-only: the server page does ALL data fetching and renders each
  * week's fixture table (and per-week action buttons) into slots; this
@@ -11,13 +15,14 @@
  */
 
 import { useId, useState, type ReactNode } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -27,8 +32,12 @@ export interface ScheduleWeekView {
   /** "Week <n>" | "Unscheduled" — the trigger's accessible name starts with this. */
   label: string;
   status: "completed" | "upcoming" | "mixed";
-  /** Muted per-week summary shown in the trigger, e.g. "2 of 4 final". */
+  /** Muted per-week subtitle shown in the trigger, e.g. "4 games". */
   summary?: string;
+  /** Total games in the week — drives the "x/y played" status chip. */
+  totalCount: number;
+  /** Completed (final or cancelled) games in the week. */
+  completedCount: number;
   /** Per-week action controls (e.g. Sim week) — rendered OUTSIDE the trigger button. */
   actions?: ReactNode;
   /**
@@ -38,47 +47,73 @@ export interface ScheduleWeekView {
   content: ReactNode;
   /** Mixed weeks: completed games, shown inside the nested collapsed subsection. */
   completedContent?: ReactNode;
-  /** Mixed weeks: how many games sit in the completed subsection. */
-  completedCount?: number;
 }
 
 export interface ScheduleWeeksProps {
   weeks: ScheduleWeekView[];
   /** Initial open accordion values — completed weeks closed, others open. */
   initialOpenKeys: string[];
+  /** Regular-season progress for the "x/y regular-season games played" line. */
+  progress?: { final: number; total: number };
 }
+
+/*
+ * Week status chip — prototype tone slot. Deliberately NOT the words
+ * "Scheduled"/"Final": those exact texts are asserted per-row by e2e
+ * (sim-scopes, gamecast) and a week-level duplicate would trip strict mode.
+ */
+const CHIP_VARIANT = {
+  completed: "secondary",
+  mixed: "warning",
+  upcoming: "outline",
+} as const;
 
 export default function ScheduleWeeks({
   weeks,
   initialOpenKeys,
+  progress,
 }: ScheduleWeeksProps) {
   const [openKeys, setOpenKeys] = useState<string[]>(initialOpenKeys);
 
   return (
-    <div className="space-y-4">
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setOpenKeys(weeks.map((week) => week.key))}
-        >
-          Expand all
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setOpenKeys([])}
-        >
-          Collapse all
-        </Button>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {progress && progress.total > 0 ? (
+          <p className="text-[13px] text-muted-foreground">
+            <span className="font-mono tabular-nums">
+              {progress.final}/{progress.total}
+            </span>{" "}
+            regular-season games played
+          </p>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
+            onClick={() => setOpenKeys(weeks.map((week) => week.key))}
+          >
+            Expand all
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
+            onClick={() => setOpenKeys([])}
+          >
+            Collapse all
+          </Button>
+        </div>
       </div>
       <Accordion
         type="multiple"
         value={openKeys}
         onValueChange={setOpenKeys}
-        className="space-y-4"
+        className="space-y-3"
       >
         {weeks.map((week) => (
           <AccordionItem
@@ -88,34 +123,50 @@ export default function ScheduleWeeks({
             // previously ui/Card elements, which carry data-slot="card".
             data-slot="card"
             data-week-status={week.status}
-            className="rounded-lg border border-border bg-card px-4 last:border-b"
+            className="overflow-hidden rounded-lg border border-border bg-card last:border-b"
           >
-            <div className="flex items-center gap-2">
-              <div className="min-w-0 flex-1">
-                <AccordionTrigger>
-                  <span className="flex flex-wrap items-baseline gap-x-2">
-                    <span>{week.label}</span>
-                    {week.summary ? (
-                      <span className="text-xs font-normal text-muted-foreground">
-                        {week.summary}
-                      </span>
-                    ) : null}
+            <div className="flex items-center gap-2 pr-3">
+              {/* The shadcn trigger appends its own right chevron as a direct-
+                  child svg — hide it and rotate a left chevron instead (the
+                  custom one lives inside the span so the [&>svg] selectors
+                  never touch it). */}
+              <AccordionTrigger className="group min-w-0 flex-1 justify-start px-4 py-3.5 hover:no-underline focus-visible:ring-inset focus-visible:ring-offset-0 [&>svg]:hidden">
+                <span className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1">
+                  <ChevronRight
+                    aria-hidden="true"
+                    className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-90"
+                  />
+                  <span className="text-[15px] font-bold tracking-tight">
+                    {week.label}
                   </span>
-                </AccordionTrigger>
-              </div>
+                  {week.summary ? (
+                    <span className="text-xs font-normal text-muted-foreground">
+                      {week.summary}
+                    </span>
+                  ) : null}
+                  <span
+                    className={cn(
+                      badgeVariants({ variant: CHIP_VARIANT[week.status] }),
+                      "font-mono text-[11px] font-medium tabular-nums",
+                    )}
+                  >
+                    {week.completedCount}/{week.totalCount} played
+                  </span>
+                </span>
+              </AccordionTrigger>
               {week.actions ? (
                 <div className="flex shrink-0 items-center gap-1">
                   {week.actions}
                 </div>
               ) : null}
             </div>
-            <AccordionContent>
+            <AccordionContent className="border-t border-border pb-0">
               {week.status === "mixed" ? (
-                <div className="space-y-3">
+                <div>
                   {week.content}
                   <CompletedSubsection
                     weekLabel={week.label}
-                    count={week.completedCount ?? 0}
+                    count={week.completedCount}
                   >
                     {week.completedContent}
                   </CompletedSubsection>
@@ -134,7 +185,8 @@ export default function ScheduleWeeks({
 /*
  * Nested disclosure for the completed games inside a mixed week. Collapsed by
  * default; a plain <button> keeps it keyboard operable, with aria-expanded /
- * aria-controls wired to an always-present (hidden) content region.
+ * aria-controls wired to an always-present (hidden) content region. The
+ * aria-label ("Completed games — Week N (n)") is an e2e-pinned accessible name.
  */
 function CompletedSubsection({
   weekLabel,
@@ -149,25 +201,29 @@ function CompletedSubsection({
   const contentId = useId();
 
   return (
-    <div className="rounded-md border border-border">
+    <div className="border-t border-border">
       <button
         type="button"
         aria-expanded={open}
         aria-controls={contentId}
         aria-label={`Completed games — ${weekLabel} (${count})`}
         onClick={() => setOpen((current) => !current)}
-        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
       >
-        <ChevronDown
+        <ChevronRight
           aria-hidden="true"
           className={cn(
             "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
-            open ? "rotate-180" : "",
+            open ? "rotate-90" : "",
           )}
         />
-        Completed ({count})
+        Completed games ({count})
       </button>
-      <div id={contentId} hidden={!open}>
+      <div
+        id={contentId}
+        hidden={!open}
+        className="border-t border-border"
+      >
         {children}
       </div>
     </div>

--- a/apps/web/src/components/schedule/StandingsTable.tsx
+++ b/apps/web/src/components/schedule/StandingsTable.tsx
@@ -1,10 +1,29 @@
+import { Fragment } from "react";
 import Link from "next/link";
 import type { Standing } from "@sports-management/shared-types";
+import { Badge } from "@/components/ui/badge";
+import { TeamMark } from "@/components/team-mark";
 
 export interface StandingsTableProps {
   rows: Standing[];
   /** When set, renders a division header above this table block. */
   divisionName?: string;
+  /**
+   * WSM-000250 dashboard polish — season playoff team count. Rows ranked at
+   * or above the cut (that have played) get a "Clinched" badge. Optional and
+   * off by default so the public viewer and visual harness stay unchanged.
+   */
+  playoffCut?: number;
+  /**
+   * Render the dashed "Playoff cut" divider under the row whose league rank
+   * equals `playoffCut`. Only meaningful when rows are league-rank ordered
+   * (the flat league table) — division tables pass `playoffCut` alone.
+   */
+  showPlayoffCutDivider?: boolean;
+  /** Render a TeamMark monogram before each team name (dashboard polish). */
+  withTeamMarks?: boolean;
+  /** Team brand colors by team id, for TeamMark (name-derived fallback). */
+  teamColors?: Record<string, string | null>;
 }
 
 /**
@@ -16,7 +35,12 @@ export interface StandingsTableProps {
 export default function StandingsTable({
   rows,
   divisionName,
+  playoffCut,
+  showPlayoffCutDivider = false,
+  withTeamMarks = false,
+  teamColors,
 }: StandingsTableProps) {
+  const cut = playoffCut && playoffCut > 0 ? playoffCut : 0;
   return (
     <div className="w-full">
       {divisionName ? (
@@ -62,18 +86,42 @@ export default function StandingsTable({
         <tbody>
           {rows.map((row) => {
             const diff = row.pointsFor - row.pointsAgainst;
+            const clinched =
+              cut > 0 &&
+              row.leagueRank <= cut &&
+              row.wins + row.losses + row.ties > 0;
+            const teamLink = (
+              <Link
+                href={`/dashboard/teams/${row.teamId}`}
+                className="text-primary hover:underline"
+              >
+                {row.teamName}
+              </Link>
+            );
             return (
-              <tr key={row.teamId} className="border-b border-border">
+              <Fragment key={row.teamId}>
+              <tr className="border-b border-border">
                 <td className="px-4 py-2 font-mono tabular-nums text-foreground">
                   {row.leagueRank}
                 </td>
                 <td className="px-4 py-2 text-foreground">
-                  <Link
-                    href={`/dashboard/teams/${row.teamId}`}
-                    className="text-primary hover:underline"
-                  >
-                    {row.teamName}
-                  </Link>
+                  {withTeamMarks || clinched ? (
+                    <span className="flex items-center gap-2.5">
+                      {withTeamMarks ? (
+                        <TeamMark
+                          name={row.teamName}
+                          primaryColor={teamColors?.[row.teamId]}
+                          size="sm"
+                        />
+                      ) : null}
+                      {teamLink}
+                      {clinched ? (
+                        <Badge variant="success">Clinched</Badge>
+                      ) : null}
+                    </span>
+                  ) : (
+                    teamLink
+                  )}
                 </td>
                 <td className="px-4 py-2 text-right font-mono tabular-nums text-foreground">
                   {row.wins}
@@ -106,6 +154,18 @@ export default function StandingsTable({
                   {row.divisionRank}
                 </td>
               </tr>
+              {showPlayoffCutDivider && cut > 0 && row.leagueRank === cut ? (
+                <tr aria-hidden="true" data-testid="playoff-cut-divider">
+                  <td colSpan={9} className="p-0">
+                    <div className="relative border-t-2 border-dashed border-border-strong">
+                      <span className="absolute -top-2 right-3 bg-card px-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                        Playoff cut
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : null}
+              </Fragment>
             );
           })}
         </tbody>


### PR DESCRIPTION
## Summary
Schedule / standings / playoffs surface polish per the leagues-seasons handoff (WSM-000250) — visual/composition only, all WSM-000235 operations intact. Schedule: accordion week treatment with "k/n played" week chips, "Completed games (n)" subsection copy (e2e-pinned aria-labels unchanged), and a regular-season progress line. Standings: playoff-cut divider, Clinched badges, and TeamMark rows — opt-in via props passed only by the dashboard page, so the public `/leagues/[id]/standings` mirror and its visual baseline stay byte-identical. Playoffs: bracket phase columns with TBD placeholders for unbuilt rounds, TeamMark on matchup cards, and an in-progress card pointing at the schedule.

Deliberate deviations from the prototype, to protect pinned e2e contracts: per-row "Scheduled"/"Final" chip texts stay row-level only (strict-mode), fixture rows skip TeamMark (gamecast button names derive from row innerText), and both "Expand all"/"Collapse all" buttons remain (accessible names pinned by specs).

No Convex changes; new data needs are read-only `getTeamsByLeague` calls for brand colors.

## Tests
- Unit: 170 files / 1210 tests pass; lint + type-check pass
- E2E: no spec changes needed — copy and aria contracts asserted by schedules-standings, playoffs-bracket, gamecast, and sim-league-setup were deliberately preserved

## Related Issue
Closes #552
