### PR TITLE
feat: add situational AI and clock management to the sim engine (#617)

### DIFF
--- a/apps/web/scripts/dist-check.ts
+++ b/apps/web/scripts/dist-check.ts
@@ -1,27 +1,123 @@
+/*
+ * Simulation distribution report — the instrument behind issue #642.
+ *
+ * Run it after ANY change to the tuning constants in `src/lib/pbp/engine.ts`:
+ *
+ *   pnpm --filter @sports-management/web exec tsx scripts/dist-check.ts
+ *
+ * Both sides use an identical 70-strength roster, so every asymmetry in the
+ * output is the engine's own rather than the harness's.
+ *
+ * The v1 row is a PIN, not a target. Already-simulated fixtures must stay
+ * reproducible, so v1 is frozen and the corrections live behind gates — if that
+ * row moves, golden parity broke.
+ */
 import { simulateGameLog } from "../src/lib/pbp/engine";
-import type { PlayerSimProfile, TeamSimProfile } from "../src/lib/pbp/types";
-const clamp=(n:number,a:number,b:number)=>Math.max(a,Math.min(b,n));
-function roster(t:string,s:number):PlayerSimProfile[]{
-  const specs:Array<[string,number]>=[["QB",2],["RB",3],["WR",5],["TE",2],["DE",2],["DT",2],["OLB",2],["MLB",2],["CB",3],["S",2],["K",1],["P",1]];
-  const out:PlayerSimProfile[]=[];
-  for(const [p,c] of specs) for(let i=1;i<=c;i++){const j=((i*7+s)%11)-5;out.push({playerId:`${t}-${p}-${i}`,position:p,overall:clamp(s+j,40,99),depthRank:i,positionSlot:p});}
+import type {
+  PbpFeatureGates,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../src/lib/pbp/types";
+
+const clamp = (n: number, a: number, b: number) => Math.max(a, Math.min(b, n));
+
+function roster(t: string, s: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2], ["RB", 3], ["WR", 5], ["TE", 2], ["DE", 2], ["DT", 2],
+    ["OLB", 2], ["MLB", 2], ["CB", 3], ["S", 2], ["K", 1], ["P", 1],
+  ];
+  const out: PlayerSimProfile[] = [];
+  for (const [p, c] of specs) {
+    for (let i = 1; i <= c; i++) {
+      const j = ((i * 7 + s) % 11) - 5;
+      out.push({
+        playerId: `${t}-${p}-${i}`,
+        position: p,
+        overall: clamp(s + j, 40, 99),
+        depthRank: i,
+        positionSlot: p,
+      });
+    }
+  }
   return out;
 }
-const team=(t:string,s:number):TeamSimProfile=>({teamId:t,strength:s,players:roster(t,s)});
-let homeWins=0,awayWins=0,ties=0,hs=0,as=0,shutouts=0,n=300;
-for(let i=0;i<n;i++){
-  const log=simulateGameLog({home:team("home",70),away:team("away",70),seed:1000+i,flavor:"balanced"});
-  hs+=log.homeScore; as+=log.awayScore;
-  if(log.homeScore>log.awayScore)homeWins++; else if(log.awayScore>log.homeScore)awayWins++; else ties++;
-  if(log.homeScore===0||log.awayScore===0)shutouts++;
+
+const team = (t: string, s: number): TeamSimProfile => ({
+  teamId: t,
+  strength: s,
+  players: roster(t, s),
+});
+
+const GAMES = 300;
+
+function report(label: string, features: PbpFeatureGates | undefined): void {
+  let homeWins = 0;
+  let awayWins = 0;
+  let ties = 0;
+  let homePoints = 0;
+  let awayPoints = 0;
+  let shutouts = 0;
+  let scrimmagePlays = 0;
+
+  for (let i = 0; i < GAMES; i++) {
+    const log = simulateGameLog({
+      home: team("home", 70),
+      away: team("away", 70),
+      seed: 1000 + i,
+      flavor: "balanced",
+      features,
+    });
+    homePoints += log.homeScore;
+    awayPoints += log.awayScore;
+    if (log.homeScore > log.awayScore) homeWins += 1;
+    else if (log.awayScore > log.homeScore) awayWins += 1;
+    else ties += 1;
+    if (log.homeScore === 0 || log.awayScore === 0) shutouts += 1;
+    for (const drive of log.drives) {
+      for (const play of drive.plays) {
+        if (
+          play.playType === "rush" ||
+          play.playType === "pass_complete" ||
+          play.playType === "pass_incomplete" ||
+          play.playType === "sack" ||
+          play.playType === "interception"
+        ) {
+          scrimmagePlays += 1;
+        }
+      }
+    }
+  }
+
+  const pct = (n: number) => `${((n / GAMES) * 100).toFixed(1)}%`;
+  const per = (n: number) => (n / GAMES).toFixed(1);
+  console.log(`\n${label}`);
+  console.log(
+    `  home ${pct(homeWins)}  away ${pct(awayWins)}  ties ${pct(ties)}  shutout ${pct(shutouts)}`,
+  );
+  console.log(
+    `  mean home ${per(homePoints)}  mean away ${per(awayPoints)}  TOTAL ${per(homePoints + awayPoints)}`,
+  );
+  console.log(`  scrimmage plays/game ${per(scrimmagePlays)}`);
 }
 
-// Control: identical rosters on both sides means any asymmetry is the engine's,
-// not the harness's. Verify the two rosters really are identical first.
-const a=roster("home",70), b=roster("away",70);
-const sameOveralls = a.every((p,i)=>p.overall===b[i].overall && p.position===b[i].position);
-console.log(`  rosters identical (overall+position): ${sameOveralls}`);
-console.log(`EVEN 70v70 over ${n} seeds:`);
-console.log(`  home wins ${homeWins} (${(homeWins/n*100).toFixed(1)}%)  away wins ${awayWins} (${(awayWins/n*100).toFixed(1)}%)  ties ${ties}`);
-console.log(`  mean home ${(hs/n).toFixed(1)}  mean away ${(as/n).toFixed(1)}  mean total ${((hs+as)/n).toFixed(1)}`);
-console.log(`  games with a shutout: ${shutouts} (${(shutouts/n*100).toFixed(1)}%)`);
+const a = roster("home", 70);
+const b = roster("away", 70);
+const identical = a.every(
+  (p, i) => p.overall === b[i].overall && p.position === b[i].position,
+);
+console.log(`EVEN 70v70 over ${GAMES} seeds`);
+console.log(`rosters identical (overall + position): ${identical}`);
+console.log(`targets: home win 52-60%, |mean home - mean away| <= 3, total 30-60`);
+
+report("v1 — FROZEN, no gates (pinned by golden parity)", undefined);
+report("+ situational (A3 clock and decisions)", { situational: true });
+report("+ situational + balance (#642 fix)", {
+  situational: true,
+  balance: true,
+});
+report("all A gates", {
+  situational: true,
+  balance: true,
+  scoringV2: true,
+  penalties: true,
+});

--- a/apps/web/src/lib/gamecast/box-score.ts
+++ b/apps/web/src/lib/gamecast/box-score.ts
@@ -33,6 +33,9 @@ const SCRIMMAGE_PLAY_TYPES = new Set<PbpPlayType>([
   "sack",
   "interception",
   "kneel",
+  // A spike is a snap that used a down, so it counts like a kneel does. A
+  // timeout is not a play and an onside kick is not from scrimmage.
+  "spike",
 ]);
 
 function emptyLine(modelsPenalties: boolean): TeamBoxScoreLine {

--- a/apps/web/src/lib/gamecast/play-text.ts
+++ b/apps/web/src/lib/gamecast/play-text.ts
@@ -23,6 +23,16 @@ export function formatDownAndDistance(play: PbpPlay): string {
   }
   if (play.playType === "punt") return "Punt";
   if (play.playType === "kneel") return "Kneel";
+  /*
+   * Plays with no down of their own. Without these they render as "0th & 0",
+   * because `down` is 0 on a kick and a timeout happens between downs.
+   */
+  if (play.playType === "onside_kick") return "Onside kick";
+  if (play.playType === "safety") return "Safety";
+  if (play.playType === "timeout") return "Timeout";
+  if (play.playType === "two_point_convert" || play.playType === "two_point_fail") {
+    return "Two-point try";
+  }
   return `${ordinalDown(play.down)} & ${play.distance}`;
 }
 
@@ -53,6 +63,25 @@ export function describePlay(play: PbpPlay): string {
       return "Extra point NO GOOD";
     case "kneel":
       return `Kneel, ${yards}`;
+    /*
+     * v2 play types. The `default` below renders raw yardage, which for a
+     * timeout reads "no gain" and for an onside kick reads "10 yd gain" —
+     * technically true and completely useless. Each of these needs its own
+     * sentence.
+     */
+    case "safety":
+      return "Safety";
+    case "two_point_convert":
+      return "Two-point conversion GOOD";
+    case "two_point_fail":
+      return "Two-point conversion NO GOOD";
+    case "onside_kick":
+      // `isTurnover` is false exactly when the kicking team kept the ball.
+      return play.isTurnover ? "Onside kick recovered by receiving team" : "Onside kick RECOVERED";
+    case "spike":
+      return "Spiked to stop the clock";
+    case "timeout":
+      return "Timeout";
     default:
       return yards;
   }

--- a/apps/web/src/lib/pbp/__tests__/situational.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/situational.test.ts
@@ -1,0 +1,587 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import {
+  clockStrategy,
+  fourthDownDecision,
+  runoffSeconds,
+  secondsLeftInGame,
+  secondsLeftInHalf,
+  shouldOnside,
+  shouldSpike,
+  shouldUseTimeout,
+  type FourthDownInput,
+} from "../situational";
+import type {
+  PbpFeatureGates,
+  PbpGameInput,
+  PbpPlay,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2],
+    ["RB", 3],
+    ["WR", 5],
+    ["TE", 2],
+    ["DE", 2],
+    ["DT", 2],
+    ["OLB", 2],
+    ["MLB", 2],
+    ["CB", 3],
+    ["S", 2],
+    ["K", 1],
+    ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return players;
+}
+
+function buildTeam(
+  teamId: string,
+  strength: number,
+  aggression?: number,
+): TeamSimProfile {
+  return {
+    teamId,
+    strength,
+    players: buildRoster(teamId, strength),
+    ...(aggression === undefined ? {} : { coach: { aggression } }),
+  };
+}
+
+const SITUATIONAL: PbpFeatureGates = { situational: true };
+
+function gameInput(overrides: Partial<PbpGameInput> = {}): PbpGameInput {
+  return {
+    home: buildTeam("home", 70),
+    away: buildTeam("away", 70),
+    seed: 4242,
+    flavor: "balanced",
+    ...overrides,
+  };
+}
+
+function allPlays(log: ReturnType<typeof simulateGameLog>): PbpPlay[] {
+  return log.drives.flatMap((d) => d.plays);
+}
+
+function simulateMany(
+  count: number,
+  features: PbpFeatureGates | undefined,
+  seedBase = 7000,
+  overrides: Partial<PbpGameInput> = {},
+): PbpPlay[] {
+  const out: PbpPlay[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push(
+      ...allPlays(
+        simulateGameLog({
+          ...gameInput({ seed: seedBase + i, ...overrides }),
+          features,
+        }),
+      ),
+    );
+  }
+  return out;
+}
+
+function fourthDown(overrides: Partial<FourthDownInput> = {}): FourthDownInput {
+  return {
+    yardsToGo: 5,
+    yardsToGoal: 55,
+    scoreDiff: 0,
+    quarter: 2,
+    clockSeconds: 400,
+    isOvertime: false,
+    aggression: 50,
+    ...overrides,
+  };
+}
+
+describe("clock arithmetic", () => {
+  it("counts remaining regulation across quarters", () => {
+    expect(secondsLeftInGame(1, 720, false)).toBe(720 * 4);
+    expect(secondsLeftInGame(4, 90, false)).toBe(90);
+    // Overtime has no later quarter to defer to, so everything is urgent.
+    expect(secondsLeftInGame(5, 300, true)).toBe(0);
+  });
+
+  it("counts to the end of the current half, not the game", () => {
+    expect(secondsLeftInHalf(1, 720, false)).toBe(1440);
+    expect(secondsLeftInHalf(2, 100, false)).toBe(100);
+    // Q3 keys on the END of the game, which is the end of its half.
+    expect(secondsLeftInHalf(3, 720, false)).toBe(1440);
+    expect(secondsLeftInHalf(4, 100, false)).toBe(100);
+  });
+});
+
+describe("fourthDownDecision", () => {
+  it("punts on 4th and long from deep in its own end", () => {
+    expect(fourthDownDecision(fourthDown({ yardsToGo: 9, yardsToGoal: 80 }))).toBe(
+      "punt",
+    );
+  });
+
+  it("kicks from field goal range on 4th and long", () => {
+    expect(fourthDownDecision(fourthDown({ yardsToGo: 8, yardsToGoal: 25 }))).toBe(
+      "field_goal",
+    );
+  });
+
+  it("goes for it on 4th and inches near midfield", () => {
+    expect(fourthDownDecision(fourthDown({ yardsToGo: 1, yardsToGoal: 45 }))).toBe(
+      "go",
+    );
+  });
+
+  it("goes for it on 4th and goal from the 2 rather than kicking", () => {
+    // A chip shot is nearly free either way, so the bar to go is low.
+    expect(fourthDownDecision(fourthDown({ yardsToGo: 2, yardsToGoal: 2 }))).toBe(
+      "go",
+    );
+  });
+
+  it("a trailing team late goes for it far more often than a leading one", () => {
+    // The headline behavior: same field position, same distance, opposite
+    // score. This is the whole reason the slice exists.
+    let trailingGoes = 0;
+    let leadingGoes = 0;
+    for (let yardsToGo = 1; yardsToGo <= 10; yardsToGo++) {
+      for (const yardsToGoal of [20, 40, 55, 70]) {
+        const base = {
+          yardsToGo,
+          yardsToGoal,
+          quarter: 4,
+          clockSeconds: 100,
+          isOvertime: false,
+          aggression: 50,
+        };
+        if (fourthDownDecision({ ...base, scoreDiff: -10 }) === "go") {
+          trailingGoes += 1;
+        }
+        if (fourthDownDecision({ ...base, scoreDiff: 10 }) === "go") {
+          leadingGoes += 1;
+        }
+      }
+    }
+    expect(trailingGoes).toBeGreaterThan(leadingGoes * 2);
+  });
+
+  it("never punts while trailing in the last two minutes", () => {
+    // A punt cannot win the game; it can only hand the ball back with less
+    // time on the clock than you had.
+    for (let yardsToGo = 1; yardsToGo <= 20; yardsToGo++) {
+      for (const yardsToGoal of [15, 30, 50, 75, 95]) {
+        const call = fourthDownDecision({
+          yardsToGo,
+          yardsToGoal,
+          scoreDiff: -7,
+          quarter: 4,
+          clockSeconds: 90,
+          isOvertime: false,
+          aggression: 50,
+        });
+        expect(call).not.toBe("punt");
+      }
+    }
+  });
+
+  it("takes the tying field goal when three points are enough", () => {
+    expect(
+      fourthDownDecision({
+        yardsToGo: 6,
+        yardsToGoal: 20,
+        scoreDiff: -3,
+        quarter: 4,
+        clockSeconds: 20,
+        isOvertime: false,
+        aggression: 50,
+      }),
+    ).toBe("field_goal");
+  });
+
+  it("does not kick a field goal that leaves it still losing", () => {
+    // Down 7 with 20 seconds left, three points is a rounding error.
+    expect(
+      fourthDownDecision({
+        yardsToGo: 6,
+        yardsToGoal: 20,
+        scoreDiff: -7,
+        quarter: 4,
+        clockSeconds: 20,
+        isOvertime: false,
+        aggression: 50,
+      }),
+    ).toBe("go");
+  });
+
+  it("is monotonic in aggression — a bolder coach never goes for it less", () => {
+    for (let yardsToGo = 1; yardsToGo <= 12; yardsToGo++) {
+      for (const yardsToGoal of [10, 30, 45, 60, 85]) {
+        let sawGo = false;
+        for (const aggression of [0, 25, 50, 75, 100]) {
+          const goes =
+            fourthDownDecision(
+              fourthDown({ yardsToGo, yardsToGoal, aggression }),
+            ) === "go";
+          if (sawGo) expect(goes).toBe(true);
+          if (goes) sawGo = true;
+        }
+      }
+    }
+  });
+
+  it("is deterministic", () => {
+    const input = fourthDown({ yardsToGo: 3, yardsToGoal: 42 });
+    const first = fourthDownDecision(input);
+    for (let i = 0; i < 20; i++) {
+      expect(fourthDownDecision(input)).toBe(first);
+    }
+  });
+});
+
+describe("shouldOnside", () => {
+  it("never onsides while level or ahead", () => {
+    for (const scoreDiff of [0, 3, 14]) {
+      expect(
+        shouldOnside({ scoreDiff, quarter: 4, clockSeconds: 40, isOvertime: false }),
+      ).toBe(false);
+    }
+  });
+
+  it("onsides while trailing inside two minutes", () => {
+    expect(
+      shouldOnside({ scoreDiff: -6, quarter: 4, clockSeconds: 90, isOvertime: false }),
+    ).toBe(true);
+  });
+
+  it("starts earlier when two possessions behind", () => {
+    const base = { quarter: 4, clockSeconds: 200, isOvertime: false };
+    expect(shouldOnside({ ...base, scoreDiff: -6 })).toBe(false);
+    expect(shouldOnside({ ...base, scoreDiff: -14 })).toBe(true);
+  });
+
+  it("never onsides in the first half", () => {
+    expect(
+      shouldOnside({ scoreDiff: -20, quarter: 1, clockSeconds: 60, isOvertime: false }),
+    ).toBe(false);
+  });
+});
+
+describe("clockStrategy", () => {
+  it("hurries at the end of the first half regardless of score", () => {
+    for (const scoreDiff of [-7, 0, 7]) {
+      expect(
+        clockStrategy({ scoreDiff, quarter: 2, clockSeconds: 60, isOvertime: false }),
+      ).toBe("hurry_up");
+    }
+  });
+
+  it("hurries late only when it needs points", () => {
+    expect(
+      clockStrategy({ scoreDiff: -4, quarter: 4, clockSeconds: 90, isOvertime: false }),
+    ).toBe("hurry_up");
+    expect(
+      clockStrategy({ scoreDiff: 4, quarter: 4, clockSeconds: 90, isOvertime: false }),
+    ).toBe("burn");
+  });
+
+  it("is normal in the middle of the game", () => {
+    expect(
+      clockStrategy({ scoreDiff: 0, quarter: 2, clockSeconds: 600, isOvertime: false }),
+    ).toBe("normal");
+  });
+});
+
+describe("runoffSeconds", () => {
+  it("charges nothing when the clock is stopped", () => {
+    for (const s of ["normal", "hurry_up", "burn"] as const) {
+      expect(runoffSeconds(s, true)).toBe(0);
+    }
+  });
+
+  it("orders hurry-up below normal below burn", () => {
+    expect(runoffSeconds("hurry_up", false)).toBeLessThan(
+      runoffSeconds("normal", false),
+    );
+    expect(runoffSeconds("normal", false)).toBeLessThan(
+      runoffSeconds("burn", false),
+    );
+  });
+});
+
+describe("shouldSpike", () => {
+  const base = {
+    strategy: "hurry_up" as const,
+    secondsLeftInHalf: 25,
+    down: 2,
+    timeoutsRemaining: 0,
+    clockStopped: false,
+  };
+
+  it("spikes with no timeouts left and the clock running out", () => {
+    expect(shouldSpike(base)).toBe(true);
+  });
+
+  it("uses the timeout instead when it still has one", () => {
+    expect(shouldSpike({ ...base, timeoutsRemaining: 2 })).toBe(false);
+  });
+
+  it("never spikes on 4th down — that surrenders the ball to save seconds", () => {
+    expect(shouldSpike({ ...base, down: 4 })).toBe(false);
+  });
+
+  it("never spikes when the clock is already stopped", () => {
+    expect(shouldSpike({ ...base, clockStopped: true })).toBe(false);
+  });
+});
+
+describe("shouldUseTimeout", () => {
+  const offense = {
+    isOffense: true,
+    scoreDiff: -3,
+    secondsLeftInHalf: 60,
+    secondsLeftInGame: 60,
+    quarter: 4,
+    timeoutsRemaining: 2,
+    clockStopped: false,
+  };
+
+  it("never spends one it does not have", () => {
+    expect(shouldUseTimeout({ ...offense, timeoutsRemaining: 0 })).toBe(false);
+  });
+
+  it("never spends one while the clock is already stopped", () => {
+    expect(shouldUseTimeout({ ...offense, clockStopped: true })).toBe(false);
+  });
+
+  it("is spent by a trailing offense late", () => {
+    expect(shouldUseTimeout(offense)).toBe(true);
+  });
+
+  it("is not spent by a leading offense late — it wants the clock running", () => {
+    expect(shouldUseTimeout({ ...offense, scoreDiff: 7 })).toBe(false);
+  });
+
+  it("is spent by a trailing defense inside two minutes", () => {
+    expect(
+      shouldUseTimeout({
+        isOffense: false,
+        scoreDiff: -5,
+        secondsLeftInHalf: 80,
+        secondsLeftInGame: 80,
+        quarter: 4,
+        timeoutsRemaining: 3,
+        clockStopped: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("situational gate in the engine", () => {
+  it("emits no A3 play type while the gate is off", () => {
+    const plays = simulateMany(20, undefined, 8000);
+    const v2Only = plays.filter((p) =>
+      ["spike", "timeout", "onside_kick"].includes(p.playType),
+    );
+    expect(v2Only).toEqual([]);
+    expect(plays.some((p) => p.tempo !== undefined)).toBe(false);
+  });
+
+  it("makes every A3 mechanic reachable across seeded games", () => {
+    /*
+     * A mechanic that can never fire is not implemented. This is the same
+     * reachability discipline A1 adopted after safeties turned out to be
+     * geometrically impossible.
+     */
+    const plays = simulateMany(120, SITUATIONAL, 12000);
+    expect(plays.filter((p) => p.playType === "spike").length).toBeGreaterThan(0);
+    expect(plays.filter((p) => p.playType === "timeout").length).toBeGreaterThan(0);
+    expect(
+      plays.filter((p) => p.playType === "onside_kick").length,
+    ).toBeGreaterThan(0);
+    expect(plays.filter((p) => p.tempo === "hurry_up").length).toBeGreaterThan(0);
+    expect(plays.filter((p) => p.tempo === "burn").length).toBeGreaterThan(0);
+  });
+
+  it("never gives a team more than three timeouts in a half", () => {
+    /*
+     * The pool is per half, so counting timeout plays per (team, half) is the
+     * direct assertion. An off-by-one in the reset would show up here as a
+     * fourth timeout rather than as a negative counter, which is why this
+     * counts events rather than reading engine state.
+     */
+    for (let i = 0; i < 200; i++) {
+      const log = simulateGameLog({
+        ...gameInput({ seed: 15000 + i }),
+        features: SITUATIONAL,
+      });
+      const counts = new Map<string, number>();
+      for (const play of allPlays(log)) {
+        if (play.playType !== "timeout") continue;
+        expect(play.timeoutTeamId).toBeDefined();
+        // Overtime carries its own smaller pool, so key it separately.
+        const period =
+          play.quarter >= 5 ? `ot${play.quarter}` : play.quarter <= 2 ? "h1" : "h2";
+        const key = `${play.timeoutTeamId}:${period}`;
+        const next = (counts.get(key) ?? 0) + 1;
+        counts.set(key, next);
+        expect(next).toBeLessThanOrEqual(period.startsWith("ot") ? 1 : 3);
+      }
+    }
+  });
+
+  it("keeps the clock and quarter monotonic, and never runs it on a timeout", () => {
+    for (let i = 0; i < 200; i++) {
+      const log = simulateGameLog({
+        ...gameInput({ seed: 16000 + i }),
+        features: SITUATIONAL,
+      });
+      const plays = allPlays(log);
+      for (let p = 1; p < plays.length; p++) {
+        const prev = plays[p - 1];
+        const play = plays[p];
+        expect(play.quarter).toBeGreaterThanOrEqual(prev.quarter);
+        if (play.quarter === prev.quarter) {
+          expect(play.clockSeconds).toBeLessThanOrEqual(prev.clockSeconds);
+        }
+        // A timeout stops the clock: the next play starts at the same second.
+        if (prev.playType === "timeout" && play.quarter === prev.quarter) {
+          expect(play.clockSeconds).toBe(prev.clockSeconds);
+        }
+        expect(play.clockSeconds).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("runs more plays than v1 in the same game", () => {
+    // The clock model is the point: v1 charged a full huddle cycle even to an
+    // incompletion, which is what capped the number of snaps.
+    const v1 = simulateMany(40, undefined, 17000).length;
+    const v2 = simulateMany(40, SITUATIONAL, 17000).length;
+    expect(v2).toBeGreaterThan(v1);
+  });
+
+  it("lets a bold coach go for it more than a timid one", () => {
+    const count = (aggression: number) => {
+      let fourthDownGoes = 0;
+      for (let i = 0; i < 60; i++) {
+        const log = simulateGameLog({
+          home: buildTeam("home", 70, aggression),
+          away: buildTeam("away", 70, aggression),
+          seed: 18000 + i,
+          flavor: "balanced",
+          features: SITUATIONAL,
+        });
+        for (const play of allPlays(log)) {
+          if (
+            play.down === 4 &&
+            ["rush", "pass_complete", "pass_incomplete", "sack", "interception"].includes(
+              play.playType,
+            )
+          ) {
+            fourthDownGoes += 1;
+          }
+        }
+      }
+      return fourthDownGoes;
+    };
+    expect(count(95)).toBeGreaterThan(count(5));
+  });
+});
+
+describe("balance gate (#642)", () => {
+  /*
+   * Two identical rosters. Any asymmetry in the result is the engine's, and the
+   * point of this gate is that the measured home advantage should match the
+   * constant that claims to produce it.
+   */
+  function evenSeries(features: PbpFeatureGates | undefined, games: number) {
+    let homeWins = 0;
+    let awayWins = 0;
+    let homePoints = 0;
+    let awayPoints = 0;
+    for (let i = 0; i < games; i++) {
+      const log = simulateGameLog({
+        home: buildTeam("home", 70),
+        away: buildTeam("away", 70),
+        seed: 1000 + i,
+        flavor: "balanced",
+        features,
+      });
+      homePoints += log.homeScore;
+      awayPoints += log.awayScore;
+      if (log.homeScore > log.awayScore) homeWins += 1;
+      else if (log.awayScore > log.homeScore) awayWins += 1;
+    }
+    return {
+      homeWinRate: homeWins / games,
+      awayWinRate: awayWins / games,
+      meanHome: homePoints / games,
+      meanAway: awayPoints / games,
+      meanTotal: (homePoints + awayPoints) / games,
+    };
+  }
+
+  it("documents the v1 numbers this gate exists to correct", () => {
+    // Not a target — a pin. v1 is frozen so that already-simulated fixtures
+    // stay reproducible, so these numbers must NOT drift silently.
+    const v1 = evenSeries(undefined, 300);
+    expect(v1.homeWinRate).toBeGreaterThan(0.63);
+    expect(v1.meanTotal).toBeLessThan(28);
+  });
+
+  it("brings the home win rate back to what a small edge implies", () => {
+    const full = evenSeries(
+      { situational: true, balance: true, scoringV2: true, penalties: true },
+      300,
+    );
+    expect(full.homeWinRate).toBeGreaterThan(0.52);
+    expect(full.homeWinRate).toBeLessThan(0.6);
+    expect(Math.abs(full.meanHome - full.meanAway)).toBeLessThan(3);
+  });
+
+  it("lands mean total points inside the design band of 30-60", () => {
+    const full = evenSeries(
+      { situational: true, balance: true, scoringV2: true, penalties: true },
+      300,
+    );
+    expect(full.meanTotal).toBeGreaterThan(30);
+    expect(full.meanTotal).toBeLessThan(60);
+  });
+
+  it("still favors the stronger team", () => {
+    // Recalibrating home field must not flatten actual quality differences.
+    let strongWins = 0;
+    const games = 200;
+    for (let i = 0; i < games; i++) {
+      const log = simulateGameLog({
+        home: buildTeam("home", 55),
+        away: buildTeam("away", 85),
+        seed: 21000 + i,
+        flavor: "balanced",
+        features: { situational: true, balance: true },
+      });
+      if (log.awayScore > log.homeScore) strongWins += 1;
+    }
+    expect(strongWins / games).toBeGreaterThan(0.65);
+  });
+});

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -5,6 +5,18 @@ import {
   weightsForFlavor,
 } from "@/lib/simulation-flavor";
 import { acceptOrDecline, meanAwareness, rollPenalty } from "./penalties";
+import {
+  NEUTRAL_AGGRESSION,
+  clockStrategy,
+  fourthDownDecision,
+  runoffSeconds,
+  secondsLeftInGame,
+  secondsLeftInHalf,
+  shouldOnside,
+  shouldSpike,
+  shouldUseTimeout,
+  type ClockStrategy,
+} from "./situational";
 import type {
   PbpFeatureGates,
   PbpDrive,
@@ -23,7 +35,25 @@ import type {
 const QUARTER_SECONDS = 720;
 const OT_SECONDS = 300;
 const HOME_FIELD_EDGE = 2.5;
+/*
+ * Recalibrated home-field weight (A3, gated by `features.balance`; issue #642).
+ *
+ * The 2.5 above is not "2.5 points" — it is a strength bonus that flows into
+ * `matchupEdge`, which then biases explosive-play rate, yardage, touchdown
+ * probability, completion rate, sack rate, interception rate, field-goal
+ * accuracy, kick returns and punt distance. Eight channels, every play. The
+ * measured result was a 6.2-point average margin and a 67.3% home win rate for
+ * two identical rosters, which is not a nudge, it is a decision.
+ *
+ * The constant is scaled down until the OUTPUT matches what the input claims.
+ * `scripts/dist-check.ts` is the instrument; re-run it if you touch this.
+ */
+const HOME_FIELD_EDGE_V2 = 0.75;
 const BASELINE_STRENGTH = 50;
+
+/** HS overtime: one timeout per period, not the three a half carries. */
+const TIMEOUTS_PER_HALF = 3;
+const TIMEOUTS_PER_OVERTIME = 1;
 
 const POSITION_TO_GROUP: Record<string, SimPositionGroup> = {
   QB: "QB",
@@ -64,6 +94,8 @@ interface GameState {
   away: TeamSimProfile;
   strengthWeight: number;
   edgeScale: number;
+  /** `HOME_FIELD_EDGE`, or the recalibrated value under `features.balance`. */
+  homeFieldEdge: number;
   decisive: boolean;
   quarter: number;
   clockSeconds: number;
@@ -86,6 +118,31 @@ interface GameState {
   gameOver: boolean;
   openingKickDone: boolean;
   secondHalfKickPending: boolean;
+  /*
+   * ── A3 clock and timeout state ──────────────────────────────────────────
+   *
+   * Only read inside `features.situational` branches. They are always present
+   * on the state (rather than optional) so the type stays simple; when the gate
+   * is off nothing reads them and nothing writes them except the resets.
+   */
+  homeTimeouts: number;
+  awayTimeouts: number;
+  /**
+   * Did the last play leave the clock stopped?
+   *
+   * This is what makes a timeout physical rather than a resource dump: you can
+   * only spend one while the clock is actually running, so a team cannot burn
+   * all three between two snaps.
+   */
+  clockStopped: boolean;
+  /**
+   * Tempo to stamp on the next recorded play, or null.
+   *
+   * Set just before a play runs rather than patched on afterwards, because a
+   * scoring play calls `endDrive` and moves itself out of `currentDrivePlays` —
+   * so there is no reliable index to write back to once the play has happened.
+   */
+  pendingTempo: "hurry_up" | "burn" | null;
 }
 
 function positionGroup(position: string): SimPositionGroup | null {
@@ -113,8 +170,9 @@ function effectiveStrength(
   isHome: boolean,
   oppStrength: number,
   strengthWeight: number,
+  homeFieldEdge: number,
 ): number {
-  const homeEdge = isHome ? HOME_FIELD_EDGE / strengthWeight : 0;
+  const homeEdge = isHome ? homeFieldEdge / strengthWeight : 0;
   return team.strength + (team.strength - oppStrength) * 0.15 + homeEdge;
 }
 
@@ -127,14 +185,90 @@ function matchupEdge(state: GameState): number {
     offIsHome,
     def.strength,
     state.strengthWeight,
+    state.homeFieldEdge,
   );
   const defEff = effectiveStrength(
     def,
     !offIsHome,
     off.strength,
     state.strengthWeight,
+    state.homeFieldEdge,
   );
   return ((offEff - defEff) / 99) * state.edgeScale;
+}
+
+/*
+ * ── A3 situational helpers ──────────────────────────────────────────────────
+ */
+
+/** Score from the possessing team's point of view. */
+function offenseScoreDiff(state: GameState): number {
+  return state.possession === "home"
+    ? state.homeScore - state.awayScore
+    : state.awayScore - state.homeScore;
+}
+
+function coachAggression(team: TeamSimProfile): number {
+  const value = team.coach?.aggression;
+  return typeof value === "number" ? value : NEUTRAL_AGGRESSION;
+}
+
+function timeoutsFor(state: GameState, side: "home" | "away"): number {
+  return side === "home" ? state.homeTimeouts : state.awayTimeouts;
+}
+
+function spendTimeout(state: GameState, side: "home" | "away"): void {
+  if (side === "home") state.homeTimeouts = Math.max(0, state.homeTimeouts - 1);
+  else state.awayTimeouts = Math.max(0, state.awayTimeouts - 1);
+}
+
+function currentClockStrategy(state: GameState): ClockStrategy {
+  return clockStrategy({
+    scoreDiff: offenseScoreDiff(state),
+    quarter: state.quarter,
+    clockSeconds: state.clockSeconds,
+    isOvertime: state.inOvertime,
+  });
+}
+
+/**
+ * Charge the clock for a single play.
+ *
+ * With the gate off this is v1 verbatim — one draw, same expression, same
+ * range — so parity is untouched. With it on, the SAME single draw becomes the
+ * snap-to-whistle duration only, and the huddle and play clock that follow are
+ * charged separately (and skipped entirely when the clock stops). Keeping the
+ * draw count identical either way means enabling `situational` changes how long
+ * plays take without changing which plays happen for a given sequence position.
+ */
+function tickPlayClock(
+  state: GameState,
+  base: number,
+  spread: number,
+  stopsClock: boolean,
+): void {
+  const roll = state.rand();
+  if (!state.features.situational) {
+    tickClock(state, Math.round(base + roll * spread));
+    return;
+  }
+  state.clockStopped = stopsClock;
+  tickClock(state, Math.round(4 + roll * 5));
+}
+
+/** Clock charge for a play with no random component (kicks, kneels). */
+function tickFixedClock(
+  state: GameState,
+  v1Seconds: number,
+  v2Seconds: number,
+  stopsClock: boolean,
+): void {
+  if (!state.features.situational) {
+    tickClock(state, v1Seconds);
+    return;
+  }
+  state.clockStopped = stopsClock;
+  tickClock(state, v2Seconds);
 }
 
 function clamp(n: number, min: number, max: number): number {
@@ -248,6 +382,12 @@ function endDrive(state: GameState, reason: PbpDriveEndReason): void {
 }
 
 function recordPlay(state: GameState, play: PbpPlay): void {
+  if (state.pendingTempo) {
+    play.tempo = state.pendingTempo;
+    // Stamp the snap itself, not the extra point and kickoff that a touchdown
+    // pulls in behind it.
+    state.pendingTempo = null;
+  }
   state.currentDrivePlays.push(play);
   state.playId += 1;
 }
@@ -271,14 +411,28 @@ function shouldKneel(state: GameState): boolean {
   return winning && state.clockSeconds <= 120 && state.quarter >= 4;
 }
 
+/**
+ * Refill timeouts.
+ *
+ * Called at the start of each half and each overtime period. It ASSIGNS rather
+ * than adds, so unspent timeouts do not carry over — which is both the rule and
+ * what keeps the per-half count exactly 3.
+ */
+function resetTimeouts(state: GameState, count: number): void {
+  state.homeTimeouts = count;
+  state.awayTimeouts = count;
+}
+
 function advanceQuarter(state: GameState): void {
   if (state.inOvertime) {
     state.otPeriod += 1;
     state.clockSeconds = OT_SECONDS;
+    resetTimeouts(state, TIMEOUTS_PER_OVERTIME);
     return;
   }
   if (state.quarter === 2) {
     state.secondHalfKickPending = true;
+    resetTimeouts(state, TIMEOUTS_PER_HALF);
   }
   state.quarter += 1;
   state.clockSeconds = QUARTER_SECONDS;
@@ -307,6 +461,7 @@ function checkPeriodEnd(state: GameState): void {
       state.otPeriod = 1;
       state.quarter = 5;
       state.clockSeconds = OT_SECONDS;
+      resetTimeouts(state, TIMEOUTS_PER_OVERTIME);
       doKickoff(state, state.possession === "home" ? "away" : "home");
       return;
     }
@@ -321,7 +476,69 @@ function checkPeriodEnd(state: GameState): void {
   }
 }
 
+/**
+ * Onside kick (A3). Recovered, the kicking team keeps the ball at its own 45;
+ * failed, the receiving team takes over there — a real cost, which is why
+ * `shouldOnside` only says yes when giving the ball back loses anyway.
+ */
+function doOnsideKick(state: GameState, kicking: "home" | "away"): void {
+  const kickingTeam = kicking === "home" ? state.home : state.away;
+  const receiving = kicking === "home" ? state.away : state.home;
+  const kicker = selectPlayer(kickingTeam, "K", state.rand);
+  const recovered = state.rand() < 0.15;
+
+  startDrive(state, kickingTeam.teamId, 35);
+  recordPlay(state, {
+    playId: state.playId,
+    driveId: state.driveId,
+    quarter: state.quarter,
+    clockSeconds: state.clockSeconds,
+    offenseTeamId: kickingTeam.teamId,
+    defenseTeamId: receiving.teamId,
+    playType: "onside_kick",
+    down: 0,
+    distance: 0,
+    fieldPosition: 35,
+    yardsGained: 10,
+    isScoring: false,
+    pointsScored: 0,
+    // A recovery means possession did NOT change hands, which is the whole
+    // point of the play.
+    isTurnover: !recovered,
+    participants: [participant(kicker, kickingTeam.teamId, "kicker")],
+  });
+  tickFixedClock(state, 6, 6, true);
+  endDrive(state, "turnover");
+
+  if (recovered) {
+    state.possession = kicking;
+    startDrive(state, kickingTeam.teamId, 45);
+  } else {
+    state.possession = kicking === "home" ? "away" : "home";
+    startDrive(state, receiving.teamId, 55);
+  }
+  state.openingKickDone = true;
+}
+
 function doKickoff(state: GameState, kicking: "home" | "away"): void {
+  if (state.features.situational) {
+    const kickingScore =
+      kicking === "home"
+        ? state.homeScore - state.awayScore
+        : state.awayScore - state.homeScore;
+    if (
+      shouldOnside({
+        scoreDiff: kickingScore,
+        quarter: state.quarter,
+        clockSeconds: state.clockSeconds,
+        isOvertime: state.inOvertime,
+      })
+    ) {
+      doOnsideKick(state, kicking);
+      return;
+    }
+  }
+
   const kickingTeam = kicking === "home" ? state.home : state.away;
   const receiving = kicking === "home" ? state.away : state.home;
   const kicker = selectPlayer(kickingTeam, "K", state.rand);
@@ -352,7 +569,7 @@ function doKickoff(state: GameState, kicking: "home" | "away"): void {
     ],
   };
   recordPlay(state, play);
-  tickClock(state, 6);
+  tickFixedClock(state, 6, 6, true);
   endDrive(state, "turnover");
 
   state.possession = kicking === "home" ? "away" : "home";
@@ -392,7 +609,7 @@ function doExtraPoint(state: GameState): void {
     else state.awayScore += 1;
     if (state.inOvertime) state.gameOver = true;
   }
-  tickClock(state, 4);
+  tickFixedClock(state, 4, 4, true);
 }
 
 function doFieldGoalAttempt(state: GameState): void {
@@ -423,7 +640,7 @@ function doFieldGoalAttempt(state: GameState): void {
     participants: [participant(kicker, off.teamId, "kicker")],
   };
   recordPlay(state, play);
-  tickClock(state, 5);
+  tickFixedClock(state, 5, 5, true);
 
   if (made) {
     if (state.possession === "home") state.homeScore += 3;
@@ -481,7 +698,7 @@ function doPunt(state: GameState): void {
     ],
   };
   recordPlay(state, play);
-  tickClock(state, 7);
+  tickFixedClock(state, 7, 7, true);
   endDrive(state, "punt");
   flipPossession(state);
   startDrive(state, offenseTeamId(state), newField);
@@ -545,7 +762,7 @@ function doRush(state: GameState): void {
     participants,
   };
   recordPlay(state, play);
-  tickClock(state, Math.round(22 + state.rand() * 18));
+  tickPlayClock(state, 22, 18, isTurnover || isScoring);
   applyPlayResult(state, yards, isScoring, points, isTurnover, play);
 }
 
@@ -594,13 +811,13 @@ function doPass(state: GameState): void {
       play.participants.push(participant(passer, off.teamId, "fumbler"));
       play.participants.push(participant(recoverer, def.teamId, "recoverer"));
       recordPlay(state, play);
-      tickClock(state, Math.round(24 + state.rand() * 12));
+      tickPlayClock(state, 24, 12, true);
       applyPlayResult(state, yards, false, 0, true, play);
       return;
     }
 
     recordPlay(state, play);
-    tickClock(state, Math.round(24 + state.rand() * 12));
+    tickPlayClock(state, 24, 12, false);
     applyPlayResult(state, yards, false, 0, false, play);
     return;
   }
@@ -640,7 +857,7 @@ function doPass(state: GameState): void {
       play.defensivePoints = 6;
       awardDefensivePoints(state, 6);
       recordPlay(state, play);
-      tickClock(state, Math.round(20 + state.rand() * 10));
+      tickPlayClock(state, 20, 10, true);
       endDrive(state, "turnover");
       // The scoring defense now kicks off to the team that threw it.
       doKickoff(state, state.possession === "home" ? "away" : "home");
@@ -649,7 +866,7 @@ function doPass(state: GameState): void {
 
     if (state.features.scoringV2) play.returnYards = returnYards;
     recordPlay(state, play);
-    tickClock(state, Math.round(20 + state.rand() * 10));
+    tickPlayClock(state, 20, 10, true);
     endDrive(state, "turnover");
     flipPossession(state);
     const spot = clamp(100 - state.fieldPosition + returnYards, 15, 85);
@@ -684,7 +901,7 @@ function doPass(state: GameState): void {
       participants,
     };
     recordPlay(state, play);
-    tickClock(state, Math.round(18 + state.rand() * 10));
+    tickPlayClock(state, 18, 10, true);
     applyPlayResult(state, 0, false, 0, false);
     return;
   }
@@ -731,7 +948,7 @@ function doPass(state: GameState): void {
     participants,
   };
   recordPlay(state, play);
-  tickClock(state, Math.round(20 + state.rand() * 18));
+  tickPlayClock(state, 20, 18, isScoring);
   applyPlayResult(state, yards, isScoring, points, false, play);
 }
 
@@ -757,7 +974,7 @@ function doKneel(state: GameState): void {
     participants: [participant(rusher, off.teamId, "rusher")],
   };
   recordPlay(state, play);
-  tickClock(state, 38);
+  tickFixedClock(state, 38, 2, false);
   applyPlayResult(state, -1, false, 0, false);
 }
 
@@ -806,7 +1023,7 @@ function doSafety(state: GameState): void {
     participants: [participant(tackler, def.teamId, "tackler_solo")],
   });
 
-  tickClock(state, 6);
+  tickFixedClock(state, 6, 6, true);
   endDrive(state, "turnover");
   // The conceding team free-kicks, so possession passes to the scoring side.
   flipPossession(state);
@@ -862,7 +1079,7 @@ function doTwoPointConversion(state: GameState): void {
       participant(target, off.teamId, "receiver"),
     ],
   });
-  tickClock(state, 5);
+  tickFixedClock(state, 5, 5, true);
 }
 
 /**
@@ -969,6 +1186,8 @@ function applyPlayResult(
         1,
         99,
       );
+      // A flag stops the clock, so the next snap pays no huddle runoff (A3).
+      state.clockStopped = true;
       const auto = !play.penalty?.onOffense && outcome.penaltyYards > 0;
       if (auto) {
         state.down = 1;
@@ -1037,35 +1256,223 @@ function applyPlayResult(
   }
 }
 
+/*
+ * ── Clock management plays (Epic A3) ──────────────────────────────────────
+ * Reached only when `features.situational` is on.
+ */
+
+/** A play that stops the clock and nothing else. Costs no random draw. */
+function emitClockPlay(
+  state: GameState,
+  playType: "spike" | "timeout",
+  extra: Partial<PbpPlay> = {},
+): void {
+  recordPlay(state, {
+    playId: state.playId,
+    driveId: state.driveId,
+    quarter: state.quarter,
+    clockSeconds: state.clockSeconds,
+    offenseTeamId: offenseTeamId(state),
+    defenseTeamId: defenseTeamId(state),
+    playType,
+    down: state.down,
+    distance: state.distance,
+    fieldPosition: state.fieldPosition,
+    yardsGained: 0,
+    isScoring: false,
+    pointsScored: 0,
+    isTurnover: false,
+    participants: [],
+    ...extra,
+  });
+  state.clockStopped = true;
+}
+
+/** Spend a timeout. Bounded by `spendTimeout`, so the count cannot go negative. */
+function doTimeout(state: GameState, side: "home" | "away"): void {
+  spendTimeout(state, side);
+  emitClockPlay(state, "timeout", {
+    timeoutTeamId: side === "home" ? state.home.teamId : state.away.teamId,
+  });
+  // A timeout consumes no game clock at all — that is the entire point of one.
+}
+
+/** Throw it at the turf. Stops the clock, costs a down. */
+function doSpike(state: GameState): void {
+  emitClockPlay(state, "spike", { tempo: "hurry_up" });
+  tickClock(state, 2);
+  state.down += 1;
+  if (state.down > 4) {
+    endDrive(state, "downs");
+    flipPossession(state);
+    startDrive(state, offenseTeamId(state), clamp(100 - state.fieldPosition, 20, 80));
+  }
+}
+
+/**
+ * v1's 4th-down logic: two hardcoded distance bands and a coin flip.
+ *
+ * Kept verbatim, and reached whenever `features.situational` is off, so the
+ * golden fixture still reproduces byte-for-byte.
+ */
+function runFourthDownV1(state: GameState): void {
+  const ytg = yardsToGoal(state);
+  if (ytg <= 35 && ytg >= 18) {
+    doFieldGoalAttempt(state);
+    return;
+  }
+  if (ytg > 45 || (ytg > 35 && state.rand() < 0.75)) {
+    doPunt(state);
+    return;
+  }
+  if (state.rand() < 0.35 + matchupEdge(state) * 0.2) {
+    if (state.rand() < 0.45) doRush(state);
+    else doPass(state);
+    return;
+  }
+  doPunt(state);
+}
+
+function runNormalDownPlay(state: GameState, tempo: ClockStrategy): void {
+  const edge = matchupEdge(state);
+  let passRate = clamp(
+    0.52 + edge * 0.1 - (state.down === 1 ? 0 : 0.08),
+    0.38,
+    0.68,
+  );
+  if (state.features.situational) {
+    /*
+     * Tempo changes what you call, not just how fast you snap it. A hurry-up
+     * offense throws because an incompletion stops the clock; a team protecting
+     * a lead runs because a handoff does not.
+     */
+    if (tempo === "hurry_up") passRate = clamp(passRate + 0.25, 0.38, 0.92);
+    else if (tempo === "burn") passRate = clamp(passRate - 0.25, 0.08, 0.68);
+  }
+  if (state.rand() < passRate) doPass(state);
+  else doRush(state);
+}
+
 function runScrimmagePlay(state: GameState): void {
+  if (!state.features.situational) {
+    if (shouldKneel(state)) {
+      doKneel(state);
+      return;
+    }
+    if (state.down === 4) {
+      runFourthDownV1(state);
+      return;
+    }
+    runNormalDownPlay(state, "normal");
+    return;
+  }
+
+  /*
+   * ── A3 path ─────────────────────────────────────────────────────────────
+   *
+   * Order matters and mirrors the real sequence between snaps: the clock is
+   * running, somebody may stop it, and only then does a play happen.
+   */
+  const tempo = currentClockStrategy(state);
+  const offenseSide = state.possession;
+  const defenseSide = offenseSide === "home" ? "away" : "home";
+  const halfLeft = secondsLeftInHalf(
+    state.quarter,
+    state.clockSeconds,
+    state.inOvertime,
+  );
+  const gameLeft = secondsLeftInGame(
+    state.quarter,
+    state.clockSeconds,
+    state.inOvertime,
+  );
+  const scoreDiff = offenseScoreDiff(state);
+
+  // The trailing DEFENSE stops the clock to get the ball back at all.
+  if (
+    shouldUseTimeout({
+      isOffense: false,
+      scoreDiff: -scoreDiff,
+      secondsLeftInHalf: halfLeft,
+      secondsLeftInGame: gameLeft,
+      quarter: state.quarter,
+      timeoutsRemaining: timeoutsFor(state, defenseSide),
+      clockStopped: state.clockStopped,
+    })
+  ) {
+    doTimeout(state, defenseSide);
+    return;
+  }
+
+  if (
+    shouldUseTimeout({
+      isOffense: true,
+      scoreDiff,
+      secondsLeftInHalf: halfLeft,
+      secondsLeftInGame: gameLeft,
+      quarter: state.quarter,
+      timeoutsRemaining: timeoutsFor(state, offenseSide),
+      clockStopped: state.clockStopped,
+    })
+  ) {
+    doTimeout(state, offenseSide);
+    return;
+  }
+
+  if (
+    shouldSpike({
+      strategy: tempo,
+      secondsLeftInHalf: halfLeft,
+      down: state.down,
+      timeoutsRemaining: timeoutsFor(state, offenseSide),
+      clockStopped: state.clockStopped,
+    })
+  ) {
+    doSpike(state);
+    return;
+  }
+
+  /*
+   * The huddle and play clock between snaps. v1 folded this into each play's
+   * duration and therefore charged it even to incompletions, which is what
+   * capped a game at ~96 scrimmage plays.
+   */
+  tickClock(state, runoffSeconds(tempo, state.clockStopped));
+  state.clockStopped = false;
+  if (state.clockSeconds <= 0) return;
+
   if (shouldKneel(state)) {
     doKneel(state);
     return;
   }
 
   if (state.down === 4) {
-    const ytg = yardsToGoal(state);
-    if (ytg <= 35 && ytg >= 18) {
+    const call = fourthDownDecision({
+      yardsToGo: state.distance,
+      yardsToGoal: yardsToGoal(state),
+      scoreDiff,
+      quarter: state.quarter,
+      clockSeconds: state.clockSeconds,
+      isOvertime: state.inOvertime,
+      aggression: coachAggression(offenseTeam(state)),
+    });
+    if (call === "field_goal") {
       doFieldGoalAttempt(state);
       return;
     }
-    if (ytg > 45 || (ytg > 35 && state.rand() < 0.75)) {
+    if (call === "punt") {
       doPunt(state);
       return;
     }
-    if (state.rand() < 0.35 + matchupEdge(state) * 0.2) {
-      if (state.rand() < 0.45) doRush(state);
-      else doPass(state);
-      return;
-    }
-    doPunt(state);
+    // Going for it: the chart chose to go, a draw only picks run or pass.
+    if (state.rand() < 0.45) doRush(state);
+    else doPass(state);
     return;
   }
 
-  const edge = matchupEdge(state);
-  const passRate = clamp(0.52 + edge * 0.1 - (state.down === 1 ? 0 : 0.08), 0.38, 0.68);
-  if (state.rand() < passRate) doPass(state);
-  else doRush(state);
+  state.pendingTempo = tempo === "normal" ? null : tempo;
+  runNormalDownPlay(state, tempo);
+  state.pendingTempo = null;
 }
 
 function simulateGameLog(input: PbpGameInput): PbpGameLog {
@@ -1078,11 +1485,15 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
     features: {
       scoringV2: input.features?.scoringV2 === true,
       penalties: input.features?.penalties === true,
+      situational: input.features?.situational === true,
+      balance: input.features?.balance === true,
     },
     home: input.home,
     away: input.away,
     strengthWeight: weights.strengthWeight,
     edgeScale: weights.edgeScale,
+    homeFieldEdge:
+      input.features?.balance === true ? HOME_FIELD_EDGE_V2 : HOME_FIELD_EDGE,
     decisive: input.decisive ?? false,
     quarter: 1,
     clockSeconds: QUARTER_SECONDS,
@@ -1105,6 +1516,10 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
     gameOver: false,
     openingKickDone: false,
     secondHalfKickPending: false,
+    homeTimeouts: TIMEOUTS_PER_HALF,
+    awayTimeouts: TIMEOUTS_PER_HALF,
+    clockStopped: true,
+    pendingTempo: null,
   };
 
   doKickoff(state, "away");

--- a/apps/web/src/lib/pbp/situational.ts
+++ b/apps/web/src/lib/pbp/situational.ts
@@ -1,0 +1,283 @@
+/*
+ * Situational decisions and clock management (Dynasty Mode A3).
+ *
+ * Pure: no engine state, no I/O, and — importantly — **no PRNG**. Every
+ * function here is deterministic. A coach who declines to punt on 4th-and-1
+ * from midfield while trailing by 10 with two minutes left is not being lucky,
+ * they are being correct, and the log should read that way every replay.
+ *
+ * That determinism is also what makes these functions cheap to gate: a decision
+ * that draws no random number cannot desynchronize the v1 sequence, so the
+ * `situational` gate is free to sit off in production without touching parity.
+ *
+ * ## Why a chart and not an expected-points model
+ *
+ * A full win-probability surface would need calibration data this project does
+ * not have, and a mis-calibrated EP model is worse than an honest chart: it
+ * looks authoritative while being wrong. What follows is the same shape as a
+ * real 4th-down chart — a yards-to-go threshold per field zone — shifted by
+ * score, time and coach aggression. Every boundary is a number you can point at
+ * and argue with, which is the property that matters for tuning a game.
+ */
+
+/** Neutral coach. Used whenever a team carries no coach profile (pre-Epic C). */
+export const NEUTRAL_AGGRESSION = 50;
+
+export type FourthDownCall = "go" | "field_goal" | "punt";
+
+export interface FourthDownInput {
+  /** Yards needed for a first down. */
+  yardsToGo: number;
+  /** Distance from the opponent's goal line (0-100). */
+  yardsToGoal: number;
+  /** Offense score minus defense score. Negative means trailing. */
+  scoreDiff: number;
+  quarter: number;
+  /** Seconds left in the current quarter. */
+  clockSeconds: number;
+  isOvertime: boolean;
+  /** 0-100; 50 is neutral. Higher goes for it more often. */
+  aggression: number;
+}
+
+/**
+ * Seconds left in regulation.
+ *
+ * Overtime returns 0: there is no later quarter to defer to, so every OT
+ * situation is treated as end-of-game urgent.
+ */
+export function secondsLeftInGame(
+  quarter: number,
+  clockSeconds: number,
+  isOvertime: boolean,
+): number {
+  if (isOvertime) return 0;
+  const quartersAfter = Math.max(0, 4 - quarter);
+  return clockSeconds + quartersAfter * 720;
+}
+
+/** Seconds left in the current half — what a two-minute drill actually keys on. */
+export function secondsLeftInHalf(
+  quarter: number,
+  clockSeconds: number,
+  isOvertime: boolean,
+): number {
+  if (isOvertime) return clockSeconds;
+  const endOfHalfQuarter = quarter <= 2 ? 2 : 4;
+  return clockSeconds + Math.max(0, endOfHalfQuarter - quarter) * 720;
+}
+
+/** A field goal from this spot is at least worth attempting. */
+export function inFieldGoalRange(yardsToGoal: number): boolean {
+  // Attempt distance is the snap distance plus 17 yards of holder and end zone,
+  // so 35 yards to goal is a 52-yard try — the edge of plausible for HS.
+  return yardsToGoal <= 35;
+}
+
+/**
+ * Baseline yards-to-go a team would still go for on 4th down, by field zone.
+ *
+ * The shape is the interesting part. It is NOT monotonic in field position,
+ * because the alternative to going for it changes as you move:
+ *
+ * - Inside the 5, a field goal is nearly automatic, so the bar to go is low.
+ * - From 6-20, the kick is still very makeable — the most conservative zone.
+ * - From 21-35, the kick gets long and a punt gains almost nothing.
+ * - From 36-50 there is no good alternative at all: too far to kick, too close
+ *   to punt profitably. This is the peak.
+ * - Beyond 50, failing hands the opponent a short field, so punt.
+ */
+function baseGoThreshold(yardsToGoal: number): number {
+  if (yardsToGoal <= 5) return 3;
+  if (yardsToGoal <= 20) return 2;
+  if (yardsToGoal <= 35) return 3;
+  if (yardsToGoal <= 50) return 5;
+  return 1;
+}
+
+/**
+ * Go for it, kick, or punt.
+ *
+ * Replaces the three hardcoded distance bands plus a coin flip that used to
+ * live in `runScrimmagePlay`.
+ */
+export function fourthDownDecision(input: FourthDownInput): FourthDownCall {
+  const { yardsToGo, yardsToGoal, scoreDiff } = input;
+  const left = secondsLeftInGame(
+    input.quarter,
+    input.clockSeconds,
+    input.isOvertime,
+  );
+  const kickable = inFieldGoalRange(yardsToGoal);
+
+  /*
+   * Desperation. Trailing late, a punt cannot win the game — it can only hand
+   * the ball back with less time than you had. The only alternative worth
+   * weighing is a field goal, and only when three points actually change the
+   * outcome.
+   */
+  const trailing = scoreDiff < 0;
+  const deficit = -scoreDiff;
+  const desperate = trailing && left <= 300;
+  if (desperate) {
+    const fieldGoalTiesOrWins = deficit <= 3;
+    // Under a minute, a field goal that leaves you still behind is worthless.
+    if (kickable && fieldGoalTiesOrWins && (left <= 60 || yardsToGoal <= 25)) {
+      return "field_goal";
+    }
+    if (left <= 120) return "go";
+  }
+
+  /*
+   * Killing the game. Leading by more than one score inside the last few
+   * minutes, the clock is the asset — do not risk a short field on 4th down.
+   */
+  const killingClock = scoreDiff > 8 && input.quarter >= 4 && left <= 240;
+
+  let threshold = baseGoThreshold(yardsToGoal);
+  threshold += (input.aggression - NEUTRAL_AGGRESSION) / 15;
+  if (desperate) threshold += 4;
+  else if (trailing && input.quarter >= 4) threshold += 2;
+  if (killingClock) threshold -= 3;
+
+  if (yardsToGo <= threshold) return "go";
+  if (kickable) return "field_goal";
+  return "punt";
+}
+
+/**
+ * Kick onside?
+ *
+ * `scoreDiff` is from the KICKING team's perspective. Onside is a trailing
+ * team's play: you are trading expected field position for the chance not to
+ * give the ball back at all, which is only worth it when giving it back loses.
+ */
+export function shouldOnside(input: {
+  scoreDiff: number;
+  quarter: number;
+  clockSeconds: number;
+  isOvertime: boolean;
+}): boolean {
+  if (input.isOvertime) return false;
+  if (input.scoreDiff >= 0) return false;
+  const left = secondsLeftInGame(
+    input.quarter,
+    input.clockSeconds,
+    input.isOvertime,
+  );
+  const deficit = -input.scoreDiff;
+  if (left <= 120) return true;
+  // Down more than a touchdown you need two possessions, so start earlier.
+  return left <= 240 && deficit > 8;
+}
+
+export type ClockStrategy = "normal" | "hurry_up" | "burn";
+
+/**
+ * How the offense is treating the clock.
+ *
+ * `hurry_up` is the two-minute drill: get to the line, stop the clock, spend
+ * timeouts. `burn` is its mirror — a lead to protect and a clock to drain.
+ */
+export function clockStrategy(input: {
+  scoreDiff: number;
+  quarter: number;
+  clockSeconds: number;
+  isOvertime: boolean;
+}): ClockStrategy {
+  if (input.isOvertime) return "normal";
+  const half = secondsLeftInHalf(
+    input.quarter,
+    input.clockSeconds,
+    input.isOvertime,
+  );
+  const game = secondsLeftInGame(
+    input.quarter,
+    input.clockSeconds,
+    input.isOvertime,
+  );
+
+  if (input.scoreDiff > 0 && input.quarter >= 4 && game <= 300) return "burn";
+  /*
+   * Hurrying at the end of the FIRST half is not about the score — points
+   * before the break are free either way, so a tie or even a small lead still
+   * hurries. At the end of the game it is only worth it when you need points.
+   */
+  if (half <= 120) {
+    if (input.quarter <= 2) return "hurry_up";
+    if (input.scoreDiff <= 0) return "hurry_up";
+  }
+  return "normal";
+}
+
+/**
+ * Seconds that elapse between plays, on top of the play itself.
+ *
+ * Zero when the clock is stopped. This split — play duration versus the huddle
+ * and play clock that follow — is the whole reason v1 ran short of plays: it
+ * charged a full ~30-second cycle to every snap, including incompletions that
+ * stop the clock in real football.
+ */
+export function runoffSeconds(
+  strategy: ClockStrategy,
+  clockStopped: boolean,
+): number {
+  if (clockStopped) return 0;
+  if (strategy === "hurry_up") return 12;
+  if (strategy === "burn") return 38;
+  return 30;
+}
+
+/**
+ * Spike the ball to stop the clock.
+ *
+ * A spike costs a down, so it is only right when the clock is the binding
+ * constraint and there is no timeout left to spend. Never on 4th down — that
+ * would surrender possession to save six seconds.
+ */
+export function shouldSpike(input: {
+  strategy: ClockStrategy;
+  secondsLeftInHalf: number;
+  down: number;
+  timeoutsRemaining: number;
+  clockStopped: boolean;
+}): boolean {
+  if (input.strategy !== "hurry_up") return false;
+  if (input.clockStopped) return false;
+  if (input.timeoutsRemaining > 0) return false;
+  if (input.down >= 4) return false;
+  return input.secondsLeftInHalf <= 40;
+}
+
+/**
+ * Spend a timeout.
+ *
+ * Two callers with opposite motives, which is why `isOffense` is an input
+ * rather than two functions: the offense stops the clock to keep its own drive
+ * alive, the defense stops it to get the ball back at all. Both are late-game
+ * behaviors and both are bounded by the same pool.
+ */
+export function shouldUseTimeout(input: {
+  isOffense: boolean;
+  scoreDiff: number;
+  secondsLeftInHalf: number;
+  secondsLeftInGame: number;
+  quarter: number;
+  timeoutsRemaining: number;
+  clockStopped: boolean;
+}): boolean {
+  if (input.timeoutsRemaining <= 0) return false;
+  if (input.clockStopped) return false;
+
+  if (input.isOffense) {
+    if (input.secondsLeftInHalf > 90) return false;
+    // First half: points before the break are worth a timeout regardless of
+    // score. Second half: only when you need them.
+    return input.quarter <= 2 || input.scoreDiff <= 0;
+  }
+
+  // Defense: trailing, in the last two minutes, with the opponent's offense
+  // sitting on the ball.
+  if (input.quarter < 4) return false;
+  return input.scoreDiff < 0 && input.secondsLeftInGame <= 120;
+}

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -35,6 +35,16 @@ export interface TeamSimProfile {
    * to `strength`, so a team with no attribute snapshots still simulates.
    */
   discipline?: number;
+  /**
+   * Coaching tendencies (A3). Absent means a neutral coach, which is why this
+   * slice does not depend on Epic C — the `coaches` table simply fills these in
+   * later. Do NOT default these to a team's strength: a bad team with a bold
+   * coach is a real thing and the model should be able to express it.
+   */
+  coach?: {
+    /** 0-100; 50 neutral. Drives 4th-down and two-point boldness. */
+    aggression?: number;
+  };
 }
 
 import type { SimulationFlavor } from "@/lib/simulation-flavor";
@@ -167,6 +177,26 @@ export interface PbpPlay {
     negatesPlay: boolean;
     reason: string;
   };
+
+  /**
+   * How the offense was treating the clock on this play (A3).
+   *
+   * Present only under the `situational` gate, and only when the tempo was not
+   * `normal` — so its absence means either "v1 log" or "nothing notable", which
+   * is fine here because tempo has no stat consequences. Anything a reader must
+   * distinguish absence from zero for gets its own honest-absence treatment
+   * (see `returnYards`).
+   */
+  tempo?: "hurry_up" | "burn";
+
+  /**
+   * Which team called this timeout (A3), for `playType === "timeout"` only.
+   *
+   * Needed because either side can call one: `offenseTeamId` identifies who has
+   * the ball, not who spent the timeout, and a defensive timeout late in a game
+   * is exactly the interesting case.
+   */
+  timeoutTeamId?: string;
 }
 
 export interface PbpDrive {
@@ -215,4 +245,23 @@ export interface PbpFeatureGates {
   scoringV2?: boolean;
   /** A2 — penalties, with accept/decline. */
   penalties?: boolean;
+  /**
+   * A3 — situational decisions and clock management: a 4th-down chart in place
+   * of a coin flip, timeouts, the two-minute drill, spikes and onside kicks.
+   *
+   * Also carries the realistic clock model. v1 charged a full ~30-second cycle
+   * to every snap including incompletions, which capped a game at roughly 96
+   * scrimmage plays and is the main reason scoring sat below the design band.
+   */
+  situational?: boolean;
+  /**
+   * A3 — the balance recalibration filed as #642.
+   *
+   * Separate from `situational` on purpose. That gate adds *mechanics*; this
+   * one only retunes constants that were already there. Keeping them apart
+   * means a league can adopt clock management without adopting the new
+   * home-field weighting, and it means the distribution report can attribute
+   * each change independently.
+   */
+  balance?: boolean;
 }


### PR DESCRIPTION
## Summary

4th-down decisions on real situational inputs instead of a coin flip, plus timeouts, the two-minute
drill, spikes and onside kicks — and the clock model that made the scoring band reachable.

Closes #617. Fixes #642. Part of #605.

## The finding that shaped the slice

#617 asks for situational AI and, separately, for the balance band to hold. Those turned out to be
the **same problem**.

v1 charged a full ~30-second huddle cycle to *every* snap, including incompletions — which stop the
clock in real football. That capped a game at **96 scrimmage plays** and is why scoring sat at 25.6,
below the design band, no matter how efficient the offense was. It was never a scoring-rate problem.
Splitting play duration from the between-plays runoff took the game to **105 plays** and **33.4
points** on its own, before a single tuning constant moved.

So the clock model ships inside the `situational` gate, because it is clock management.

## What changed

**`pbp/situational.ts`** (new, pure, and — deliberately — **no PRNG**). `fourthDownDecision`,
`shouldOnside`, `clockStrategy`, `runoffSeconds`, `shouldSpike`, `shouldUseTimeout`. Every decision
is deterministic, so none of them can desynchronize the v1 sequence and all of them replay
identically.

**Why a chart and not an expected-points model.** A calibrated EP surface needs data this project
does not have, and a *mis*-calibrated one is worse than an honest chart: it looks authoritative
while being wrong. What ships is the shape of a real 4th-down chart — a yards-to-go threshold per
field zone — shifted by score, time and coach aggression. Every boundary is a number you can point
at and argue with.

The threshold is **not monotonic in field position**, which is the interesting part: it dips from
6–20 (the kick is easy, so stay conservative) and peaks from 36–50, where there is no good
alternative at all — too far to kick, too close to punt profitably.

**Timeouts are physical, not a resource dump.** One can only be spent while the clock is actually
running, tracked by `state.clockStopped`. Without that a team burns all three between two snaps.

**Coach aggression** reads `TeamSimProfile.coach.aggression` and defaults to a neutral 50, so this
slice does **not** depend on Epic C — the `coaches` table just fills it in later. It is deliberately
not defaulted to team strength: a bad team with a bold coach is a real thing.

## #642, and why v1 stays broken on purpose

Two identical rosters produced a **67.3% home win rate**. `HOME_FIELD_EDGE = 2.5` is not "2.5
points" — it feeds `matchupEdge`, which biases explosive-play rate, yardage, touchdown probability,
completion rate, sack rate, interception rate, field-goal accuracy, kick returns and punt distance.
Eight channels, every play. A nudge compounds into a decision.

The fix is behind its own `balance` gate, **separate from `situational`**, so the report can
attribute each change independently and a league can adopt one without the other.

**v1 is left at 67.3% deliberately.** Every fixture already simulated in production carries a v1
log, and those logs are the evidence for the box scores derived from them. Retuning v1 in place
would silently change games that have already been played. `dist-check.ts` now labels that row
`FROZEN` and a unit test *pins* it, so it cannot drift unnoticed.

```
                                     home     mean H/A    total   plays
v1 — FROZEN                          67.3%    15.9/9.7     25.6    96.0
+ situational                        67.3%    19.6/13.8    33.4   105.2
+ situational + balance              57.3%    18.1/15.8    33.9   104.8
all A gates                          56.7%    17.4/14.9    32.3   110.4
```

Targets: home win 52–60%, |home − away| ≤ 3, total 30–60. All three met, and a separate test
confirms an 85-strength team still beats a 55 more than 65% of the time — recalibrating home field
must not flatten real quality differences.

## Verification

- [x] `tsc --noEmit` clean (turbo type-check, 7/7)
- [x] `test:unit` — **191 files / 1415 tests pass** (was 190/1375)
- [x] `next build` succeeds
- [x] `turbo lint` clean
- [x] **A1 golden parity still holds byte-for-byte** — all 16 A1 tests and all 24 A2 tests pass
      unchanged

40 new tests. The ones that earn their place:

- **A trailing team late goes for it more than twice as often** as a leading team across the same
  40 field-position/distance combinations. This is the headline behavior of the slice.
- **Never punts while trailing inside two minutes**, across 100 combinations — a punt cannot win a
  game, it can only hand the ball back with less time than you had.
- **Takes the tying field goal down 3; refuses the same kick down 7.** Three points that leave you
  losing are worthless.
- **Monotonic in aggression**: once a bolder coach goes for it, no bolder one declines. Catches a
  sign error the boundary cases would not.
- **No team ever gets a fourth timeout in a half** across 200 seeded games, counted from emitted
  events rather than engine state so an off-by-one in the reset shows up as a real fourth timeout.
- **The clock never advances across a timeout**, and quarter/clock stay monotonic, over 200 games.
- Every A3 mechanic — spike, timeout, onside kick, hurry-up, clock burn — is **reachable** across
  120 seeded games. A mechanic that can never fire is not implemented; A1 learned that when safeties
  turned out to be geometrically impossible.
- **No A3 play type and no `tempo` field appears while the gate is off.**

## Gamecast text

`describePlay` fell through to raw yardage for every v2 play type, so a timeout rendered as "no
gain" and an onside kick as "10 yd gain" — true and useless. Added sentences for the A3 types and,
since the same one-line gap made a safety read "no gain", for A1's four as well. `formatDownAndDistance`
no longer prints "0th & 0" for plays that have no down of their own.

A spike now counts in the box-score play total, the way a kneel already did — it is a snap that used
a down.

## Two pre-existing defects found, filed not fixed

**#645 — the box score counts kickoffs and punts as turnovers.** `applyPlayToLine` increments `to`
on any `isTurnover` play, and v1 marks every kickoff and punt that way to model the change of
possession. The existing test mirrors the implementation line-for-line, so it cannot catch this;
fixing it needs a real oracle, which is its own change.

**#646 — `logModels` answers a question the engine version cannot answer.** It reports mechanics as
modelled based on `engineVersion === "2.0.0"`, but every mechanic is *gated*, and production writes
2.0.0 with all gates off. So it currently claims a log models safeties when it models nothing. No
production caller yet, which is why it is a trap rather than a bug — the fix is to record the
enabled gates in the log itself.

Neither is A3's, and neither is in its scope. Both are in code A3 touches, so they are called out
rather than left for someone to rediscover.

## Out of scope

- Wiring the gates to `FLAG_DYNASTY_SIM_V2` / `dynastyConfig`. `simulateAndPersistFixture` still
  passes no `features`, so **production behavior is unchanged by this PR** — as with A1 and A2.
  Three slices now ship dark and the F5 config knobs still have nothing reading them; that wiring
  needs to be somebody's explicit slice.
- Out-of-bounds plays stopping the clock. Hurry-up works through incompletions, spikes and timeouts;
  modelling sideline routes needs a target-location model that does not exist yet.
- Defensive two-point returns, and penalties on kicks (A2's boundary, unchanged).
