### PR TITLE
feat: add per-league dynasty settings with runtime kill switches (#611)

### DIFF
--- a/apps/web/convex/__tests__/dynastyConfig.test.ts
+++ b/apps/web/convex/__tests__/dynastyConfig.test.ts
@@ -1,0 +1,207 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import {
+  DYNASTY_CONFIG_BOUNDS,
+  DYNASTY_CONFIG_DEFAULTS,
+  normalizeDynastyConfigPatch,
+  resolveDynastyConfig,
+} from "../lib/dynastyConfig";
+import {
+  DYNASTY_CONFIG_DEFAULTS as NEXT_DEFAULTS,
+  resolveDynastyConfig as nextResolve,
+} from "../../src/lib/dynasty-config";
+
+const modules = import.meta.glob("../**/*.*s");
+
+describe("dynasty config — one definition, two import paths", () => {
+  it("gives the Convex side and the Next side identical defaults", () => {
+    // `src/lib/dynasty-config.ts` re-exports rather than mirroring, so these
+    // are the same object. The assertion exists to FAIL LOUDLY if someone
+    // later forks it into a copy — at which point the simulation and the
+    // settings UI could silently disagree about what "normal" means.
+    expect(NEXT_DEFAULTS).toEqual(DYNASTY_CONFIG_DEFAULTS);
+    expect(nextResolve(null)).toEqual(resolveDynastyConfig(null));
+  });
+});
+
+describe("resolveDynastyConfig", () => {
+  it("treats absence as fully configured", () => {
+    expect(resolveDynastyConfig(null)).toEqual(DYNASTY_CONFIG_DEFAULTS);
+    expect(resolveDynastyConfig(undefined)).toEqual(DYNASTY_CONFIG_DEFAULTS);
+    expect(resolveDynastyConfig({})).toEqual(DYNASTY_CONFIG_DEFAULTS);
+  });
+
+  it("fills only the missing knobs on a partial row", () => {
+    const resolved = resolveDynastyConfig({ injuriesEnabled: false });
+    expect(resolved.injuriesEnabled).toBe(false);
+    expect(resolved.penaltiesEnabled).toBe(
+      DYNASTY_CONFIG_DEFAULTS.penaltiesEnabled,
+    );
+    expect(resolved.targetRosterSize).toBe(
+      DYNASTY_CONFIG_DEFAULTS.targetRosterSize,
+    );
+  });
+
+  it("clamps out-of-range numbers rather than propagating them", () => {
+    // Settings must never be able to break a simulation.
+    const high = resolveDynastyConfig({
+      injurySeverityScale: 99,
+      targetRosterSize: 5000,
+    });
+    expect(high.injurySeverityScale).toBe(
+      DYNASTY_CONFIG_BOUNDS.injurySeverityScale.max,
+    );
+    expect(high.targetRosterSize).toBe(
+      DYNASTY_CONFIG_BOUNDS.targetRosterSize.max,
+    );
+
+    const low = resolveDynastyConfig({ injurySeverityScale: -4 });
+    expect(low.injurySeverityScale).toBe(
+      DYNASTY_CONFIG_BOUNDS.injurySeverityScale.min,
+    );
+  });
+
+  it("falls back to a default for a garbage value instead of throwing", () => {
+    const resolved = resolveDynastyConfig({
+      injuriesEnabled: "yes" as unknown as boolean,
+      transferVolume: "cataclysmic",
+      injurySeverityScale: Number.NaN,
+    });
+    expect(resolved.injuriesEnabled).toBe(
+      DYNASTY_CONFIG_DEFAULTS.injuriesEnabled,
+    );
+    expect(resolved.transferVolume).toBe(
+      DYNASTY_CONFIG_DEFAULTS.transferVolume,
+    );
+    expect(Number.isFinite(resolved.injurySeverityScale)).toBe(true);
+  });
+
+  it("accepts every documented transfer volume", () => {
+    for (const volume of ["low", "normal", "high"] as const) {
+      expect(resolveDynastyConfig({ transferVolume: volume }).transferVolume).toBe(
+        volume,
+      );
+    }
+  });
+});
+
+describe("normalizeDynastyConfigPatch", () => {
+  it("keeps only keys the caller actually sent", () => {
+    const patch = normalizeDynastyConfigPatch({ pollsEnabled: false });
+    expect(Object.keys(patch)).toEqual(["pollsEnabled"]);
+    expect(patch.pollsEnabled).toBe(false);
+  });
+
+  it("drops unknown keys so they can never reach storage", () => {
+    const patch = normalizeDynastyConfigPatch({
+      pollsEnabled: false,
+      cheatMode: true,
+    } as never);
+    expect(Object.keys(patch)).toEqual(["pollsEnabled"]);
+  });
+});
+
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) =>
+    ctx.db.insert("leagues", {
+      name: "Config League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    }),
+  );
+}
+
+describe("dynastyConfig storage", () => {
+  it("returns defaults for a league that has never been configured", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await seedLeague(t);
+
+    const config = await t.query(api.dynasty.getDynastyConfig, { leagueId });
+    expect(config).toEqual(DYNASTY_CONFIG_DEFAULTS);
+
+    // No row was created by reading — absence stays absence.
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("dynastyConfig").collect(),
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("persists a patch and leaves other knobs alone", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await seedLeague(t);
+
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId,
+      actorUserId: "user_admin",
+      patch: { injuriesEnabled: false },
+    });
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId,
+      actorUserId: "user_admin",
+      patch: { transferVolume: "high" },
+    });
+
+    const config = await t.query(api.dynasty.getDynastyConfig, { leagueId });
+    expect(config.injuriesEnabled).toBe(false);
+    expect(config.transferVolume).toBe("high");
+    expect(config.penaltiesEnabled).toBe(true);
+  });
+
+  it("keeps exactly one row per league across repeated saves", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await seedLeague(t);
+
+    for (let i = 0; i < 4; i++) {
+      await t.mutation(internal.dynasty.setDynastyConfig, {
+        leagueId,
+        actorUserId: "user_admin",
+        patch: { targetRosterSize: 40 + i },
+      });
+    }
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("dynastyConfig").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.targetRosterSize).toBe(43);
+  });
+
+  it("clamps on the way in, so storage can never hold a bad value", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await seedLeague(t);
+
+    const returned = await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId,
+      actorUserId: "user_admin",
+      patch: { targetRosterSize: 9999 },
+    });
+    expect(returned.targetRosterSize).toBe(
+      DYNASTY_CONFIG_BOUNDS.targetRosterSize.max,
+    );
+
+    const stored = await t.run(async (ctx) =>
+      ctx.db.query("dynastyConfig").collect(),
+    );
+    expect(stored[0]!.targetRosterSize).toBe(
+      DYNASTY_CONFIG_BOUNDS.targetRosterSize.max,
+    );
+  });
+
+  it("rejects a save against a league that does not exist", async () => {
+    const t = convexTest(schema, modules);
+    const leagueId = await seedLeague(t);
+    await t.run(async (ctx) => ctx.db.delete(leagueId));
+
+    await expect(
+      t.mutation(internal.dynasty.setDynastyConfig, {
+        leagueId,
+        actorUserId: "user_admin",
+        patch: { pollsEnabled: false },
+      }),
+    ).rejects.toThrow(/league_not_found/);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -49,6 +49,7 @@ void internal.sports.setLeaguePublic;
 void internal.sports.recordGameResult;
 void internal.sports.rebuildSeasonTeamRecords;
 void internal.sports.rebuildSeasonPlayerAggregates;
+void internal.dynasty.setDynastyConfig;
 void internal.sports.assignPlayerToRoster;
 void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;
@@ -225,7 +226,7 @@ void api.sim.moduleStatus;
 void api.program.moduleStatus;
 void api.history.moduleStatus;
 
-type AllowedPublicDynastyReads = "moduleStatus";
+type AllowedPublicDynastyReads = "moduleStatus" | "getDynastyConfig";
 type AllowedPublicSimReads = "moduleStatus";
 type AllowedPublicProgramReads = "moduleStatus";
 type AllowedPublicHistoryReads = "moduleStatus";

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as lib_auditLog from "../lib/auditLog.js";
 import type * as lib_bracket from "../lib/bracket.js";
 import type * as lib_draft from "../lib/draft.js";
 import type * as lib_dynasty from "../lib/dynasty.js";
+import type * as lib_dynastyConfig from "../lib/dynastyConfig.js";
 import type * as lib_events from "../lib/events.js";
 import type * as lib_hsSprt from "../lib/hsSprt.js";
 import type * as lib_liveScore from "../lib/liveScore.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   "lib/bracket": typeof lib_bracket;
   "lib/draft": typeof lib_draft;
   "lib/dynasty": typeof lib_dynasty;
+  "lib/dynastyConfig": typeof lib_dynastyConfig;
   "lib/events": typeof lib_events;
   "lib/hsSprt": typeof lib_hsSprt;
   "lib/liveScore": typeof lib_liveScore;

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -1,5 +1,11 @@
-import { query } from "./_generated/server";
+import { v } from "convex/values";
+import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
+import {
+  normalizeDynastyConfigPatch,
+  resolveDynastyConfig,
+  type DynastyConfig,
+} from "./lib/dynastyConfig";
 
 /*
  * Dynasty Mode — offseason pipeline (Epic B).
@@ -36,4 +42,99 @@ export const moduleStatus = query({
     epic: "B",
     ready: true,
   }),
+});
+
+/*
+ * ── Per-league Dynasty settings (F5) ────────────────────────────────────────
+ */
+
+const dynastyConfigValidator = v.object({
+  penaltiesEnabled: v.boolean(),
+  injuriesEnabled: v.boolean(),
+  weatherEnabled: v.boolean(),
+  injurySeverityScale: v.number(),
+  transfersEnabled: v.boolean(),
+  transferVolume: v.string(),
+  scoutingPointsPerOffseason: v.number(),
+  trainingPointsPerOffseason: v.number(),
+  targetRosterSize: v.number(),
+  jobSecurityEnabled: v.boolean(),
+  pollsEnabled: v.boolean(),
+});
+
+/**
+ * A league's effective settings — always fully populated.
+ *
+ * Returns defaults for a league with no stored row rather than null, so every
+ * caller gets a usable config and no call site has to remember to default.
+ * That is the whole reason absence is legal.
+ */
+export const getDynastyConfig = query({
+  args: { leagueId: v.id("leagues") },
+  returns: dynastyConfigValidator,
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("dynastyConfig")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .first();
+    return resolveDynastyConfig(row);
+  },
+});
+
+/**
+ * Patch a league's settings. Partial by design — the UI saves one section at a
+ * time, and an omitted knob keeps its current value rather than resetting.
+ *
+ * `internalMutation` (WSM-000096): the admin gate lives in the server action.
+ */
+export const setDynastyConfig = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    actorUserId: v.string(),
+    patch: v.object({
+      penaltiesEnabled: v.optional(v.boolean()),
+      injuriesEnabled: v.optional(v.boolean()),
+      weatherEnabled: v.optional(v.boolean()),
+      injurySeverityScale: v.optional(v.number()),
+      transfersEnabled: v.optional(v.boolean()),
+      transferVolume: v.optional(v.string()),
+      scoutingPointsPerOffseason: v.optional(v.number()),
+      trainingPointsPerOffseason: v.optional(v.number()),
+      targetRosterSize: v.optional(v.number()),
+      jobSecurityEnabled: v.optional(v.boolean()),
+      pollsEnabled: v.optional(v.boolean()),
+    }),
+  },
+  returns: dynastyConfigValidator,
+  handler: async (ctx, args) => {
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) throw new Error("league_not_found");
+
+    const existing = await ctx.db
+      .query("dynastyConfig")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .first();
+
+    // Clamp and drop unknown keys before they reach storage, so an
+    // out-of-range value can never be persisted and re-read later.
+    const patch = normalizeDynastyConfigPatch(
+      args.patch as Partial<DynastyConfig>,
+    );
+    const merged = resolveDynastyConfig({ ...(existing ?? {}), ...patch });
+
+    const payload = {
+      leagueId: args.leagueId,
+      ...merged,
+      updatedAt: new Date().toISOString(),
+      updatedBy: args.actorUserId,
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, payload);
+    } else {
+      await ctx.db.insert("dynastyConfig", payload);
+    }
+
+    return merged;
+  },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -162,6 +162,16 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
+  // Per-league Dynasty settings (F5). A row left behind would carry one spec's
+  // toggles into the next run.
+  const configRows = (await ctx.db
+    .query("dynastyConfig")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"dynastyConfig"> }>;
+  for (const row of configRows) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
   for (const team of teams as Array<{ _id: Id<"teams"> }>) {
     const teamDepth = (await ctx.db
       .query("depthChartEntries")

--- a/apps/web/convex/lib/dynastyConfig.ts
+++ b/apps/web/convex/lib/dynastyConfig.ts
@@ -1,0 +1,160 @@
+/*
+ * Dynasty Mode per-league settings (F5) — shared shape and defaults.
+ *
+ * This module is the CANONICAL definition and lives under `convex/` because the
+ * Convex bundler can only reach files in that directory, while `src/` can reach
+ * both — the same direction `convex/lib/standings.ts` and `convex/lib/hsSprt.ts`
+ * are already imported from Next code.
+ *
+ * `src/lib/dynasty-config.ts` re-exports this module rather than mirroring it,
+ * so the Convex runtime and the Next layer CANNOT drift: one object, one
+ * resolver, one set of defaults, no copy to keep in sync.
+ *
+ * ## Why a table and not a feature flag
+ *
+ * Flags are per-deploy and per-environment. "This league finds injuries too
+ * punishing" is per-league and needs to change at runtime, mid-season, without
+ * shipping. The roadmap spends only four flags total (one per epic) and gates
+ * individual mechanics here.
+ *
+ * ## Absence is legal
+ *
+ * A league with no `dynastyConfig` row is fully configured — it uses every
+ * default below. That is what keeps the table migration-free: a new knob needs
+ * no backfill, because `resolveDynastyConfig` fills it in.
+ */
+
+export type TransferVolume = "low" | "normal" | "high";
+
+export interface DynastyConfig {
+  /** Penalties are rolled during simulation (Epic A2). */
+  penaltiesEnabled: boolean;
+  /** Injuries can occur during simulation (Epic A4). */
+  injuriesEnabled: boolean;
+  /** Weather affects play outcomes (Epic A5). */
+  weatherEnabled: boolean;
+  /** 0 = none, 1 = normal, 2 = brutal. Scales injury severity. */
+  injurySeverityScale: number;
+  /** Players may transfer in and out during the offseason (Epic B4). */
+  transfersEnabled: boolean;
+  /** How much roster churn an offseason produces. */
+  transferVolume: TransferVolume;
+  /** Scouting budget per offseason (Epic B3). */
+  scoutingPointsPerOffseason: number;
+  /** Training budget per offseason (Epic B6). */
+  trainingPointsPerOffseason: number;
+  /** Roster size the freshman generator tops teams back up to. */
+  targetRosterSize: number;
+  /** Coaches can be fired for missing goals (Epic C2). */
+  jobSecurityEnabled: boolean;
+  /** Weekly power rankings are computed (Epic D3). */
+  pollsEnabled: boolean;
+}
+
+/**
+ * Defaults describe a league that plays the full game. Mechanics default ON so
+ * that enabling an epic's feature flag is enough to see it; a commissioner opts
+ * OUT of anything their league dislikes.
+ *
+ * `targetRosterSize` matches `DEFAULT_TARGET_ROSTER_SIZE` in
+ * `convex/lib/offseason.ts` — the generator and this knob must agree.
+ */
+export const DYNASTY_CONFIG_DEFAULTS: Readonly<DynastyConfig> = Object.freeze({
+  penaltiesEnabled: true,
+  injuriesEnabled: true,
+  weatherEnabled: true,
+  injurySeverityScale: 1,
+  transfersEnabled: true,
+  transferVolume: "normal",
+  scoutingPointsPerOffseason: 100,
+  trainingPointsPerOffseason: 100,
+  targetRosterSize: 48,
+  jobSecurityEnabled: true,
+  pollsEnabled: true,
+});
+
+/** Bounds. Values outside these are clamped rather than rejected. */
+export const DYNASTY_CONFIG_BOUNDS = Object.freeze({
+  injurySeverityScale: { min: 0, max: 2 },
+  scoutingPointsPerOffseason: { min: 0, max: 500 },
+  trainingPointsPerOffseason: { min: 0, max: 500 },
+  targetRosterSize: { min: 1, max: 60 },
+});
+
+const TRANSFER_VOLUMES: readonly TransferVolume[] = ["low", "normal", "high"];
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+/** A stored row: every knob optional, plus bookkeeping we do not surface. */
+export type DynastyConfigDoc = Partial<
+  Record<keyof DynastyConfig, number | boolean | string | undefined>
+>;
+
+/**
+ * Resolve a stored row (or its absence) into a fully-populated config.
+ *
+ * Total by construction: `null`, `{}`, a partial row and a row with an
+ * out-of-range or misspelled value all produce a valid config. Settings should
+ * never be able to break a simulation — a bad value falls back to the default
+ * rather than propagating `undefined` into the engine.
+ */
+export function resolveDynastyConfig(
+  doc: DynastyConfigDoc | null | undefined,
+): DynastyConfig {
+  if (!doc) return { ...DYNASTY_CONFIG_DEFAULTS };
+
+  const bool = (key: keyof DynastyConfig): boolean => {
+    const value = doc[key];
+    return typeof value === "boolean"
+      ? value
+      : (DYNASTY_CONFIG_DEFAULTS[key] as boolean);
+  };
+
+  const num = (
+    key: keyof typeof DYNASTY_CONFIG_BOUNDS & keyof DynastyConfig,
+  ): number => {
+    const value = doc[key];
+    const bounds = DYNASTY_CONFIG_BOUNDS[key];
+    return typeof value === "number"
+      ? clamp(value, bounds.min, bounds.max)
+      : (DYNASTY_CONFIG_DEFAULTS[key] as number);
+  };
+
+  const volume =
+    typeof doc.transferVolume === "string" &&
+    (TRANSFER_VOLUMES as readonly string[]).includes(doc.transferVolume)
+      ? (doc.transferVolume as TransferVolume)
+      : DYNASTY_CONFIG_DEFAULTS.transferVolume;
+
+  return {
+    penaltiesEnabled: bool("penaltiesEnabled"),
+    injuriesEnabled: bool("injuriesEnabled"),
+    weatherEnabled: bool("weatherEnabled"),
+    injurySeverityScale: num("injurySeverityScale"),
+    transfersEnabled: bool("transfersEnabled"),
+    transferVolume: volume,
+    scoutingPointsPerOffseason: num("scoutingPointsPerOffseason"),
+    trainingPointsPerOffseason: num("trainingPointsPerOffseason"),
+    targetRosterSize: num("targetRosterSize"),
+    jobSecurityEnabled: bool("jobSecurityEnabled"),
+    pollsEnabled: bool("pollsEnabled"),
+  };
+}
+
+/** Normalize an inbound patch: drop unknown keys, clamp what is in range. */
+export function normalizeDynastyConfigPatch(
+  patch: Partial<DynastyConfig>,
+): Partial<DynastyConfig> {
+  const resolved = resolveDynastyConfig(patch as DynastyConfigDoc);
+  const out: Partial<DynastyConfig> = {};
+  for (const key of Object.keys(patch) as Array<keyof DynastyConfig>) {
+    if (key in DYNASTY_CONFIG_DEFAULTS) {
+      // @ts-expect-error index write across a heterogeneous record
+      out[key] = resolved[key];
+    }
+  }
+  return out;
+}

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -144,4 +144,44 @@ export const dynastyTables = {
     .index("by_dedupeKey", ["dedupeKey"])
     .index("by_playerId", ["playerId"])
     .index("by_teamId", ["teamId"]),
+
+  /*
+   * Per-league Dynasty Mode settings (F5).
+   *
+   * A feature flag is the wrong tool for a game mechanic: flags are per-deploy
+   * and per-environment, but "this league finds injuries too punishing" is
+   * per-league and needs changing at runtime. The roadmap therefore spends only
+   * four flags total, and gates individual mechanics through these knobs — so a
+   * live league can back out a mechanic without a deploy.
+   *
+   * EVERY field is optional and an absent document is legal. That is what makes
+   * this table migration-free forever: adding a knob never requires a backfill,
+   * because `resolveDynastyConfig` fills defaults for anything missing. Read it
+   * through that resolver, never off the raw document.
+   */
+  dynastyConfig: defineTable({
+    leagueId: v.id("leagues"),
+
+    // Sim mechanics (Epic A). Kill switches for a live league.
+    penaltiesEnabled: v.optional(v.boolean()),
+    injuriesEnabled: v.optional(v.boolean()),
+    weatherEnabled: v.optional(v.boolean()),
+    /** 0 = none, 1 = normal, 2 = brutal. Scales injury roll severity. */
+    injurySeverityScale: v.optional(v.number()),
+
+    // Offseason economy (Epic B).
+    transfersEnabled: v.optional(v.boolean()),
+    /** "low" | "normal" | "high" — how much roster churn a offseason produces. */
+    transferVolume: v.optional(v.string()),
+    scoutingPointsPerOffseason: v.optional(v.number()),
+    trainingPointsPerOffseason: v.optional(v.number()),
+    targetRosterSize: v.optional(v.number()),
+
+    // Program and narrative (Epics C, D).
+    jobSecurityEnabled: v.optional(v.boolean()),
+    pollsEnabled: v.optional(v.boolean()),
+
+    updatedAt: v.string(),
+    updatedBy: v.string(),
+  }).index("by_leagueId", ["leagueId"]),
 };

--- a/apps/web/src/app/dashboard/_actions/dynasty-config.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty-config.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  getLeagueOrgId,
+  setDynastyConfig as setDynastyConfigData,
+} from "@/lib/data-api";
+import type { DynastyConfig } from "@/lib/dynasty-config";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/**
+ * Save a league's Dynasty settings (F5).
+ *
+ * ORG-SETTINGS level, not coach level. These knobs change how every team's
+ * games simulate and how large every roster may be, so they belong to whoever
+ * runs the league — unlike the per-team offseason actions, which authorize on a
+ * `teamId` so a coach can act on their own team.
+ */
+export async function saveDynastyConfigAction(input: {
+  leagueId: string;
+  patch: Partial<DynastyConfig>;
+}): Promise<ActionResult<DynastyConfig>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  let orgId: string | null;
+  try {
+    orgId = await getLeagueOrgId(input.leagueId);
+  } catch {
+    return { ok: false, error: "league_not_found" };
+  }
+  if (!orgId) return { ok: false, error: "not_authorized" };
+
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageOrgSettings(role)) return { ok: false, error: "not_authorized" };
+
+  try {
+    const data = await setDynastyConfigData({
+      leagueId: input.leagueId,
+      actorUserId: userId,
+      patch: input.patch,
+    });
+    revalidatePath("/dashboard/settings/league");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/src/app/dashboard/settings/league/league-settings-view.tsx
+++ b/apps/web/src/app/dashboard/settings/league/league-settings-view.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import {
+  getDynastyConfig,
   getLeagueVisibility,
   getLeagueClaimable,
   getSeasons,
@@ -12,6 +13,7 @@ import { isSeasonStarted } from "@/lib/season-started";
 import type { OrgContext } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/card";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import { DynastySettingsCard } from "@/components/dynasty/DynastySettingsCard";
 import { leagueHomeHref } from "@/components/workspace/resource-navigation";
 import InviteForm from "@/app/dashboard/leagues/[id]/invite-form";
 import InvitationList from "@/app/dashboard/leagues/[id]/invitation-list";
@@ -67,6 +69,8 @@ export async function LeagueSettingsView({
 }) {
   const id = league.id;
   const visibility = await getLeagueVisibility(id);
+  // Always resolves — a league with no stored row uses defaults (F5).
+  const dynastyConfig = await getDynastyConfig(id).catch(() => null);
   const claimable = await getLeagueClaimable(id);
   const canGenerateRosters = await syntheticRostersV1();
 
@@ -105,6 +109,15 @@ export async function LeagueSettingsView({
             <SettingsRow title="League name" description="Rename this league.">
               <RenameLeagueForm leagueId={id} currentName={league.name} />
             </SettingsRow>
+
+            {dynastyConfig ? (
+              <div className="py-4">
+                <DynastySettingsCard
+                  leagueId={id}
+                  initialConfig={dynastyConfig}
+                />
+              </div>
+            ) : null}
 
             <div className="space-y-4 py-4">
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/apps/web/src/components/dynasty/DynastySettingsCard.tsx
+++ b/apps/web/src/components/dynasty/DynastySettingsCard.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { saveDynastyConfigAction } from "@/app/dashboard/_actions/dynasty-config";
+import {
+  DYNASTY_CONFIG_BOUNDS,
+  type DynastyConfig,
+  type TransferVolume,
+} from "@/lib/dynasty-config";
+
+/*
+ * Dynasty settings (F5).
+ *
+ * Commissioner-facing kill switches and budgets, saved per league at runtime.
+ * Each row saves on its own so a slow save never blocks the rest of the form
+ * and a failure is scoped to the knob that failed — a single "Save all" button
+ * would leave the user unsure which setting actually landed.
+ */
+
+const TOGGLES: Array<{
+  key: keyof DynastyConfig;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "penaltiesEnabled",
+    label: "Penalties",
+    description: "Flags are thrown during simulated games.",
+  },
+  {
+    key: "injuriesEnabled",
+    label: "Injuries",
+    description: "Players can be hurt and miss games.",
+  },
+  {
+    key: "weatherEnabled",
+    label: "Weather",
+    description: "Cold, wind and rain affect play outcomes.",
+  },
+  {
+    key: "transfersEnabled",
+    label: "Transfers",
+    description: "Players move between programs in the offseason.",
+  },
+  {
+    key: "jobSecurityEnabled",
+    label: "Job security",
+    description: "Coaches can be fired for missing season goals.",
+  },
+  {
+    key: "pollsEnabled",
+    label: "Weekly polls",
+    description: "Power rankings are computed after each week.",
+  },
+];
+
+const NUMBERS: Array<{
+  key: "injurySeverityScale" | "scoutingPointsPerOffseason" | "trainingPointsPerOffseason" | "targetRosterSize";
+  label: string;
+  description: string;
+  step: number;
+}> = [
+  {
+    key: "injurySeverityScale",
+    label: "Injury severity",
+    description: "0 is none, 1 is normal, 2 is brutal.",
+    step: 0.1,
+  },
+  {
+    key: "scoutingPointsPerOffseason",
+    label: "Scouting budget",
+    description: "Points each team spends scouting incoming freshmen.",
+    step: 10,
+  },
+  {
+    key: "trainingPointsPerOffseason",
+    label: "Training budget",
+    description: "Points each team spends developing players.",
+    step: 10,
+  },
+  {
+    key: "targetRosterSize",
+    label: "Target roster size",
+    description: "Size the freshman class tops each roster back up to.",
+    step: 1,
+  },
+];
+
+const VOLUMES: TransferVolume[] = ["low", "normal", "high"];
+
+export function DynastySettingsCard({
+  leagueId,
+  initialConfig,
+}: {
+  leagueId: string;
+  initialConfig: DynastyConfig;
+}) {
+  const [config, setConfig] = useState<DynastyConfig>(initialConfig);
+  const [pending, startTransition] = useTransition();
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  function save(patch: Partial<DynastyConfig>, label: string) {
+    const key = Object.keys(patch)[0] ?? label;
+    setSavingKey(key);
+    startTransition(async () => {
+      const result = await saveDynastyConfigAction({ leagueId, patch });
+      if (result.ok) {
+        // Trust the server's normalized result rather than the local guess —
+        // it has clamped anything out of range.
+        setConfig(result.data);
+        toast.success(`${label} saved.`);
+      } else {
+        toast.error(`Could not save ${label}: ${result.error}`);
+      }
+      setSavingKey(null);
+    });
+  }
+
+  return (
+    <div className="space-y-4" data-testid="dynasty-settings">
+      <div>
+        <h3 className="text-label-14 text-foreground">Dynasty settings</h3>
+        <p className="text-caption-12 text-text-muted">
+          Simulation and offseason rules for this league. Changes apply to the
+          next simulated game — no deploy needed.
+        </p>
+      </div>
+
+      <div className="divide-y divide-border">
+        {TOGGLES.map((toggle) => {
+          const enabled = config[toggle.key] as boolean;
+          return (
+            <div
+              key={toggle.key}
+              className="flex flex-wrap items-center justify-between gap-3 py-3"
+            >
+              <div className="min-w-0">
+                <p className="text-label-14 text-foreground">{toggle.label}</p>
+                <p className="text-caption-12 text-text-muted">
+                  {toggle.description}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant={enabled ? "default" : "outline"}
+                disabled={pending && savingKey === toggle.key}
+                data-testid={`dynasty-toggle-${toggle.key}`}
+                aria-pressed={enabled}
+                onClick={() =>
+                  save({ [toggle.key]: !enabled } as Partial<DynastyConfig>, toggle.label)
+                }
+              >
+                {enabled ? "On" : "Off"}
+              </Button>
+            </div>
+          );
+        })}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 py-3">
+          <div className="min-w-0">
+            <p className="text-label-14 text-foreground">Transfer volume</p>
+            <p className="text-caption-12 text-text-muted">
+              How much roster churn an offseason produces.
+            </p>
+          </div>
+          <div className="flex gap-1">
+            {VOLUMES.map((volume) => (
+              <Button
+                key={volume}
+                size="sm"
+                variant={config.transferVolume === volume ? "default" : "outline"}
+                disabled={pending && savingKey === "transferVolume"}
+                data-testid={`dynasty-volume-${volume}`}
+                aria-pressed={config.transferVolume === volume}
+                onClick={() => save({ transferVolume: volume }, "Transfer volume")}
+              >
+                {volume}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {NUMBERS.map((field) => {
+          const bounds = DYNASTY_CONFIG_BOUNDS[field.key];
+          return (
+            <div
+              key={field.key}
+              className="flex flex-wrap items-center justify-between gap-3 py-3"
+            >
+              <div className="min-w-0">
+                <p className="text-label-14 text-foreground">{field.label}</p>
+                <p className="text-caption-12 text-text-muted">
+                  {field.description} Range {bounds.min}–{bounds.max}.
+                </p>
+              </div>
+              <input
+                type="number"
+                className="h-9 w-24 rounded-control border border-border bg-surface px-2 text-body-15 text-foreground"
+                min={bounds.min}
+                max={bounds.max}
+                step={field.step}
+                defaultValue={config[field.key]}
+                disabled={pending && savingKey === field.key}
+                data-testid={`dynasty-number-${field.key}`}
+                aria-label={field.label}
+                onBlur={(event) => {
+                  const next = Number(event.target.value);
+                  if (!Number.isFinite(next) || next === config[field.key]) {
+                    return;
+                  }
+                  save(
+                    { [field.key]: next } as Partial<DynastyConfig>,
+                    field.label,
+                  );
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -29,6 +29,7 @@ import { resolveLifecycleSeason } from "@/lib/season-view";
 import type { api, internal } from "../../convex/_generated/api";
 import type { LeagueImportPayload } from "@sports-management/api-contracts";
 import { getConvexClient } from "./convex-client";
+import type { DynastyConfig } from "./dynasty-config";
 import type { OrgContext } from "./org-context";
 
 async function getClerkServerClient() {
@@ -2788,4 +2789,32 @@ export async function getPublicLeagueSchedule(leagueId: string): Promise<{
   );
 
   return { seasonName: season.name, rows };
+}
+
+/*
+ * Dynasty per-league settings (F5).
+ *
+ * Reached through the compile-checked `dynastyRef` helpers from F1 rather than
+ * raw strings: a typo in the function name fails `tsc`, which CI runs, instead
+ * of 404ing at runtime where vitest would not catch it.
+ */
+export async function getDynastyConfig(
+  leagueId: string,
+): Promise<DynastyConfig> {
+  const client = getConvexClient();
+  return client.query(dynastyRef.query<DynastyConfig>("getDynastyConfig"), {
+    leagueId,
+  });
+}
+
+export async function setDynastyConfig(input: {
+  leagueId: string;
+  actorUserId: string;
+  patch: Partial<DynastyConfig>;
+}): Promise<DynastyConfig> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<DynastyConfig>("setDynastyConfig"),
+    input,
+  );
 }

--- a/apps/web/src/lib/dynasty-config.ts
+++ b/apps/web/src/lib/dynasty-config.ts
@@ -1,0 +1,21 @@
+/*
+ * Dynasty Mode per-league settings (F5) — Next-layer entry point.
+ *
+ * The definition lives in `convex/lib/dynastyConfig.ts` because the Convex
+ * bundler can only reach files under `convex/`, while `src/` can reach both.
+ * This is a re-export, NOT a copy: mirroring the defaults in two places would
+ * let the simulation and the settings UI disagree about what "normal" means,
+ * and nothing would catch it until a league behaved oddly.
+ *
+ * Import from here in Next code so the direction of the dependency stays
+ * obvious; import from `convex/lib/dynastyConfig` inside Convex functions.
+ */
+export {
+  DYNASTY_CONFIG_BOUNDS,
+  DYNASTY_CONFIG_DEFAULTS,
+  normalizeDynastyConfigPatch,
+  resolveDynastyConfig,
+  type DynastyConfig,
+  type DynastyConfigDoc,
+  type TransferVolume,
+} from "../../convex/lib/dynastyConfig";


### PR DESCRIPTION
## Summary

Per-league Dynasty settings, changeable at runtime. Completes Wave 0.

A feature flag is the wrong tool for a game mechanic: flags are per-deploy and per-environment,
but "this league finds injuries too punishing" is per-league and needs changing mid-season
without shipping. The roadmap therefore spends only four flags total (one per epic) and gates
individual mechanics here.

Closes #611. Part of #604.

## What changed

**`dynastyConfig` table** — keyed `by_leagueId`, **every knob optional**: sim kill switches
(`penaltiesEnabled`, `injuriesEnabled`, `weatherEnabled`, `injurySeverityScale`), offseason
economy (`transfersEnabled`, `transferVolume`, scouting/training budgets, `targetRosterSize`),
and program/narrative (`jobSecurityEnabled`, `pollsEnabled`).

An absent document is legal and means "all defaults". That is what makes this table
**migration-free forever** — adding a knob never needs a backfill, because the resolver fills it.
Unlike F2 and F3, there is nothing to run against prod.

**`convex/dynasty.ts`** gains `getDynastyConfig` (query) and `setDynastyConfig`
(`internalMutation`) — the first real functions in the module F1 scaffolded, reached through F1's
compile-checked `dynastyRef` helpers rather than raw strings.

**Server action** `saveDynastyConfigAction` — gated at **org-settings level**, not coach level.
These knobs change how every team's games simulate and how large every roster may be, so they
belong to whoever runs the league. That is deliberately different from the per-team offseason
actions, which authorize on a `teamId`.

**`DynastySettingsCard`** on `/dashboard/settings/league`. Each row saves independently, so a
slow save never blocks the rest of the form and a failure is scoped to the knob that failed — a
single "Save all" would leave the user unsure what actually landed. The card trusts the server's
normalized response rather than its local guess, so a clamped value is reflected immediately.

## One design correction

The issue specified that `convex/lib/dynastyConfig.ts` and `src/lib/dynasty-config.ts` should
**both export** `resolveDynastyConfig`, with a test asserting their defaults are deep-equal —
i.e. two mirrored copies plus a drift detector.

Mirroring isn't necessary here. Convex bundles only `convex/`, but `src/` can reach both — a
direction this repo already uses twice (`src/.../players/[id]/page.tsx` imports
`convex/lib/hsSprt`, `src/lib/local/local-workspace-provider.ts` imports `convex/lib/standings`).

So the definition lives once in `convex/lib/dynastyConfig.ts` and `src/lib/dynasty-config.ts`
**re-exports** it. Drift becomes impossible rather than merely detectable. The deep-equal test
still ships — it now guards against someone later forking the re-export into a copy, which is the
scenario where the simulation and the settings UI could silently disagree about what "normal"
means.

## Verification

- [x] `tsc --noEmit` clean
- [x] `test:unit` — **187 files / 1323 tests pass**
- [x] `next build` succeeds
- [x] `turbo lint` clean

13 new tests. The resolver is **total by construction** — settings must never be able to break a
simulation, so every malformed input yields a valid config rather than propagating `undefined`
into the engine:

- `null`, `undefined` and `{}` all resolve to defaults; a partial row fills only what's missing.
- Out-of-range numbers are **clamped, not rejected** (9999 roster size → 60).
- Garbage values fall back to defaults: a string where a boolean belongs, `NaN`, and an
  unrecognized `transferVolume` ("cataclysmic").
- Unknown keys are dropped by `normalizeDynastyConfigPatch` so they can never reach storage.
- Reading an unconfigured league returns defaults **without creating a row** — absence stays
  absence.
- Repeated saves keep exactly one row per league.
- Clamping happens on the way *in*, so storage can never hold a bad value.
- Saving against a deleted league throws `league_not_found`.

**The F1 guard fired again** — adding `getDynastyConfig` to `api.dynasty` failed `tsc` until it
was added to `AllowedPublicDynastyReads`, which is the security-reviewed act it's meant to force.
That's the third time an F1 guard has caught a real omission (schema composition in F2, table
registration in F2, this).

## Merge order

Branched from `main` at F3, so it does **not** include F4 (#639). Both touch
`convex/tables/dynasty.ts` and `convex/e2eSeed.ts` with purely additive hunks. **Merge #639
first**; I'll rebase this branch onto main afterwards.

## Out of scope

- Consuming the knobs. Nothing reads `dynastyConfig` yet because the mechanics it gates
  (penalties A2, injuries A4, weather A5, transfers B4, job security C2, polls D3) are unbuilt.
  This ships the control surface those slices plug into, with defaults chosen so enabling an
  epic's flag is enough to see it.
- A Playwright spec for the card. The card is admin-only on a route already covered by a
  non-disclosing-404 spec; the save path is covered by the Convex integration tests above.
