### PR TITLE
feat: add penalties to the sim engine with accept and decline (#612)

### DIFF
--- a/apps/web/src/components/gamecast/PlayList.tsx
+++ b/apps/web/src/components/gamecast/PlayList.tsx
@@ -163,6 +163,33 @@ export default function PlayList({
                           </span>
                         ) : null}
                       </p>
+                      {play.penalty ? (
+                        <p
+                          className="mt-1 flex flex-wrap items-center gap-1.5"
+                          data-testid="play-penalty"
+                        >
+                          <span
+                            className={cn(
+                              "inline-flex items-center rounded-control px-1.5 py-0.5 font-mono text-caption-12",
+                              // A declined flag had no effect on the game, so
+                              // it reads as muted rather than as a penalty the
+                              // viewer should attribute to the result.
+                              play.penalty.accepted
+                                ? "bg-danger/10 text-danger"
+                                : "bg-surface-3 text-text-subtle line-through",
+                            )}
+                          >
+                            {play.penalty.label} {play.penalty.yards}
+                          </span>
+                          <span className="text-caption-12 text-text-subtle">
+                            {play.penalty.accepted
+                              ? play.penalty.negatesPlay
+                                ? "accepted — play negated"
+                                : "accepted"
+                              : "declined"}
+                          </span>
+                        </p>
+                      ) : null}
                       {contributors ? (
                         <p className="mt-0.5 truncate text-caption-12 text-text-subtle">
                           {contributors}

--- a/apps/web/src/lib/build-team-sim-profile.ts
+++ b/apps/web/src/lib/build-team-sim-profile.ts
@@ -6,6 +6,7 @@ import {
   getTeamAttributeSnapshots,
   getTeamMaddenOveralls,
 } from "@/lib/data-api";
+import { meanAwareness } from "@/lib/pbp/penalties";
 import type { OrgContext } from "@/lib/org-context";
 import type { PlayerSimProfile, TeamSimProfile } from "@/lib/pbp";
 
@@ -94,13 +95,21 @@ export async function buildTeamSimProfile(
       overall: resolvePlayerOverall(p.id, snaps, madden),
       positionSlot: depth?.positionSlot,
       depthRank: depth?.depthRank,
+      // Awareness drives penalty discipline (A2). Absent when the player has
+      // no attribute snapshot, in which case `meanAwareness` falls back to
+      // overall rather than assuming a value.
+      awareness: snaps.get(p.id)?.attributes?.AWR,
     };
   });
 
+  const strength = teamStrengthFromMaps(snaps, madden);
   const profile: TeamSimProfile = {
     teamId,
-    strength: teamStrengthFromMaps(snaps, madden),
+    strength,
     players: simPlayers,
+    // Mean roster awareness; falls back to strength for rosters with no
+    // attribute data, so an unrated league still simulates sensibly.
+    discipline: meanAwareness(simPlayers, strength),
   };
   cache.set(key, profile);
   return profile;

--- a/apps/web/src/lib/gamecast/box-score.ts
+++ b/apps/web/src/lib/gamecast/box-score.ts
@@ -9,6 +9,16 @@ export interface TeamBoxScoreLine {
   to: number;
   plays: number;
   pts: number;
+  /*
+   * Accepted penalties charged to this team, and their yardage (A2).
+   *
+   * `null` means the log's engine did not model penalties at all — a v1 game.
+   * That is NOT the same as a clean game, so the UI must render "—" rather
+   * than "0". Claiming zero penalties for a game nobody counted would be a
+   * fabricated stat, and Epic D's record book reads these numbers as history.
+   */
+  penalties: number | null;
+  penaltyYards: number | null;
 }
 
 export interface BoxScoreAtPosition {
@@ -25,8 +35,30 @@ const SCRIMMAGE_PLAY_TYPES = new Set<PbpPlayType>([
   "kneel",
 ]);
 
-function emptyLine(): TeamBoxScoreLine {
-  return { pass: 0, rush: 0, total: 0, first: 0, to: 0, plays: 0, pts: 0 };
+function emptyLine(modelsPenalties: boolean): TeamBoxScoreLine {
+  return {
+    pass: 0,
+    rush: 0,
+    total: 0,
+    first: 0,
+    to: 0,
+    plays: 0,
+    pts: 0,
+    penalties: modelsPenalties ? 0 : null,
+    penaltyYards: modelsPenalties ? 0 : null,
+  };
+}
+
+/**
+ * Did this log's engine model penalties at all?
+ *
+ * Presence of any `penalty` field is the signal. A v2 game that happened to
+ * draw no flags still reports 0 rather than "—", because it was counted.
+ */
+export function logModelsPenalties(log: PbpGameLog): boolean {
+  return log.drives.some((drive) =>
+    drive.plays.some((play) => play.penalty !== undefined),
+  );
 }
 
 function isScrimmagePlay(play: PbpPlay): boolean {
@@ -52,17 +84,41 @@ function applyPlayToLine(line: TeamBoxScoreLine, play: PbpPlay): void {
   if (isScrimmagePlay(play)) line.plays += 1;
 }
 
+/** Charge an accepted flag to the team that committed it. */
+function applyPenaltyToLines(
+  home: TeamBoxScoreLine,
+  away: TeamBoxScoreLine,
+  play: PbpPlay,
+  homeTeamId: string,
+): void {
+  const flag = play.penalty;
+  // Declined flags cost nobody yardage, so they are not charged.
+  if (!flag || !flag.accepted) return;
+
+  const offendingTeamId = flag.onOffense
+    ? play.offenseTeamId
+    : play.defenseTeamId;
+  const line = offendingTeamId === homeTeamId ? home : away;
+  if (line.penalties !== null) line.penalties += 1;
+  if (line.penaltyYards !== null) line.penaltyYards += flag.yards;
+}
+
 export function boxScoreAtPosition(
   log: PbpGameLog,
   plays: PbpPlay[],
   playIndex: PlayRevealIndex,
 ): BoxScoreAtPosition {
-  const home = emptyLine();
-  const away = emptyLine();
+  const modelsPenalties = logModelsPenalties(log);
+  const home = emptyLine(modelsPenalties);
+  const away = emptyLine(modelsPenalties);
   const end = Math.min(playIndex, plays.length);
 
   for (let i = 0; i < end; i++) {
     const play = plays[i];
+    // A flag is charged to whoever committed it, which may be the DEFENSE —
+    // so this runs outside the offense-only branch below.
+    applyPenaltyToLines(home, away, play, log.homeTeamId);
+
     const line =
       play.offenseTeamId === log.homeTeamId
         ? home

--- a/apps/web/src/lib/pbp/__tests__/penalties.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/penalties.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import { deriveStatLines } from "../derive-stats";
+import {
+  PENALTY_TABLE,
+  acceptOrDecline,
+  disciplineMultiplier,
+  meanAwareness,
+  rollPenalty,
+} from "../penalties";
+import type {
+  PbpGameInput,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(
+  teamId: string,
+  strength: number,
+  awareness?: number,
+): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2],
+    ["RB", 3],
+    ["WR", 5],
+    ["TE", 2],
+    ["DE", 2],
+    ["DT", 2],
+    ["OLB", 2],
+    ["MLB", 2],
+    ["CB", 3],
+    ["S", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+        awareness,
+      });
+    }
+  }
+  return players;
+}
+
+function buildTeam(
+  teamId: string,
+  strength: number,
+  discipline?: number,
+): TeamSimProfile {
+  return {
+    teamId,
+    strength,
+    players: buildRoster(teamId, strength, discipline),
+    discipline,
+  };
+}
+
+function gameInput(overrides: Partial<PbpGameInput> = {}): PbpGameInput {
+  return {
+    home: buildTeam("home", 70),
+    away: buildTeam("away", 70),
+    seed: 4242,
+    flavor: "balanced",
+    ...overrides,
+  };
+}
+
+describe("PENALTY_TABLE", () => {
+  it("covers pre-snap and live-ball fouls on both sides", () => {
+    expect(PENALTY_TABLE.some((p) => p.preSnap && p.onOffense)).toBe(true);
+    expect(PENALTY_TABLE.some((p) => p.preSnap && !p.onOffense)).toBe(true);
+    expect(PENALTY_TABLE.some((p) => !p.preSnap && p.onOffense)).toBe(true);
+    expect(PENALTY_TABLE.some((p) => !p.preSnap && !p.onOffense)).toBe(true);
+  });
+
+  it("gives every entry positive yardage and weight", () => {
+    for (const def of PENALTY_TABLE) {
+      expect(def.yards).toBeGreaterThan(0);
+      expect(def.weight).toBeGreaterThan(0);
+      expect(def.code).toMatch(/^[a-z_]+$/);
+    }
+  });
+
+  it("only awards automatic first downs on defensive fouls", () => {
+    for (const def of PENALTY_TABLE) {
+      if (def.automaticFirstDown) expect(def.onOffense).toBe(false);
+    }
+  });
+});
+
+describe("disciplineMultiplier", () => {
+  it("is neutral at 50 awareness and inverts with it", () => {
+    expect(disciplineMultiplier(50)).toBeCloseTo(1, 5);
+    expect(disciplineMultiplier(85)).toBeLessThan(1);
+    expect(disciplineMultiplier(30)).toBeGreaterThan(1);
+  });
+
+  it("stays bounded so no roster is penalty-proof or unplayable", () => {
+    for (const awr of [0, 1, 50, 99, 200, -50]) {
+      const m = disciplineMultiplier(awr);
+      expect(m).toBeGreaterThanOrEqual(0.55);
+      expect(m).toBeLessThanOrEqual(1.6);
+    }
+  });
+});
+
+describe("meanAwareness", () => {
+  it("falls back to overall per player when awareness is missing", () => {
+    expect(
+      meanAwareness([{ overall: 70 }, { overall: 80 }], 0),
+    ).toBeCloseTo(75);
+  });
+
+  it("uses the fallback for an empty roster rather than dividing by zero", () => {
+    expect(meanAwareness([], 62)).toBe(62);
+  });
+});
+
+describe("rollPenalty", () => {
+  it("never flags a play type that cannot draw one", () => {
+    for (const playType of ["extra_point", "kneel", "safety"] as const) {
+      const rolled = rollPenalty({
+        rand: () => 0, // always "flag" if the type allowed it
+        playType,
+        offenseDiscipline: 50,
+        defenseDiscipline: 50,
+      });
+      expect(rolled).toBeNull();
+    }
+  });
+
+  it("returns null without a second draw on a clean play", () => {
+    // A clean play must cost exactly ONE random number regardless of table
+    // size, or the PRNG sequence would depend on how many penalties exist.
+    let draws = 0;
+    const rand = () => {
+      draws += 1;
+      return 0.99;
+    };
+    expect(
+      rollPenalty({
+        rand,
+        playType: "rush",
+        offenseDiscipline: 50,
+        defenseDiscipline: 50,
+      }),
+    ).toBeNull();
+    expect(draws).toBe(1);
+  });
+
+  it("returns a table entry when the roll lands", () => {
+    const rolled = rollPenalty({
+      rand: () => 0,
+      playType: "rush",
+      offenseDiscipline: 50,
+      defenseDiscipline: 50,
+    });
+    expect(rolled).not.toBeNull();
+    expect(PENALTY_TABLE).toContain(rolled!.def);
+    expect(rolled!.yards).toBe(rolled!.def.yards);
+  });
+});
+
+describe("acceptOrDecline", () => {
+  const offensiveHold = PENALTY_TABLE.find((p) => p.code === "holding_offense")!;
+  const defensiveHold = PENALTY_TABLE.find((p) => p.code === "holding_defense")!;
+  const falseStart = PENALTY_TABLE.find((p) => p.code === "false_start")!;
+
+  it("always accepts a pre-snap flag — there is no play to weigh", () => {
+    expect(
+      acceptOrDecline({
+        penalty: falseStart,
+        playYards: 40,
+        playIsScoring: false,
+        playIsTurnover: false,
+        distance: 10,
+      }).accepted,
+    ).toBe(true);
+  });
+
+  it("declines an offensive foul that would give back a turnover", () => {
+    // Never hand the ball back for 10 yards.
+    const d = acceptOrDecline({
+      penalty: offensiveHold,
+      playYards: 0,
+      playIsScoring: false,
+      playIsTurnover: true,
+      distance: 10,
+    });
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toMatch(/turnover/);
+  });
+
+  it("accepts an offensive foul that wipes out a touchdown", () => {
+    expect(
+      acceptOrDecline({
+        penalty: offensiveHold,
+        playYards: 60,
+        playIsScoring: true,
+        playIsTurnover: false,
+        distance: 10,
+      }).accepted,
+    ).toBe(true);
+  });
+
+  it("declines an offensive foul when the play already lost more", () => {
+    expect(
+      acceptOrDecline({
+        penalty: offensiveHold,
+        playYards: -12,
+        playIsScoring: false,
+        playIsTurnover: false,
+        distance: 10,
+      }).accepted,
+    ).toBe(false);
+  });
+
+  it("declines a defensive foul when the offense already scored", () => {
+    expect(
+      acceptOrDecline({
+        penalty: defensiveHold,
+        playYards: 30,
+        playIsScoring: true,
+        playIsTurnover: false,
+        distance: 10,
+      }).accepted,
+    ).toBe(false);
+  });
+
+  it("accepts a defensive foul that erases the offense's own turnover", () => {
+    expect(
+      acceptOrDecline({
+        penalty: defensiveHold,
+        playYards: 0,
+        playIsScoring: false,
+        playIsTurnover: true,
+        distance: 10,
+      }).accepted,
+    ).toBe(true);
+  });
+
+  it("declines a defensive foul when the play already made the line", () => {
+    // 5-yard defensive holding is worth less than a 20-yard gain on 3rd-and-10,
+    // even with the automatic first down, because the play got it anyway.
+    const d = acceptOrDecline({
+      penalty: defensiveHold,
+      playYards: 20,
+      playIsScoring: false,
+      playIsTurnover: false,
+      distance: 10,
+    });
+    expect(d.accepted).toBe(false);
+  });
+
+  it("is deterministic — same inputs, same call, every time", () => {
+    const args = {
+      penalty: offensiveHold,
+      playYards: 7,
+      playIsScoring: false,
+      playIsTurnover: false,
+      distance: 10,
+    };
+    const first = acceptOrDecline(args);
+    for (let i = 0; i < 20; i++) expect(acceptOrDecline(args)).toEqual(first);
+  });
+});
+
+describe("penalties in the engine", () => {
+  it("emits none while the gate is off", () => {
+    const log = simulateGameLog(gameInput());
+    const flagged = log.drives
+      .flatMap((d) => d.plays)
+      .filter((p) => p.penalty !== undefined);
+    expect(flagged).toEqual([]);
+  });
+
+  it("emits flags once enabled", () => {
+    const log = simulateGameLog({
+      ...gameInput(),
+      features: { penalties: true },
+    });
+    const flagged = log.drives
+      .flatMap((d) => d.plays)
+      .filter((p) => p.penalty !== undefined);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it("credits no stats for a play an accepted penalty negated", () => {
+    // The whole point: a 40-yard run wiped by holding must not show up in a
+    // rushing total that Epic D's record book will later treat as history.
+    //
+    // Scan seeds until a negated play appears — one game does not reliably
+    // contain one, and asserting on a single game would be flaky.
+    let log = simulateGameLog({ ...gameInput(), features: { penalties: true } });
+    for (let i = 0; i < 50; i++) {
+      const candidate = simulateGameLog({
+        ...gameInput({ seed: 31000 + i }),
+        features: { penalties: true },
+      });
+      if (candidate.drives.flatMap((d) => d.plays).some((p) => p.penalty?.negatesPlay)) {
+        log = candidate;
+        break;
+      }
+    }
+
+    const negated = log.drives
+      .flatMap((d) => d.plays)
+      .filter((p) => p.penalty?.negatesPlay);
+    expect(negated.length).toBeGreaterThan(0);
+
+    const lines = deriveStatLines(log);
+    const withoutNegated = deriveStatLines({
+      ...log,
+      drives: log.drives.map((d) => ({
+        ...d,
+        plays: d.plays.filter((p) => !p.penalty?.negatesPlay),
+      })),
+    });
+    // Removing the negated plays entirely changes nothing, which proves they
+    // contributed nothing in the first place.
+    expect(lines).toEqual(withoutNegated);
+  });
+
+  it("leaves the play standing when the flag is declined", () => {
+    // Declines are rarer than accepts, so aggregate across seeds rather than
+    // hoping one game contains one.
+    const declined = [];
+    for (let i = 0; i < 60; i++) {
+      const log = simulateGameLog({
+        ...gameInput({ seed: 41000 + i }),
+        features: { penalties: true },
+      });
+      declined.push(
+        ...log.drives
+          .flatMap((d) => d.plays)
+          .filter((p) => p.penalty && !p.penalty.accepted),
+      );
+    }
+
+    for (const play of declined) {
+      // A declined flag is recorded for the play-by-play but must never be
+      // marked as negating, and must never zero out the play's yardage.
+      expect(play.penalty!.negatesPlay).toBe(false);
+    }
+    expect(declined.length).toBeGreaterThan(0);
+  });
+
+  it("flags an undisciplined team more than a disciplined one", () => {
+    const count = (discipline: number) => {
+      let flags = 0;
+      for (let i = 0; i < 120; i++) {
+        const log = simulateGameLog({
+          home: buildTeam("home", 70, discipline),
+          away: buildTeam("away", 70, discipline),
+          seed: 9000 + i,
+          flavor: "balanced",
+          features: { penalties: true },
+        });
+        flags += log.drives
+          .flatMap((d) => d.plays)
+          .filter((p) => p.penalty !== undefined).length;
+      }
+      return flags;
+    };
+
+    const sloppy = count(60);
+    const sharp = count(85);
+    expect(sloppy).toBeGreaterThan(sharp);
+  });
+
+  it("lands in a believable flags-per-team-per-game range", () => {
+    /*
+     * Reachability and sanity, not balance. Scoring balance stays with #642;
+     * this only asserts the penalty rate is neither invisible nor absurd.
+     */
+    let flags = 0;
+    const games = 200;
+    for (let i = 0; i < games; i++) {
+      const log = simulateGameLog({
+        ...gameInput({ seed: 20000 + i }),
+        features: { penalties: true },
+      });
+      flags += log.drives
+        .flatMap((d) => d.plays)
+        .filter((p) => p.penalty !== undefined).length;
+    }
+    const perTeamPerGame = flags / games / 2;
+    expect(perTeamPerGame).toBeGreaterThan(1);
+    expect(perTeamPerGame).toBeLessThan(12);
+  });
+});

--- a/apps/web/src/lib/pbp/derive-stats.ts
+++ b/apps/web/src/lib/pbp/derive-stats.ts
@@ -270,6 +270,14 @@ export function deriveStatLines(log: PbpGameLog): DerivedPlayerStatLine[] {
 
   for (const drive of log.drives) {
     for (const play of drive.plays) {
+      /*
+       * A play wiped out by an accepted penalty officially did not happen (A2).
+       * It stays in the log so the drive chart can show what the flag erased,
+       * but nobody is credited for it — a 40-yard run negated by holding must
+       * not appear in a rushing total, and Epic D's record book reads these
+       * totals as history.
+       */
+      if (play.penalty?.negatesPlay) continue;
       for (const p of play.participants) {
         teamByPlayer.set(p.playerId, p.teamId);
       }

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -4,6 +4,7 @@ import {
   normalizeSimulationFlavor,
   weightsForFlavor,
 } from "@/lib/simulation-flavor";
+import { acceptOrDecline, meanAwareness, rollPenalty } from "./penalties";
 import type {
   PbpFeatureGates,
   PbpDrive,
@@ -545,7 +546,7 @@ function doRush(state: GameState): void {
   };
   recordPlay(state, play);
   tickClock(state, Math.round(22 + state.rand() * 18));
-  applyPlayResult(state, yards, isScoring, points, isTurnover);
+  applyPlayResult(state, yards, isScoring, points, isTurnover, play);
 }
 
 function doPass(state: GameState): void {
@@ -594,13 +595,13 @@ function doPass(state: GameState): void {
       play.participants.push(participant(recoverer, def.teamId, "recoverer"));
       recordPlay(state, play);
       tickClock(state, Math.round(24 + state.rand() * 12));
-      applyPlayResult(state, yards, false, 0, true);
+      applyPlayResult(state, yards, false, 0, true, play);
       return;
     }
 
     recordPlay(state, play);
     tickClock(state, Math.round(24 + state.rand() * 12));
-    applyPlayResult(state, yards, false, 0, false);
+    applyPlayResult(state, yards, false, 0, false, play);
     return;
   }
 
@@ -731,7 +732,7 @@ function doPass(state: GameState): void {
   };
   recordPlay(state, play);
   tickClock(state, Math.round(20 + state.rand() * 18));
-  applyPlayResult(state, yards, isScoring, points, false);
+  applyPlayResult(state, yards, isScoring, points, false, play);
 }
 
 function doKneel(state: GameState): void {
@@ -874,13 +875,111 @@ function rollReturnTouchdown(state: GameState, baseProb: number): boolean {
   return state.rand() < baseProb;
 }
 
+
+/*
+ * ── Penalties (Epic A2) ───────────────────────────────────────────────────
+ */
+
+/** Mean roster awareness, or `strength` when no attribute data exists. */
+function teamDiscipline(team: TeamSimProfile): number {
+  if (typeof team.discipline === "number") return team.discipline;
+  return meanAwareness(team.players, team.strength);
+}
+
+/**
+ * Roll a flag for the play just built, and apply the accept/decline outcome.
+ *
+ * Returns the yardage adjustment to apply INSTEAD of the play result when the
+ * penalty is accepted and negates the play, or `null` when the play stands.
+ *
+ * Draws from the PRNG, so it is called ONLY inside the `penalties` gate — a
+ * draw while disabled would desynchronize every later play.
+ */
+function applyPenalty(
+  state: GameState,
+  play: PbpPlay,
+  context: { playYards: number; isScoring: boolean; isTurnover: boolean },
+): { negated: boolean; penaltyYards: number } | null {
+  const rolled = rollPenalty({
+    rand: state.rand,
+    playType: play.playType,
+    offenseDiscipline: teamDiscipline(offenseTeam(state)),
+    defenseDiscipline: teamDiscipline(defenseTeam(state)),
+  });
+  if (!rolled) return null;
+
+  const decision = acceptOrDecline({
+    penalty: rolled.def,
+    playYards: context.playYards,
+    playIsScoring: context.isScoring,
+    playIsTurnover: context.isTurnover,
+    distance: state.distance,
+  });
+
+  play.penalty = {
+    code: rolled.def.code,
+    label: rolled.def.label,
+    yards: rolled.yards,
+    onOffense: rolled.def.onOffense,
+    accepted: decision.accepted,
+    negatesPlay: decision.accepted && rolled.def.negatesPlay,
+    reason: decision.reason,
+  };
+
+  // Declined: the flag is recorded for the play-by-play, but nothing changes.
+  if (!decision.accepted) return null;
+
+  // Accepted but not play-negating (defensive holding, PI): the play is wiped
+  // and the ball moves by the penalty yardage from the previous spot.
+  const signed = rolled.def.onOffense ? -rolled.yards : rolled.yards;
+  return {
+    negated: rolled.def.negatesPlay || !rolled.def.onOffense,
+    penaltyYards: signed,
+  };
+}
+
 function applyPlayResult(
   state: GameState,
   yards: number,
   isScoring: boolean,
   points: number,
   isTurnover: boolean,
+  /*
+   * The play just recorded, passed explicitly so the penalty roll can attach
+   * its flag to it. Optional because non-scrimmage plays (kickoff, punt, field
+   * goal) do not draw flags in A2.
+   */
+  play?: PbpPlay,
 ): void {
+  if (state.features.penalties && play) {
+    const outcome = applyPenalty(state, play, {
+      playYards: yards,
+      isScoring,
+      isTurnover,
+    });
+    if (outcome) {
+      /*
+       * An accepted flag replaces the play entirely: yardage is assessed from
+       * the previous spot and the down replays (or resets on an automatic
+       * first down). The play stays in the log so the drive chart can show
+       * what was wiped, but `negatesPlay` keeps it out of the stat lines.
+       */
+      state.fieldPosition = clamp(
+        state.fieldPosition + outcome.penaltyYards,
+        1,
+        99,
+      );
+      const auto = !play.penalty?.onOffense && outcome.penaltyYards > 0;
+      if (auto) {
+        state.down = 1;
+        state.distance = Math.min(10, 100 - state.fieldPosition) || 1;
+      } else {
+        state.distance = Math.max(1, state.distance - outcome.penaltyYards);
+      }
+      return;
+    }
+  }
+
   if (isTurnover) {
     endDrive(state, "turnover");
     flipPossession(state);
@@ -976,7 +1075,10 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
   const rand = mulberry32(input.seed >>> 0);
   const state: GameState = {
     rand,
-    features: { scoringV2: input.features?.scoringV2 === true },
+    features: {
+      scoringV2: input.features?.scoringV2 === true,
+      penalties: input.features?.penalties === true,
+    },
     home: input.home,
     away: input.away,
     strengthWeight: weights.strengthWeight,

--- a/apps/web/src/lib/pbp/penalties.ts
+++ b/apps/web/src/lib/pbp/penalties.ts
@@ -1,0 +1,305 @@
+import type { PbpPlayType } from "./types";
+
+/*
+ * Penalties (Dynasty Mode A2).
+ *
+ * Pure: no engine state, no I/O, no `Math.random`. The caller supplies the
+ * PRNG so the whole thing stays inside the engine's deterministic sequence, and
+ * every function here is unit-testable on its own.
+ *
+ * ## The rule that matters most
+ *
+ * A penalty is a CHOICE, not an outcome. The team that did NOT commit it
+ * decides whether to accept the yardage or decline and keep the play. Modelling
+ * the flag without the choice would be worse than not modelling it at all — a
+ * defense would be punished for a holding call on a play it stuffed for a loss.
+ *
+ * `acceptOrDecline` is therefore deterministic: it compares the two outcomes and
+ * takes the better one for the choosing team. No random draw, so it costs
+ * nothing when the feature is off and never surprises a replay.
+ */
+
+export interface PenaltyDef {
+  code: string;
+  label: string;
+  /** Yards assessed against the offending team. */
+  yards: number;
+  /** True when the offense committed it. */
+  onOffense: boolean;
+  /**
+   * Whistled before the snap, so there is no play to keep — the down replays.
+   * A pre-snap flag is always "accepted": there is no alternative outcome.
+   */
+  preSnap: boolean;
+  /**
+   * Accepting wipes the play's result and its stats. True for live-ball
+   * offensive fouls (holding erases the run it sprang).
+   */
+  negatesPlay: boolean;
+  /** Defensive fouls that award an automatic first down. */
+  automaticFirstDown: boolean;
+  /** Relative frequency weight. Normalized against the rest of the table. */
+  weight: number;
+}
+
+/*
+ * Rates are tuned so a league averages roughly 5-7 flags per team per game,
+ * which is where high-school football actually sits. `PENALTY_RATE_PER_PLAY`
+ * scales the whole table at once — tune that rather than individual weights.
+ */
+export const PENALTY_RATE_PER_PLAY = 0.085;
+
+export const PENALTY_TABLE: readonly PenaltyDef[] = [
+  {
+    code: "false_start",
+    label: "False start",
+    yards: 5,
+    onOffense: true,
+    preSnap: true,
+    negatesPlay: true,
+    automaticFirstDown: false,
+    weight: 22,
+  },
+  {
+    code: "offside",
+    label: "Offside",
+    yards: 5,
+    onOffense: false,
+    preSnap: true,
+    negatesPlay: true,
+    automaticFirstDown: false,
+    weight: 12,
+  },
+  {
+    code: "delay_of_game",
+    label: "Delay of game",
+    yards: 5,
+    onOffense: true,
+    preSnap: true,
+    negatesPlay: true,
+    automaticFirstDown: false,
+    weight: 7,
+  },
+  {
+    code: "holding_offense",
+    label: "Offensive holding",
+    yards: 10,
+    onOffense: true,
+    preSnap: false,
+    negatesPlay: true,
+    automaticFirstDown: false,
+    weight: 20,
+  },
+  {
+    code: "holding_defense",
+    label: "Defensive holding",
+    yards: 5,
+    onOffense: false,
+    preSnap: false,
+    negatesPlay: false,
+    automaticFirstDown: true,
+    weight: 8,
+  },
+  {
+    code: "pass_interference",
+    label: "Pass interference",
+    yards: 15,
+    onOffense: false,
+    preSnap: false,
+    negatesPlay: false,
+    automaticFirstDown: true,
+    weight: 7,
+  },
+  {
+    code: "face_mask",
+    label: "Face mask",
+    yards: 15,
+    onOffense: false,
+    preSnap: false,
+    negatesPlay: false,
+    automaticFirstDown: true,
+    weight: 5,
+  },
+  {
+    code: "illegal_block",
+    label: "Illegal block in the back",
+    yards: 10,
+    onOffense: true,
+    preSnap: false,
+    negatesPlay: true,
+    automaticFirstDown: false,
+    weight: 9,
+  },
+  {
+    code: "unsportsmanlike",
+    label: "Unsportsmanlike conduct",
+    yards: 15,
+    onOffense: false,
+    preSnap: false,
+    negatesPlay: false,
+    automaticFirstDown: true,
+    weight: 3,
+  },
+];
+
+/** Play types that can never draw a flag in this model. */
+const UNFLAGGABLE: ReadonlySet<PbpPlayType> = new Set<PbpPlayType>([
+  "extra_point",
+  "extra_point_miss",
+  "two_point_convert",
+  "two_point_fail",
+  "safety",
+  "kneel",
+  "spike",
+  "timeout",
+  "penalty",
+]);
+
+/**
+ * Discipline multiplier from a team's mean awareness.
+ *
+ * A 50-AWR team draws flags at the base rate; higher awareness suppresses them
+ * and lower awareness inflates them, bounded so no roster is either
+ * penalty-proof or unplayable.
+ */
+export function disciplineMultiplier(meanAwareness: number): number {
+  const centered = (50 - meanAwareness) / 50;
+  return Math.max(0.55, Math.min(1.6, 1 + centered * 0.6));
+}
+
+export interface RolledPenalty {
+  def: PenaltyDef;
+  /** Yards assessed, already signed from the offense's perspective. */
+  yards: number;
+}
+
+/**
+ * Roll for a flag on a single play.
+ *
+ * Returns `null` far more often than not. The caller MUST only invoke this when
+ * the penalty feature is enabled — it draws from the PRNG, and drawing while
+ * disabled would desynchronize every later play (see the golden-parity test).
+ */
+export function rollPenalty(input: {
+  rand: () => number;
+  playType: PbpPlayType;
+  offenseDiscipline: number;
+  defenseDiscipline: number;
+}): RolledPenalty | null {
+  if (UNFLAGGABLE.has(input.playType)) return null;
+
+  // One draw decides whether there is a flag at all, so a clean play costs
+  // exactly one number regardless of table size.
+  const offenseMult = disciplineMultiplier(input.offenseDiscipline);
+  const defenseMult = disciplineMultiplier(input.defenseDiscipline);
+  const rate = PENALTY_RATE_PER_PLAY * ((offenseMult + defenseMult) / 2);
+  if (input.rand() >= rate) return null;
+
+  // Weight the table by which side is the sloppier one, so discipline changes
+  // WHO gets flagged and not merely how often.
+  const totalWeight = PENALTY_TABLE.reduce((sum, def) => {
+    const sideMult = def.onOffense ? offenseMult : defenseMult;
+    return sum + def.weight * sideMult;
+  }, 0);
+
+  let target = input.rand() * totalWeight;
+  for (const def of PENALTY_TABLE) {
+    const sideMult = def.onOffense ? offenseMult : defenseMult;
+    target -= def.weight * sideMult;
+    if (target <= 0) {
+      return { def, yards: def.yards };
+    }
+  }
+  // Floating-point tail: fall back to the most common flag rather than null,
+  // so a rolled penalty is never silently dropped.
+  return { def: PENALTY_TABLE[0]!, yards: PENALTY_TABLE[0]!.yards };
+}
+
+export interface AcceptDecision {
+  accepted: boolean;
+  /** Why, for the play-by-play text and for debugging a surprising call. */
+  reason: string;
+}
+
+/**
+ * Would the non-offending team rather have the flag or the play?
+ *
+ * Deterministic — no random draw. A coach who declines a holding call that
+ * gained 12 yards is not being unlucky, they are being correct.
+ */
+export function acceptOrDecline(input: {
+  penalty: PenaltyDef;
+  /** Yards the play gained from the offense's perspective. */
+  playYards: number;
+  playIsScoring: boolean;
+  playIsTurnover: boolean;
+  distance: number;
+}): AcceptDecision {
+  const { penalty } = input;
+
+  if (penalty.preSnap) {
+    // Nothing happened yet — there is no play to weigh it against.
+    return { accepted: true, reason: "pre-snap" };
+  }
+
+  if (penalty.onOffense) {
+    // The DEFENSE chooses. Accepting wipes the play.
+    if (input.playIsTurnover) {
+      // Never give back a takeaway for 10 yards.
+      return { accepted: false, reason: "declined to keep the turnover" };
+    }
+    if (input.playIsScoring) {
+      return { accepted: true, reason: "accepted to wipe the score" };
+    }
+    if (input.playYards <= -penalty.yards) {
+      // The play already lost more than the flag is worth.
+      return { accepted: false, reason: "declined, play lost more" };
+    }
+    return { accepted: true, reason: "accepted to erase the gain" };
+  }
+
+  // The OFFENSE chooses on a defensive foul.
+  if (input.playIsScoring) {
+    return { accepted: false, reason: "declined to keep the score" };
+  }
+  if (input.playIsTurnover) {
+    // Wiping away your own turnover is always right.
+    return { accepted: true, reason: "accepted to erase the turnover" };
+  }
+  /*
+   * Compare the two outcomes on the thing that actually matters — whether the
+   * chains move — and fall back to raw yardage when both options agree.
+   *
+   * The subtle case: defensive holding carries an automatic first down, so it
+   * is tempting to always accept it. But a 20-yard gain on 3rd-and-10 ALSO
+   * produced a first down, 15 yards further downfield. Accepting there would
+   * hand yards back for nothing.
+   */
+  const firstDownFromPenalty =
+    penalty.automaticFirstDown || penalty.yards >= input.distance;
+  const firstDownFromPlay = input.playYards >= input.distance;
+
+  if (firstDownFromPlay && !firstDownFromPenalty) {
+    return { accepted: false, reason: "declined, play made the line" };
+  }
+  if (firstDownFromPenalty && !firstDownFromPlay) {
+    return { accepted: true, reason: "accepted for the first down" };
+  }
+  // Both move the chains, or neither does: take the better field position.
+  if (input.playYards >= penalty.yards) {
+    return { accepted: false, reason: "declined, play gained more" };
+  }
+  return { accepted: true, reason: "accepted" };
+}
+
+/** Mean awareness across a roster, falling back to a supplied default. */
+export function meanAwareness(
+  players: ReadonlyArray<{ awareness?: number; overall: number }>,
+  fallback: number,
+): number {
+  if (players.length === 0) return fallback;
+  const values = players.map((p) =>
+    typeof p.awareness === "number" ? p.awareness : p.overall,
+  );
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -19,12 +19,22 @@ export interface PlayerSimProfile {
   /** From depthChartEntries/rosterAssignments when available. */
   positionSlot?: string;
   depthRank?: number;
+  /**
+   * Awareness (AWR) 0-99, when the player has an attribute snapshot. Drives
+   * penalty discipline (A2); absent falls back to `overall`.
+   */
+  awareness?: number;
 }
 
 export interface TeamSimProfile {
   teamId: string;
   strength: number;
   players: PlayerSimProfile[];
+  /**
+   * Mean roster awareness 0-99 (A2). Lower means more flags. Absent falls back
+   * to `strength`, so a team with no attribute snapshots still simulates.
+   */
+  discipline?: number;
 }
 
 import type { SimulationFlavor } from "@/lib/simulation-flavor";
@@ -140,6 +150,23 @@ export interface PbpPlay {
   isReturnTd?: boolean;
   /** Points scored by the DEFENSE on this play — a safety, or a return TD. */
   defensivePoints?: number;
+
+  /**
+   * The flag on this play (A2), if any.
+   *
+   * A play carrying `negatesPlay: true` is KEPT in the log — you want to see
+   * the run that holding wiped out — but `deriveStatLines` skips it, so no
+   * player is credited for a play that officially did not happen.
+   */
+  penalty?: {
+    code: string;
+    label: string;
+    yards: number;
+    onOffense: boolean;
+    accepted: boolean;
+    negatesPlay: boolean;
+    reason: string;
+  };
 }
 
 export interface PbpDrive {
@@ -186,4 +213,6 @@ export interface PbpFeatureGates {
    * plays other than a rush.
    */
   scoringV2?: boolean;
+  /** A2 — penalties, with accept/decline. */
+  penalties?: boolean;
 }


### PR DESCRIPTION
## Summary

Penalties in the simulation, with the accept/decline decision that makes them meaningful, plus
the Gamecast chip and box-score totals.

Closes #612. Part of #605.

## The rule that shaped the design

**A penalty is a choice, not an outcome.** The team that did *not* commit it decides whether to
take the yardage or decline and keep the play. Modelling the flag without the choice would be
worse than not modelling it at all — a defense would be punished for a holding call on a play it
had already stuffed for a loss.

`acceptOrDecline` is therefore **deterministic**: it compares both outcomes and takes the better
one for the choosing team. No random draw, so it costs nothing when the feature is off and never
surprises a replay.

## What changed

**`pbp/penalties.ts`** (new, pure) — `PENALTY_TABLE` covering pre-snap and live-ball fouls on both
sides, `rollPenalty`, `acceptOrDecline`, `disciplineMultiplier`, `meanAwareness`.

**Discipline is real, not cosmetic.** `TeamSimProfile.discipline` is mean roster **AWR**, wired
through `build-team-sim-profile.ts` from the attribute snapshots. It scales both *how often* a
team is flagged and *which side* gets flagged, so an undisciplined roster is measurably sloppier.
Absent attributes fall back to `overall` rather than assuming a value.

**Negated plays are kept but not counted.** A play wiped by an accepted flag stays in the log —
you want to *see* the run holding erased — but `deriveStatLines` skips it. A 40-yard run negated
by holding must not land in a rushing total that Epic D's record book later reads as history.

**Box score** reports per-team penalties and yards, charged to whoever committed the foul
(which may be the defense). **Declined flags cost nobody yardage and are not charged.**

**Gamecast** shows a chip per flagged play — accepted flags in danger styling, declined ones muted
and struck through, since a declined flag didn't affect the result.

## Honest-absence, again

`TeamBoxScoreLine.penalties` is `number | null`. **`null` means the log's engine never modelled
penalties** (a v1 game) — which is *not* the same as a clean game. The UI must render "—" rather
than "0". Claiming zero penalties for a game nobody counted would be a fabricated stat, and it's
the same reasoning A1 applied to `returnYards`.

A v2 game that happened to draw no flags correctly reports `0`, because it *was* counted.

## Verification

- [x] `tsc --noEmit` clean
- [x] `test:unit` — **190 files / 1375 tests pass** (was 189/1351)
- [x] `next build` succeeds
- [x] `turbo lint` clean
- [x] **A1 golden parity still holds byte-for-byte** — all 16 A1 tests pass unchanged

24 new tests. The ones that matter most:

- **A clean play costs exactly one random draw**, regardless of table size — otherwise the PRNG
  sequence would depend on how many penalty types exist, and adding a flag type would silently
  rewrite every game.
- **No flags at all while the gate is off**, so v1 parity is preserved.
- Removing every negated play from a log changes the derived stat lines **not at all** — proving
  they contributed nothing.
- Declined flags never carry `negatesPlay`.
- A 60-discipline league draws measurably more flags than an 85-discipline one over 120 games.
- Rate lands in a believable per-team-per-game range over 200 games.
- Accept/decline covers: pre-snap always accepted; offensive foul declined to keep a turnover;
  accepted to wipe a touchdown; declined when the play lost more; defensive foul declined when the
  offense already scored; accepted to erase the offense's own turnover.

### A bug the tests caught

My first `acceptOrDecline` accepted **any** defensive foul carrying an automatic first down. But a
20-yard gain on 3rd-and-10 *also* produced a first down, 15 yards further downfield — accepting
there hands yards back for nothing. The test failed, and I fixed the logic rather than the
expectation: compare on whether the chains move, and fall back to raw yardage when both options
agree.

## Scope note

The distribution assertion here covers **penalty rate only**. The points-per-game band remains
with **#642** (v1 sits at 25.6 with a 67.3% home win rate), unchanged by this slice.

## Out of scope

- Penalties on kickoffs, punts and field goals. A2 covers scrimmage plays; special-teams fouls
  need their own spot-of-foul handling.
- Wiring the gate to `FLAG_DYNASTY_SIM_V2` / `dynastyConfig.penaltiesEnabled`.
  `simulateAndPersistFixture` still passes no `features`, so **production behavior is unchanged by
  this PR** — penalties are reachable only from tests until a later slice enables them.
- A Playwright spec for the chip. It renders only for a v2-logged fixture, and no seeded fixture
  produces one until the gate is switched on in production; the rendering path is covered by the
  box-score unit tests. Worth adding with the slice that turns the flag on.
