### PR TITLE
feat: persist player season aggregates and remove the stat-leader N+1 loops (#615)

### DIFF
--- a/apps/web/convex/__tests__/playerSeasonAggregates.test.ts
+++ b/apps/web/convex/__tests__/playerSeasonAggregates.test.ts
@@ -1,0 +1,400 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { aggregateStatLines, parseStatLine } from "../lib/playerStats";
+import {
+  computeHsSprtRatings,
+  positionToRatingGroup,
+} from "../lib/hsSprt";
+
+const modules = import.meta.glob("../**/*.*s");
+
+/*
+ * Integration guard for the persisted player season aggregate (F3).
+ *
+ * The property under test: the `playerSeasonAggregates` row always equals what
+ * aggregating that player's raw `playerGameStats` rows produces. The raw
+ * aggregation is the oracle, so expectations are never hand-derived.
+ */
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Aggregates League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamId = await ctx.db.insert("teams", {
+      name: "Aggregates Team",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "City",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const playerId = await ctx.db.insert("players", {
+      name: "Marcus Hill",
+      leagueId,
+      teamId,
+      position: "RB",
+      positionGroup: "RB",
+      jerseyNumber: 22,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+    });
+
+    const fixtureIds: Id<"fixtures">[] = [];
+    for (let week = 1; week <= 3; week++) {
+      fixtureIds.push(
+        await ctx.db.insert("fixtures", {
+          seasonId,
+          homeTeamId: teamId,
+          awayTeamId: teamId,
+          scheduledAt: null,
+          week,
+          venue: null,
+          status: "scheduled",
+          stage: "regular",
+          createdAt: new Date(0).toISOString(),
+          createdBy: "test",
+        }),
+      );
+    }
+
+    return { leagueId, teamId, seasonId, playerId, fixtureIds };
+  });
+}
+
+const rushing = (yards: number, long: number) =>
+  JSON.stringify({ rushing: { carries: 10, yards, td: 1, long } });
+
+async function upsert(
+  t: ReturnType<typeof convexTest>,
+  args: {
+    fixtureId: Id<"fixtures">;
+    playerId: Id<"players">;
+    teamId: Id<"teams">;
+    seasonId: Id<"seasons">;
+    statsJson: string;
+  },
+) {
+  await t.mutation(internal.sports.upsertPlayerGameStats, {
+    ...args,
+    actorUserId: "user_test",
+  });
+}
+
+/** HsRatingInput names the game count `games`, not `gamesPlayed`. */
+function toRatingInput(o: { totals: ReturnType<typeof parseStatLine>; gamesPlayed: number }) {
+  return { totals: o.totals, games: o.gamesPlayed };
+}
+
+/** Aggregate straight from the raw rows — the oracle. */
+async function oracle(
+  t: ReturnType<typeof convexTest>,
+  playerId: Id<"players">,
+) {
+  return t.run(async (ctx) => {
+    const rows = (await ctx.db.query("playerGameStats").collect()).filter(
+      (r) => r.playerId === playerId,
+    );
+    return {
+      totals: aggregateStatLines(rows.map((r) => parseStatLine(r.statsJson))),
+      gamesPlayed: rows.length,
+    };
+  });
+}
+
+async function storedAggregate(
+  t: ReturnType<typeof convexTest>,
+  playerId: Id<"players">,
+) {
+  return t.run(async (ctx) => {
+    const rows = (
+      await ctx.db.query("playerSeasonAggregates").collect()
+    ).filter((r) => r.playerId === playerId);
+    if (rows.length === 0) return null;
+    return {
+      totals: parseStatLine(rows[0]!.totalsJson),
+      gamesPlayed: rows[0]!.gamesPlayed,
+    };
+  });
+}
+
+describe("playerSeasonAggregates", () => {
+  it("matches the raw aggregation after each entered line", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    for (const [i, fixtureId] of fixtureIds.entries()) {
+      await upsert(t, {
+        fixtureId,
+        playerId,
+        teamId,
+        seasonId,
+        statsJson: rushing(80 + i * 10, 25 + i * 5),
+      });
+      expect(await storedAggregate(t, playerId)).toEqual(
+        await oracle(t, playerId),
+      );
+    }
+
+    const stored = await storedAggregate(t, playerId);
+    expect(stored?.gamesPlayed).toBe(3);
+  });
+
+  it("recomputes a MAX field downward when the long run is overwritten", async () => {
+    // The case a subtraction-based delta cannot handle. "long" reduces with
+    // MAX, not sum: if the 55-yard game is rewritten to 12, the correct season
+    // long is the next-longest remaining run (40), and no amount of arithmetic
+    // on the stored 55 recovers it.
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    await upsert(t, {
+      fixtureId: fixtureIds[0]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(90, 40),
+    });
+    await upsert(t, {
+      fixtureId: fixtureIds[1]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(120, 55),
+    });
+
+    expect(
+      (await storedAggregate(t, playerId))?.totals.rushing?.long,
+    ).toBe(55);
+
+    // Re-enter the second game with a much shorter long run.
+    await upsert(t, {
+      fixtureId: fixtureIds[1]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(120, 12),
+    });
+
+    const after = await storedAggregate(t, playerId);
+    expect(after?.totals.rushing?.long).toBe(40);
+    expect(after).toEqual(await oracle(t, playerId));
+  });
+
+  it("removes the row entirely when the last line is deleted", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    await upsert(t, {
+      fixtureId: fixtureIds[0]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(90, 40),
+    });
+    expect(await storedAggregate(t, playerId)).not.toBeNull();
+
+    await t.mutation(internal.sports.deletePlayerGameStats, {
+      fixtureId: fixtureIds[0]!,
+      playerId,
+    });
+
+    expect(await storedAggregate(t, playerId)).toBeNull();
+  });
+
+  it("keeps the aggregate correct through a bulk upsert", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    await t.mutation(internal.sports.bulkUpsertPlayerGameStats, {
+      fixtureId: fixtureIds[0]!,
+      seasonId,
+      actorUserId: "user_test",
+      lines: [{ playerId, teamId, statsJson: rushing(70, 33) }],
+    });
+
+    expect(await storedAggregate(t, playerId)).toEqual(
+      await oracle(t, playerId),
+    );
+  });
+
+  it("feeds stat leaders from live player and team rows", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    await upsert(t, {
+      fixtureId: fixtureIds[0]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(150, 60),
+    });
+
+    const leaders = await t.query(api.sports.getSeasonStatLeaders, {
+      seasonId,
+    });
+    const rushYards = leaders.find((c) => c.key.includes("rush"));
+    expect(rushYards?.leaders[0]?.playerId).toBe(playerId);
+    // Name, jersey and team are joined from the LIVE rows rather than the
+    // aggregate snapshot, so a rename shows up without a rebuild.
+    expect(rushYards?.leaders[0]?.playerName).toBe("Marcus Hill");
+    expect(rushYards?.leaders[0]?.jerseyNumber).toBe(22);
+    expect(rushYards?.leaders[0]?.teamName).toBe("Aggregates Team");
+  });
+
+  it("produces SPRT ratings equal to rating the raw totals directly", async () => {
+    // SPRT needs a cohort: `computeHsSprtRatings` skips any group with fewer
+    // than 2 qualified players, so this seeds a second back. The assertion is
+    // parity against rating the oracle totals, not merely "non-empty".
+    const t = convexTest(schema, modules);
+    const { leagueId, teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    const secondPlayerId = await t.run(async (ctx) =>
+      ctx.db.insert("players", {
+        name: "Devin Carter",
+        leagueId,
+        teamId,
+        position: "RB",
+        positionGroup: "RB",
+        jerseyNumber: 28,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      }),
+    );
+
+    for (const [i, fixtureId] of fixtureIds.entries()) {
+      await upsert(t, {
+        fixtureId,
+        playerId,
+        teamId,
+        seasonId,
+        statsJson: rushing(100 + i * 10, 30),
+      });
+      await upsert(t, {
+        fixtureId,
+        playerId: secondPlayerId,
+        teamId,
+        seasonId,
+        statsJson: rushing(40 + i * 5, 15),
+      });
+    }
+
+    const sprt = await t.query(api.sports.computeSeasonSprt, { seasonId });
+
+    const expected = computeHsSprtRatings([
+      {
+        id: playerId as string,
+        group: positionToRatingGroup("RB")!,
+        ...toRatingInput(await oracle(t, playerId)),
+      },
+      {
+        id: secondPlayerId as string,
+        group: positionToRatingGroup("RB")!,
+        ...toRatingInput(await oracle(t, secondPlayerId)),
+      },
+    ]);
+
+    expect(sprt).toHaveLength(expected.size);
+    for (const row of sprt) {
+      const want = expected.get(row.playerId)!;
+      expect(row.overall).toBe(want.overall);
+      expect(row.positionGroup).toBe(want.positionGroup);
+    }
+    // The stronger back must rate higher — a sanity check that the join
+    // did not shuffle players against their totals.
+    const strong = sprt.find((r) => r.playerId === playerId)!;
+    const weak = sprt.find((r) => r.playerId === secondPlayerId)!;
+    expect(strong.overall).toBeGreaterThan(weak.overall);
+  });
+
+  it("backfills a season whose stat lines predate the table", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    // Insert lines DIRECTLY, bypassing the mutation, so no aggregate is
+    // maintained — the state prod data is in before the migration runs.
+    await t.run(async (ctx) => {
+      for (const [i, fixtureId] of fixtureIds.entries()) {
+        await ctx.db.insert("playerGameStats", {
+          fixtureId,
+          playerId,
+          teamId,
+          seasonId,
+          statsJson: rushing(60 + i * 20, 20 + i * 15),
+          enteredBy: "test",
+          updatedAt: new Date(0).toISOString(),
+        });
+      }
+    });
+
+    expect(await storedAggregate(t, playerId)).toBeNull();
+
+    const summary = await t.mutation(
+      internal.migrations["20260801_playerSeasonAggregates"]
+        .backfillPlayerSeasonAggregates,
+      { seasonId },
+    );
+    expect(summary).toEqual({ playersWritten: 1, linesCounted: 3 });
+
+    expect(await storedAggregate(t, playerId)).toEqual(
+      await oracle(t, playerId),
+    );
+
+    // Idempotent.
+    await t.mutation(
+      internal.migrations["20260801_playerSeasonAggregates"]
+        .backfillPlayerSeasonAggregates,
+      { seasonId },
+    );
+    expect(await storedAggregate(t, playerId)).toEqual(
+      await oracle(t, playerId),
+    );
+  });
+
+  it("rebuildSeasonPlayerAggregates repairs a corrupted row", async () => {
+    const t = convexTest(schema, modules);
+    const { teamId, seasonId, playerId, fixtureIds } = await seed(t);
+
+    await upsert(t, {
+      fixtureId: fixtureIds[0]!,
+      playerId,
+      teamId,
+      seasonId,
+      statsJson: rushing(90, 40),
+    });
+    const before = await storedAggregate(t, playerId);
+
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("playerSeasonAggregates").collect();
+      for (const row of rows) {
+        await ctx.db.patch(row._id, { totalsJson: "{}", gamesPlayed: 99 });
+      }
+    });
+
+    await t.mutation(internal.sports.rebuildSeasonPlayerAggregates, {
+      seasonId,
+    });
+
+    expect(await storedAggregate(t, playerId)).toEqual(before);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -48,6 +48,7 @@ void internal.sports.deleteDivision;
 void internal.sports.setLeaguePublic;
 void internal.sports.recordGameResult;
 void internal.sports.rebuildSeasonTeamRecords;
+void internal.sports.rebuildSeasonPlayerAggregates;
 void internal.sports.assignPlayerToRoster;
 void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;
@@ -286,6 +287,8 @@ void internal.migrations["20260428_playersPositionGroup"]
 void internal.migrations["20260428_depthChartToRoster"].migrateDepthChartToRoster;
 void internal.migrations["20260801_seasonTeamRecords"]
   .backfillSeasonTeamRecords;
+void internal.migrations["20260801_playerSeasonAggregates"]
+  .backfillPlayerSeasonAggregates;
 // @ts-expect-error backfillSeasonsRosterLocked is internal, not public
 void api.migrations["20260422_seasonsRosterLocked"].backfillSeasonsRosterLocked;
 // @ts-expect-error backfillPlayersPositionGroup is internal, not public

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as lib_teamRecords from "../lib/teamRecords.js";
 import type * as migrations_20260422_seasonsRosterLocked from "../migrations/20260422_seasonsRosterLocked.js";
 import type * as migrations_20260428_depthChartToRoster from "../migrations/20260428_depthChartToRoster.js";
 import type * as migrations_20260428_playersPositionGroup from "../migrations/20260428_playersPositionGroup.js";
+import type * as migrations_20260801_playerSeasonAggregates from "../migrations/20260801_playerSeasonAggregates.js";
 import type * as migrations_20260801_seasonTeamRecords from "../migrations/20260801_seasonTeamRecords.js";
 import type * as program from "../program.js";
 import type * as sim from "../sim.js";
@@ -68,6 +69,7 @@ declare const fullApi: ApiFromModules<{
   "migrations/20260422_seasonsRosterLocked": typeof migrations_20260422_seasonsRosterLocked;
   "migrations/20260428_depthChartToRoster": typeof migrations_20260428_depthChartToRoster;
   "migrations/20260428_playersPositionGroup": typeof migrations_20260428_playersPositionGroup;
+  "migrations/20260801_playerSeasonAggregates": typeof migrations_20260801_playerSeasonAggregates;
   "migrations/20260801_seasonTeamRecords": typeof migrations_20260801_seasonTeamRecords;
   program: typeof program;
   sim: typeof sim;

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -132,14 +132,23 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
-  // Cached season records (F2). A table left behind here leaks state between
-  // e2e runs and produces order-dependent, flaky standings assertions.
+  // Cached season aggregates (F2, F3). A table left behind here leaks state
+  // between e2e runs and produces order-dependent, flaky standings and stat
+  // leader assertions.
   for (const season of seasons as Array<{ _id: Id<"seasons"> }>) {
     const records = (await ctx.db
       .query("seasonTeamRecords")
       .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
       .collect()) as Array<{ _id: Id<"seasonTeamRecords"> }>;
     for (const row of records) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    const aggregates = (await ctx.db
+      .query("playerSeasonAggregates")
+      .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
+      .collect()) as Array<{ _id: Id<"playerSeasonAggregates"> }>;
+    for (const row of aggregates) {
       await ctx.db.delete(row._id);
       deleted += 1;
     }

--- a/apps/web/convex/lib/playerStats.ts
+++ b/apps/web/convex/lib/playerStats.ts
@@ -40,3 +40,42 @@ export function parseStatLine(json: string): StatLine {
     return {};
   }
 }
+
+/**
+ * Sum two stat lines. Convenience wrapper over `aggregateStatLines` for the
+ * two-operand case; identical semantics, including MAX on "long" fields.
+ */
+export function addStatLines(a: StatLine, b: StatLine): StatLine {
+  return aggregateStatLines([a, b]);
+}
+
+/**
+ * Why there is no `subtractStatLines` (F3).
+ *
+ * A persisted season aggregate has to survive a game line being OVERWRITTEN or
+ * DELETED — re-entering a box score, or a re-sim under a new engine version.
+ * The obvious way to do that is to subtract the old contribution and add the
+ * new one. That is unsound here.
+ *
+ * `MAX_FIELDS` ("long" — longest run, catch, punt, return) takes the MAX across
+ * a player's games, not the sum, and a max cannot be inverted. If a player's
+ * longs are 40, 55 and 30, the season long is 55; remove the 55-yard game and
+ * the correct answer is 40, but nothing in the stored aggregate remembers it.
+ * Subtracting would leave 55 forever, silently inflating a record that Epic D's
+ * record book will later treat as history.
+ *
+ * So the aggregate is maintained by REBUILDING the affected player from their
+ * own game rows. `playerGameStats` is indexed `by_playerId_seasonId`, so that
+ * is a single indexed read of ~10–16 rows — cheaper than the season-wide scan
+ * it replaces, and exactly equal to a full rebuild by construction.
+ *
+ * This is the same conclusion F2 reached for `streak`/`lastResults`, for the
+ * analogous reason: an aggregate containing a non-invertible reduction cannot
+ * be maintained by deltas.
+ */
+export function summarizeStatLines(lines: StatLine[]): {
+  totals: StatLine;
+  gamesPlayed: number;
+} {
+  return { totals: aggregateStatLines(lines), gamesPlayed: lines.length };
+}

--- a/apps/web/convex/migrations/20260801_playerSeasonAggregates.ts
+++ b/apps/web/convex/migrations/20260801_playerSeasonAggregates.ts
@@ -1,0 +1,89 @@
+import { v } from "convex/values";
+import { internalMutation } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { parseStatLine, summarizeStatLines } from "../lib/playerStats";
+
+/*
+ * Backfill `playerSeasonAggregates` for seasons with existing stat lines (F3).
+ *
+ * Stat leaders and SPRT now read the aggregate, so a season whose box scores
+ * predate this table would show an empty leaderboard until each player's next
+ * stat write. This populates it.
+ *
+ * ONE SEASON PER INVOCATION, deliberately: a whole-league backfill would read
+ * every `playerGameStats` row across every season in one transaction and can
+ * exceed Convex's 8192-document query ceiling on a long dynasty. A single
+ * season is ~600 rows for a 12-team league, ~1900 for a 32-team league.
+ *
+ *   npx convex run migrations/20260801_playerSeasonAggregates:backfillPlayerSeasonAggregates \
+ *     '{"seasonId":"<id>"}'
+ *
+ * Idempotent — it rebuilds from source and replaces.
+ */
+export const backfillPlayerSeasonAggregates = internalMutation({
+  args: { seasonId: v.id("seasons") },
+  returns: v.object({
+    playersWritten: v.number(),
+    linesCounted: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) return { playersWritten: 0, linesCounted: 0 };
+
+    const rows = await ctx.db
+      .query("playerGameStats")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    // Group in memory rather than one indexed read per player: the backfill
+    // already holds every row, so per-player reads would be pure waste.
+    const byPlayer = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const list = byPlayer.get(row.playerId as string) ?? [];
+      list.push(row);
+      byPlayer.set(row.playerId as string, list);
+    }
+
+    const now = new Date().toISOString();
+    let playersWritten = 0;
+
+    for (const [playerId, playerRows] of byPlayer) {
+      const player = await ctx.db.get(playerId as Id<"players">);
+      if (!player) continue;
+
+      const { totals, gamesPlayed } = summarizeStatLines(
+        playerRows.map((r) => parseStatLine(r.statsJson)),
+      );
+
+      const payload = {
+        leagueId: season.leagueId,
+        seasonId: args.seasonId,
+        teamId: playerRows[playerRows.length - 1]!.teamId,
+        playerId: playerId as Id<"players">,
+        position: player.position,
+        positionGroup: player.positionGroup ?? null,
+        gamesPlayed,
+        totalsJson: JSON.stringify(totals),
+        updatedAt: now,
+      };
+
+      const existing = await ctx.db
+        .query("playerSeasonAggregates")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q
+            .eq("playerId", playerId as Id<"players">)
+            .eq("seasonId", args.seasonId),
+        )
+        .first();
+
+      if (existing) {
+        await ctx.db.replace(existing._id, payload);
+      } else {
+        await ctx.db.insert("playerSeasonAggregates", payload);
+      }
+      playersWritten += 1;
+    }
+
+    return { playersWritten, linesCounted: rows.length };
+  },
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -14,7 +14,11 @@ import {
   recordsToRankableStats,
   serializeHeadToHead,
 } from "./lib/teamRecords";
-import { aggregateStatLines, parseStatLine } from "./lib/playerStats";
+import {
+  aggregateStatLines,
+  parseStatLine,
+  summarizeStatLines,
+} from "./lib/playerStats";
 import {
   categoryValues,
   computeStatLeaders,
@@ -1013,6 +1017,7 @@ export const deleteLeagueBatch = internalMutationGeneric({
         .collect())
         await ctx.db.delete(pa._id);
       await clearSeasonTeamRecords(ctx as MutationCtx, season._id);
+      await clearSeasonPlayerAggregates(ctx as MutationCtx, season._id);
       await ctx.db.delete(season._id);
     }
 
@@ -1089,6 +1094,7 @@ export const deleteLeague = internalMutationGeneric({
         .collect())
         await ctx.db.delete(pa._id);
       await clearSeasonTeamRecords(ctx as MutationCtx, season._id);
+      await clearSeasonPlayerAggregates(ctx as MutationCtx, season._id);
       await ctx.db.delete(season._id);
     }
 
@@ -2575,8 +2581,9 @@ export const deleteSeason = internalMutationGeneric({
     const season = await ctx.db.get(args.seasonId);
     if (!season) return null;
 
-    // Cached season records go with the season they summarize (F2).
+    // Cached season aggregates go with the season they summarize (F2, F3).
     await clearSeasonTeamRecords(ctx as MutationCtx, args.seasonId);
+    await clearSeasonPlayerAggregates(ctx as MutationCtx, args.seasonId);
 
     const fixtures = await ctx.db
       .query("fixtures")
@@ -6427,6 +6434,121 @@ const playerGameStatsRowValidator = v.object({
   updatedAt: v.string(),
 });
 
+/*
+ * ── Persisted player season aggregates (Dynasty Mode F3) ────────────────────
+ *
+ * Same cache discipline as `seasonTeamRecords` (F2): the row is exactly what
+ * `aggregateStatLines` produces over a player's game rows, and it is kept
+ * correct by REBUILDING the affected player rather than applying deltas.
+ *
+ * Deltas are unsound here because "long" fields reduce with MAX, not sum, and a
+ * max cannot be inverted when a game line is overwritten or deleted — see the
+ * long-form note in `lib/playerStats.ts`. The rebuild is a single indexed read
+ * (`by_playerId_seasonId`, ~10–16 rows), cheaper than the season-wide scan it
+ * replaces.
+ */
+async function rebuildPlayerSeasonAggregate(
+  ctx: MutationCtx,
+  args: { playerId: Id<"players">; seasonId: Id<"seasons"> },
+): Promise<void> {
+  const rows = await ctx.db
+    .query("playerGameStats")
+    .withIndex("by_playerId_seasonId", (q) =>
+      q.eq("playerId", args.playerId).eq("seasonId", args.seasonId),
+    )
+    .collect();
+
+  const existing = await ctx.db
+    .query("playerSeasonAggregates")
+    .withIndex("by_playerId_seasonId", (q) =>
+      q.eq("playerId", args.playerId).eq("seasonId", args.seasonId),
+    )
+    .first();
+
+  // No entered lines means no aggregate. Keeping the table minimal makes a
+  // rebuild produce exactly the row set incremental maintenance would, and
+  // lets a fully-deleted box score return the season to empty (F2 precedent).
+  if (rows.length === 0) {
+    if (existing) await ctx.db.delete(existing._id);
+    return;
+  }
+
+  const player = await ctx.db.get(args.playerId);
+  if (!player) return;
+
+  const { totals, gamesPlayed } = summarizeStatLines(
+    rows.map((r) => parseStatLine(r.statsJson)),
+  );
+
+  const payload = {
+    leagueId: player.leagueId,
+    seasonId: args.seasonId,
+    // The team the player's most recent line was entered under, so a
+    // mid-season transfer attributes the aggregate to where they finished.
+    teamId: rows[rows.length - 1]!.teamId,
+    playerId: args.playerId,
+    position: player.position,
+    positionGroup: player.positionGroup ?? null,
+    gamesPlayed,
+    totalsJson: JSON.stringify(totals),
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (existing) {
+    await ctx.db.replace(existing._id, payload);
+  } else {
+    await ctx.db.insert("playerSeasonAggregates", payload);
+  }
+}
+
+/** Rebuild every player with entered stats in a season. Repair + backfill. */
+async function rebuildSeasonPlayerAggregatesCore(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+): Promise<number> {
+  const rows = await ctx.db
+    .query("playerGameStats")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+
+  const playerIds = new Set(rows.map((r) => r.playerId as string));
+  for (const playerId of playerIds) {
+    await rebuildPlayerSeasonAggregate(ctx, {
+      playerId: playerId as Id<"players">,
+      seasonId,
+    });
+  }
+  return playerIds.size;
+}
+
+/** Drop a season's cached aggregates (season delete, schedule wipe). */
+async function clearSeasonPlayerAggregates(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+): Promise<void> {
+  const rows = await ctx.db
+    .query("playerSeasonAggregates")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+  for (const row of rows) await ctx.db.delete(row._id);
+}
+
+/**
+ * Repair entry point, mirroring `rebuildSeasonTeamRecords`. Also the fix for a
+ * stale denormalized `position` after an offseason position change (Epic B5).
+ */
+export const rebuildSeasonPlayerAggregates = internalMutation({
+  args: { seasonId: v.id("seasons") },
+  returns: v.object({ playersRebuilt: v.number() }),
+  handler: async (ctx, args) => {
+    const playersRebuilt = await rebuildSeasonPlayerAggregatesCore(
+      ctx,
+      args.seasonId,
+    );
+    return { playersRebuilt };
+  },
+});
+
 export const upsertPlayerGameStats = internalMutation({
   args: {
     fixtureId: v.id("fixtures"),
@@ -6468,6 +6590,13 @@ export const upsertPlayerGameStats = internalMutation({
     } else {
       id = await ctx.db.insert("playerGameStats", payload);
     }
+
+    // Keep the season aggregate in step, in the same transaction (F3).
+    await rebuildPlayerSeasonAggregate(ctx, {
+      playerId: args.playerId,
+      seasonId: args.seasonId,
+    });
+
     return { id };
   },
 });
@@ -6519,6 +6648,17 @@ export const bulkUpsertPlayerGameStats = internalMutation({
         await ctx.db.insert("playerGameStats", payload);
       }
       upserted += 1;
+    }
+
+    // Rebuild each affected player once, after all lines are written — a
+    // per-line rebuild would redo the same read for a player appearing twice
+    // and would observe a half-written box score (F3).
+    const touchedPlayers = new Set(args.lines.map((l) => l.playerId as string));
+    for (const playerId of touchedPlayers) {
+      await rebuildPlayerSeasonAggregate(ctx, {
+        playerId: playerId as Id<"players">,
+        seasonId: args.seasonId,
+      });
     }
 
     return { upserted };
@@ -6607,7 +6747,12 @@ export const deletePlayerGameStats = internalMutation({
       )
       .first();
     if (!row) return false;
+    const { playerId, seasonId } = row;
     await ctx.db.delete(row._id);
+
+    // Deleting the player's only line removes the aggregate entirely (F3).
+    await rebuildPlayerSeasonAggregate(ctx, { playerId, seasonId });
+
     return true;
   },
 });
@@ -6695,29 +6840,44 @@ export const computeSeasonSprt = query({
     }),
   ),
   handler: async (ctx, args) => {
-    const rows = await ctx.db
-      .query("playerGameStats")
-      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
-      .collect();
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) return [];
 
-    const byPlayer = new Map<string, string[]>();
-    for (const r of rows) {
-      const arr = byPlayer.get(r.playerId) ?? [];
-      arr.push(r.statsJson);
-      byPlayer.set(r.playerId, arr);
-    }
+    /*
+     * F3: reads the persisted aggregates plus ONE batch read of the league's
+     * players, joined in memory. Previously this collected every game-stat row
+     * in the season, re-aggregated on each read, and issued a `ctx.db.get` PER
+     * PLAYER inside the loop.
+     *
+     * Position is taken from the live `players` row rather than the
+     * aggregate's denormalized snapshot: a stale position would silently place
+     * a player in the wrong rating group, which is a wrong number rather than a
+     * missing one.
+     */
+    const [aggregates, players] = await Promise.all([
+      ctx.db
+        .query("playerSeasonAggregates")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+        .collect(),
+      ctx.db
+        .query("players")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+        .collect(),
+    ]);
+
+    const playerById = new Map(players.map((p) => [p._id as string, p]));
 
     const inputs: HsRatingInput[] = [];
-    for (const [playerId, jsons] of byPlayer) {
-      const player = await ctx.db.get(playerId as Id<"players">);
+    for (const agg of aggregates) {
+      const player = playerById.get(agg.playerId as string);
       if (!player) continue;
       const group = positionToRatingGroup(player.position);
       if (!group) continue;
       inputs.push({
-        id: playerId,
+        id: agg.playerId as string,
         group,
-        totals: aggregateStatLines(jsons.map(parseStatLine)),
-        games: jsons.length,
+        totals: parseStatLine(agg.totalsJson),
+        games: agg.gamesPlayed,
       });
     }
 
@@ -6767,29 +6927,46 @@ async function seasonStatLeaders(
   ctx: QueryCtx,
   seasonId: Id<"seasons">,
 ): Promise<ReturnType<typeof computeStatLeaders>> {
-  const rows = await ctx.db
-    .query("playerGameStats")
-    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
-    .collect();
+  const season = await ctx.db.get(seasonId);
+  if (!season) return computeStatLeaders([], 5);
 
-  const byPlayer = new Map<string, string[]>();
-  for (const r of rows) {
-    const arr = byPlayer.get(r.playerId) ?? [];
-    arr.push(r.statsJson);
-    byPlayer.set(r.playerId, arr);
-  }
+  /*
+   * F3: aggregates + ONE batch read each of the league's players and teams,
+   * joined in memory. Previously this issued TWO `ctx.db.get` calls per player
+   * inside the loop (the player, then their team) on top of re-aggregating
+   * every game-stat row in the season on each read.
+   *
+   * Names and jersey numbers come from the live rows, not the aggregate, so a
+   * renamed player or team is reflected immediately.
+   */
+  const [aggregates, playerRows, teamRows] = await Promise.all([
+    ctx.db
+      .query("playerSeasonAggregates")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+      .collect(),
+    ctx.db
+      .query("players")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .collect(),
+    ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .collect(),
+  ]);
+
+  const playerById = new Map(playerRows.map((p) => [p._id as string, p]));
+  const teamById = new Map(teamRows.map((tm) => [tm._id as string, tm]));
 
   const players: LeaderInput[] = [];
-  for (const [playerId, jsons] of byPlayer) {
-    const totals = aggregateStatLines(jsons.map(parseStatLine));
-    const values = categoryValues(totals);
+  for (const agg of aggregates) {
+    const values = categoryValues(parseStatLine(agg.totalsJson));
     // Skip players with no leaderboard-relevant stats this season.
     if (Object.values(values).every((v2) => v2 === 0)) continue;
-    const player = await ctx.db.get(playerId as Id<"players">);
+    const player = playerById.get(agg.playerId as string);
     if (!player) continue;
-    const team = await ctx.db.get(player.teamId);
+    const team = teamById.get(player.teamId as string);
     players.push({
-      playerId,
+      playerId: agg.playerId as string,
       playerName: player.name,
       teamName: team?.name ?? "(unknown)",
       jerseyNumber: player.jerseyNumber ?? null,

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -56,4 +56,45 @@ export const dynastyTables = {
     // Program history across seasons (Epics C and D read this).
     .index("by_teamId", ["teamId"])
     .index("by_leagueId_seasonId", ["leagueId", "seasonId"]),
+
+  /*
+   * Persisted per-player season totals (F3).
+   *
+   * `computeSeasonSprt` and the `seasonStatLeaders` helper both collected every
+   * `playerGameStats` row in a season, grouped by player, re-aggregated on each
+   * read, and then issued a `ctx.db.get` PER PLAYER inside the loop (stat
+   * leaders did two — player and team). This row is the pre-aggregated result,
+   * so those reads become one indexed scan plus in-memory joins.
+   *
+   * It is also the layer career totals are built from in D1: never scan
+   * `playerGameStats` for history — go
+   * playerGameStats → playerSeasonAggregates → playerCareerTotals.
+   *
+   * Like `seasonTeamRecords`, this is a CACHE with a repair path
+   * (`rebuildSeasonPlayerAggregates`); `totalsJson` is exactly what
+   * `aggregateStatLines` produces over the player's game rows.
+   *
+   * `position` / `positionGroup` are a snapshot for downstream consumers. The
+   * SPRT read path deliberately does NOT trust them for grouping — it joins
+   * against live `players` rows — so an offseason position change (Epic B5)
+   * cannot silently mis-rate a player before a rebuild runs.
+   */
+  playerSeasonAggregates: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    playerId: v.id("players"),
+    position: v.string(),
+    positionGroup: v.union(v.string(), v.null()),
+    /** Games with an entered stat line. Feeds SPRT's per-game rates. */
+    gamesPlayed: v.number(),
+    /** `aggregateStatLines` output — sums, with "long" fields taking the max. */
+    totalsJson: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_playerId_seasonId", ["playerId", "seasonId"])
+    // Career totals (D1): a HS player has at most four rows here.
+    .index("by_playerId", ["playerId"])
+    .index("by_leagueId_seasonId", ["leagueId", "seasonId"]),
 };

--- a/docs/design/dynasty-foundations.md
+++ b/docs/design/dynasty-foundations.md
@@ -69,18 +69,27 @@ seasonTeamRecords: defineTable({
   .index("by_teamId", ["teamId"])
   .index("by_leagueId_seasonId", ["leagueId", "seasonId"]),
 
+// AS SHIPPED in F3 (#615). `gamesPlayed` is required — SPRT rates per-game,
+// so deriving it would mean re-reading the rows this table exists to avoid.
+// `position` is stored alongside `positionGroup`, but the SPRT read path
+// deliberately does NOT trust either for grouping: it joins live `players`
+// rows, so an offseason position change (B5) cannot silently mis-rate a player
+// before a rebuild runs.
 playerSeasonAggregates: defineTable({
   leagueId: v.id("leagues"),
   seasonId: v.id("seasons"),
   teamId: v.id("teams"),
   playerId: v.id("players"),
-  positionGroup: v.string(),
-  statsJson: v.string(),
+  position: v.string(),
+  positionGroup: v.union(v.string(), v.null()),
+  gamesPlayed: v.number(),
+  totalsJson: v.string(),
   updatedAt: v.string(),
 })
-  .index("by_season_player", ["seasonId", "playerId"])
+  .index("by_seasonId", ["seasonId"])
+  .index("by_playerId_seasonId", ["playerId", "seasonId"])
   .index("by_playerId", ["playerId"])
-  .index("by_season_team", ["seasonId", "teamId"]),
+  .index("by_leagueId_seasonId", ["leagueId", "seasonId"]),
 
 dynastyEvents: defineTable({
   leagueId: v.id("leagues"),


### PR DESCRIPTION
## Summary

Removes the second and third N+1 read patterns in the codebase. `computeSeasonSprt` and the
`seasonStatLeaders` helper each collected **every** `playerGameStats` row in a season,
re-aggregated on each read, and then issued a `ctx.db.get` **per player** inside the loop — stat
leaders issued two (the player, then their team).

Both now read a persisted per-player aggregate plus one batch read each of the league's players
and teams, joined in memory. Output is unchanged.

Closes #615. Part of #604.

## What changed

**`playerSeasonAggregates` table** — `gamesPlayed`, `totalsJson`, denormalized
`position`/`positionGroup`, indexed `by_seasonId`, `by_playerId_seasonId`, `by_playerId`
(career totals in D1) and `by_leagueId_seasonId`.

**Read paths rewritten** — `computeSeasonSprt` and `seasonStatLeaders` now do a fixed number of
indexed reads regardless of roster size, with **zero `ctx.db.get` inside a loop**.

**Maintenance** — the affected player's aggregate is rebuilt from `by_playerId_seasonId` on
`upsertPlayerGameStats`, `bulkUpsertPlayerGameStats` and `deletePlayerGameStats`. The bulk path
rebuilds each touched player **once, after all lines are written**, so a player appearing twice
isn't rebuilt twice against a half-written box score.

## Why there is no `subtractStatLines`

The issue specified add/subtract deltas with a `subtract(add(a,b),b) === a` round-trip. That
property **cannot hold here**, and shipping it would have been a latent data-corruption bug.

`aggregateStatLines` reduces `long` fields (longest run, catch, punt, return) with **MAX**, not
sum — and a max cannot be inverted. If a back's longs are 40, 55 and 30, the season long is 55.
Re-enter the 55-yard game as a 12-yard game and the correct answer is 40, but nothing in the
stored aggregate remembers it. Subtraction would leave 55 forever, silently inflating a number
that Epic D's record book will later treat as history.

So the aggregate is maintained by **rebuilding the affected player from their own rows** —
`playerGameStats` is indexed `by_playerId_seasonId`, so that's a single indexed read of ~10–16
rows, cheaper than the season-wide scan it replaces, and equal to a full rebuild by construction.

This is the second time the roadmap's delta premise didn't survive contact with the data. F2 hit
the same wall for `streak`/`lastResults` (order-dependent). The general rule, now recorded in
`lib/playerStats.ts` and the design doc: **an aggregate containing a non-invertible reduction
cannot be maintained by deltas.**

`addStatLines` ships as a two-operand convenience over `aggregateStatLines`; `summarizeStatLines`
is what the rebuild uses.

## Verification

- [x] `tsc --noEmit` clean
- [x] `test:unit` — **186 files / 1310 tests pass** (was 185/1302)
- [x] `next build` succeeds
- [x] `turbo lint` clean

Eight new integration tests, using raw aggregation as an independent oracle:

1. Aggregate matches the oracle after **every** entered line.
2. **The MAX case** — a 55-yard long overwritten to 12 correctly recomputes the season long
   *downward* to 40. This is the test a delta implementation fails.
3. Deleting the last line removes the row entirely.
4. Bulk upsert stays correct.
5. Stat leaders join name, jersey and team from **live** rows, not the aggregate snapshot.
6. **SPRT parity** — ratings equal `computeHsSprtRatings` applied to the oracle totals, plus a
   sanity check that the stronger back rates higher (so a bad join can't pass by shuffling
   players against totals).
7. Backfill against lines inserted directly, bypassing the mutation — the real pre-F3 prod state.
8. `rebuildSeasonPlayerAggregates` repairs a corrupted row.

One thing caught rather than assumed: my first SPRT test asserted "non-empty" and failed. The
cause was **not** a regression — `computeHsSprtRatings` skips any group with fewer than two
qualified players (`qualified.length < 2`). I verified that in the source and rewrote the test as
a real parity assertion over a two-player cohort rather than weakening it.

**On the N+1 claim specifically:** it is verified by reading the rewritten functions — neither
contains a `ctx.db.get` in a loop — not by a read-counter spy, which `convex-test` does not
expose. The tests above prove correctness; the read-count improvement is structural.

## Migration

`convex/migrations/20260801_playerSeasonAggregates.ts`, **one season per invocation** (~600 rows
for a 12-team league, ~1900 for 32 teams; a whole-league backfill risks the 8192-document ceiling):

```
npx convex run migrations/20260801_playerSeasonAggregates:backfillPlayerSeasonAggregates '{"seasonId":"<id>"}'
```

Idempotent. **Required** — a season with existing box scores shows an empty leaderboard until it
runs. Note this is the second such backfill; F2's `backfillSeasonTeamRecords` needs the same
treatment on the same seasons.

## Deliberately out of scope

- `getPlayerSeasonTotals` and `getPlayerCareerTotals` still aggregate on read. They are
  single-player queries with no N+1, and D1 will re-point career totals at this table properly.
- Cascade clearing on schedule regeneration. That path deletes fixtures and results but **not**
  `playerGameStats`, so clearing aggregates there would make the cache disagree with its own
  source. Aggregates are cleared where the season itself is deleted.
