### PR TITLE
feat(web): align mobile nav and command palette with canonical routes (#577)

### DIFF
--- a/apps/web/e2e/tests/mobile-navigation.spec.ts
+++ b/apps/web/e2e/tests/mobile-navigation.spec.ts
@@ -1,7 +1,16 @@
 import { test, expect } from "@playwright/test";
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 
-const NAV_LABELS = ["Overview", "Teams", "Players", "Seasons"];
+/** Shell destinations shared by desktop aside + mobile sheet (ASR-13 / #577). */
+const NAV_LABELS = [
+  "Overview",
+  "Teams",
+  "Players",
+  "Seasons",
+  "Import",
+  "Billing",
+];
+const OBSOLETE_TOP_LEVEL = ["Divisions", "Discover", "Leagues"];
 
 test.describe("Mobile Responsive Navigation", () => {
   test.beforeEach(async ({ page }) => {
@@ -30,6 +39,11 @@ test.describe("Mobile Responsive Navigation", () => {
 
     for (const label of NAV_LABELS) {
       await expect(sheet.getByRole("link", { name: label })).toBeVisible();
+    }
+
+    // ASR-4 / ASR-23 — obsolete top-level destinations stay out of the shell
+    for (const label of OBSOLETE_TOP_LEVEL) {
+      await expect(sheet.getByRole("link", { name: label })).toHaveCount(0);
     }
   });
 
@@ -73,6 +87,29 @@ test.describe("Mobile Responsive Navigation", () => {
     for (const label of NAV_LABELS) {
       const link = sidebar.getByRole("link", { name: label });
       await expect(link.locator("svg")).toBeVisible();
+    }
+
+    for (const label of OBSOLETE_TOP_LEVEL) {
+      await expect(sidebar.getByRole("link", { name: label })).toHaveCount(0);
+    }
+  });
+
+  test("desktop sidebar exposes the same shell destinations as mobile", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/dashboard");
+
+    const sidebar = page.locator("aside");
+    await expect(
+      sidebar.getByRole("heading", { name: "Sports League" }),
+    ).toBeVisible();
+
+    for (const label of NAV_LABELS) {
+      await expect(sidebar.getByRole("link", { name: label })).toBeVisible();
+    }
+    for (const label of OBSOLETE_TOP_LEVEL) {
+      await expect(sidebar.getByRole("link", { name: label })).toHaveCount(0);
     }
   });
 });

--- a/apps/web/src/app/dashboard/_components/__tests__/command-palette-nav.test.ts
+++ b/apps/web/src/app/dashboard/_components/__tests__/command-palette-nav.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { leagueActivationHref } from "@/components/workspace/resource-navigation";
+import { buildPaletteNavItems, buildShellNavItems } from "../shell-nav";
+
+describe("shell + command palette nav contracts (issue #577)", () => {
+  it("builds identical league-scoped shell destinations for sidebar parity", () => {
+    const items = buildShellNavItems("league-1");
+    expect(items.map((i) => i.label)).toEqual([
+      "Overview",
+      "Teams",
+      "Players",
+      "Seasons",
+      "Import",
+      "Billing",
+    ]);
+    expect(items.find((i) => i.id === "overview")?.href).toBe(
+      "/dashboard/leagues/league-1",
+    );
+    expect(items.some((i) => i.href === "/dashboard/divisions")).toBe(false);
+    expect(items.some((i) => i.href === "/dashboard/discover")).toBe(false);
+  });
+
+  it("palette Navigate group keeps League Directory and drops obsolete commands", () => {
+    const items = buildPaletteNavItems("league-1");
+    const labels = items.map((i) => i.label);
+
+    expect(labels).toContain("League Directory");
+    expect(labels).toContain("Overview");
+    expect(labels).toContain("Import");
+    expect(labels).toContain("Billing");
+
+    expect(labels).not.toContain("Divisions");
+    expect(labels).not.toContain("Discover");
+    expect(labels).not.toContain("Roles & permissions");
+    expect(labels).not.toContain("Leagues");
+
+    expect(items.find((i) => i.id === "league-directory")?.href).toBe(
+      "/dashboard/leagues",
+    );
+    expect(items.find((i) => i.id === "overview")?.href).toBe(
+      "/dashboard/leagues/league-1",
+    );
+  });
+
+  it("palette Overview falls back to League Directory without an Active League", () => {
+    const items = buildPaletteNavItems(null);
+    expect(items.find((i) => i.id === "overview")?.href).toBe(
+      "/dashboard/leagues",
+    );
+  });
+
+  it("League palette picks activate via the Active League handler (ASR-1/23)", () => {
+    const href = leagueActivationHref("league-2");
+    expect(href).toContain("/dashboard/active-league?");
+    expect(href).toContain("leagueId=league-2");
+    expect(href).toContain(
+      encodeURIComponent("/dashboard/leagues/league-2"),
+    );
+  });
+});

--- a/apps/web/src/app/dashboard/_components/command-palette.tsx
+++ b/apps/web/src/app/dashboard/_components/command-palette.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   LayoutDashboard,
   Trophy,
-  Compass,
   Users,
   UserCircle,
   Calendar,
-  Layers,
   Upload,
   CreditCard,
-  Shield,
+  type LucideIcon,
 } from "lucide-react";
 import {
   CommandDialog,
@@ -22,6 +20,8 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { leagueActivationHref } from "@/components/workspace/resource-navigation";
+import { buildPaletteNavItems } from "./shell-nav";
 
 /** Window event that any trigger button dispatches to open the single palette. */
 export const COMMAND_PALETTE_EVENT = "command-palette:open";
@@ -30,18 +30,15 @@ export function openCommandPalette() {
   window.dispatchEvent(new Event(COMMAND_PALETTE_EVENT));
 }
 
-const NAV = [
-  { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
-  { href: "/dashboard/leagues", label: "Leagues", icon: Trophy },
-  { href: "/dashboard/discover", label: "Discover", icon: Compass },
-  { href: "/dashboard/teams", label: "Teams", icon: Users },
-  { href: "/dashboard/players", label: "Players", icon: UserCircle },
-  { href: "/dashboard/seasons", label: "Seasons", icon: Calendar },
-  { href: "/dashboard/divisions", label: "Divisions", icon: Layers },
-  { href: "/dashboard/import", label: "Import", icon: Upload },
-  { href: "/dashboard/roles", label: "Roles & permissions", icon: Shield },
-  { href: "/dashboard/billing", label: "Billing", icon: CreditCard },
-];
+const PALETTE_ICONS: Record<string, LucideIcon> = {
+  overview: LayoutDashboard,
+  "league-directory": Trophy,
+  teams: Users,
+  players: UserCircle,
+  seasons: Calendar,
+  import: Upload,
+  billing: CreditCard,
+};
 
 interface LeagueOption {
   id: string;
@@ -49,14 +46,24 @@ interface LeagueOption {
 }
 
 /**
- * Global ⌘K command palette (WSM-000136 P2). Mounted ONCE in the dashboard
- * layout; opens on ⌘K / Ctrl+K or a `command-palette:open` window event (so
- * header buttons can trigger the same instance). Jumps to nav destinations and
- * the user's leagues.
+ * Global ⌘K command palette (WSM-000136 P2 / issue #577). Mounted ONCE in the
+ * dashboard layout; opens on ⌘K / Ctrl+K or a `command-palette:open` window
+ * event. Emits only canonical Home destinations (ASR-23) and activates the
+ * Active League when a League is selected (ASR-1).
  */
-export function CommandPalette({ leagues }: { leagues: LeagueOption[] }) {
+export function CommandPalette({
+  leagues,
+  activeLeagueId = null,
+}: {
+  leagues: LeagueOption[];
+  activeLeagueId?: string | null;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const navItems = useMemo(
+    () => buildPaletteNavItems(activeLeagueId),
+    [activeLeagueId],
+  );
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -90,16 +97,19 @@ export function CommandPalette({ leagues }: { leagues: LeagueOption[] }) {
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Navigate">
-          {NAV.map((item) => (
-            <CommandItem
-              key={item.href}
-              value={`go ${item.label}`}
-              onSelect={() => go(item.href)}
-            >
-              <item.icon />
-              {item.label}
-            </CommandItem>
-          ))}
+          {navItems.map((item) => {
+            const Icon = PALETTE_ICONS[item.id] ?? LayoutDashboard;
+            return (
+              <CommandItem
+                key={item.id}
+                value={`go ${item.label}`}
+                onSelect={() => go(item.href)}
+              >
+                <Icon />
+                {item.label}
+              </CommandItem>
+            );
+          })}
         </CommandGroup>
         {leagues.length > 0 && (
           <CommandGroup heading="Leagues">
@@ -107,7 +117,7 @@ export function CommandPalette({ leagues }: { leagues: LeagueOption[] }) {
               <CommandItem
                 key={league.id}
                 value={`league ${league.name}`}
-                onSelect={() => go(`/dashboard/leagues/${league.id}`)}
+                onSelect={() => go(leagueActivationHref(league.id))}
               >
                 <Trophy />
                 {league.name}

--- a/apps/web/src/app/dashboard/_components/shell-nav.ts
+++ b/apps/web/src/app/dashboard/_components/shell-nav.ts
@@ -1,0 +1,72 @@
+import {
+  dashboardEntryPath,
+  leagueDirectoryHref,
+} from "@/components/workspace/resource-navigation";
+
+/**
+ * Canonical shell destinations shared by the desktop/mobile sidebar and the
+ * ⌘K command palette (ASR-4, ASR-13, ASR-23). Import/Billing remain until #576.
+ */
+export interface ShellNavDestination {
+  id: string;
+  label: string;
+  href: string;
+  /** Hidden from the sidebar when the operator has no leagues (ASR-22). */
+  hideWithoutLeague?: boolean;
+}
+
+/** Destinations for the desktop/mobile sidebar rail. */
+export function buildShellNavItems(
+  activeLeagueId: string | null,
+): ShellNavDestination[] {
+  return [
+    {
+      id: "overview",
+      label: "Overview",
+      href: dashboardEntryPath(activeLeagueId),
+      hideWithoutLeague: true,
+    },
+    {
+      id: "teams",
+      label: "Teams",
+      href: "/dashboard/teams",
+      hideWithoutLeague: true,
+    },
+    {
+      id: "players",
+      label: "Players",
+      href: "/dashboard/players",
+      hideWithoutLeague: true,
+    },
+    {
+      id: "seasons",
+      label: "Seasons",
+      href: "/dashboard/seasons",
+      hideWithoutLeague: true,
+    },
+    { id: "import", label: "Import", href: "/dashboard/import" },
+    { id: "billing", label: "Billing", href: "/dashboard/billing" },
+  ];
+}
+
+/**
+ * Command palette Navigate group (ASR-23). Same shell destinations as the
+ * sidebar, plus League Directory as the explicit cross-league command.
+ * Obsolete standalone Leagues / Divisions / Discover / Roles are omitted.
+ */
+export function buildPaletteNavItems(
+  activeLeagueId: string | null,
+): ShellNavDestination[] {
+  const shell = buildShellNavItems(activeLeagueId);
+  const overview = shell[0];
+  const rest = shell.slice(1);
+  return [
+    overview,
+    {
+      id: "league-directory",
+      label: "League Directory",
+      href: leagueDirectoryHref(),
+    },
+    ...rest,
+  ];
+}

--- a/apps/web/src/app/dashboard/_components/sidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/sidebar.tsx
@@ -9,47 +9,20 @@ import {
   Upload,
   CreditCard,
   PlusCircle,
+  type LucideIcon,
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import NavLink from "./nav-link";
-import { leagueHomeHref } from "@/components/workspace/resource-navigation";
+import { leagueDirectoryHref } from "@/components/workspace/resource-navigation";
+import { buildShellNavItems } from "./shell-nav";
 
-interface NavItem {
-  label: string;
-  icon: LucideIcon;
-  hideWithoutLeague?: boolean;
-  getHref: (activeLeagueId?: string | null) => string;
-}
-
-const navItems: NavItem[] = [
-  {
-    label: "Overview",
-    icon: LayoutDashboard,
-    hideWithoutLeague: true,
-    getHref: (activeLeagueId) =>
-      activeLeagueId ? leagueHomeHref(activeLeagueId) : "/dashboard",
-  },
-  {
-    label: "Teams",
-    icon: Users,
-    hideWithoutLeague: true,
-    getHref: () => "/dashboard/teams",
-  },
-  {
-    label: "Players",
-    icon: UserCircle,
-    hideWithoutLeague: true,
-    getHref: () => "/dashboard/players",
-  },
-  {
-    label: "Seasons",
-    icon: Calendar,
-    hideWithoutLeague: true,
-    getHref: () => "/dashboard/seasons",
-  },
-  { label: "Import", icon: Upload, getHref: () => "/dashboard/import" },
-  { label: "Billing", icon: CreditCard, getHref: () => "/dashboard/billing" },
-];
+const SHELL_ICONS: Record<string, LucideIcon> = {
+  overview: LayoutDashboard,
+  teams: Users,
+  players: UserCircle,
+  seasons: Calendar,
+  import: Upload,
+  billing: CreditCard,
+};
 
 interface SidebarProps {
   hasLeagues?: boolean;
@@ -62,6 +35,7 @@ export default function Sidebar({
   activeLeagueId = null,
   onNavigate,
 }: SidebarProps) {
+  const navItems = buildShellNavItems(activeLeagueId);
   const visibleNavItems = hasLeagues
     ? navItems
     : navItems.filter((item) => !item.hideWithoutLeague);
@@ -86,7 +60,7 @@ export default function Sidebar({
       >
         {!hasLeagues ? (
           <NavLink
-            href="/dashboard/leagues"
+            href={leagueDirectoryHref()}
             icon={PlusCircle}
             onClick={onNavigate}
           >
@@ -94,12 +68,12 @@ export default function Sidebar({
           </NavLink>
         ) : null}
         {visibleNavItems.map((item) => {
-          const href = item.getHref(activeLeagueId);
+          const Icon = SHELL_ICONS[item.id] ?? LayoutDashboard;
           return (
             <NavLink
-              key={item.label}
-              href={href}
-              icon={item.icon}
+              key={item.id}
+              href={item.href}
+              icon={Icon}
               onClick={onNavigate}
             >
               {item.label}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -74,7 +74,7 @@ export default async function DashboardLayout({
           </div>
         </header>
 
-        <CommandPalette leagues={leagues} />
+        <CommandPalette leagues={leagues} activeLeagueId={activeLeagueId} />
 
         <main id="main-content" className="flex-1 p-4 sm:p-6 lg:p-8">
           <MigrateLocalPrompt />

--- a/docs/issue-577-IMPLEMENTATION_PLAN.md
+++ b/docs/issue-577-IMPLEMENTATION_PLAN.md
@@ -1,0 +1,170 @@
+# Issue 577 — Align mobile navigation and command palette with canonical routes
+
+## 1. Product goal and scope boundaries
+
+Bring desktop/mobile shell destinations and the ⌘K command palette in line with the post-#572/#573/#575 canonical navigation model (ASR-13, ASR-23), without waiting on Settings (#576) or Players cleanup (#574).
+
+**In scope**
+- Command palette destination list and League activation paths
+- Mobile/desktop destination parity for the shared `Sidebar` shell (already largely shared; verify + extend tests)
+- Drawer-close behavior on mobile nav selection (already wired via `onNavigate`; verify coverage)
+- Unit + focused Playwright verification
+
+**Out of scope / deferred**
+- Settings Home / Import+Billing relocation (#576)
+- Players Home / `?from=` cleanup (#574)
+- Full navigation acceptance sweep (#578)
+- Changing Season-owned competition routes (#575 already shipped)
+
+## 2. Current baseline
+
+- `sidebar.tsx` already exposes Overview → Active League Home, Teams, Players, Seasons, Import, Billing; no-league state shows League Directory onboarding; Divisions/Discover/Leagues removed from the rail (#572/#573).
+- `mobile-header.tsx` mounts the same `Sidebar` inside a Sheet and passes `onNavigate={() => setOpen(false)}` (ASR-13 drawer close). League switcher + HistoryBackButton live in the mobile chrome (not a breadcrumb trail).
+- `command-palette.tsx` is stale relative to ASR-4/ASR-23:
+  - Navigate group still lists **Leagues**, **Discover**, **Divisions**, **Roles & permissions**
+  - Overview hard-codes `/dashboard` instead of Active League Home
+  - League group uses bare `router.push(/dashboard/leagues/${id})` instead of `leagueActivationHref` (Directory/switcher pattern)
+- #572 plan explicitly deferred palette canonicalization to #577.
+
+## 3. Missing capabilities
+
+| Gap | ASR | Fix |
+| --- | --- | --- |
+| Palette still offers standalone Divisions / Leagues / Discover / Roles | ASR-4, ASR-23 | Remove obsolete commands; keep **League Directory** as the explicit cross-league command |
+| Palette Overview ≠ sidebar Overview | ASR-6, ASR-13, ASR-21 | Resolve Overview via `leagueHomeHref(activeLeagueId)` / directory fallback |
+| Palette League picks skip activation handler | ASR-1, ASR-23 | Use `leagueActivationHref(league.id)` |
+| No shared source of truth for shell destinations | ASR-13 | Extract a small nav-destination helper consumed by sidebar + palette (or keep sidebar as source and build palette NAV from the same helpers) |
+| Mobile/palette e2e do not assert canonical palette commands | ASR-13, ASR-23, ASR-25 | Extend `mobile-navigation.spec.ts` + add unit coverage for palette destination contracts |
+
+## 4. Milestones / phases
+
+### Phase 1 — Shared destination helpers + palette rewrite
+
+**Goals:** Palette emits only canonical shell destinations; League picks activate Active League.
+
+**Deliverables**
+- Thread `activeLeagueId` into `CommandPalette` from `layout.tsx` (same value already passed to sidebar/mobile header).
+- Rewrite `NAV` in `command-palette.tsx`:
+  - Overview → Active League Home when `activeLeagueId` is set, else League Directory
+  - Teams / Players / Seasons (unchanged)
+  - League Directory (rename; href `/dashboard/leagues`)
+  - Import / Billing (remain until #576 so palette matches current sidebar)
+  - Remove Divisions, Discover, Roles, and the obsolete “Leagues” label
+- League group `onSelect` → `go(leagueActivationHref(league.id))`
+- Prefer extracting pure helpers (e.g. `buildShellNavItems(activeLeagueId)` / `buildPaletteNavItems(...)`) under `apps/web/src/app/dashboard/_components/` or `resource-navigation.ts` so sidebar and palette cannot drift.
+
+**Dependencies:** none (uses helpers from #572)
+
+**Risks:** Discover must remain reachable from League Directory only — do not re-add it to the rail or palette Navigate group.
+
+**Acceptance criteria**
+- [ ] Palette Navigate group contains no Divisions / Discover / Roles / “Leagues” labels
+- [ ] League Directory remains selectable
+- [ ] Overview matches sidebar Active League Home resolution
+- [ ] Selecting a League in the palette goes through `/dashboard/active-league?...`
+
+### Phase 2 — Viewport parity verification (mobile)
+
+**Goals:** Confirm ASR-13: same destinations + drawer close; no breadcrumb substitute introduced.
+
+**Deliverables**
+- Audit `mobile-header.tsx` / `sidebar.tsx`: no new breadcrumb UI; keep HistoryBackButton as history affordance only
+- Extend `apps/web/e2e/tests/mobile-navigation.spec.ts`:
+  - Sheet destinations match desktop sidebar labels (Overview, Teams, Players, Seasons, Import, Billing when leagues exist)
+  - Selecting a link closes the sheet (already partially covered)
+  - No “Divisions” / “Discover” / “Leagues” top-level links in the sheet
+- Optional: desktop navigation smoke that palette opens (⌘K / trigger) and League Directory command is present while Divisions is absent — prefer unit test if Playwright key-modifier flakiness is high
+
+**Dependencies:** Phase 1
+
+**Risks:** Import/Billing still in shell until #576 — tests must expect them, not Settings Home.
+
+**Acceptance criteria**
+- [ ] Mobile sheet and desktop sidebar expose the same destination set
+- [ ] Sheet closes on nav selection
+- [ ] No breadcrumb substitute added on mobile
+
+### Phase 3 — Tests + type-check
+
+**Goals:** Lock contracts; keep suites green.
+
+**Deliverables**
+- Unit tests: `apps/web/src/app/dashboard/_components/__tests__/command-palette-nav.test.ts` (or extend `active-league-navigation.test.ts`) asserting destination list + `leagueActivationHref` usage
+- Update any snapshots/assertions that still expect palette Divisions/Discover
+- `pnpm --filter @sports-management/web type-check`
+- Focused Playwright: `mobile-navigation.spec.ts` (+ navigation.spec.ts if touched)
+
+**Acceptance criteria**
+- [ ] New/updated unit tests pass
+- [ ] Focused Playwright green
+- [ ] Type-check green
+
+## 5. Out-of-scope / deferred
+
+- Settings branching and Import/Billing removal from the shell (#576)
+- Players Resource Header / legacy `?from=` (#574)
+- Epic-wide verification matrix (#578)
+- Visual-regression baseline updates unless a shared shell snapshot fails and is clearly caused by this work
+
+## 6. Immediate next steps
+
+1. Create branch `feat/issue-577-mobile-palette-nav` from updated `main`.
+2. Implement Phase 1 (palette + helpers).
+3. Phase 2–3 tests, then ship PR with `Closes #577`.
+
+## Implementation Plan (task checklist)
+
+**Story:** #577 Align mobile navigation and command palette with canonical routes  
+**Branch:** `feat/issue-577-mobile-palette-nav`
+
+### Analysis
+
+Sidebar/mobile already share destinations and drawer-close. The blocking drift is `command-palette.tsx`, still advertising pre-Wayfinder destinations and bare League pushes. Align the palette to ASR-23 and prove ASR-13 with mobile e2e.
+
+### Tasks
+
+- [ ] **1. Thread Active League into CommandPalette**
+  - Files: `apps/web/src/app/dashboard/layout.tsx`, `apps/web/src/app/dashboard/_components/command-palette.tsx`
+  - Details: Pass `activeLeagueId` alongside `leagues`.
+
+- [ ] **2. Canonicalize palette Navigate destinations**
+  - Files: `command-palette.tsx`, optional shared helper next to sidebar
+  - Details: Overview → League Home; League Directory; drop Divisions/Discover/Roles/Leagues; keep Import/Billing until #576.
+
+- [ ] **3. Palette League activation via `leagueActivationHref`**
+  - Files: `command-palette.tsx`, `resource-navigation.ts` (reuse)
+  - Details: Replace bare `/dashboard/leagues/${id}` pushes.
+
+- [ ] **4. Unit tests for palette destination contracts**
+  - Files: `apps/web/src/app/dashboard/_components/__tests__/command-palette-nav.test.ts` (new) and/or `active-league-navigation.test.ts`
+
+- [ ] **5. Mobile Playwright parity + drawer close**
+  - Files: `apps/web/e2e/tests/mobile-navigation.spec.ts`
+
+- [ ] **6. Type-check + focused e2e**
+  - Commands: `pnpm --filter @sports-management/web type-check`; Playwright `mobile-navigation.spec.ts`
+
+### Test Strategy
+
+- [ ] **Unit:** palette nav item hrefs/labels; League activation href shape
+- [ ] **E2E:** mobile sheet destination parity + close-on-navigate; no obsolete top-level links
+- [ ] **Manual QA:** ⌘K → League Directory; ⌘K → pick other League → switcher shows new Active League; mobile hamburger → Overview lands on League Home
+
+### Acceptance Criteria Mapping
+
+| Criterion | Task(s) | How Verified |
+| --- | --- | --- |
+| ASR-13 same destinations across viewports | 2, 5 | Unit + mobile Playwright |
+| ASR-13 mobile selection closes drawer | 5 | `mobile-navigation.spec.ts` |
+| ASR-13 no breadcrumb substitute | 5 | Audit + e2e (no breadcrumb UI) |
+| ASR-23 palette canonical Homes only | 2, 4 | Unit assertions on NAV |
+| ASR-23 remove obsolete Leagues/Divisions commands | 2, 4, 5 | Unit + e2e absence checks |
+| ASR-23 League Directory remains | 2, 4 | Unit + e2e |
+| ASR-23 Active League sync on palette League open | 3, 4 | Unit href + manual/e2e switcher state |
+| Import/Billing unchanged until #576 | 2 | Explicit keep in NAV matching sidebar |
+
+### Risks & Notes
+
+- Do not invent Settings Home here; #576 owns that move.
+- Prefer `leagueActivationHref` over relying only on League Home’s `syncActiveLeagueForResource` so palette matches Directory semantics (ASR-1).
+- `#574` still open but not a hard blocker for shell/palette work.

--- a/docs/issue-577-progress.txt
+++ b/docs/issue-577-progress.txt
@@ -1,0 +1,18 @@
+issue-577 - Mobile nav + command palette - Progress
+Generated: 2026-07-19 20:00:39 EDT
+Updated: 2026-07-19
+On completion, move this file and the plan to docs/archive/.
+
+[x] 1.0 - Phase 1 - Shared destination helpers + palette rewrite
+    [x] 1.1 - Thread activeLeagueId into CommandPalette from layout
+    [x] 1.2 - Canonicalize Navigate destinations (drop Divisions/Discover/Roles/Leagues; keep League Directory + Import/Billing)
+    [x] 1.3 - League picks use leagueActivationHref
+[x] 2.0 - Phase 2 - Viewport parity verification (mobile)
+    [x] 2.1 - Audit mobile chrome (no breadcrumb substitute; Sidebar shared via Sheet + onNavigate close)
+    [x] 2.2 - Extend mobile-navigation.spec.ts for destination parity + drawer close
+[x] 3.0 - Phase 3 - Tests + type-check
+    [x] 3.1 - Unit tests for palette destination contracts
+    [x] 3.2 - type-check + focused Playwright green (mobile-navigation 12/12)
+[ ] 4.0 - Ship & archive
+    [ ] 4.1 - Open PR with Closes #577
+    [ ] 4.2 - On merge: move docs/issue-577-IMPLEMENTATION_PLAN.md + docs/issue-577-progress.txt to docs/archive/


### PR DESCRIPTION
## Summary
- Share canonical shell destinations between sidebar and ⌘K command palette (`shell-nav.ts`).
- Drop obsolete palette commands (Divisions, Discover, Roles, “Leagues”); keep League Directory; Overview resolves to Active League Home.
- Palette League picks go through `leagueActivationHref` (Active League sync). Extend mobile Playwright for destination parity.

Closes #577

## Test plan
- [x] `pnpm --filter @sports-management/web type-check`
- [x] Unit: `command-palette-nav.test.ts` + `active-league-navigation.test.ts`
- [x] Focused Playwright: `mobile-navigation.spec.ts` (12/12)
- [ ] CI green on this PR

