### PR TITLE
feat: extend the sim engine to v2 with gated scoring completeness (#616)

### DIFF
--- a/apps/web/scripts/dist-check.ts
+++ b/apps/web/scripts/dist-check.ts
@@ -1,0 +1,27 @@
+import { simulateGameLog } from "../src/lib/pbp/engine";
+import type { PlayerSimProfile, TeamSimProfile } from "../src/lib/pbp/types";
+const clamp=(n:number,a:number,b:number)=>Math.max(a,Math.min(b,n));
+function roster(t:string,s:number):PlayerSimProfile[]{
+  const specs:Array<[string,number]>=[["QB",2],["RB",3],["WR",5],["TE",2],["DE",2],["DT",2],["OLB",2],["MLB",2],["CB",3],["S",2],["K",1],["P",1]];
+  const out:PlayerSimProfile[]=[];
+  for(const [p,c] of specs) for(let i=1;i<=c;i++){const j=((i*7+s)%11)-5;out.push({playerId:`${t}-${p}-${i}`,position:p,overall:clamp(s+j,40,99),depthRank:i,positionSlot:p});}
+  return out;
+}
+const team=(t:string,s:number):TeamSimProfile=>({teamId:t,strength:s,players:roster(t,s)});
+let homeWins=0,awayWins=0,ties=0,hs=0,as=0,shutouts=0,n=300;
+for(let i=0;i<n;i++){
+  const log=simulateGameLog({home:team("home",70),away:team("away",70),seed:1000+i,flavor:"balanced"});
+  hs+=log.homeScore; as+=log.awayScore;
+  if(log.homeScore>log.awayScore)homeWins++; else if(log.awayScore>log.homeScore)awayWins++; else ties++;
+  if(log.homeScore===0||log.awayScore===0)shutouts++;
+}
+
+// Control: identical rosters on both sides means any asymmetry is the engine's,
+// not the harness's. Verify the two rosters really are identical first.
+const a=roster("home",70), b=roster("away",70);
+const sameOveralls = a.every((p,i)=>p.overall===b[i].overall && p.position===b[i].position);
+console.log(`  rosters identical (overall+position): ${sameOveralls}`);
+console.log(`EVEN 70v70 over ${n} seeds:`);
+console.log(`  home wins ${homeWins} (${(homeWins/n*100).toFixed(1)}%)  away wins ${awayWins} (${(awayWins/n*100).toFixed(1)}%)  ties ${ties}`);
+console.log(`  mean home ${(hs/n).toFixed(1)}  mean away ${(as/n).toFixed(1)}  mean total ${((hs+as)/n).toFixed(1)}`);
+console.log(`  games with a shutout: ${shutouts} (${(shutouts/n*100).toFixed(1)}%)`);

--- a/apps/web/scripts/gen-v1-golden.ts
+++ b/apps/web/scripts/gen-v1-golden.ts
@@ -1,0 +1,150 @@
+/*
+ * One-shot generator for the v1 golden-log fixture (Dynasty Mode A1).
+ *
+ * Run against the UNMODIFIED v1 engine, before any v2 work, to capture what the
+ * engine produced for a set of fixed seeds. Every later Epic A slice asserts it
+ * still reproduces this byte-for-byte with v2 features disabled — that is the
+ * guard against silently changing how existing leagues simulate.
+ *
+ *   pnpm --filter @sports-management/web exec tsx scripts/gen-v1-golden.ts
+ *
+ * Kept in the repo so the fixture is reproducible rather than a mystery blob.
+ */
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { simulateGameLog } from "../src/lib/pbp/engine";
+import type {
+  PbpGameInput,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../src/lib/pbp/types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2],
+    ["RB", 3],
+    ["WR", 5],
+    ["TE", 2],
+    ["DE", 2],
+    ["DT", 2],
+    ["OLB", 2],
+    ["MLB", 2],
+    ["CB", 3],
+    ["S", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+// A deliberate spread: an even matchup, a mismatch, a playoff game that cannot
+// tie, and each simulation flavor — so the fixture pins more than one code path.
+const CASES: Array<{ name: string; input: PbpGameInput }> = [
+  {
+    name: "even-balanced",
+    input: {
+      home: buildTeam("home", 70),
+      away: buildTeam("away", 70),
+      seed: 123456,
+      flavor: "balanced",
+    },
+  },
+  {
+    name: "mismatch-chalk",
+    input: {
+      home: buildTeam("home", 85),
+      away: buildTeam("away", 55),
+      seed: 987654,
+      flavor: "chalk",
+    },
+  },
+  {
+    name: "upsets-flavor",
+    input: {
+      home: buildTeam("home", 60),
+      away: buildTeam("away", 75),
+      seed: 246810,
+      flavor: "upsets",
+    },
+  },
+  {
+    name: "decisive-playoff",
+    input: {
+      home: buildTeam("home", 68),
+      away: buildTeam("away", 68),
+      seed: 555001,
+      decisive: true,
+      flavor: "balanced",
+    },
+  },
+];
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+/*
+ * Storing a SHA-256 per case proves byte-for-byte identity at a fraction of the
+ * size (four full logs is ~470KB of JSON in git). The FIRST case additionally
+ * keeps its full log so a failure has a readable deep-equal diff rather than
+ * just "hash mismatch" — regenerate and diff locally for the others.
+ */
+const fixture = {
+  engineVersion: "1.0.0",
+  note:
+    "Captured from the v1 engine before Epic A. Every A slice must reproduce " +
+    "these logs byte-for-byte with v2 features disabled. Regenerate with " +
+    "scripts/gen-v1-golden.ts ONLY when a v1 behavior change is intended.",
+  cases: CASES.map((c, index) => {
+    const log = simulateGameLog(c.input);
+    return {
+      name: c.name,
+      seed: c.input.seed,
+      decisive: c.input.decisive ?? false,
+      flavor: c.input.flavor ?? "balanced",
+      homeStrength: c.input.home.strength,
+      awayStrength: c.input.away.strength,
+      homeScore: log.homeScore,
+      awayScore: log.awayScore,
+      driveCount: log.drives.length,
+      playCount: log.drives.reduce((n, d) => n + d.plays.length, 0),
+      sha256: digest(log),
+      // Only the first case carries its full log — see note above.
+      log: index === 0 ? log : undefined,
+    };
+  }),
+};
+
+const out = new URL(
+  "../src/lib/pbp/__tests__/fixtures/v1-golden-logs.json",
+  import.meta.url,
+);
+writeFileSync(out, `${JSON.stringify(fixture, null, 2)}\n`);
+console.log(`wrote ${CASES.length} cases to ${out.pathname}`);
+for (const c of fixture.cases) {
+  console.log(
+    `  ${c.name}: ${c.homeScore}-${c.awayScore}, ${c.driveCount} drives, ` +
+      `${c.playCount} plays, sha=${c.sha256.slice(0, 12)}`,
+  );
+}

--- a/apps/web/src/lib/pbp/__tests__/fixtures/v1-golden-logs.json
+++ b/apps/web/src/lib/pbp/__tests__/fixtures/v1-golden-logs.json
@@ -1,0 +1,3688 @@
+{
+  "engineVersion": "1.0.0",
+  "note": "Captured from the v1 engine before Epic A. Every A slice must reproduce these logs byte-for-byte with v2 features disabled. Regenerate with scripts/gen-v1-golden.ts ONLY when a v1 behavior change is intended.",
+  "cases": [
+    {
+      "name": "even-balanced",
+      "seed": 123456,
+      "decisive": false,
+      "flavor": "balanced",
+      "homeStrength": 70,
+      "awayStrength": 70,
+      "homeScore": 31,
+      "awayScore": 0,
+      "driveCount": 23,
+      "playCount": 115,
+      "sha256": "4e8af47a5005815d1bf3923c7240cbc9b5120f71a096c4b649718c7d3be2e9e7",
+      "log": {
+        "seed": 123456,
+        "decisive": false,
+        "homeTeamId": "home",
+        "awayTeamId": "away",
+        "homeScore": 31,
+        "awayScore": 0,
+        "drives": [
+          {
+            "driveId": 1,
+            "teamId": "away",
+            "startQuarter": 1,
+            "startClockSeconds": 720,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 1,
+                "driveId": 1,
+                "quarter": 1,
+                "clockSeconds": 720,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 36,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-K-1",
+                    "teamId": "away",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 2,
+            "teamId": "home",
+            "startQuarter": 1,
+            "startClockSeconds": 714,
+            "startFieldPosition": 36,
+            "endReason": "touchdown",
+            "plays": [
+              {
+                "playId": 2,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 714,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 36,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-MLB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 3,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 685,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 6,
+                "fieldPosition": 40,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 4,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 654,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 47,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 5,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 624,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 52,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-DE-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DE-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 6,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 598,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 59,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-2",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 7,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 573,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 59,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DE-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 8,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 545,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 3,
+                "distance": 5,
+                "fieldPosition": 64,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-2",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 9,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 513,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 71,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-S-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 10,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 475,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 76,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 11,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 440,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 81,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 12,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 404,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 7,
+                "fieldPosition": 84,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-S-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 13,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 372,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 3,
+                "distance": 1,
+                "fieldPosition": 90,
+                "yardsGained": 26,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DE-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 14,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 344,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DE-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 15,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 307,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 16,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 278,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 17,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 247,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 18,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 229,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-1",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 19,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 206,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 3,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 29,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 20,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 177,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 1,
+                "isScoring": true,
+                "pointsScored": 6,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-1",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-CB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 21,
+                "driveId": 2,
+                "quarter": 1,
+                "clockSeconds": 153,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "extra_point",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 98,
+                "yardsGained": 0,
+                "isScoring": true,
+                "pointsScored": 1,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 3,
+            "teamId": "home",
+            "startQuarter": 1,
+            "startClockSeconds": 149,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 22,
+                "driveId": 3,
+                "quarter": 1,
+                "clockSeconds": 149,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 31,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 4,
+            "teamId": "away",
+            "startQuarter": 1,
+            "startClockSeconds": 143,
+            "startFieldPosition": 31,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 23,
+                "driveId": 4,
+                "quarter": 1,
+                "clockSeconds": 143,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 31,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-3",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 24,
+                "driveId": 4,
+                "quarter": 1,
+                "clockSeconds": 125,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 31,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "fumbler"
+                  },
+                  {
+                    "playerId": "home-DT-1",
+                    "teamId": "home",
+                    "role": "recoverer"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 5,
+            "teamId": "home",
+            "startQuarter": 1,
+            "startClockSeconds": 98,
+            "startFieldPosition": 69,
+            "endReason": "end_of_half",
+            "plays": [
+              {
+                "playId": 25,
+                "driveId": 5,
+                "quarter": 1,
+                "clockSeconds": 98,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 69,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 26,
+                "driveId": 5,
+                "quarter": 1,
+                "clockSeconds": 61,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 7,
+                "fieldPosition": 72,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 27,
+                "driveId": 5,
+                "quarter": 1,
+                "clockSeconds": 22,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 3,
+                "distance": 3,
+                "fieldPosition": 76,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 6,
+            "teamId": "home",
+            "startQuarter": 2,
+            "startClockSeconds": 720,
+            "startFieldPosition": 76,
+            "endReason": "touchdown",
+            "plays": [
+              {
+                "playId": 28,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 720,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 76,
+                "yardsGained": 18,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 29,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 692,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 6,
+                "fieldPosition": 94,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DE-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 30,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 664,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 31,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 638,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DT-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 32,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 603,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 33,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 573,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 1,
+                "isScoring": true,
+                "pointsScored": 6,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 34,
+                "driveId": 6,
+                "quarter": 2,
+                "clockSeconds": 537,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "extra_point",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 98,
+                "yardsGained": 0,
+                "isScoring": true,
+                "pointsScored": 1,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 7,
+            "teamId": "home",
+            "startQuarter": 2,
+            "startClockSeconds": 533,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 35,
+                "driveId": 7,
+                "quarter": 2,
+                "clockSeconds": 533,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 28,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 8,
+            "teamId": "away",
+            "startQuarter": 2,
+            "startClockSeconds": 527,
+            "startFieldPosition": 28,
+            "endReason": "punt",
+            "plays": [
+              {
+                "playId": 36,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 527,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 28,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-DE-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 37,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 497,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 2,
+                "distance": 6,
+                "fieldPosition": 32,
+                "yardsGained": 27,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-S-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 38,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 463,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 59,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-3",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 39,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 443,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 59,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-4",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-CB-1",
+                    "teamId": "home",
+                    "role": "pass_defender"
+                  }
+                ]
+              },
+              {
+                "playId": 40,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 425,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 3,
+                "distance": 10,
+                "fieldPosition": 59,
+                "yardsGained": 2,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-DE-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 41,
+                "driveId": 8,
+                "quarter": 2,
+                "clockSeconds": 387,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "punt",
+                "down": 4,
+                "distance": 8,
+                "fieldPosition": 61,
+                "yardsGained": 50,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-P-1",
+                    "teamId": "away",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 9,
+            "teamId": "home",
+            "startQuarter": 2,
+            "startClockSeconds": 380,
+            "startFieldPosition": 15,
+            "endReason": "touchdown",
+            "plays": [
+              {
+                "playId": 42,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 380,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 43,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 362,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DE-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 44,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 326,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 3,
+                "distance": 6,
+                "fieldPosition": 19,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 45,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 294,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 25,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 46,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 266,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 30,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 47,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 242,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 37,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DT-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 48,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 202,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 42,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-DE-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 49,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 177,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 49,
+                "yardsGained": 12,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 50,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 150,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "sack",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 61,
+                "yardsGained": -8,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "sacker"
+                  }
+                ]
+              },
+              {
+                "playId": 51,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 122,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 18,
+                "fieldPosition": 53,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 52,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 98,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 3,
+                "distance": 15,
+                "fieldPosition": 56,
+                "yardsGained": 26,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-MLB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 53,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 69,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 82,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 54,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 45,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 87,
+                "yardsGained": 13,
+                "isScoring": true,
+                "pointsScored": 6,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-2",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 55,
+                "driveId": 9,
+                "quarter": 2,
+                "clockSeconds": 17,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "extra_point",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 98,
+                "yardsGained": 0,
+                "isScoring": true,
+                "pointsScored": 1,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 10,
+            "teamId": "home",
+            "startQuarter": 2,
+            "startClockSeconds": 13,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 56,
+                "driveId": 10,
+                "quarter": 2,
+                "clockSeconds": 13,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 37,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 11,
+            "teamId": "away",
+            "startQuarter": 2,
+            "startClockSeconds": 7,
+            "startFieldPosition": 37,
+            "endReason": "end_of_half",
+            "plays": [
+              {
+                "playId": 57,
+                "driveId": 11,
+                "quarter": 2,
+                "clockSeconds": 7,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 37,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-1",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-S-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 12,
+            "teamId": "home",
+            "startQuarter": 3,
+            "startClockSeconds": 720,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 58,
+                "driveId": 12,
+                "quarter": 3,
+                "clockSeconds": 720,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 24,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 13,
+            "teamId": "away",
+            "startQuarter": 3,
+            "startClockSeconds": 714,
+            "startFieldPosition": 24,
+            "endReason": "punt",
+            "plays": [
+              {
+                "playId": 59,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 714,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 24,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-DE-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "home-DT-1",
+                    "teamId": "home",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 60,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 684,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "sack",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 29,
+                "yardsGained": -4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-MLB-1",
+                    "teamId": "home",
+                    "role": "sacker"
+                  }
+                ]
+              },
+              {
+                "playId": 61,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 659,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 3,
+                "distance": 9,
+                "fieldPosition": 25,
+                "yardsGained": 19,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-MLB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 62,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 625,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 44,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 63,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 596,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 2,
+                "distance": 6,
+                "fieldPosition": 48,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-3",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-S-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 64,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 558,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 3,
+                "distance": 2,
+                "fieldPosition": 52,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-1",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-CB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 65,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 525,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 57,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-DE-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 66,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 485,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 6,
+                "fieldPosition": 61,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-2",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 67,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 465,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 3,
+                "distance": 6,
+                "fieldPosition": 61,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-2",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 68,
+                "driveId": 13,
+                "quarter": 3,
+                "clockSeconds": 437,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "punt",
+                "down": 4,
+                "distance": 6,
+                "fieldPosition": 61,
+                "yardsGained": 39,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-P-1",
+                    "teamId": "away",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 14,
+            "teamId": "home",
+            "startQuarter": 3,
+            "startClockSeconds": 430,
+            "startFieldPosition": 15,
+            "endReason": "punt",
+            "plays": [
+              {
+                "playId": 69,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 430,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 70,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 410,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 71,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 382,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 3,
+                "distance": 5,
+                "fieldPosition": 20,
+                "yardsGained": 17,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-S-2",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 72,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 344,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 37,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 73,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 319,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 42,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 74,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 287,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 48,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-3",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 75,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 262,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 7,
+                "fieldPosition": 51,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 76,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 239,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 3,
+                "distance": 7,
+                "fieldPosition": 51,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-2",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 77,
+                "driveId": 14,
+                "quarter": 3,
+                "clockSeconds": 217,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "punt",
+                "down": 4,
+                "distance": 7,
+                "fieldPosition": 51,
+                "yardsGained": 42,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-P-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-WR-2",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 15,
+            "teamId": "away",
+            "startQuarter": 3,
+            "startClockSeconds": 210,
+            "startFieldPosition": 15,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 78,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 210,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-1",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 79,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 184,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-CB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 80,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 151,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 3,
+                "distance": 4,
+                "fieldPosition": 21,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-CB-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 81,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 128,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 26,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-1",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-S-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 82,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 100,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 3,
+                "fieldPosition": 33,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-3",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 83,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 73,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 3,
+                "distance": 3,
+                "fieldPosition": 33,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-2",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-CB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "home-DT-2",
+                    "teamId": "home",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 84,
+                "driveId": 15,
+                "quarter": 3,
+                "clockSeconds": 50,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "interception",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 38,
+                "yardsGained": 17,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-2",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-S-1",
+                    "teamId": "home",
+                    "role": "interceptor"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 16,
+            "teamId": "home",
+            "startQuarter": 3,
+            "startClockSeconds": 27,
+            "startFieldPosition": 79,
+            "endReason": "end_of_half",
+            "plays": [
+              {
+                "playId": 85,
+                "driveId": 16,
+                "quarter": 3,
+                "clockSeconds": 27,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 79,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-CB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 17,
+            "teamId": "home",
+            "startQuarter": 4,
+            "startClockSeconds": 720,
+            "startFieldPosition": 84,
+            "endReason": "touchdown",
+            "plays": [
+              {
+                "playId": 86,
+                "driveId": 17,
+                "quarter": 4,
+                "clockSeconds": 720,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 84,
+                "yardsGained": 2,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 87,
+                "driveId": 17,
+                "quarter": 4,
+                "clockSeconds": 698,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 2,
+                "distance": 8,
+                "fieldPosition": 86,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-4",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-DE-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 88,
+                "driveId": 17,
+                "quarter": 4,
+                "clockSeconds": 675,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 3,
+                "distance": 1,
+                "fieldPosition": 93,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 89,
+                "driveId": 17,
+                "quarter": 4,
+                "clockSeconds": 652,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 1,
+                "fieldPosition": 99,
+                "yardsGained": 1,
+                "isScoring": true,
+                "pointsScored": 6,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-OLB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 90,
+                "driveId": 17,
+                "quarter": 4,
+                "clockSeconds": 625,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "extra_point",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 98,
+                "yardsGained": 0,
+                "isScoring": true,
+                "pointsScored": 1,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 18,
+            "teamId": "home",
+            "startQuarter": 4,
+            "startClockSeconds": 621,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 91,
+                "driveId": 18,
+                "quarter": 4,
+                "clockSeconds": 621,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 22,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 19,
+            "teamId": "away",
+            "startQuarter": 4,
+            "startClockSeconds": 615,
+            "startFieldPosition": 22,
+            "endReason": "punt",
+            "plays": [
+              {
+                "playId": 92,
+                "driveId": 19,
+                "quarter": 4,
+                "clockSeconds": 615,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "sack",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 22,
+                "yardsGained": -9,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-CB-2",
+                    "teamId": "home",
+                    "role": "sacker"
+                  }
+                ]
+              },
+              {
+                "playId": 93,
+                "driveId": 19,
+                "quarter": 4,
+                "clockSeconds": 580,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 2,
+                "distance": 19,
+                "fieldPosition": 13,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 94,
+                "driveId": 19,
+                "quarter": 4,
+                "clockSeconds": 549,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 3,
+                "distance": 15,
+                "fieldPosition": 17,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 95,
+                "driveId": 19,
+                "quarter": 4,
+                "clockSeconds": 521,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "punt",
+                "down": 4,
+                "distance": 10,
+                "fieldPosition": 22,
+                "yardsGained": 34,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-P-1",
+                    "teamId": "away",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "home-WR-1",
+                    "teamId": "home",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 20,
+            "teamId": "home",
+            "startQuarter": 4,
+            "startClockSeconds": 514,
+            "startFieldPosition": 44,
+            "endReason": "field_goal",
+            "plays": [
+              {
+                "playId": 96,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 514,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 44,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-CB-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 97,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 484,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_complete",
+                "down": 2,
+                "distance": 6,
+                "fieldPosition": 48,
+                "yardsGained": 9,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-2",
+                    "teamId": "home",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 98,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 460,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 57,
+                "yardsGained": 6,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-MLB-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 99,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 423,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 4,
+                "fieldPosition": 63,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-2",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-DT-2",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "away-CB-1",
+                    "teamId": "away",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 100,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 388,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 68,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 101,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 362,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 2,
+                "distance": 10,
+                "fieldPosition": 68,
+                "yardsGained": 4,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 102,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 326,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "pass_incomplete",
+                "down": 3,
+                "distance": 6,
+                "fieldPosition": 72,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 103,
+                "driveId": 20,
+                "quarter": 4,
+                "clockSeconds": 306,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "field_goal",
+                "down": 4,
+                "distance": 6,
+                "fieldPosition": 72,
+                "yardsGained": 0,
+                "isScoring": true,
+                "pointsScored": 3,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 21,
+            "teamId": "home",
+            "startQuarter": 4,
+            "startClockSeconds": 301,
+            "startFieldPosition": 35,
+            "endReason": "turnover",
+            "plays": [
+              {
+                "playId": 104,
+                "driveId": 21,
+                "quarter": 4,
+                "clockSeconds": 301,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kickoff",
+                "down": 0,
+                "distance": 0,
+                "fieldPosition": 35,
+                "yardsGained": 35,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "home-K-1",
+                    "teamId": "home",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 22,
+            "teamId": "away",
+            "startQuarter": 4,
+            "startClockSeconds": 295,
+            "startFieldPosition": 35,
+            "endReason": "punt",
+            "plays": [
+              {
+                "playId": 105,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 295,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 35,
+                "yardsGained": 3,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-2",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 106,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 265,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 2,
+                "distance": 7,
+                "fieldPosition": 38,
+                "yardsGained": 8,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-4",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-CB-1",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 107,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 243,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_complete",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 46,
+                "yardsGained": 40,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-1",
+                    "teamId": "away",
+                    "role": "receiver"
+                  },
+                  {
+                    "playerId": "home-S-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "home-DT-1",
+                    "teamId": "home",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 108,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 221,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 86,
+                "yardsGained": 7,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-RB-1",
+                    "teamId": "away",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "home-OLB-2",
+                    "teamId": "home",
+                    "role": "tackler_solo"
+                  },
+                  {
+                    "playerId": "home-DT-1",
+                    "teamId": "home",
+                    "role": "tackler_ast"
+                  }
+                ]
+              },
+              {
+                "playId": 109,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 182,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 2,
+                "distance": 3,
+                "fieldPosition": 93,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-3",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 110,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 162,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "pass_incomplete",
+                "down": 3,
+                "distance": 3,
+                "fieldPosition": 93,
+                "yardsGained": 0,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "away-QB-1",
+                    "teamId": "away",
+                    "role": "passer"
+                  },
+                  {
+                    "playerId": "away-WR-3",
+                    "teamId": "away",
+                    "role": "receiver"
+                  }
+                ]
+              },
+              {
+                "playId": 111,
+                "driveId": 22,
+                "quarter": 4,
+                "clockSeconds": 136,
+                "offenseTeamId": "away",
+                "defenseTeamId": "home",
+                "playType": "punt",
+                "down": 4,
+                "distance": 3,
+                "fieldPosition": 93,
+                "yardsGained": 38,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": true,
+                "participants": [
+                  {
+                    "playerId": "away-P-1",
+                    "teamId": "away",
+                    "role": "kicker"
+                  },
+                  {
+                    "playerId": "home-WR-3",
+                    "teamId": "home",
+                    "role": "returner"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "driveId": 23,
+            "teamId": "home",
+            "startQuarter": 4,
+            "startClockSeconds": 129,
+            "startFieldPosition": 15,
+            "endReason": "downs",
+            "plays": [
+              {
+                "playId": 112,
+                "driveId": 23,
+                "quarter": 4,
+                "clockSeconds": 129,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "rush",
+                "down": 1,
+                "distance": 10,
+                "fieldPosition": 15,
+                "yardsGained": 5,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-RB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  },
+                  {
+                    "playerId": "away-S-1",
+                    "teamId": "away",
+                    "role": "tackler_solo"
+                  }
+                ]
+              },
+              {
+                "playId": 113,
+                "driveId": 23,
+                "quarter": 4,
+                "clockSeconds": 99,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kneel",
+                "down": 2,
+                "distance": 5,
+                "fieldPosition": 20,
+                "yardsGained": -1,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  }
+                ]
+              },
+              {
+                "playId": 114,
+                "driveId": 23,
+                "quarter": 4,
+                "clockSeconds": 61,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kneel",
+                "down": 3,
+                "distance": 6,
+                "fieldPosition": 19,
+                "yardsGained": -1,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  }
+                ]
+              },
+              {
+                "playId": 115,
+                "driveId": 23,
+                "quarter": 4,
+                "clockSeconds": 23,
+                "offenseTeamId": "home",
+                "defenseTeamId": "away",
+                "playType": "kneel",
+                "down": 4,
+                "distance": 7,
+                "fieldPosition": 18,
+                "yardsGained": -1,
+                "isScoring": false,
+                "pointsScored": 0,
+                "isTurnover": false,
+                "participants": [
+                  {
+                    "playerId": "home-QB-1",
+                    "teamId": "home",
+                    "role": "rusher"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "mismatch-chalk",
+      "seed": 987654,
+      "decisive": false,
+      "flavor": "chalk",
+      "homeStrength": 85,
+      "awayStrength": 55,
+      "homeScore": 35,
+      "awayScore": 0,
+      "driveCount": 23,
+      "playCount": 114,
+      "sha256": "a41f793ba6e3e8ef19eca9194af696fcf242ffc4309c772fe244aead47cf051f"
+    },
+    {
+      "name": "upsets-flavor",
+      "seed": 246810,
+      "decisive": false,
+      "flavor": "upsets",
+      "homeStrength": 60,
+      "awayStrength": 75,
+      "homeScore": 14,
+      "awayScore": 14,
+      "driveCount": 23,
+      "playCount": 115,
+      "sha256": "9bb2d6637b68010ad7a08f89a06fecce8f663070815c57a4b9e19ce44f896422"
+    },
+    {
+      "name": "decisive-playoff",
+      "seed": 555001,
+      "decisive": true,
+      "flavor": "balanced",
+      "homeStrength": 68,
+      "awayStrength": 68,
+      "homeScore": 20,
+      "awayScore": 3,
+      "driveCount": 24,
+      "playCount": 117,
+      "sha256": "04f4e62c2234046d55285e9d12b1c609de6fe38d6d711aeb961a531d5ac688f5"
+    }
+  ]
+}

--- a/apps/web/src/lib/pbp/__tests__/golden-parity.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/golden-parity.test.ts
@@ -1,0 +1,291 @@
+import { createHash } from "node:crypto";
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import { normalizeGameLog, logModels } from "../migrate-log";
+import type {
+  PbpGameInput,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../types";
+import golden from "./fixtures/v1-golden-logs.json";
+
+/*
+ * Golden-log parity (Dynasty Mode A1) — the guard for every Epic A slice.
+ *
+ * The engine is shared by every league that has ever simulated a game. Changing
+ * how it plays out is sometimes intended (see #642) but must never be
+ * accidental, and "accidental" is easy here: the PRNG is a sequence, so a
+ * single stray `rand()` inside a disabled feature shifts every later draw and
+ * silently rewrites the whole game.
+ *
+ * So: with v2 features OFF, the engine must reproduce the pinned v1 logs
+ * byte-for-byte. Regenerate the fixture with `scripts/gen-v1-golden.ts` ONLY
+ * when a v1 behavior change is deliberate, and call the diff out in the PR.
+ */
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2],
+    ["RB", 3],
+    ["WR", 5],
+    ["TE", 2],
+    ["DE", 2],
+    ["DT", 2],
+    ["OLB", 2],
+    ["MLB", 2],
+    ["CB", 3],
+    ["S", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return players;
+}
+
+function buildTeam(teamId: string, strength: number): TeamSimProfile {
+  return { teamId, strength, players: buildRoster(teamId, strength) };
+}
+
+function inputFor(c: (typeof golden.cases)[number]): PbpGameInput {
+  return {
+    home: buildTeam("home", c.homeStrength),
+    away: buildTeam("away", c.awayStrength),
+    seed: c.seed,
+    decisive: c.decisive,
+    flavor: c.flavor as PbpGameInput["flavor"],
+  };
+}
+
+function sha(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+describe("v1 golden parity (features off)", () => {
+  it("pins four cases spanning even, mismatch, upsets and decisive", () => {
+    expect(golden.cases).toHaveLength(4);
+    expect(golden.engineVersion).toBe("1.0.0");
+  });
+
+  for (const c of golden.cases) {
+    it(`reproduces "${c.name}" byte-for-byte`, () => {
+      const log = simulateGameLog(inputFor(c));
+      expect(sha(log)).toBe(c.sha256);
+      // Cheap, readable assertions first so a failure says WHAT drifted
+      // before the hash says THAT it drifted.
+      expect(log.homeScore).toBe(c.homeScore);
+      expect(log.awayScore).toBe(c.awayScore);
+      expect(log.drives).toHaveLength(c.driveCount);
+      expect(log.drives.reduce((n, d) => n + d.plays.length, 0)).toBe(
+        c.playCount,
+      );
+    });
+  }
+
+  it("gives a deep-equal diff for the case that stores its full log", () => {
+    const c = golden.cases[0]!;
+    expect(c.log).toBeDefined();
+    expect(simulateGameLog(inputFor(c))).toEqual(c.log);
+  });
+
+  it("treats an explicitly-disabled gate the same as an omitted one", () => {
+    const c = golden.cases[0]!;
+    const omitted = simulateGameLog(inputFor(c));
+    const explicit = simulateGameLog({
+      ...inputFor(c),
+      features: { scoringV2: false },
+    });
+    expect(sha(explicit)).toBe(sha(omitted));
+  });
+
+  it("emits no v2-only play types while the gate is off", () => {
+    const v2Only = new Set([
+      "two_point_convert",
+      "two_point_fail",
+      "safety",
+      "onside_kick",
+      "penalty",
+      "spike",
+      "timeout",
+    ]);
+    for (const c of golden.cases) {
+      const log = simulateGameLog(inputFor(c));
+      const types = log.drives.flatMap((d) => d.plays.map((p) => p.playType));
+      expect(types.filter((t) => v2Only.has(t))).toEqual([]);
+    }
+  });
+});
+
+describe("v2 enabled", () => {
+  it("diverges from v1 — proving the gate is actually wired", () => {
+    // A gate that changed nothing when flipped would make the parity tests
+    // above vacuous.
+    const c = golden.cases[0]!;
+    const v2 = simulateGameLog({
+      ...inputFor(c),
+      features: { scoringV2: true },
+    });
+    expect(sha(v2)).not.toBe(c.sha256);
+  });
+
+  it("keeps the serialized log well under the 400KB budget", () => {
+    for (const c of golden.cases) {
+      const v2 = simulateGameLog({
+        ...inputFor(c),
+        features: { scoringV2: true },
+      });
+      expect(JSON.stringify(v2).length).toBeLessThan(400_000);
+    }
+  });
+
+  it("scores consistently: 6*TD + XP + 3*FG + 2*safety + 2*two-point", () => {
+    for (const c of golden.cases) {
+      const log = simulateGameLog({
+        ...inputFor(c),
+        features: { scoringV2: true },
+      });
+      const plays = log.drives.flatMap((d) => d.plays);
+
+      for (const teamId of [log.homeTeamId, log.awayTeamId]) {
+        const offense = plays
+          .filter((p) => p.offenseTeamId === teamId)
+          .reduce((n, p) => n + p.pointsScored, 0);
+        // Points the team scored while on DEFENSE (safeties, return TDs).
+        const defense = plays
+          .filter((p) => p.defenseTeamId === teamId)
+          .reduce((n, p) => n + (p.defensivePoints ?? 0), 0);
+        const expected = teamId === log.homeTeamId ? log.homeScore : log.awayScore;
+        expect(offense + defense).toBe(expected);
+      }
+    }
+  });
+
+  it("never lets a two-point try coexist with an extra point on the same score", () => {
+    for (const c of golden.cases) {
+      const log = simulateGameLog({
+        ...inputFor(c),
+        features: { scoringV2: true },
+      });
+      const plays = log.drives.flatMap((d) => d.plays);
+      const tries = plays.filter((p) =>
+        ["extra_point", "extra_point_miss", "two_point_convert", "two_point_fail"].includes(
+          p.playType,
+        ),
+      );
+      const touchdowns = plays.filter((p) => p.pointsScored === 6).length;
+      // Exactly one conversion attempt per touchdown.
+      expect(tries).toHaveLength(touchdowns);
+    }
+  });
+});
+
+describe("normalizeGameLog", () => {
+  it("reads a stored v1 log without inventing v2 data", () => {
+    const raw = golden.cases[0]!.log;
+    const normalized = normalizeGameLog(raw, "1.0.0");
+
+    expect(normalized.engineVersion).toBe("1.0.0");
+    expect(normalized.upconverted).toBe(true);
+    expect(normalized.homeScore).toBe(golden.cases[0]!.homeScore);
+    expect(normalized.drives).toHaveLength(golden.cases[0]!.driveCount);
+
+    // Absent means "this engine did not model it", NOT zero. Defaulting to 0
+    // would turn unknown into a factual claim the record book later trusts.
+    const play = normalized.drives[0]!.plays[0]!;
+    expect(play.returnYards).toBeUndefined();
+    expect(play.defensivePoints).toBeUndefined();
+    expect(logModels(normalized, "safeties")).toBe(false);
+    expect(logModels(normalized, "penalties")).toBe(false);
+  });
+
+  it("degrades a corrupt blob to an empty log rather than throwing", () => {
+    // One bad row should cost one Gamecast, not the page listing it.
+    for (const bad of [null, undefined, "nonsense", 42, [], {}]) {
+      const normalized = normalizeGameLog(bad, "1.0.0");
+      expect(normalized.drives).toEqual([]);
+      expect(normalized.homeScore).toBe(0);
+    }
+  });
+
+  it("marks a current-engine log as not upconverted", () => {
+    const v2 = simulateGameLog({
+      ...inputFor(golden.cases[0]!),
+      features: { scoringV2: true },
+    });
+    const normalized = normalizeGameLog(v2, "2.0.0");
+    expect(normalized.upconverted).toBe(false);
+    expect(logModels(normalized, "safeties")).toBe(true);
+    // Penalties still arrive in A2, so this stays false even on a v2 log.
+    expect(logModels(normalized, "penalties")).toBe(false);
+  });
+});
+
+describe("v2 mechanics are reachable", () => {
+  /*
+   * A mechanic that is implemented but can never fire is not implemented.
+   *
+   * Safeties were exactly that at first: v1 clamped every drive start to the
+   * 15, so being pinned deep enough to concede one was geometrically
+   * impossible, and 200 games produced zero. This test is why that was caught
+   * rather than shipped as a silent no-op.
+   *
+   * Bounds are loose on purpose — this asserts REACHABILITY, not balance.
+   * Scoring balance is #642 and belongs to a tuning slice.
+   */
+  it("produces every A1 mechanic across 200 seeded games", () => {
+    const counts = {
+      safety: 0,
+      twoPoint: 0,
+      returnTd: 0,
+      stripSack: 0,
+    };
+
+    for (let i = 0; i < 200; i++) {
+      const log = simulateGameLog({
+        home: buildTeam("home", 70),
+        away: buildTeam("away", 70),
+        seed: 7000 + i,
+        flavor: "balanced",
+        features: { scoringV2: true },
+      });
+      for (const drive of log.drives) {
+        for (const play of drive.plays) {
+          if (play.playType === "safety") counts.safety += 1;
+          if (
+            play.playType === "two_point_convert" ||
+            play.playType === "two_point_fail"
+          ) {
+            counts.twoPoint += 1;
+          }
+          if (play.isReturnTd) counts.returnTd += 1;
+          if (play.playType === "sack" && play.isTurnover) counts.stripSack += 1;
+        }
+      }
+    }
+
+    expect(counts.safety).toBeGreaterThan(0);
+    expect(counts.twoPoint).toBeGreaterThan(0);
+    expect(counts.returnTd).toBeGreaterThan(0);
+    expect(counts.stripSack).toBeGreaterThan(0);
+
+    // Upper bounds guard against a mechanic firing absurdly often — a safety
+    // every other game would be as wrong as never.
+    expect(counts.safety).toBeLessThan(200);
+    expect(counts.returnTd).toBeLessThan(200);
+  });
+});

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -5,6 +5,7 @@ import {
   weightsForFlavor,
 } from "@/lib/simulation-flavor";
 import type {
+  PbpFeatureGates,
   PbpDrive,
   PbpDriveEndReason,
   PbpGameInput,
@@ -51,6 +52,13 @@ const POSITION_TO_GROUP: Record<string, SimPositionGroup> = {
 
 interface GameState {
   rand: () => number;
+  /*
+   * v2 mechanics (Epic A). EVERY branch guarded by one of these must consume
+   * ZERO random draws when the gate is off — the PRNG is a sequence, so one
+   * stray `rand()` shifts every later draw and the log diverges from v1. The
+   * golden-parity test exists to catch exactly that.
+   */
+  features: Required<PbpFeatureGates>;
   home: TeamSimProfile;
   away: TeamSimProfile;
   strengthWeight: number;
@@ -440,7 +448,16 @@ function doPunt(state: GameState): void {
   const returner = selectPlayer(def, "WR", state.rand, true);
   const gross = Math.round(38 + state.rand() * 12 - matchupEdge(state) * 10);
   const net = clamp(gross - Math.round(state.rand() * 8), 25, 55);
-  const newField = clamp(100 - (state.fieldPosition + net), 15, 75);
+  /*
+   * Where the receiving team starts (v2 widens the floor).
+   *
+   * v1 clamped this to the 15, which meant a team could never be pinned deep —
+   * and therefore a safety was geometrically impossible no matter how the rest
+   * of the engine behaved. Real punts are downed inside the 5 regularly, so v2
+   * lowers the floor to the 1. Costs no random draw, so v1 parity is unaffected.
+   */
+  const pinFloor = state.features.scoringV2 ? 1 : 15;
+  const newField = clamp(100 - (state.fieldPosition + net), pinFloor, 75);
 
   const play: PbpPlay = {
     playId: state.playId,
@@ -563,6 +580,24 @@ function doPass(state: GameState): void {
         participant(sacker, def.teamId, "sacker"),
       ],
     };
+
+    /*
+     * Strip-sack (v2). v1 modelled fumbles on rushes only, so a quarterback
+     * could never lose the ball while being sacked — the single most common
+     * non-rush fumble in the sport. Gated, and the draw happens ONLY inside
+     * the gate so v1's PRNG sequence is untouched.
+     */
+    if (state.features.scoringV2 && state.rand() < 0.12) {
+      const recoverer = selectDefender(def, state.rand, "tackle");
+      play.isTurnover = true;
+      play.participants.push(participant(passer, off.teamId, "fumbler"));
+      play.participants.push(participant(recoverer, def.teamId, "recoverer"));
+      recordPlay(state, play);
+      tickClock(state, Math.round(24 + state.rand() * 12));
+      applyPlayResult(state, yards, false, 0, true);
+      return;
+    }
+
     recordPlay(state, play);
     tickClock(state, Math.round(24 + state.rand() * 12));
     applyPlayResult(state, yards, false, 0, false);
@@ -593,6 +628,25 @@ function doPass(state: GameState): void {
         participant(interceptor, def.teamId, "interceptor"),
       ],
     };
+    /*
+     * Pick-six (v2). v1 always spotted the ball after an interception, so a
+     * defense could never score. The return distance already exists; this only
+     * decides whether it reached the end zone.
+     */
+    if (state.features.scoringV2 && rollReturnTouchdown(state, 0.06)) {
+      play.returnYards = returnYards;
+      play.isReturnTd = true;
+      play.defensivePoints = 6;
+      awardDefensivePoints(state, 6);
+      recordPlay(state, play);
+      tickClock(state, Math.round(20 + state.rand() * 10));
+      endDrive(state, "turnover");
+      // The scoring defense now kicks off to the team that threw it.
+      doKickoff(state, state.possession === "home" ? "away" : "home");
+      return;
+    }
+
+    if (state.features.scoringV2) play.returnYards = returnYards;
     recordPlay(state, play);
     tickClock(state, Math.round(20 + state.rand() * 10));
     endDrive(state, "turnover");
@@ -706,6 +760,120 @@ function doKneel(state: GameState): void {
   applyPlayResult(state, -1, false, 0, false);
 }
 
+
+/*
+ * ── v2 scoring plays (Epic A1) ────────────────────────────────────────────
+ * Reached only when `features.scoringV2` is on, so v1 logs are untouched.
+ */
+
+/** Points the DEFENSE just scored go to the other side of the ledger. */
+function awardDefensivePoints(state: GameState, points: number): void {
+  if (state.possession === "home") state.awayScore += points;
+  else state.homeScore += points;
+}
+
+/**
+ * Tackled in your own end zone: two points to the defense, then a free kick
+ * from the 20 by the team that conceded.
+ */
+function doSafety(state: GameState): void {
+  const off = offenseTeam(state);
+  const def = defenseTeam(state);
+  const tackler = selectDefender(def, state.rand, "tackle");
+
+  awardDefensivePoints(state, 2);
+
+  recordPlay(state, {
+    playId: state.playId,
+    driveId: state.driveId,
+    quarter: state.quarter,
+    clockSeconds: state.clockSeconds,
+    offenseTeamId: off.teamId,
+    defenseTeamId: def.teamId,
+    playType: "safety",
+    down: state.down,
+    distance: state.distance,
+    fieldPosition: state.fieldPosition,
+    yardsGained: 0,
+    // The scoring side is the DEFENSE, so `pointsScored` (an offense-relative
+    // field in v1) stays 0 and `defensivePoints` carries the 2. Readers that
+    // sum `pointsScored` for a team must add `defensivePoints` for the other.
+    isScoring: false,
+    pointsScored: 0,
+    defensivePoints: 2,
+    isTurnover: true,
+    participants: [participant(tackler, def.teamId, "tackler_solo")],
+  });
+
+  tickClock(state, 6);
+  endDrive(state, "turnover");
+  // The conceding team free-kicks, so possession passes to the scoring side.
+  flipPossession(state);
+  startDrive(state, offenseTeamId(state), 35);
+}
+
+/**
+ * Whether to go for two rather than kick.
+ *
+ * Deliberately deterministic — no random draw. The classic chart: down 2, 5 or
+ * 8 late, a two-point try changes the number of scores needed. Anything else
+ * kicks. A3 can widen this once it owns situational decisions.
+ */
+function shouldGoForTwo(state: GameState): boolean {
+  if (state.quarter < 4 && !state.inOvertime) return false;
+  const scoring = state.possession === "home" ? state.homeScore : state.awayScore;
+  const opposing = state.possession === "home" ? state.awayScore : state.homeScore;
+  const deficit = opposing - scoring;
+  return deficit === 2 || deficit === 5 || deficit === 8;
+}
+
+/** Two-point try from the 2. Succeeds a shade under half the time. */
+function doTwoPointConversion(state: GameState): void {
+  const off = offenseTeam(state);
+  const def = defenseTeam(state);
+  const passer = selectPlayer(off, "QB", state.rand);
+  const target = selectPlayer(off, "WR", state.rand, true);
+  const edge = matchupEdge(state);
+  const success = state.rand() < clamp(0.45 + edge * 0.1, 0.3, 0.62);
+
+  if (success) {
+    if (state.possession === "home") state.homeScore += 2;
+    else state.awayScore += 2;
+  }
+
+  recordPlay(state, {
+    playId: state.playId,
+    driveId: state.driveId,
+    quarter: state.quarter,
+    clockSeconds: state.clockSeconds,
+    offenseTeamId: off.teamId,
+    defenseTeamId: def.teamId,
+    playType: success ? "two_point_convert" : "two_point_fail",
+    down: 0,
+    distance: 2,
+    fieldPosition: 98,
+    yardsGained: success ? 2 : 0,
+    isScoring: success,
+    pointsScored: success ? 2 : 0,
+    isTurnover: false,
+    participants: [
+      participant(passer, off.teamId, "passer"),
+      participant(target, off.teamId, "receiver"),
+    ],
+  });
+  tickClock(state, 5);
+}
+
+/**
+ * Did a return reach the end zone?
+ *
+ * Called ONLY inside a `scoringV2` branch — it draws, so calling it while the
+ * gate is off would desynchronize the PRNG.
+ */
+function rollReturnTouchdown(state: GameState, baseProb: number): boolean {
+  return state.rand() < baseProb;
+}
+
 function applyPlayResult(
   state: GameState,
   yards: number,
@@ -721,13 +889,29 @@ function applyPlayResult(
     return;
   }
 
+  /*
+   * Safety (v2). v1 clamped field position to a floor of 1, so being tackled
+   * in your own end zone was silently impossible. Detect it BEFORE the clamp.
+   *
+   * Costs no random draw — it is pure geometry — but it is still gated,
+   * because emitting the play at all would change the log.
+   */
+  if (state.features.scoringV2 && !isScoring && state.fieldPosition + yards <= 0) {
+    doSafety(state);
+    return;
+  }
+
   state.fieldPosition = clamp(state.fieldPosition + yards, 1, 99);
 
   if (isScoring) {
     if (state.possession === "home") state.homeScore += points;
     else state.awayScore += points;
     if (points === 6) {
-      doExtraPoint(state);
+      if (state.features.scoringV2 && shouldGoForTwo(state)) {
+        doTwoPointConversion(state);
+      } else {
+        doExtraPoint(state);
+      }
     }
     endDrive(state, points === 6 ? "touchdown" : "field_goal");
     if (state.inOvertime && points === 6) {
@@ -792,6 +976,7 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
   const rand = mulberry32(input.seed >>> 0);
   const state: GameState = {
     rand,
+    features: { scoringV2: input.features?.scoringV2 === true },
     home: input.home,
     away: input.away,
     strengthWeight: weights.strengthWeight,

--- a/apps/web/src/lib/pbp/index.ts
+++ b/apps/web/src/lib/pbp/index.ts
@@ -7,15 +7,25 @@ export type {
   PbpParticipantRole,
   PbpPlay,
   PbpPlayType,
+  PbpFeatureGates,
   PlayerSimProfile,
   SimPositionGroup,
   TeamSimProfile,
 } from "./types";
 
 /** Bump when play model / serialization changes (stored on each gamePlayLogs row). */
-export const PBP_ENGINE_VERSION = "1.0.0";
+export const PBP_ENGINE_VERSION = "2.0.0";
+
+/** The version every log written before Epic A carries. */
+export const PBP_ENGINE_VERSION_V1 = "1.0.0";
 
 export { simulateGameLog } from "./engine";
+export {
+  normalizeGameLog,
+  normalizedPlays,
+  logModels,
+  type NormalizedGameLog,
+} from "./migrate-log";
 export {
   deriveStatLines,
   allPlays,

--- a/apps/web/src/lib/pbp/migrate-log.ts
+++ b/apps/web/src/lib/pbp/migrate-log.ts
@@ -1,0 +1,105 @@
+import type { PbpGameLog, PbpPlay } from "./types";
+
+/*
+ * Stored play-log compatibility (Dynasty Mode A1).
+ *
+ * `gamePlayLogs` rows are IMMUTABLE. A game that was simulated under engine
+ * 1.0.0 keeps its 1.0.0 log forever — we never rewrite history to match a newer
+ * engine, because the log is the evidence for the box score and stat lines that
+ * were derived from it at the time. Re-deriving them under a different engine
+ * would silently change a player's recorded season.
+ *
+ * So compatibility happens on READ. Every consumer (Gamecast, box score, and
+ * later the record book) calls `normalizeGameLog` and gets a shape it can rely
+ * on, whatever version produced it.
+ *
+ * ## What normalizing does NOT do
+ *
+ * It does not invent data. A v1 log has no penalties and no return yardage
+ * because the v1 engine did not model them — not because they were zero. Those
+ * fields stay `undefined`, and a reader must render "—" rather than "0".
+ * Defaulting them to zero would turn "unknown" into a factual claim, and Epic
+ * D's record book would later treat that claim as history.
+ */
+
+/** Versions this module knows how to read. */
+export type KnownEngineVersion = "1.0.0" | "2.0.0";
+
+export interface NormalizedGameLog extends PbpGameLog {
+  /** Resolved version, defaulted to 1.0.0 when a row predates the field. */
+  engineVersion: string;
+  /** True when the log came from an engine older than the current one. */
+  upconverted: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Coerce a stored log into the current shape.
+ *
+ * Tolerant by design: a malformed or partial blob yields an empty-but-valid log
+ * rather than throwing. A corrupt row should degrade one game's Gamecast, not
+ * take down the page that lists it.
+ */
+export function normalizeGameLog(
+  raw: unknown,
+  engineVersion?: string,
+): NormalizedGameLog {
+  const version = engineVersion ?? "1.0.0";
+
+  if (!isRecord(raw)) {
+    return {
+      seed: 0,
+      decisive: false,
+      homeTeamId: "",
+      awayTeamId: "",
+      homeScore: 0,
+      awayScore: 0,
+      drives: [],
+      engineVersion: version,
+      upconverted: version !== "2.0.0",
+    };
+  }
+
+  const drives = Array.isArray(raw.drives) ? raw.drives : [];
+
+  return {
+    seed: typeof raw.seed === "number" ? raw.seed : 0,
+    decisive: raw.decisive === true,
+    homeTeamId: typeof raw.homeTeamId === "string" ? raw.homeTeamId : "",
+    awayTeamId: typeof raw.awayTeamId === "string" ? raw.awayTeamId : "",
+    homeScore: typeof raw.homeScore === "number" ? raw.homeScore : 0,
+    awayScore: typeof raw.awayScore === "number" ? raw.awayScore : 0,
+    // Drives and plays pass through untouched. The v2 additions are all
+    // optional, so a v1 play already satisfies the current `PbpPlay` type —
+    // there is nothing to fill in, and filling anything in would be a lie.
+    drives: drives as PbpGameLog["drives"],
+    version: raw.version === 2 ? 2 : undefined,
+    engineVersion: version,
+    upconverted: version !== "2.0.0",
+  };
+}
+
+/**
+ * Did this engine model the given mechanic?
+ *
+ * The honest question a UI should ask before rendering a stat. Penalties on a
+ * v1 log are unknown, not zero, and a box score should show "—" rather than
+ * claiming a clean game.
+ */
+export function logModels(
+  log: Pick<NormalizedGameLog, "engineVersion">,
+  mechanic: "returns" | "safeties" | "twoPointConversions" | "penalties",
+): boolean {
+  if (log.engineVersion === "1.0.0") return false;
+  // Penalties arrive in A2; everything else in this list ships with A1.
+  if (mechanic === "penalties") return false;
+  return true;
+}
+
+/** Flatten a normalized log's plays, in order. */
+export function normalizedPlays(log: NormalizedGameLog): PbpPlay[] {
+  return log.drives.flatMap((drive) => drive.plays);
+}

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -38,9 +38,15 @@ export interface PbpGameInput {
   decisive?: boolean;
   /** Season simulation flavor; `balanced` preserves legacy weighting. */
   flavor?: SimulationFlavor;
+  /**
+   * v2 mechanics to enable. Omitted or all-false reproduces the v1 engine
+   * byte-for-byte for the same seed — see `PbpFeatureGates`.
+   */
+  features?: PbpFeatureGates;
 }
 
 export type PbpPlayType =
+  // ── v1 (engine 1.0.0) ──────────────────────────────────────────────────
   | "kickoff"
   | "rush"
   | "pass_complete"
@@ -52,7 +58,24 @@ export type PbpPlayType =
   | "field_goal_miss"
   | "extra_point"
   | "extra_point_miss"
-  | "kneel";
+  | "kneel"
+  /*
+   * ── v2 (engine 2.0.0, Epic A) ─────────────────────────────────────────
+   *
+   * Additive only. A stored v1 log contains none of these, which is exactly
+   * why every consumer must widen rather than assume: `normalizeGameLog` in
+   * `migrate-log.ts` up-converts old logs on read, and stored rows are never
+   * rewritten.
+   */
+  | "two_point_convert"
+  | "two_point_fail"
+  | "safety"
+  | "onside_kick"
+  // A2 (penalties) and A3 (clock management) emit these; the type is declared
+  // in A1 so the log format has a single version bump rather than three.
+  | "penalty"
+  | "spike"
+  | "timeout";
 
 export type PbpParticipantRole =
   | "kicker"
@@ -102,6 +125,21 @@ export interface PbpPlay {
   pointsScored: number;
   isTurnover: boolean;
   participants: PbpParticipant[];
+
+  /*
+   * ── v2 additions (engine 2.0.0) ───────────────────────────────────────
+   *
+   * ALL optional. A v1 log has none of them, and `normalizeGameLog` does not
+   * invent values — absent means "this engine did not model it", which is
+   * different from zero. Readers must treat `undefined` as unknown.
+   */
+
+  /** Yards gained on a kickoff, punt, interception or fumble return. */
+  returnYards?: number;
+  /** The return itself reached the end zone (A1). */
+  isReturnTd?: boolean;
+  /** Points scored by the DEFENSE on this play — a safety, or a return TD. */
+  defensivePoints?: number;
 }
 
 export interface PbpDrive {
@@ -122,4 +160,30 @@ export interface PbpGameLog {
   homeScore: number;
   awayScore: number;
   drives: PbpDrive[];
+
+  /*
+   * ── v2 additions (engine 2.0.0) ───────────────────────────────────────
+   *
+   * `version` is absent on every v1 log, which is how `normalizeGameLog`
+   * recognizes one. Do not default it at write time — its absence is the
+   * signal.
+   */
+  version?: 2;
+}
+
+/*
+ * Engine feature gates (Epic A).
+ *
+ * Every v2 mechanic is opt-in and, when disabled, must consume ZERO random
+ * draws. The PRNG is a sequence: a disabled feature that calls `rand()` even
+ * once shifts every subsequent draw and the whole log diverges from v1. That
+ * is what makes byte-for-byte golden parity testable at all, so treat "no
+ * draws when off" as a hard rule, not an optimization.
+ */
+export interface PbpFeatureGates {
+  /**
+   * A1 — safeties, two-point conversions, return touchdowns, and fumbles on
+   * plays other than a rush.
+   */
+  scoringV2?: boolean;
 }


### PR DESCRIPTION
## Summary

Opens Epic A. Bumps the play-by-play engine to `2.0.0`, adds the versioned-log read path, and
fills the scoring and turnover gaps v1 could not represent — all behind a gate that, when off,
reproduces v1 **byte-for-byte**.

Closes #616. Part of #605.

## The constraint that shaped everything

The engine is shared by every league that has ever simulated a game, so changing how it plays out
must never be accidental. That is easy to get wrong here: the PRNG is a **sequence**, so a single
stray `rand()` inside a disabled feature shifts every later draw and silently rewrites the whole
game.

So the hard rule, stated in `PbpFeatureGates` and enforced by test: **a disabled v2 feature
consumes zero random draws.** Every new branch either sits inside a `features.scoringV2` guard or
costs no draw at all (the safety check is pure geometry; the two-point decision is a deterministic
chart).

## What changed

**Types** — new play types (`two_point_convert`, `two_point_fail`, `safety`, `onside_kick`, plus
`penalty`/`spike`/`timeout` declared now so the log format takes one version bump instead of
three) and optional `PbpPlay` fields (`returnYards`, `isReturnTd`, `defensivePoints`). All
additive; a v1 play already satisfies the current type.

**`migrate-log.ts`** — `normalizeGameLog` up-converts a stored log on read. Stored rows are
**never rewritten**: a game simulated under 1.0.0 keeps its 1.0.0 log, because that log is the
evidence for the box score derived from it at the time.

It deliberately **does not invent data.** A v1 log has no return yardage because v1 did not model
it — not because it was zero. Those fields stay `undefined`, and `logModels(log, mechanic)` lets a
UI ask honestly so it renders "—" rather than claiming a fact. Defaulting to 0 would turn unknown
into a claim that Epic D's record book later treats as history.

**New mechanics** (gated): safeties, two-point conversions on the standard down-2/5/8 chart,
pick-sixes, and strip-sacks — the most common non-rush fumble, which v1 could not produce at all
since it modelled fumbles on rushes only.

## Two findings, both caught by tests rather than shipped

**1. The gate wasn't observable.** My "v2 diverges from v1" canary failed at first: enabling v2
produced an *identical* log, because safeties and two-point situations never arose in those seeds.
That made the parity tests nearly vacuous. Fixed by implementing the higher-frequency mechanics
(strip-sack, pick-six) rather than by weakening the canary.

**2. Safeties were implemented but unreachable.** 200 games produced **zero**. v1 clamps every
drive start to the 15, so being pinned deep enough to concede one was *geometrically impossible*
regardless of the rest of the engine. Real punts are downed inside the 5 routinely, so v2 lowers
the pin floor to the 1 — no extra random draw, so parity is unaffected. Safeties now occur ~25
times per 200 games.

A mechanic that can never fire is not implemented, which is why the reachability assertion is now
a permanent test.

## Verification

- [x] `tsc --noEmit` clean
- [x] `test:unit` — **189 files / 1351 tests pass** (was 188/1335)
- [x] `next build` succeeds
- [x] `turbo lint` clean

**The golden fixture is the durable artifact here.** `v1-golden-logs.json` pins four cases (even,
mismatch, upsets, decisive) captured from the unmodified v1 engine before any change, with a
SHA-256 per case plus one full log so a failure gives a readable deep-equal diff rather than just
"hash mismatch". 117KB rather than 468KB by storing digests. Reproducible via
`scripts/gen-v1-golden.ts` — regenerate **only** when a v1 behavior change is intended, and call
the diff out in the PR.

16 tests, including:

- All four cases reproduce **byte-for-byte** with v2 off.
- An explicitly-`false` gate equals an omitted one.
- **No v2-only play type appears** while the gate is off.
- v2 on **diverges** — so the parity tests aren't vacuous.
- Score consistency including defensive points: for each team, offensive `pointsScored` plus the
  opponent-play `defensivePoints` equals the final score.
- Exactly one conversion attempt per touchdown — a two-point try can't coexist with an extra point.
- Serialized v2 log peaks at **52KB** against the 400KB budget.
- Every A1 mechanic is reachable across 200 seeded games, with upper bounds so a mechanic firing
  absurdly often fails too.
- `normalizeGameLog` reads a v1 log without inventing v2 fields, and degrades a corrupt blob to an
  empty log rather than throwing — one bad row should cost one Gamecast, not the page listing it.

## Scope change, agreed before implementation

The **balance-band criterion was dropped from this slice** and filed as **#642**.

It is mutually exclusive with byte-for-byte parity: v1 already sits at **25.6 mean total points**
(outside the documented 30–60 band) with a **67.3% home win rate on identical rosters**. Preserving
parity preserves both numbers. #642 carries the fix and names A3 (#617) as its home, since A3
already reworks the playcalling and 4th-down paths that need retuning.

With v2 on, scoring rises only to 27.1 — as predicted, the new mechanics nudge but nowhere near
close a 25.6 → 30 gap.

## Out of scope

- Penalties (A2), situational/clock AI (A3), injuries (A4), weather (A5), schemes (A6). Their play
  types are declared so the format is stable, but nothing emits them.
- Wiring the gate to `FLAG_DYNASTY_SIM_V2` / `dynastyConfig`. `simulateAndPersistFixture` still
  passes no `features`, so **production behavior is unchanged by this PR** — v2 is reachable only
  from tests until a later slice turns it on deliberately.
- Gamecast/box-score UI for the new play types.
