### PR TITLE
feat(web): reskin operator shell to prototype chrome (WSM-000246)

### DIFF
--- a/apps/web/src/app/dashboard/_components/command-trigger.tsx
+++ b/apps/web/src/app/dashboard/_components/command-trigger.tsx
@@ -46,7 +46,7 @@ export function CommandTrigger({
       variant="outline"
       size="sm"
       onClick={openCommandPalette}
-      className="text-text-subtle h-[38px] max-w-[360px] flex-1 justify-between gap-2 border-border bg-surface-2 font-medium hover:bg-surface-2 hover:text-text-subtle"
+      className="text-text-subtle h-[38px] max-w-[360px] flex-1 justify-between gap-2 rounded-control border-border bg-surface-2 font-medium hover:bg-surface-2 hover:text-text-subtle"
     >
       <span className="flex items-center gap-2">
         <Search className="h-3.5 w-3.5" />

--- a/apps/web/src/app/dashboard/_components/command-trigger.tsx
+++ b/apps/web/src/app/dashboard/_components/command-trigger.tsx
@@ -46,13 +46,13 @@ export function CommandTrigger({
       variant="outline"
       size="sm"
       onClick={openCommandPalette}
-      className="text-muted-foreground w-56 justify-between gap-2 font-normal"
+      className="text-text-subtle h-[38px] max-w-[360px] flex-1 justify-between gap-2 border-border bg-surface-2 font-medium hover:bg-surface-2 hover:text-text-subtle"
     >
       <span className="flex items-center gap-2">
-        <Search className="h-4 w-4" />
+        <Search className="h-3.5 w-3.5" />
         Search…
       </span>
-      <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium select-none">
+      <kbd className="text-text-subtle pointer-events-none inline-flex items-center rounded-md border border-border px-1.5 py-0.5 font-mono text-[11px] font-medium select-none">
         {isMac ? "⌘" : "Ctrl"} K
       </kbd>
     </Button>

--- a/apps/web/src/app/dashboard/_components/league-switcher.tsx
+++ b/apps/web/src/app/dashboard/_components/league-switcher.tsx
@@ -48,15 +48,15 @@ export function LeagueSwitcher({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-60"
+        className="flex h-9 min-w-0 items-center gap-2 rounded-control border border-border bg-surface px-3 text-[13px] font-semibold text-text transition-colors hover:bg-surface-2 disabled:opacity-60"
         disabled={isPending}
         aria-label="Switch league"
       >
-        <Trophy className="h-4 w-4 shrink-0 text-primary" />
+        <Trophy className="h-3.5 w-3.5 shrink-0 text-accent" strokeWidth={1.9} />
         <span className="max-w-[10rem] truncate">
           {active?.name ?? "Select league"}
         </span>
-        <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-text-muted" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
         <DropdownMenuLabel>Active league</DropdownMenuLabel>

--- a/apps/web/src/app/dashboard/_components/league-switcher.tsx
+++ b/apps/web/src/app/dashboard/_components/league-switcher.tsx
@@ -48,7 +48,7 @@ export function LeagueSwitcher({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className="flex h-9 min-w-0 items-center gap-2 rounded-control border border-border bg-surface px-3 text-[13px] font-semibold text-text transition-colors hover:bg-surface-2 disabled:opacity-60"
+        className="flex h-9 min-w-0 items-center gap-2 rounded-control border border-border bg-surface-2 px-3 text-[13px] font-semibold text-text transition-colors hover:bg-surface-3 disabled:opacity-60"
         disabled={isPending}
         aria-label="Switch league"
       >

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import { Menu } from "lucide-react";
 import { UserButton } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import Sidebar from "./sidebar";
 import { LeagueSwitcher } from "./league-switcher";
 import { CommandTrigger } from "./command-trigger";
@@ -33,7 +38,12 @@ export default function MobileHeader({
             <Menu className="h-5 w-5" />
           </Button>
         </SheetTrigger>
-        <SheetContent side="left" className="w-[212px] border-r border-border bg-bg p-0">
+        <SheetContent
+          side="left"
+          hideCloseButton
+          className="w-[248px] border-r border-border bg-bg p-0"
+        >
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
           <Sidebar onNavigate={() => setOpen(false)} />
         </SheetContent>
       </Sheet>

--- a/apps/web/src/app/dashboard/_components/mobile-header.tsx
+++ b/apps/web/src/app/dashboard/_components/mobile-header.tsx
@@ -26,23 +26,25 @@ export default function MobileHeader({
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3 lg:hidden">
+    <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b border-border bg-bg px-4 lg:hidden">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="Open navigation menu">
             <Menu className="h-5 w-5" />
           </Button>
         </SheetTrigger>
-        <SheetContent side="left" className="w-64 p-0">
+        <SheetContent side="left" className="w-[212px] border-r border-border bg-bg p-0">
           <Sidebar onNavigate={() => setOpen(false)} />
         </SheetContent>
       </Sheet>
       {leagues.length > 0 ? (
         <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
       ) : (
-        <h1 className="text-lg font-semibold text-foreground">Dashboard</h1>
+        <h1 className="text-base font-bold tracking-[-0.4px] text-text">
+          Sports League
+        </h1>
       )}
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1.5">
         <CommandTrigger variant="icon" />
         <DensityToggle />
         <ThemeToggle />

--- a/apps/web/src/app/dashboard/_components/nav-link.tsx
+++ b/apps/web/src/app/dashboard/_components/nav-link.tsx
@@ -26,14 +26,15 @@ export default function NavLink({
     <Link
       href={href}
       onClick={onClick}
+      aria-current={isActive ? "page" : undefined}
       className={cn(
-        "flex items-center gap-3 rounded-control px-3 py-2 text-label-14 transition-colors",
+        "flex h-[38px] w-full items-center gap-2.5 rounded-control px-3 text-label-14 font-semibold transition-colors",
         isActive
           ? "bg-primary text-primary-foreground"
-          : "text-text-muted hover:bg-surface-3 hover:text-text",
+          : "text-text-muted hover:bg-surface-2 hover:text-text",
       )}
     >
-      {Icon && <Icon className="h-4 w-4" />}
+      {Icon && <Icon className="h-[18px] w-[18px] shrink-0" strokeWidth={1.9} />}
       {children}
     </Link>
   );

--- a/apps/web/src/app/dashboard/_components/sidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/sidebar.tsx
@@ -31,11 +31,23 @@ interface SidebarProps {
 
 export default function Sidebar({ onNavigate }: SidebarProps) {
   return (
-    <div className="flex h-full flex-col">
-      <div className="px-4 py-5">
-        <h2 className="text-lg font-semibold text-foreground">Sports League</h2>
+    <div className="flex h-full flex-col px-3 py-[18px]">
+      <div className="flex items-center gap-2.5 px-2 pb-4">
+        <span
+          className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-[9px] bg-primary text-primary-foreground"
+          aria-hidden="true"
+        >
+          <Trophy className="h-3.5 w-3.5" strokeWidth={2.4} />
+        </span>
+        <h2 className="text-base font-bold tracking-[-0.4px] text-text">
+          Sports League
+        </h2>
       </div>
-      <nav className="flex-1 space-y-1 px-2" role="navigation" aria-label="Main navigation">
+      <nav
+        className="flex flex-1 flex-col gap-0.5"
+        role="navigation"
+        aria-label="Main navigation"
+      >
         {navItems.map((item) => (
           <NavLink
             key={item.href}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -22,13 +22,13 @@ export default async function DashboardLayout({
     : { leagues: [], activeLeagueId: null };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen bg-bg">
       <a href="#main-content" className="skip-to-content">
         Skip to content
       </a>
 
-      {/* Desktop sidebar */}
-      <aside className="hidden w-56 border-r border-border bg-card lg:block">
+      {/* Desktop sidebar — prototype shell: 212px rail on --bg */}
+      <aside className="hidden w-[212px] shrink-0 border-r border-border bg-bg lg:block">
         <Sidebar />
       </aside>
 
@@ -39,13 +39,13 @@ export default async function DashboardLayout({
         {/* Mobile header with hamburger */}
         <MobileHeader leagues={leagues} activeLeagueId={activeLeagueId} />
 
-        {/* Desktop header — the league switcher is the focus anchor (WSM-000103) */}
-        <header className="hidden items-center justify-between border-b border-border px-8 py-4 lg:flex">
-          <div className="flex items-center gap-3">
+        {/* Desktop header — league switcher + command left; density/theme/account right */}
+        <header className="hidden h-14 shrink-0 items-center justify-between gap-3.5 border-b border-border bg-bg px-[22px] lg:flex">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             <LeagueSwitcher leagues={leagues} activeLeagueId={activeLeagueId} />
             <CommandTrigger />
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2.5">
             <DensityToggle />
             <ThemeToggle />
             <UserButton />

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -27,8 +27,8 @@ export default async function DashboardLayout({
         Skip to content
       </a>
 
-      {/* Desktop sidebar — prototype shell: 212px rail on --bg */}
-      <aside className="hidden w-[212px] shrink-0 border-r border-border bg-bg lg:block">
+      {/* Desktop sidebar — prototype shell: 248px rail on --bg */}
+      <aside className="hidden w-[248px] shrink-0 border-r border-border bg-bg lg:block">
         <Sidebar />
       </aside>
 

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -25,12 +25,25 @@ const SheetOverlay = React.forwardRef<
 ));
 SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
 const SheetContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     side?: "left" | "right" | "top" | "bottom";
+    hideCloseButton?: boolean;
   }
->(({ side = "left", className, children, ...props }, ref) => (
+>(({ side = "left", className, children, hideCloseButton = false, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <DialogPrimitive.Content
@@ -46,13 +59,23 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideCloseButton ? (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      ) : null}
     </DialogPrimitive.Content>
   </SheetPortal>
 ));
 SheetContent.displayName = "SheetContent";
 
-export { Sheet, SheetPortal, SheetOverlay, SheetTrigger, SheetClose, SheetContent };
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+};


### PR DESCRIPTION
## Summary
- Reskins the persistent dashboard operator shell (sidebar, desktop/mobile header, brand, active nav) to match the approved Leagues & Seasons prototype chrome.
- Keeps CommandPalette (⌘K), DensityToggle, ThemeToggle, league switcher, skip-to-content, and main landmark intact.
- No route, Convex, or data API changes.

## Related Issue
Closes #548
Parent epic: #547 (WSM-000245)

## Test plan
- [ ] Desktop `/dashboard`: 212px sidebar, trophy brand block, active nav pill
- [ ] Desktop header: league switcher + search left; density/theme/account right
- [ ] ⌘K / Ctrl+K opens command palette
- [ ] Mobile hamburger opens sidebar sheet; skip-to-content works
- [ ] `pnpm --filter web exec vitest run src/app/dashboard` green

