### PR TITLE
docs: Dynasty Mode roadmap — design docs for epics F, A, B, C and D

### DIFF
--- a/docs/design/dynasty-foundations.md
+++ b/docs/design/dynasty-foundations.md
@@ -1,0 +1,180 @@
+# Dynasty Foundations (Epic F)
+
+Status: approved design (2026-07-25). Decision record: persist season and player
+aggregates plus an append-only dynasty event log so later epics never scan fixtures
+or loop `ctx.db.get` on stat leaders. Covers Epic F / Wave 0 (slices F1–F5); no
+dedicated feature flag — consumers gate on `FLAG_DYNASTY_*` and `dynastyConfig`.
+
+## Context
+
+**Shipped today**
+
+- Standings recompute from every fixture on read via `computeStandingsPure`
+  (`apps/web/convex/lib/standings.ts:105`) — correct but full-scan.
+- Per-game stats live in `playerGameStats`; season SPRT and leaders call
+  `computeSeasonSprt` (`apps/web/convex/sports.ts:6497`) and `seasonStatLeaders`
+  (`sports.ts:6576`) with per-row `ctx.db.get` — known N+1.
+- `recordGameResult` (`sports.ts:5522`) and `upsertPlayerGameStats` (`sports.ts:6240`)
+  are the only write hooks that touch game outcomes; no persisted W/L counters or
+  career rows exist.
+- Convex writes are already `internalMutation` only (WSM-000096); the compile-time
+  guard lives in `apps/web/convex/__tests__/writeMutationsAreInternal.test.ts`.
+- Pages call Convex only through `apps/web/src/lib/data-api.ts` →
+  `getConvexClient()` — no `convex/react`.
+- DTO mappers pin `Infer<typeof xDtoValidator>` (`sports.ts:143` — `playerDtoValidator`).
+
+**Missing**
+
+- `seasonTeamRecords`, `playerSeasonAggregates`, `dynastyEvents`, `dynastyConfig` tables.
+- Module split: all sports surface still in `sports.ts` (~7500+ LOC); new dynasty
+  surface must land in `convex/dynasty.ts` without moving existing exports.
+- Shared deterministic RNG namespace (`seedFromString` / mulberry32 still live only in
+  `simulate-game.ts`).
+- Typed function-reference helpers for new modules (`data-api.ts:63` — string names
+  compile on typos).
+
+## Schema changes
+
+Compose from `apps/web/convex/tables/dynasty.ts` (new) and spread into `schema.ts`.
+All new fields on existing tables remain `v.optional` elsewhere; these tables are new.
+
+```ts
+seasonTeamRecords: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  wins: v.number(),
+  losses: v.number(),
+  ties: v.number(),
+  pointsFor: v.number(),
+  pointsAgainst: v.number(),
+  divisionWins: v.optional(v.number()),
+  divisionLosses: v.optional(v.number()),
+  divisionTies: v.optional(v.number()),
+  headToHeadJson: v.optional(v.string()),
+  streakJson: v.optional(v.string()),
+  updatedAt: v.string(),
+})
+  .index("by_season_team", ["seasonId", "teamId"])
+  .index("by_teamId", ["teamId"]),
+
+playerSeasonAggregates: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  playerId: v.id("players"),
+  positionGroup: v.string(),
+  statsJson: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_season_player", ["seasonId", "playerId"])
+  .index("by_playerId", ["playerId"])
+  .index("by_season_team", ["seasonId", "teamId"]),
+
+dynastyEvents: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.optional(v.id("seasons")),
+  category: v.string(),
+  eventType: v.string(),
+  severity: v.string(),
+  headline: v.string(),
+  bodyJson: v.optional(v.string()),
+  dedupeKey: v.string(),
+  createdAt: v.string(),
+})
+  .index("by_league_created", ["leagueId", "createdAt"])
+  .index("by_dedupeKey", ["dedupeKey"]),
+
+dynastyConfig: defineTable({
+  leagueId: v.id("leagues"),
+  simV2Enabled: v.optional(v.boolean()),
+  offseasonV2Enabled: v.optional(v.boolean()),
+  programV1Enabled: v.optional(v.boolean()),
+  historyV1Enabled: v.optional(v.boolean()),
+  updatedAt: v.string(),
+}).index("by_leagueId", ["leagueId"]),
+```
+
+No backfill migration: absence of `dynastyConfig` means all defaults; F2/F3 deltas
+apply on the next `recordGameResult` / stat upsert after deploy.
+
+## Function surface
+
+**Module:** `apps/web/convex/dynasty.ts` (queries + `internalMutation` only).
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `getDynastyConfig` | query | League kill switches / defaults |
+| `upsertDynastyConfig` | internalMutation | Settings card writes |
+| `getSeasonTeamRecord` | query | Single team-season row |
+| `listSeasonTeamRecords` | query | Season standings inputs |
+| `applyGameResultToRecords` | internalMutation | Called from `recordGameResult` txn |
+| `rebuildSeasonTeamRecords` | internalMutation | Admin repair / golden tests |
+| `applyPlayerGameStatsDelta` | internalMutation | Called from `upsertPlayerGameStats` |
+| `rebuildPlayerSeasonAggregates` | internalMutation | Admin repair |
+| `emitDynastyEvent` | internalMutation | Append event; dedupe by key |
+| `listDynastyEvents` | query | Paginated feed (D4 consumer) |
+
+Existing `sports.ts` handlers gain **calls into** these internal mutations; they are
+not moved or renamed (`internal.sports.*` guard strings stay stable).
+
+**`data-api.ts`:** add `dynastyQueryRef` / `dynastyInternalRef` template-literal helpers
+typed from `import type { api } from "../convex/_generated/api"` (F1 verifies no client
+bundle pull).
+
+## Pure-lib work
+
+| Module | Exports |
+|--------|---------|
+| `apps/web/convex/lib/teamRecords.ts` | `applyResultDelta(row, delta): SeasonTeamRecordCounters` |
+| `apps/web/convex/lib/events.ts` | `buildDedupeKey(parts): string`, `shouldSkipEmit(existingKey): boolean` |
+| `apps/web/convex/lib/narrative.ts` | `renderHeadline(template, ctx): string` |
+| `apps/web/src/lib/rng.ts` | `seedFromString(s): number`, `mulberry32(seed): () => number`, namespace helpers (`pbp:fixtureId`, etc.) |
+
+Ranking display still runs `computeStandingsPure` on **read models** built from
+`seasonTeamRecords` so tiebreaker tests remain authoritative.
+
+## UI surface
+
+- `/dashboard/settings/league` — Dynasty settings card (read/write `dynastyConfig` via
+  server action → internal mutation). No new routes.
+- ADR 0001 unchanged: no competition views added here.
+
+## Slices
+
+- **F1 — scaffolding:** `convex/tables/dynasty.ts`, empty `dynasty.ts` module, typed
+  refs in `data-api.ts`, `rng.ts` promotion, guard-test backstop for `dynasty` writes.
+  **Depends:** none. **Same PR:** extend `resetCanonicalFixture`
+  (`apps/web/convex/e2eSeed.ts:530`) for any table touched (initially none beyond seed
+  tolerance).
+- **F2 — season team records:** hook `recordGameResult`; delta subtract prior contribution
+  on re-sim. **Depends:** F1.
+- **F3 — player season aggregates:** hook `upsertPlayerGameStats`; refactor
+  `computeSeasonSprt` / `seasonStatLeaders` to read aggregates only. **Depends:** F1.
+- **F4 — event log:** `emitDynastyEvent` + dedupe. **Depends:** F1.
+- **F5 — dynasty config:** settings UI + per-league toggles. **Depends:** F1.
+
+Every slice that adds rows must add cleanup to `resetCanonicalFixture` in the same PR.
+
+## Invariants
+
+1. `computeStandingsPure` output deep-equals pre-F2 standings for the canonical e2e
+   fixture (golden test).
+2. Record → re-record → delete game leaves `seasonTeamRecords` identical to a full
+   rebuild (property test).
+3. `computeSeasonSprt` and `seasonStatLeaders` perform zero `ctx.db.get` inside player
+   loops (read-spy on ctx).
+4. Duplicate `dedupeKey` inserts at most one `dynastyEvents` row.
+5. All `dynasty.ts` write handlers are `internalMutation` and appear only on
+   `internal.dynasty.*` in the guard test.
+6. Every new handler declares `returns:`; every DTO mapper uses `Infer<typeof …Validator>`.
+7. `applyResultDelta` is pure; Convex handlers only persist its output.
+
+## Non-goals
+
+- Moving or renaming existing `sports.ts` exports.
+- Public Convex mutations or `convex/react` subscriptions.
+- Career totals, awards, polls (Epic D).
+- Penalties, injuries, or play-log schema (Epic A).
+- Offseason phase machine (Epic B).
+- Wave 5 multi-coach UX (only data hooks that later epics require).

--- a/docs/design/dynasty-history-awards.md
+++ b/docs/design/dynasty-history-awards.md
@@ -1,0 +1,173 @@
+# Dynasty History, Awards & Narrative (Epic D)
+
+Status: approved design (2026-07-25). Decision record: build career history from F3
+`playerSeasonAggregates` at `completeSeason`, never scan `playerGameStats` or
+`gamePlayLogs` for record books or awards. Covers Epic D / Wave 4 (slices D1–D5); gated
+by `FLAG_DYNASTY_HISTORY_V1` and `dynastyConfig.historyV1Enabled`.
+
+## Context
+
+**Shipped today**
+
+- Per-fixture stats in `playerGameStats`; play logs in `gamePlayLogs` (`schema.ts:329`).
+- No tables spanning seasons for records, awards, polls, HoF, or recaps.
+- `dynastyEvents` (Epic F4) can store headlines but no D-specific producers yet.
+- League Home has no program history or record book routes.
+
+**Missing**
+
+- `playerCareerTotals`, `programRecords`, `awards`, `hallOfFame`, `weeklyPolls`,
+  `seasonRecaps`.
+- `convex/history.ts` + `finalizeSeasonHistory` idempotent hook from `completeSeason`
+  (`sports.ts:2163`).
+- Routes: `/dashboard/seasons/[id]/{rankings,awards,recap}` and
+  `/dashboard/leagues/[id]/history` (league-scoped — ADR 0001 allows; season-scoped
+  competition stays under Season Home).
+- `DynastyNewsFeed` on League and Season Home; career totals on Player Home.
+
+**Load-bearing pipeline**
+
+```
+playerGameStats (per fixture) → sim writes
+  → incremental delta (F3) → playerSeasonAggregates
+  → materialize at completeSeason (D1) → playerCareerTotals
+```
+
+If aggregate batch exceeds Convex read limits, shard by team using existing
+`seasonRollovers` lease/stage pattern — do not invent a second concurrency idiom.
+
+## Schema changes
+
+```ts
+playerCareerTotals: defineTable({
+  leagueId: v.id("leagues"),
+  playerId: v.id("players"),
+  totalsJson: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_playerId", ["playerId"])
+  .index("by_leagueId", ["leagueId"]),
+
+programRecords: defineTable({
+  leagueId: v.id("leagues"),
+  teamId: v.optional(v.id("teams")),
+  category: v.string(),
+  span: v.string(),
+  entriesJson: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_league_category", ["leagueId", "category"])
+  .index("by_team_category", ["teamId", "category"]),
+
+awards: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  awardType: v.string(),
+  playerId: v.id("players"),
+  teamId: v.id("teams"),
+  scoreValue: v.number(),
+  tieBreakJson: v.optional(v.string()),
+  createdAt: v.string(),
+})
+  .index("by_season", ["seasonId"])
+  .index("by_season_type", ["seasonId", "awardType"]),
+
+hallOfFame: defineTable({
+  leagueId: v.id("leagues"),
+  playerId: v.id("players"),
+  inductedSeasonId: v.optional(v.id("seasons")),
+  citation: v.string(),
+  inductedAt: v.string(),
+})
+  .index("by_leagueId", ["leagueId"]),
+
+weeklyPolls: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  week: v.number(),
+  rankingsJson: v.string(),
+  publishedAt: v.string(),
+})
+  .index("by_season_week", ["seasonId", "week"]),
+
+seasonRecaps: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  bodyMarkdown: v.string(),
+  generatedAt: v.string(),
+})
+  .index("by_seasonId", ["seasonId"]),
+```
+
+## Function surface
+
+**Module:** `apps/web/convex/history.ts`.
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `finalizeSeasonHistory` | internalMutation | Idempotent; called from `completeSeason` |
+| `getCareerTotals` | query | Player Home |
+| `listProgramRecords` | query | Record book |
+| `listSeasonAwards` | query | Awards page |
+| `getWeeklyPoll` | query | Rankings page |
+| `listSeasonRecaps` | query | Recap page |
+| `listHallOfFame` | query | League history |
+| `computeWeeklyPoll` | internalMutation | Inline from `simulateWeekAction` (~12 team records) |
+
+Award/record scoring stays in pure libs; Convex only persists outputs + `scoreValue`.
+
+## Pure-lib work
+
+| Module | Exports |
+|--------|---------|
+| `apps/web/convex/lib/awards.ts` | `computeAwardSlate(aggregates, weights): AwardWinner[]` |
+| `apps/web/convex/lib/records.ts` | `mergeTopN(existing, candidate): { entries, broken[] }` |
+| `apps/web/src/lib/history/power-rankings.ts` | `dampedRankings(prev, standings): PollRow[]` |
+| `apps/web/src/lib/history/recap.ts` | `renderSeasonRecap(ctx): string` |
+| `apps/web/src/lib/history/hall-of-fame.ts` | `scoreHoFCandidate(career): number` |
+
+`broken[]` from `mergeTopN` feeds F4 `record_broken` dynasty events.
+
+## UI surface
+
+- `/dashboard/seasons/[id]/rankings` — extend `seasonSubpageHref` union
+  (`resource-navigation.ts:107`) + `buildSeasonSiblingLinks` (`:184`).
+- `/dashboard/seasons/[id]/awards`, `/dashboard/seasons/[id]/recap` — same pattern.
+- `/dashboard/leagues/[id]/history` — record book, HoF, champions (League Home child).
+- `DynastyNewsFeed` card on League Home and Season Home (reads `listDynastyEvents`).
+- Player Home: career totals + accolades.
+- Add **Program History** and **Record Book** to `CONTEXT.md` before UI slices.
+
+Data path: page → `data-api.ts` → `getConvexClient()` — no `convex/react`.
+
+## Slices
+
+- **D1 — career totals + program records** + `finalizeSeasonHistory` core. **Depends:** F3, F2.
+- **D2 — awards** (pure scorer + persist). **Depends:** D1, C1 (identity labels).
+- **D3 — weekly polls** (damped rankings). **Depends:** F2, D1.
+- **D4 — news feed + season recap** (F4 consumers). **Depends:** D1–D3, prior event producers.
+- **D5 — Hall of Fame.** **Depends:** D1.
+
+Table-adding slices extend `resetCanonicalFixture` (`e2eSeed.ts:530`) in the same PR.
+
+## Invariants
+
+1. `finalizeSeasonHistory` is idempotent (second call no-op writes).
+2. Career `totalsJson` keys equal sum of F3 season aggregates per player.
+3. Award computation is a pure function including tie handling; every `scoreValue` reproduces
+   from the documented weights ("why did he win").
+4. Program record ranks are contiguous 1..n with monotonically non-increasing stat values.
+5. Poll ranks are a permutation; week-over-week movement bounded (damping).
+6. `finalizeSeasonHistory` reads **zero** `playerGameStats` and **zero** `gamePlayLogs` rows
+   (read-spy).
+7. All writes `internalMutation` (WSM-000096); handlers declare `returns:` validators.
+8. Weekly poll inline path reads O(teams) `seasonTeamRecords` docs, not fixtures.
+
+## Non-goals
+
+- Scanning per-game stat tables for career or award math.
+- Real-media licensing or external news APIs.
+- Player-facing social feed or comments.
+- Extending `PlayerGameStatLine` for award metadata.
+- Moving stat ingestion out of existing sim path.
+- Wave 5 shared commissioner workflows for history editing.

--- a/docs/design/dynasty-mode.md
+++ b/docs/design/dynasty-mode.md
@@ -1,9 +1,20 @@
 # Dynasty Mode
 
-Status: approved design (2026-07-05). Decisions confirmed: graduates are archived (never
+Status: **SHIPPED** (2026-07-25). Both slices landed — D1 (rollover backend) and D2 (dynasty
+panel + FR/SO/JR/SR labels). Decisions confirmed: graduates are archived (never
 deleted); class year reuses the existing `grade` field (9–12 ↔ FR/SO/JR/SR); progression is
 seeded and position-weighted (~+2–4 OVR/year mean with variance, larger FR→SO jumps);
 freshman generation tops rosters back to the existing target size.
+
+Extended by `docs/design/offseason-pipeline.md` — the six mechanical stages below become the
+*prologue* to a persisted, user-driven multi-phase offseason (scouting, transfers, JV→Varsity
+promotions, position changes, cuts, training). Nothing here is replaced; `seasonRollovers` keeps
+owning the automatic, lease-protected stages.
+
+As built: `startNextSeasonAction` (`apps/web/src/app/dashboard/_actions/dynasty.ts:149`),
+`seasonRollovers` table (`apps/web/convex/schema.ts:141`), `computeProgressedAttributes`
+(`apps/web/src/lib/dynasty-progression.ts:72`), `DynastyPanel`
+(`apps/web/src/components/dynasty/DynastyPanel.tsx`).
 
 ## Context
 

--- a/docs/design/offseason-free-agency-draft.md
+++ b/docs/design/offseason-free-agency-draft.md
@@ -1,8 +1,25 @@
 # Offseason: Free Agents + Optional Draft
 
-Status: DRAFT for review (2026-07-06). Net-new feature slice on top of the dynasty
-rollover (docs/design/dynasty-mode.md). Nothing here is built; no code ships until
-this doc is signed off.
+Status: **SHIPPED** (2026-07-25). Built on top of the dynasty rollover
+(docs/design/dynasty-mode.md). All four phases (O1–O4) landed; the "Open questions
+for sign-off" below are resolved and recorded against the shipped behavior.
+
+Extended by `docs/design/offseason-pipeline.md`, which turns this fixed
+Rollover → Draft → Free agency → Activate sequence into a persisted, multi-phase
+offseason machine (scouting, transfers, promotions, training). The free-agency and
+draft mechanics described here are **reused, not replaced**.
+
+As built:
+
+- `drafts` + `draftPicks` tables — `apps/web/convex/schema.ts:496,511`
+- `startDraft` / `makeDraftPick` / `endDraft` — `apps/web/convex/sports.ts:5300,5358,5451`
+- `releasePlayerToFreeAgency` / `signFreeAgent` / `listFreeAgents` — `sports.ts:5050,5086,5163`
+- Pick-order helper — `apps/web/convex/lib/draft.ts`; roster-size helper — `convex/lib/offseason.ts`
+- UI — `apps/web/src/components/offseason/` (OffseasonHub, OffseasonPhaseStepper,
+  DraftBoard, DraftStartToggle, FreeAgencyPanel, FreeAgencyTableView,
+  ReleasePlayerButton, ActivateSeasonWarningDialog)
+- Server actions — `apps/web/src/app/dashboard/_actions/{offseason,draft}.ts`
+- e2e — `apps/web/e2e/tests/offseason-{draft,free-agency}.spec.ts`
 
 ## Context
 
@@ -116,12 +133,25 @@ panes stack.
 Each phase is one PR through the standard pipeline. O1+O2 deliver user value
 without the draft; O3+O4 are cleanly additive.
 
-## Open questions for sign-off
+## Open questions — resolved as built
 
-1. Roster cap on signing: hard block at target size, or allow overflow with a
-   warning (real HS rosters vary)?
-2. Coach permissions: may coaches release/sign for their own team during FA, or is
-   the whole offseason admin-only in v1?
-3. Draft rounds: fixed small number (3?) or `ceil(pool/teams)` uncapped?
-4. Should "send freshmen to draft pool" be remembered per league as the default for
-   future offseasons?
+1. **Roster cap on signing: soft, not hard.** `signFreeAgent` (`sports.ts:5086`)
+   computes `overCap = activeCount >= targetRosterSize()` and returns it to the
+   caller, but signs anyway — it passes `enforceRosterLimit: false` to
+   `assignPlayerToRosterCore`. The UI warns; nothing blocks. Real HS rosters vary.
+   Target is 48, clamped to 60 (`convex/lib/offseason.ts`).
+2. **Coaches may release and sign for their own team.** The offseason is *not*
+   admin-only. `canAdminOrManageTeam` (`_actions/offseason.ts:18`) grants access to
+   an org admin **or** anyone `canManageTeam(teamId, userId)` — i.e. a coach scoped
+   to that team, resolved through `resolveTeamRole` across both the league org and a
+   forking org (WSM-000121). This per-`teamId` gate is the precedent
+   `offseason-pipeline.md` follows for every new per-team offseason action, and it is
+   what keeps multi-coach online dynasty open without a rewrite.
+3. **Draft rounds are a fixed 3**, not `ceil(pool/teams)` — `DRAFT_ROUNDS = 3`
+   (`sports.ts:5202`). Undrafted players remain in free agency.
+4. **"Send freshmen to draft pool" is not remembered.** It is a per-invocation
+   `freshmenToPool?: boolean` argument on `startNextSeasonAction`
+   (`_actions/dynasty.ts:151`), defaulting to `false` (auto-assign to teams), which
+   preserves the pre-draft behavior exactly. Per-league persistence of this and other
+   knobs is picked up by the `dynastyConfig` table in
+   `docs/design/dynasty-foundations.md`.

--- a/docs/design/offseason-pipeline.md
+++ b/docs/design/offseason-pipeline.md
@@ -1,0 +1,177 @@
+# Offseason & Roster Pipeline (Epic B)
+
+Status: approved design (2026-07-25). Decision record: keep `seasonRollovers` for the
+60-second mechanical prologue; add persisted `offseasons` for human-paced phases;
+authorize per-team actions via `teamId` + `authorizeTeamMutation`, never org-admin-only.
+Covers Epic B / Waves 1–2 (slices B1–B6); gated by `FLAG_DYNASTY_OFFSEASON_V2`.
+
+Extends `docs/design/dynasty-mode.md` and `docs/design/offseason-free-agency-draft.md`
+(reuses draft/FA mutations; does not replace them).
+
+## Context
+
+**Shipped today**
+
+- Six-stage rollover with lease (`ROLLOVER_STAGES` at `dynasty.ts:40`;
+  `startNextSeasonAction` at `:149`).
+- Offseason hub UI derives phases from draft status — `buildPhases(draftStatus)` at
+  `OffseasonPhaseStepper.tsx:12` (not stored, not resumable).
+- Draft: `startDraft` / `makeDraftPick` / `endDraft` (`sports.ts:5300,5358,5451`);
+  `DRAFT_ROUNDS = 3` (`:5202`).
+- FA: `releasePlayerToFreeAgency` (`:5050`), `signFreeAgent` (`:5086`).
+- Roster caps: `targetRosterSize` — default 48, max 60 (`convex/lib/offseason.ts:8-13`).
+- Freshmen generated in rollover without scouting (`dynasty.ts:418` —
+  `generateSyntheticRoster`).
+
+**Missing**
+
+- `offseasons`, `recruitProspects`, `transferEvents`, `playerTrainingAllocations`.
+- Rollover stages `injuries_healed`, `prospects_generated` before `completed`.
+- Scouting uncertainty, transfers, JV→Varsity promotions, position changes, training
+  loops on `players.squad`.
+- Route `/dashboard/seasons/[id]/offseason` and `"offseason"` in `seasonSubpageHref`
+  union (`resource-navigation.ts:107`).
+
+**Authorization precedent:** `canAdminOrManageTeam` in
+`apps/web/src/app/dashboard/_actions/offseason.ts:18` — Wave 5 requires the same
+pattern using `authorizeTeamMutation` / `resolveTeamRole`
+(`apps/web/src/lib/authorization.ts:53`).
+
+## Schema changes
+
+```ts
+offseasons: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  phase: v.string(),
+  completedPhases: v.array(v.string()),
+  scoutingPoints: v.optional(v.number()),
+  trainingPoints: v.optional(v.number()),
+  phaseLeaseOwnerId: v.optional(v.string()),
+  phaseLeaseExpiresAt: v.optional(v.string()),
+  configSnapshotJson: v.optional(v.string()),
+  updatedAt: v.string(),
+})
+  .index("by_seasonId", ["seasonId"])
+  .index("by_leagueId", ["leagueId"]),
+
+recruitProspects: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.optional(v.id("teams")),
+  trueAttributesJson: v.string(),
+  scoutedAttributesJson: v.optional(v.string()),
+  scoutLevel: v.number(),
+  projectedRangeJson: v.optional(v.string()),
+  archetype: v.optional(v.string()),
+  potentialTier: v.optional(v.string()),
+  status: v.string(),
+})
+  .index("by_season_team", ["seasonId", "teamId"])
+  .index("by_season", ["seasonId"]),
+
+transferEvents: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  playerId: v.id("players"),
+  fromTeamId: v.optional(v.id("teams")),
+  toTeamId: v.optional(v.id("teams")),
+  eventType: v.string(),
+  createdAt: v.string(),
+})
+  .index("by_season", ["seasonId"]),
+
+playerTrainingAllocations: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  playerId: v.id("players"),
+  allocationJson: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_season_team", ["seasonId", "teamId"])
+  .index("by_season_player", ["seasonId", "playerId"]),
+```
+
+Extend `seasonRollovers.stage` vocabulary with `injuries_healed` and
+`prospects_generated` (string stage values; no table migration beyond code).
+
+## Function surface
+
+**Module:** `apps/web/convex/dynasty.ts` (offseason subset; same module as Epic F).
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `getOffseason` | query | Phase + budgets for hub |
+| `advanceOffseasonPhase` | internalMutation | Commissioner advance (lease) |
+| `allocateScoutingPoints` | internalMutation | Per-team; `teamId` in args |
+| `scoutProspect` | internalMutation | Per-team |
+| `listProspects` | query | **Never returns `trueAttributesJson`** |
+| `proposeTransfer` / `resolveTransfer` | internalMutation | Transfer pipeline |
+| `setPromotion` / `setPositionChange` | internalMutation | Per-team |
+| `allocateTraining` | internalMutation | Per-team |
+| `applyTrainingToProgression` | internalMutation | Calls progression with optional inputs |
+
+Reused unchanged: `signFreeAgent`, `releasePlayerToFreeAgency`, `startDraft`,
+`makeDraftPick`, `endDraft` in `sports.ts`.
+
+Server actions in `apps/web/src/app/dashboard/_actions/offseason.ts` (and new files)
+call `authorizeTeamMutation(teamId, userId)` before internal calls.
+
+## Pure-lib work
+
+Under `apps/web/src/lib/dynasty/`:
+
+| Module | Exports |
+|--------|---------|
+| `offseason-phases.ts` | `nextPhase(current)`, `canAdvance(offseason)` — mirrors `hasReachedRolloverStage` |
+| `prospects.ts` | `generateProspectClass(input)` |
+| `scouting.ts` | `scoutedBand(trueAttrs, level)` — monotonic shrink, never zero width |
+| `transfers.ts` | `validateTransfer(ctx)` |
+| `promotions.ts` | `applySquadChange(player, targetSquad)` |
+| `training.ts` | `sumAllocations(allocations)` |
+
+Optional `ProgressionInput` extensions in `dynasty-progression.ts`: `training?`,
+`developmentMultiplier?` — base delta unchanged when `training: []`.
+
+## UI surface
+
+- `/dashboard/seasons/[id]/offseason` — Offseason Hub (flag-gated).
+- Extend `seasonSubpageHref` and `buildSeasonSiblingLinks` (`resource-navigation.ts:184`)
+  with `"offseason"`.
+- Rewire `OffseasonPhaseStepper` to persisted `offseasons.phase`, not `buildPhases`.
+- Panels: Scouting, Transfers, Promotions, Training, Summary (DS components).
+- Add **Offseason Hub** to `CONTEXT.md` before UI merge.
+- ADR 0001: offseason is season-scoped under Season Home.
+
+## Slices
+
+- **B1 — persisted phase machine** (structural; no new gameplay). **Depends:** F1.
+- **B2 — injury healing stage** on rollover + `sim.healInjuriesForSeason`. **Depends:** A4, B1.
+- **B3 — recruiting class + scouting.** **Depends:** B1.
+- **B4 — transfers.** **Depends:** B1.
+- **B5 — promotions / position changes / cuts** (cuts → `releasePlayerToFreeAgency`).
+  **Depends:** B1.
+- **B6 — training → progression.** **Depends:** B1, B5.
+
+Table-adding slices must update `resetCanonicalFixture` (`e2eSeed.ts:530`) in the same PR.
+
+## Invariants
+
+1. `trueAttributesJson` never appears in any page-reachable query `returns:` validator
+   (assert on `listProspects`).
+2. Scouting bands nest monotonically and are deterministic per `(prospectId, scoutLevel)`.
+3. Offseason phases only move forward.
+4. Concurrent `advanceOffseasonPhase` → one winner, other gets `phase_busy`.
+5. Signing a prospect is idempotent on re-invoke.
+6. `computeProgressedAttributes` with `training: []` byte-matches pre-B6 output.
+7. Per-team mutations reject when `authorizeTeamMutation` fails for the supplied `teamId`.
+8. All writes `internalMutation`; handlers include `returns:` validators.
+
+## Non-goals
+
+- College recruiting hours, star ratings, or national signing day metaphors.
+- Contracts or salary cap.
+- Replacing snake draft or FA tables from offseason-free-agency-draft.
+- Wave 5 coach assignment UI (data model only via `teamId` auth).
+- Moving draft/FA functions out of `sports.ts`.

--- a/docs/design/play-by-play-engine.md
+++ b/docs/design/play-by-play-engine.md
@@ -1,7 +1,15 @@
 # Play-by-Play Simulation Engine
 
-Status: approved design (2026-07-05). Decision record: stats derive from plays — no
-score-derived stat synthesizer. Class-year dynasty and Gamecast UI build on this later.
+Status: **SHIPPED** (2026-07-25). All three slices landed — A (engine lib), B (persistence +
+wiring), C (Gamecast UI). Decision record: stats derive from plays — no score-derived stat
+synthesizer. Class-year dynasty and Gamecast UI build on this later.
+
+Extended by `docs/design/sim-engine-v2.md`, which adds penalties, injuries, fatigue, weather,
+situational/clock AI, and schemes on top of this engine. That extension is **strictly additive**:
+new `PbpPlay`/`PbpGameLog` fields are optional, `PBP_ENGINE_VERSION` (`src/lib/pbp/index.ts:16`)
+bumps per slice, stored logs are never rewritten, and a golden-log parity test asserts that with
+v2 features disabled the engine still reproduces the v1 log byte-for-byte for a fixed seed. The
+Slice A contract below remains the v1 baseline that parity test pins against.
 
 ## Context
 

--- a/docs/design/program-management.md
+++ b/docs/design/program-management.md
@@ -1,0 +1,168 @@
+# Program Management (Epic C)
+
+Status: approved design (2026-07-25). Decision record: model coach identity, prestige,
+schemes, goals, and job security as first-class persisted state; hook season finalize off
+`completeSeason` reading F2 `seasonTeamRecords` only. Covers Epic C / Wave 3 (slices C1–C4);
+gated by `FLAG_DYNASTY_PROGRAM_V1` and `dynastyConfig.programV1Enabled`.
+
+## Context
+
+**Shipped today**
+
+- No `coach` documents in `schema.ts`; "coach" is an org membership role string only.
+- `completeSeason` (`apps/web/convex/sports.ts:2163`) finalizes season status without
+  program evaluation.
+- Team strength for sim uses attributes / Madden overalls — no offensive/defensive scheme
+  or tempo stored on teams.
+- `computeStandingsPure` (`standings.ts:105`) supplies standings; no prestige or goals.
+
+**Missing**
+
+- `coaches`, `coachSeasons`, `teamSeasonPrograms` tables and `convex/program.ts`.
+- Coach Home route, Program/Staff cards, season goals card, weekly gameplan on fixtures.
+- `src/lib/program/*` pure libs feeding A6 `pbp/schemes.ts`.
+- `coaches.userId` + `by_userId` index for Wave 5 (day one).
+
+**Dependencies:** Epic F2 (`seasonTeamRecords`) for goals/prestige; Epic B6 (training) before
+C4 skill-tree payoff; slice **A6** ships immediately after **C3** (scheme setters).
+
+## Schema changes
+
+```ts
+coaches: defineTable({
+  leagueId: v.id("leagues"),
+  teamId: v.id("teams"),
+  userId: v.optional(v.string()),
+  displayName: v.string(),
+  archetype: v.string(),
+  offensiveScheme: v.optional(v.string()),
+  defensiveScheme: v.optional(v.string()),
+  aggression: v.optional(v.number()),
+  clockManagement: v.optional(v.number()),
+  developmentRating: v.optional(v.number()),
+  recruitingRating: v.optional(v.number()),
+  gameplanRating: v.optional(v.number()),
+  prestige: v.number(),
+  skillPoints: v.optional(v.number()),
+  unlockedNodesJson: v.optional(v.string()),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_teamId", ["teamId"])
+  .index("by_userId", ["userId"])
+  .index("by_leagueId", ["leagueId"]),
+
+coachSeasons: defineTable({
+  coachId: v.id("coaches"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  wins: v.number(),
+  losses: v.number(),
+  ties: v.number(),
+  playoffResult: v.optional(v.string()),
+  goalsMetJson: v.optional(v.string()),
+  prestigeDelta: v.optional(v.number()),
+  finalizedAt: v.optional(v.string()),
+})
+  .index("by_coach_season", ["coachId", "seasonId"])
+  .index("by_season_team", ["seasonId", "teamId"]),
+
+teamSeasonPrograms: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  prestige: v.number(),
+  facilitiesTier: v.optional(v.number()),
+  offensiveScheme: v.optional(v.string()),
+  defensiveScheme: v.optional(v.string()),
+  tempo: v.optional(v.string()),
+  blitzRate: v.optional(v.number()),
+  seasonGoalsJson: v.optional(v.string()),
+  jobSecurity: v.optional(v.number()),
+  boosterConfidence: v.optional(v.number()),
+  weeklyGameplanJson: v.optional(v.string()),
+  updatedAt: v.string(),
+})
+  .index("by_season_team", ["seasonId", "teamId"]),
+```
+
+Seed migration optional: `resolveProgram(doc | null)` returns defaults when row missing.
+
+## Function surface
+
+**Module:** `apps/web/convex/program.ts`.
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `getCoach` / `listCoaches` | query | Coach Home / Team Home |
+| `upsertCoach` | internalMutation | Staff assignment |
+| `getTeamSeasonProgram` | query | Program card |
+| `upsertTeamSeasonProgram` | internalMutation | Commissioner / admin |
+| `setWeeklyGameplan` | internalMutation | Per-fixture prep |
+| `finalizeCoachSeason` | internalMutation | Called from `completeSeason` |
+| `evaluateSeasonGoals` | internalMutation | Pure lib wrapper persist |
+| `applyProgramPrestige` | internalMutation | Post-season prestige delta |
+
+`completeSeason` (`sports.ts:2163`) orchestrates: read `seasonTeamRecords` (indexed per
+team), run evaluation, write `coachSeasons` + program prestige — no fixture scans.
+
+Per-team gameplan writes use `authorizeTeamMutation(teamId, userId)` in server actions
+(same pattern as `offseason.ts:18`).
+
+## Pure-lib work
+
+Under `apps/web/src/lib/program/`:
+
+| Module | Exports |
+|--------|---------|
+| `prestige.ts` | `applyPrestigeDelta(current, seasonOutcome): { prestige, delta }` (hysteresis) |
+| `goals.ts` | `generateGoals(teamId, seasonId, records, aggregates)`, `evaluateGoals(...)` |
+| `job-security.ts` | `computeJobSecurity(inputs): number` |
+| `schemes.ts` | scheme catalog + `tendencyVector(scheme): Tendencies` — **consumed by A6** |
+| `coach-skills.ts` | `unlockNode(tree, nodeId)`, `spendSkillPoints(...)` |
+| `gameplan.ts` | `mergeGameplan(base, weekly): Gameplan` |
+
+Goal evaluation reads **only** F2/F3 aggregates (read-spy) — never loops game stats.
+
+## UI surface
+
+- `/dashboard/coaches/[coachId]` — Coach Home (new `ResourceHeaderKind` `"coach"`,
+  `coachHomeHref`, `buildCoachSiblingLinks` in `resource-navigation.ts`).
+- Team Home: Program + Staff cards.
+- Season Home: season goals card (`seasonSubpageHref` siblings unchanged except goals on
+  main season page).
+- Fixture surface: weekly gameplan (not a nav destination).
+- No new sidebar entry — reach coaches from Team Home.
+- `CONTEXT.md` entries before merge.
+
+ADR 0001: competition views remain season-owned; coach resource is program-scoped.
+
+## Slices
+
+- **C1 — coach identity + staff** (read-only w.r.t. sim). **Depends:** F1.
+- **C2 — prestige, goals, job security** + `completeSeason` hooks. **Depends:** F2, C1.
+- **C3 — schemes + gameplanning** data on `teamSeasonPrograms`. **Depends:** C1.
+- **A6 — sim schemes** (Epic A; immediately after C3). **Depends:** C3.
+- **C4 — skill tree + development economy.** **Depends:** B6, C1.
+
+New tables → `resetCanonicalFixture` (`e2eSeed.ts:530`) in the same PR.
+
+## Invariants
+
+1. `|prestigeDelta| ≤ 12` per season per team.
+2. Goal generation deterministic per `(teamId, seasonId)`.
+3. Goal evaluation performs zero reads of `playerGameStats` / `gamePlayLogs` (read-spy).
+4. Sum of a coach's `coachSeasons` W/L/T matches summed `seasonTeamRecords` for their teams.
+5. **Scheme neutrality:** default scheme + aggression 50 → `simulateGameLog` byte-matches
+   pre-A6 log with v2 disabled.
+6. All `program.ts` writes are `internalMutation` with guard-test backstop.
+7. Every handler has `returns:`; DTO mappers use `Infer<typeof …Validator>`.
+8. `coaches.userId` index exists from C1 for future Wave 5 binding.
+
+## Non-goals
+
+- Multi-coach simultaneous online play (Wave 5).
+- AI coach carousel or firing minigames beyond job-security number.
+- College NIL or booster payola simulation.
+- Moving `completeSeason` out of `sports.ts` (only add internal calls).
+- Public Convex mutations or client `useQuery`.

--- a/docs/design/sim-engine-v2.md
+++ b/docs/design/sim-engine-v2.md
@@ -1,0 +1,151 @@
+# Sim Engine v2 (Epic A)
+
+Status: approved design (2026-07-25). Decision record: extend the versioned play log
+with optional fields and bump `PBP_ENGINE_VERSION` per slice; never rewrite stored logs
+or extend `PlayerGameStatLine` in `packages/api-contracts`. Covers Epic A / Waves 1–3
+(slices A1–A6); gated by `FLAG_DYNASTY_SIM_V2` (`resolveFlag` idiom in
+`apps/web/src/lib/flags.ts:11`) plus the per-league `dynastyConfig` kill switches
+`penaltiesEnabled`, `injuriesEnabled` and `weatherEnabled` (Epic F, slice F5), which let a
+live league back a mechanic out without a deploy.
+
+Extended by nothing yet — extends `docs/design/play-by-play-engine.md` (v1 baseline).
+
+## Context
+
+**Shipped today**
+
+- `simulateGameLog` (`apps/web/src/lib/pbp/engine.ts:788`), `runScrimmagePlay` (`:757`),
+  `doRush` (`:472`), `doPass` (`:534`); `PBP_ENGINE_VERSION = "1.0.0"`
+  (`apps/web/src/lib/pbp/index.ts:16`).
+- Logs persist on `gamePlayLogs` with `engineVersion` (`apps/web/convex/schema.ts:329`).
+- Stats derive via `derive-stats.ts` into `PlayerGameStatLine`; sim path uses
+  `upsertPlayerGameStats` (`sports.ts:6240`).
+- 4th-down decision is three distance bands + random pass/rush inside `runScrimmagePlay`.
+- No penalties, injuries, fatigue, weather, timeouts, two-point, onside, or safety play
+  types in `engine.ts` / `types.ts`.
+
+**Missing**
+
+- Optional `PbpPlay` / `PbpGameLog` fields and new play types; `pbp/migrate-log.ts`
+  `normalizeGameLog()` for in-memory up-convert.
+- `playerInjuries` and `rivalries` tables; Convex surface in `convex/sim.ts`.
+- Gamecast penalty/injury/weather UI; injury report on Team Home; schedule weather icon.
+- Scheme parameters (A6) — ships immediately after program schemes (C3).
+
+**Explicit contract rule:** penalties, snap counts, and penalty totals stay in the
+versioned play log only. Do **not** extend `PlayerGameStatLine` in
+`packages/api-contracts` — box score, MaxPreps export, SPRT, and stat leaders must not
+gain penalty columns (WSM-000166 drift class).
+
+## Schema changes
+
+```ts
+playerInjuries: defineTable({
+  leagueId: v.id("leagues"),
+  seasonId: v.id("seasons"),
+  teamId: v.id("teams"),
+  playerId: v.id("players"),
+  fixtureId: v.optional(v.id("fixtures")),
+  injuryType: v.string(),          // "hamstring" | "ankle" | "concussion" | "acl" | …
+  severity: v.string(),            // "minor" | "moderate" | "severe" | "season_ending"
+  gamesOut: v.number(),
+  weekOccurred: v.optional(v.number()),
+  returnsAfterWeek: v.optional(v.number()),
+  status: v.string(),              // "out" | "questionable" | "recovered"
+  createdAt: v.string(),
+  updatedAt: v.string(),
+})
+  .index("by_season_player", ["seasonId", "playerId"])
+  .index("by_season_team", ["seasonId", "teamId"])
+  .index("by_season_status", ["seasonId", "status"]),
+
+rivalries: defineTable({
+  leagueId: v.id("leagues"),
+  teamAId: v.id("teams"),
+  teamBId: v.id("teams"),
+  intensity: v.number(),
+  label: v.optional(v.string()),
+})
+  .index("by_league", ["leagueId"])
+  .index("by_pair", ["leagueId", "teamAId", "teamBId"]),
+```
+
+`PbpPlay` / `PbpGameLog` TypeScript-only extensions (optional): `penalty`, `injury`,
+`returnYards`, `isReturnTd`, `isTwoMinuteDrill`, `timeoutsRemaining`, `weather`,
+`penaltyTotals`, `rivalry`; play types include `two_point_convert`, `safety`,
+`onside_kick`, `penalty`, `spike`, `timeout`. Bump `PBP_ENGINE_VERSION` each slice.
+
+## Function surface
+
+**Module:** `apps/web/convex/sim.ts`.
+
+| Symbol | Kind | Purpose |
+|--------|------|---------|
+| `listPlayerInjuries` | query | Team / season injury report |
+| `upsertInjuryFromSim` | internalMutation | Post-game injury rows |
+| `healInjuriesForSeason` | internalMutation | Offseason hook (B2) |
+| `listRivalries` | query | League rivalry config |
+| `upsertRivalry` | internalMutation | Commissioner setup |
+
+Sim execution stays in Next server actions (existing schedule sim path); `sim.ts` only
+persists injury/rivalry docs. `recordGameResult` transaction may call injury upserts.
+
+## Pure-lib work
+
+All under `apps/web/src/lib/pbp/` — zero Convex in unit tests.
+
+| Module | Exports |
+|--------|---------|
+| `penalties.ts` | `rollPenalty(ctx)`, `resolveAcceptDecline(ctx)` |
+| `situational.ts` | `chooseFourthDown(ctx)`, onside/clock/spike/timeout helpers |
+| `fatigue.ts` | `applyFatigue(state, play)` |
+| `injuries.ts` | `rollInjury(ctx)` |
+| `weather.ts` | `weatherForFixture(season, week, venueId)` |
+| `schemes.ts` | `applySchemeTendencies(profile, schemeDoc)` — **identity default** |
+| `crowd.ts` | `crowdModifier(home, rivalry)` |
+| `migrate-log.ts` | `normalizeGameLog(log): PbpGameLog` |
+
+RNG uses `apps/web/src/lib/rng.ts` namespaces from Epic F.
+
+## UI surface
+
+- Gamecast: penalty chips, injury callouts, weather strip (existing fixture route).
+- Box score: penalty totals from log JSON (not DTO contract).
+- Team Home: injury report card.
+- Season schedule: weather icon per fixture.
+- No new top-level routes; use existing season/fixture URLs per ADR 0001 and
+  `seasonSubpageHref` (`resource-navigation.ts:105`).
+
+## Slices
+
+- **A1 — scaffolding + scoring completeness:** safeties, two-point, fumble/return TD
+  paths, version bump, golden-log parity harness. **Depends:** F1.
+- **A2 — penalties.** **Depends:** A1.
+- **A3 — situational AI + clock** (highest feel-per-LOC). **Depends:** A1.
+- **A4 — fatigue / durability / injuries** + `playerInjuries`. **Depends:** F4, A1.
+- **A5 — weather / crowd / rivalry.** **Depends:** A1 (prestige input optional until C2).
+- **A6 — schemes** (consumes `src/lib/program/schemes.ts` after C3). **Depends:** C3, A1.
+
+Each slice adding tables extends `resetCanonicalFixture` (`e2eSeed.ts:530`) in the same PR.
+
+## Invariants
+
+1. With v2 features disabled, `simulateGameLog` reproduces the pinned v1 log byte-for-byte
+   for a fixed seed (re-run every A slice).
+2. A `negatesPlay` penalty grants zero stat credit in `deriveStatLines`.
+3. Injured-out players never appear as participants in a later fixture in the same season.
+4. Timeouts remaining never negative.
+5. Balance band over 200 seeded games per flavor: mean total points 30–60; 4–9 penalties
+   per team; 0–2 injuries per game; favorite wins ≥65% at ≥15 strength differential.
+6. Serialized v2 log < 400KB per game.
+7. Stored `gamePlayLogs` rows are never updated in place for migration — readers call
+   `normalizeGameLog`.
+8. `PlayerGameStatLineSchema` unchanged in api-contracts; penalty data only in log JSON.
+
+## Non-goals
+
+- Rewriting historical `logJson` blobs on deploy.
+- Extending `packages/api-contracts` stat lines for penalties or snap counts.
+- Coach skill tree or program prestige (Epic C) except scheme hook at A6.
+- Public Convex mutations; all writes `internalMutation` (WSM-000096).
+- Moving sim orchestration out of existing server actions into client-side Convex.


### PR DESCRIPTION
## Summary

Planning artifacts for the full Dynasty Mode build-out — a College Football 26 / Madden 26 style
simulation and management system, scaled to the high-school program model this app already uses
(grades 9–12, FR/SO/JR/SR, Varsity/JV). Docs only; no code, schema, or test changes.

Dynasty Mode is **not** greenfield. A real play-by-play engine, six-stage season rollover with
seeded progression, snake draft, free agency and playoffs all already ship. These docs cover what
is missing, organized as 5 epics / 26 independently shippable slices.

### New design docs

| Doc | Epic | Delivers |
|---|---|---|
| `dynasty-foundations.md` | F | Persisted `seasonTeamRecords` and `playerSeasonAggregates`, `dynastyEvents` log, `dynastyConfig`, and four new Convex modules |
| `sim-engine-v2.md` | A | Penalties, injuries, fatigue, weather, situational/clock AI, schemes |
| `offseason-pipeline.md` | B | Persisted offseason phase machine, freshman scouting, transfers, promotions, cuts, training |
| `program-management.md` | C | Coaches, staff, prestige, season goals, job security, schemes, skill tree |
| `dynasty-history-awards.md` | D | Career totals, record books, awards, polls, news feed, recaps, Hall of Fame |

### Corrected stale status lines

- **`offseason-free-agency-draft.md`** said "Nothing here is built; no code ships until this doc
  is signed off." It has been fully built. Flipped to shipped, with as-built file references and
  its four open questions resolved against the behavior that actually shipped:
  - Roster cap on signing is **soft** — `signFreeAgent` returns `overCap` but passes
    `enforceRosterLimit: false`.
  - Coaches **may** release and sign for their own team — `canAdminOrManageTeam` grants org admin
    **or** `canManageTeam(teamId, userId)`.
  - Draft rounds are a **fixed 3** (`DRAFT_ROUNDS = 3`), not `ceil(pool/teams)`.
  - "Send freshmen to draft pool" is **not** remembered — per-invocation argument defaulting to
    auto-assign.
- **`dynasty-mode.md`** and **`play-by-play-engine.md`** marked shipped, each with a pointer to
  the doc that extends it.

## Key architectural decisions recorded

- **Foundations first.** F2 and F3 remove the standings full-scan and both stat-leader N+1 loops
  (`computeSeasonSprt` at `sports.ts:6497` and the `seasonStatLeaders` helper at `:6576` currently
  `ctx.db.get` inside a loop) while changing no observable behavior.
- **Split forward only.** New Convex surface lands in `convex/{dynasty,sim,program,history}.ts`.
  Existing functions are *not* moved out of `sports.ts` — that would rename `internal.sports.X`
  and break both the guard test and every untyped `"sports:name"` string in `data-api.ts`.
- **Versioned, immutable play logs.** All new `PbpPlay`/`PbpGameLog` fields are optional,
  `PBP_ENGINE_VERSION` bumps per slice, and `normalizeGameLog` up-converts v1 on read. Stored logs
  are never rewritten.
- **`PlayerGameStatLine` is not extended.** Penalties and snap counts stay in the log. Touching
  that contract ripples into box score, MaxPreps export, SPRT and stat leaders — the WSM-000166
  drift class.
- **Per-`teamId` authorization everywhere.** Every new per-team offseason/program action gates
  through `authorizeTeamMutation`/`resolveTeamRole`, following the shipped
  `canAdminOrManageTeam` precedent. This is what keeps multi-coach online dynasty open without a
  rewrite.
- **Four flags only**, with per-league `dynastyConfig` booleans for per-slice gating, so a live
  league can back a mechanic out without a deploy.

## Verification

- [x] All 35 distinct file citations across the five new docs checked to exist; every one of the
      line-number citations resolves to the exact symbol claimed
- [x] Two line numbers corrected against the plan during review — `computeSeasonSprt` is at
      `sports.ts:6497` (not 6468) and the `seasonStatLeaders` helper at `:6576` (not 6510)
- [x] Cross-checked every proposed `defineTable` index against its declared fields; fixed one real
      defect where `playerInjuries.by_season_team` referenced an undeclared `teamId`
- [x] `commitlint` passes on the commit message

## Tracked by

Epics #604 (F), #605 (A), #606 (B), #607 (C), #608 (D), with 26 slice issues #609–#634 linked from
each epic body.

## Out of scope

- Any implementation. This PR ships documentation only.
- Multi-coach online dynasty, designed as a later wave but deliberately not architected out.
- Contracts, salary cap, and college-style recruiting boards — explicitly excluded by the
  high-school program model.
