### PR TITLE
feat: add weather, venue and rivalry effects to the sim engine (#613)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -227,7 +227,7 @@ void api.program.moduleStatus;
 void api.history.moduleStatus;
 
 type AllowedPublicDynastyReads = "moduleStatus" | "getDynastyConfig";
-type AllowedPublicSimReads = "moduleStatus";
+type AllowedPublicSimReads = "moduleStatus" | "listRivalries";
 type AllowedPublicProgramReads = "moduleStatus";
 type AllowedPublicHistoryReads = "moduleStatus";
 

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -172,6 +172,17 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
+  // Declared rivalries (A5). A rivalry left behind changes how later runs
+  // simulate that matchup, and would make the rivalry admin spec pass on a
+  // second run purely because the first run's row was still there.
+  const rivalryRows = (await ctx.db
+    .query("rivalries")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"rivalries"> }>;
+  for (const row of rivalryRows) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
   for (const team of teams as Array<{ _id: Id<"teams"> }>) {
     const teamDepth = (await ctx.db
       .query("depthChartEntries")

--- a/apps/web/convex/lib/rivalries.ts
+++ b/apps/web/convex/lib/rivalries.ts
@@ -1,0 +1,54 @@
+/*
+ * Rivalry pairing rules (Dynasty Mode A5) — shared shape and key derivation.
+ *
+ * CANONICAL, and it lives under `convex/` for the same reason
+ * `convex/lib/dynastyConfig.ts` does: the Convex bundler can only reach files
+ * in this directory, while `src/` can reach both. `src/lib/pbp/crowd.ts`
+ * re-exports `rivalryPairKey` rather than reimplementing it, so the key the
+ * database deduplicates on and the key the engine looks up with cannot drift.
+ *
+ * That drift is the whole risk here. If the two sides ever disagreed about how
+ * a pair is keyed, a declared rivalry would simply stop being found at
+ * simulation time — silently, with no error, and only visible as "the rivalry
+ * setting does nothing".
+ *
+ * No Convex imports: this module must stay importable from the Next bundle.
+ */
+
+/** Bounds for a rivalry's intensity. */
+export const RIVALRY_INTENSITY_MIN = 1;
+export const RIVALRY_INTENSITY_MAX = 100;
+export const RIVALRY_INTENSITY_DEFAULT = 60;
+
+/**
+ * Canonical key for an unordered team pair.
+ *
+ * A rivalry is symmetric, so the ids are sorted before joining: "A vs B" and
+ * "B vs A" produce the same key and therefore the same row.
+ */
+export function rivalryPairKey(teamIdA: string, teamIdB: string): string {
+  return [teamIdA, teamIdB].sort().join("|");
+}
+
+/** The two ids in the same order `pairKey` puts them. */
+export function sortRivalryTeams(
+  teamIdA: string,
+  teamIdB: string,
+): [string, string] {
+  return [teamIdA, teamIdB].sort() as [string, string];
+}
+
+/**
+ * Clamp an intensity into range.
+ *
+ * A rivalry with intensity 0 is not a rivalry — it would be a row that changes
+ * nothing, which is worse than no row because it looks configured. The minimum
+ * is 1, and callers delete rather than zero.
+ */
+export function normalizeIntensity(value: number): number {
+  if (!Number.isFinite(value)) return RIVALRY_INTENSITY_DEFAULT;
+  return Math.max(
+    RIVALRY_INTENSITY_MIN,
+    Math.min(RIVALRY_INTENSITY_MAX, Math.round(value)),
+  );
+}

--- a/apps/web/convex/sim.ts
+++ b/apps/web/convex/sim.ts
@@ -1,5 +1,12 @@
-import { query } from "./_generated/server";
+import { v } from "convex/values";
+import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
+import {
+  normalizeIntensity,
+  rivalryPairKey,
+  sortRivalryTeams,
+} from "./lib/rivalries";
+import type { Id } from "./_generated/dataModel";
 
 /*
  * Dynasty Mode — simulation persistence (Epic A).
@@ -34,4 +41,148 @@ export const moduleStatus = query({
     epic: "A",
     ready: true,
   }),
+});
+
+/*
+ * ── Rivalries (A5) ──────────────────────────────────────────────────────────
+ */
+
+const rivalryValidator = v.object({
+  id: v.id("rivalries"),
+  leagueId: v.id("leagues"),
+  teamAId: v.id("teams"),
+  teamBId: v.id("teams"),
+  pairKey: v.string(),
+  name: v.union(v.string(), v.null()),
+  intensity: v.number(),
+  createdAt: v.string(),
+});
+
+/**
+ * Every declared rivalry in a league.
+ *
+ * A league has a handful at most, so this reads the whole indexed set rather
+ * than paginating — the caller wants them all to decorate a schedule.
+ */
+export const listRivalries = query({
+  args: { leagueId: v.id("leagues") },
+  returns: v.array(rivalryValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("rivalries")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    return rows.map((row) => ({
+      id: row._id,
+      leagueId: row.leagueId,
+      teamAId: row.teamAId,
+      teamBId: row.teamBId,
+      pairKey: row.pairKey,
+      name: row.name ?? null,
+      intensity: row.intensity,
+      createdAt: row.createdAt,
+    }));
+  },
+});
+
+/**
+ * Declare a rivalry, or update the one that already exists for this pairing.
+ *
+ * Upsert rather than insert, keyed on the sorted pair: re-declaring "A vs B"
+ * after declaring "B vs A" must adjust the existing rivalry, not create a
+ * second row that disagrees with it about how big the game is.
+ *
+ * `internalMutation` (WSM-000096) — the admin gate lives in the server action.
+ */
+export const upsertRivalry = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    actorUserId: v.string(),
+    teamAId: v.id("teams"),
+    teamBId: v.id("teams"),
+    name: v.optional(v.string()),
+    intensity: v.optional(v.number()),
+  },
+  returns: rivalryValidator,
+  handler: async (ctx, args) => {
+    if (args.teamAId === args.teamBId) throw new Error("same_team");
+
+    const league = await ctx.db.get(args.leagueId);
+    if (!league) throw new Error("league_not_found");
+
+    const [teamA, teamB] = await Promise.all([
+      ctx.db.get(args.teamAId),
+      ctx.db.get(args.teamBId),
+    ]);
+    if (!teamA || !teamB) throw new Error("team_not_found");
+    // A rivalry spans two teams in ONE league; a cross-league row would be
+    // unreachable from either league's schedule.
+    if (teamA.leagueId !== args.leagueId || teamB.leagueId !== args.leagueId) {
+      throw new Error("team_not_in_league");
+    }
+
+    const [sortedA, sortedB] = sortRivalryTeams(args.teamAId, args.teamBId);
+    const pairKey = rivalryPairKey(args.teamAId, args.teamBId);
+    const intensity = normalizeIntensity(args.intensity ?? 60);
+
+    const existing = await ctx.db
+      .query("rivalries")
+      .withIndex("by_leagueId_pairKey", (q) =>
+        q.eq("leagueId", args.leagueId).eq("pairKey", pairKey),
+      )
+      .first();
+
+    const now = new Date().toISOString();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        intensity,
+        ...(args.name === undefined ? {} : { name: args.name }),
+      });
+      const updated = await ctx.db.get(existing._id);
+      if (!updated) throw new Error("rivalry_not_found");
+      return {
+        id: updated._id,
+        leagueId: updated.leagueId,
+        teamAId: updated.teamAId,
+        teamBId: updated.teamBId,
+        pairKey: updated.pairKey,
+        name: updated.name ?? null,
+        intensity: updated.intensity,
+        createdAt: updated.createdAt,
+      };
+    }
+
+    const id = await ctx.db.insert("rivalries", {
+      leagueId: args.leagueId,
+      teamAId: sortedA as Id<"teams">,
+      teamBId: sortedB as Id<"teams">,
+      pairKey,
+      ...(args.name === undefined ? {} : { name: args.name }),
+      intensity,
+      createdAt: now,
+      createdBy: args.actorUserId,
+    });
+
+    return {
+      id,
+      leagueId: args.leagueId,
+      teamAId: sortedA as Id<"teams">,
+      teamBId: sortedB as Id<"teams">,
+      pairKey,
+      name: args.name ?? null,
+      intensity,
+      createdAt: now,
+    };
+  },
+});
+
+/** Remove a rivalry. Idempotent: deleting one that is already gone succeeds. */
+export const deleteRivalry = internalMutation({
+  args: { rivalryId: v.id("rivalries") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.rivalryId);
+    if (existing) await ctx.db.delete(args.rivalryId);
+    return null;
+  },
 });

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -184,4 +184,39 @@ export const dynastyTables = {
     updatedAt: v.string(),
     updatedBy: v.string(),
   }).index("by_leagueId", ["leagueId"]),
+
+  /*
+   * Declared rivalries (A5).
+   *
+   * A rivalry is SYMMETRIC — "A vs B" and "B vs A" are one rivalry — so the row
+   * carries a sorted `pairKey` alongside the two ids. Without it the same
+   * rivalry could be stored twice with different intensities and the two rows
+   * would disagree about how big the game is. `pairKey` is built by
+   * `rivalryPairKey` in `src/lib/pbp/crowd.ts`; it is the deduplication key,
+   * and the `by_leagueId_pairKey` index is what makes the check one read.
+   *
+   * `teamAId` / `teamBId` are also stored sorted, so a caller never has to
+   * guess which side it is looking at.
+   *
+   * Absence is the norm: almost no pairing is a rivalry, and a league with no
+   * rows here simulates exactly as it did before A5.
+   */
+  rivalries: defineTable({
+    leagueId: v.id("leagues"),
+    teamAId: v.id("teams"),
+    teamBId: v.id("teams"),
+    /** Sorted `${teamAId}|${teamBId}` — the unordered pair's primary key. */
+    pairKey: v.string(),
+    /** Display name, e.g. "The Backyard Brawl". Optional; falls back to the matchup. */
+    name: v.optional(v.string()),
+    /** 0-100. Damps home-field advantage — see `crowd.ts` for why. */
+    intensity: v.number(),
+    createdAt: v.string(),
+    createdBy: v.string(),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_leagueId_pairKey", ["leagueId", "pairKey"])
+    // A fixture asks "is this matchup a rivalry" from either team's side.
+    .index("by_teamAId", ["teamAId"])
+    .index("by_teamBId", ["teamBId"]),
 };

--- a/apps/web/e2e/helpers/sim-league-setup.ts
+++ b/apps/web/e2e/helpers/sim-league-setup.ts
@@ -66,7 +66,11 @@ export async function addTeamsToLeague(
   for (const name of names) {
     await page.getByRole("button", { name: "Add team" }).click();
     await page.getByPlaceholder("Team name").fill(name);
-    await page.getByRole("button", { name: "Add" }).click();
+    // `exact` matters: accessible-name matching is a substring match by
+    // default, so a bare "Add" also matches any other "Add …" button that
+    // League Settings grows later. This is the submit inside the add-team
+    // dialog and nothing else.
+    await page.getByRole("button", { name: "Add", exact: true }).click();
     await expect(page.getByText(`Added ${name}.`)).toBeVisible({
       timeout: 30_000,
     });

--- a/apps/web/e2e/tests/weather-rivalries.spec.ts
+++ b/apps/web/e2e/tests/weather-rivalries.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { setActiveLeague } from "../helpers/seed-canonical";
+import { pickSelectOption } from "../helpers/select";
+
+/*
+ * Weather and rivalries (A5).
+ *
+ * Runs in its own fixture league rather than the canonical one. A declared
+ * rivalry changes how a matchup simulates, so leaving one behind in the shared
+ * league would quietly alter unrelated specs' results.
+ */
+const FIXTURE_KEY = "weather";
+const HOME_TEAM = "E2E Wx Home";
+const AWAY_TEAM = "E2E Wx Away";
+
+test.describe("Weather and rivalries (A5)", () => {
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: HOME_TEAM,
+      awayTeamName: AWAY_TEAM,
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("the schedule shows a forecast for a game that has not been played", async ({
+    page,
+  }) => {
+    if (!fixture) test.skip();
+
+    await page.goto(`/dashboard/seasons/${fixture!.seasonId}/schedule`);
+    await page.getByRole("button", { name: "New fixture" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await pickSelectOption(page, "#fix-home", HOME_TEAM);
+    await pickSelectOption(page, "#fix-away", AWAY_TEAM);
+    // The chip is derived from season, week and venue, so a week is required.
+    await dialog.getByLabel("Week").fill("1");
+    await dialog.getByRole("button", { name: "Create fixture" }).click();
+    await expect(dialog).toBeHidden();
+
+    const chip = page.getByTestId("weather-chip").first();
+    await expect(chip).toBeVisible();
+    // Forecast, not a record of what happened — the Gamecast reads the real
+    // conditions off the stored log instead.
+    await expect(chip).toHaveAttribute("data-weather-variant", "forecast");
+    await expect(chip).toHaveAccessibleName(/^Forecast: /);
+  });
+
+  test("an admin can declare and remove a rivalry", async ({ page }) => {
+    if (!fixture) test.skip();
+
+    // League Settings is scoped to the Active League, so point the cookie at
+    // this spec's isolated league rather than the canonical one.
+    await setActiveLeague(page, fixture!.leagueId);
+    await page.goto("/dashboard/settings/league");
+
+    const card = page.getByTestId("rivalries-settings");
+    await expect(card).toBeVisible();
+    await expect(page.getByTestId("rivalries-empty")).toBeVisible();
+
+    // Native <select> elements here, not the Radix combobox the fixture
+    // dialog uses — so drive them with selectOption rather than pickSelectOption.
+    await page.getByTestId("rivalry-team-a").selectOption({ label: HOME_TEAM });
+    await page.getByTestId("rivalry-team-b").selectOption({ label: AWAY_TEAM });
+    await page.getByTestId("rivalry-name").fill("The E2E Bowl");
+    await page.getByTestId("rivalry-intensity").fill("80");
+    await page.getByTestId("rivalry-save").click();
+
+    const row = page.getByTestId("rivalry-row");
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText(HOME_TEAM);
+    await expect(row).toContainText(AWAY_TEAM);
+    await expect(row).toContainText("The E2E Bowl");
+    await expect(row).toContainText("80");
+
+    await page.getByTestId("rivalry-remove").click();
+    await expect(page.getByTestId("rivalries-empty")).toBeVisible();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/rivalries.ts
+++ b/apps/web/src/app/dashboard/_actions/rivalries.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  deleteRivalry as deleteRivalryData,
+  getLeagueOrgId,
+  upsertRivalry as upsertRivalryData,
+  type RivalryDto,
+} from "@/lib/data-api";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/**
+ * Authorize a rivalry mutation.
+ *
+ * ORG-SETTINGS level, like the Dynasty settings card. A rivalry is a property
+ * of the league schedule — it changes how a game between two OTHER teams
+ * plays — so it is not something a single team's coach should be able to
+ * declare unilaterally, even once multi-coach lands.
+ */
+async function requireLeagueAdmin(
+  leagueId: string,
+): Promise<{ userId: string } | { error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "unauthorized" };
+
+  let orgId: string | null;
+  try {
+    orgId = await getLeagueOrgId(leagueId);
+  } catch {
+    return { error: "league_not_found" };
+  }
+  if (!orgId) return { error: "not_authorized" };
+
+  const role = await resolveOrgRole(orgId, userId);
+  if (!canManageOrgSettings(role)) return { error: "not_authorized" };
+
+  return { userId };
+}
+
+export async function saveRivalryAction(input: {
+  leagueId: string;
+  teamAId: string;
+  teamBId: string;
+  name?: string;
+  intensity?: number;
+}): Promise<ActionResult<RivalryDto>> {
+  const gate = await requireLeagueAdmin(input.leagueId);
+  if ("error" in gate) return { ok: false, error: gate.error };
+
+  try {
+    const data = await upsertRivalryData({
+      leagueId: input.leagueId,
+      actorUserId: gate.userId,
+      teamAId: input.teamAId,
+      teamBId: input.teamBId,
+      name: input.name,
+      intensity: input.intensity,
+    });
+    revalidatePath("/dashboard/settings/league");
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function removeRivalryAction(input: {
+  leagueId: string;
+  rivalryId: string;
+}): Promise<ActionResult<null>> {
+  const gate = await requireLeagueAdmin(input.leagueId);
+  if ("error" in gate) return { ok: false, error: gate.error };
+
+  try {
+    await deleteRivalryData(input.rivalryId);
+    revalidatePath("/dashboard/settings/league");
+    return { ok: true, data: null };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/src/app/dashboard/settings/league/league-settings-view.tsx
+++ b/apps/web/src/app/dashboard/settings/league/league-settings-view.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import {
   getDynastyConfig,
   getLeagueVisibility,
+  listRivalries,
   getLeagueClaimable,
   getSeasons,
   listFixturesBySeason,
@@ -14,6 +15,7 @@ import type { OrgContext } from "@/lib/org-context";
 import { Card, CardContent } from "@/components/ui/card";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
 import { DynastySettingsCard } from "@/components/dynasty/DynastySettingsCard";
+import { RivalriesCard } from "@/components/dynasty/RivalriesCard";
 import { leagueHomeHref } from "@/components/workspace/resource-navigation";
 import InviteForm from "@/app/dashboard/leagues/[id]/invite-form";
 import InvitationList from "@/app/dashboard/leagues/[id]/invitation-list";
@@ -72,6 +74,8 @@ export async function LeagueSettingsView({
   // Always resolves — a league with no stored row uses defaults (F5).
   const dynastyConfig = await getDynastyConfig(id).catch(() => null);
   const claimable = await getLeagueClaimable(id);
+  // Absence is the norm — most leagues declare none (A5).
+  const rivalries = await listRivalries(id).catch(() => []);
   const canGenerateRosters = await syntheticRostersV1();
 
   const seasons = await getSeasons([id]).catch(() => []);
@@ -118,6 +122,14 @@ export async function LeagueSettingsView({
                 />
               </div>
             ) : null}
+
+            <div className="py-4">
+              <RivalriesCard
+                leagueId={id}
+                teams={teams.map((team) => ({ id: team.id, name: team.name }))}
+                initialRivalries={rivalries}
+              />
+            </div>
 
             <div className="space-y-4 py-4">
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/apps/web/src/components/dynasty/RivalriesCard.tsx
+++ b/apps/web/src/components/dynasty/RivalriesCard.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  removeRivalryAction,
+  saveRivalryAction,
+} from "@/app/dashboard/_actions/rivalries";
+import {
+  RIVALRY_INTENSITY_DEFAULT,
+  RIVALRY_INTENSITY_MAX,
+  RIVALRY_INTENSITY_MIN,
+} from "@/lib/rivalries";
+import type { RivalryDto } from "@/lib/data-api";
+
+/*
+ * Rivalry management (A5).
+ *
+ * A rivalry is a property of the SCHEDULE, not of one team — it changes how a
+ * game between two programs plays for both of them — so it lives on League
+ * Settings alongside the other commissioner controls rather than on Team Home.
+ */
+
+export interface RivalryTeamOption {
+  id: string;
+  name: string;
+}
+
+function teamName(teams: RivalryTeamOption[], id: string): string {
+  return teams.find((t) => t.id === id)?.name ?? "Unknown team";
+}
+
+export function RivalriesCard({
+  leagueId,
+  teams,
+  initialRivalries,
+}: {
+  leagueId: string;
+  teams: RivalryTeamOption[];
+  initialRivalries: RivalryDto[];
+}) {
+  const [rivalries, setRivalries] = useState<RivalryDto[]>(initialRivalries);
+  const [teamAId, setTeamAId] = useState("");
+  const [teamBId, setTeamBId] = useState("");
+  const [name, setName] = useState("");
+  const [intensity, setIntensity] = useState(RIVALRY_INTENSITY_DEFAULT);
+  const [pending, startTransition] = useTransition();
+
+  const sorted = useMemo(
+    () =>
+      [...rivalries].sort((a, b) =>
+        teamName(teams, a.teamAId).localeCompare(teamName(teams, b.teamAId)),
+      ),
+    [rivalries, teams],
+  );
+
+  // The two selects must not name the same program, and the pairing has to be
+  // complete before there is anything to save.
+  const canSave = teamAId !== "" && teamBId !== "" && teamAId !== teamBId;
+
+  function add() {
+    if (!canSave) return;
+    startTransition(async () => {
+      const result = await saveRivalryAction({
+        leagueId,
+        teamAId,
+        teamBId,
+        name: name.trim() === "" ? undefined : name.trim(),
+        intensity,
+      });
+      if (!result.ok) {
+        toast.error(`Could not save rivalry: ${result.error}`);
+        return;
+      }
+      // Upsert, so replace any existing row for this pairing rather than
+      // appending a duplicate the server already merged.
+      setRivalries((prev) => [
+        ...prev.filter((r) => r.pairKey !== result.data.pairKey),
+        result.data,
+      ]);
+      setTeamAId("");
+      setTeamBId("");
+      setName("");
+      toast.success("Rivalry saved.");
+    });
+  }
+
+  function remove(rivalry: RivalryDto) {
+    startTransition(async () => {
+      const result = await removeRivalryAction({
+        leagueId,
+        rivalryId: rivalry.id,
+      });
+      if (!result.ok) {
+        toast.error(`Could not remove rivalry: ${result.error}`);
+        return;
+      }
+      setRivalries((prev) => prev.filter((r) => r.id !== rivalry.id));
+      toast.success("Rivalry removed.");
+    });
+  }
+
+  return (
+    <div className="space-y-4" data-testid="rivalries-settings">
+      <div>
+        <h3 className="text-label-14 text-foreground">Rivalries</h3>
+        <p className="text-caption-12 text-text-muted">
+          Declared rivalries carry extra weight. A rivalry game damps home-field
+          advantage — the one night nobody is intimidated.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-caption-12 text-text-muted">Team</span>
+          <select
+            className="h-9 w-44 rounded-control border border-border bg-surface px-2 text-body-15 text-foreground"
+            value={teamAId}
+            data-testid="rivalry-team-a"
+            onChange={(e) => setTeamAId(e.target.value)}
+          >
+            <option value="">Select…</option>
+            {teams.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-caption-12 text-text-muted">Rival</span>
+          <select
+            className="h-9 w-44 rounded-control border border-border bg-surface px-2 text-body-15 text-foreground"
+            value={teamBId}
+            data-testid="rivalry-team-b"
+            onChange={(e) => setTeamBId(e.target.value)}
+          >
+            <option value="">Select…</option>
+            {teams
+              .filter((team) => team.id !== teamAId)
+              .map((team) => (
+                <option key={team.id} value={team.id}>
+                  {team.name}
+                </option>
+              ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-caption-12 text-text-muted">Name</span>
+          <input
+            className="h-9 w-44 rounded-control border border-border bg-surface px-2 text-body-15 text-foreground"
+            value={name}
+            placeholder="Optional"
+            data-testid="rivalry-name"
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-caption-12 text-text-muted">
+            Intensity {RIVALRY_INTENSITY_MIN}–{RIVALRY_INTENSITY_MAX}
+          </span>
+          <input
+            type="number"
+            min={RIVALRY_INTENSITY_MIN}
+            max={RIVALRY_INTENSITY_MAX}
+            className="h-9 w-24 rounded-control border border-border bg-surface px-2 text-body-15 text-foreground"
+            value={intensity}
+            data-testid="rivalry-intensity"
+            onChange={(e) => setIntensity(Number(e.target.value))}
+          />
+        </label>
+
+        <Button
+          size="sm"
+          disabled={!canSave || pending}
+          data-testid="rivalry-save"
+          onClick={add}
+        >
+          Add rivalry
+        </Button>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className="text-caption-12 text-text-muted" data-testid="rivalries-empty">
+          No rivalries declared.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border" data-testid="rivalries-list">
+          {sorted.map((rivalry) => (
+            <li
+              key={rivalry.id}
+              className="flex flex-wrap items-center justify-between gap-3 py-3"
+              data-testid="rivalry-row"
+            >
+              <div className="min-w-0">
+                <p className="text-label-14 text-foreground">
+                  {teamName(teams, rivalry.teamAId)} vs{" "}
+                  {teamName(teams, rivalry.teamBId)}
+                </p>
+                <p className="text-caption-12 text-text-muted">
+                  {rivalry.name ? `${rivalry.name} · ` : ""}Intensity{" "}
+                  {rivalry.intensity}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                data-testid="rivalry-remove"
+                onClick={() => remove(rivalry)}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dynasty/WeatherChip.tsx
+++ b/apps/web/src/components/dynasty/WeatherChip.tsx
@@ -1,0 +1,84 @@
+import { CloudRain, CloudSnow, Snowflake, Sun, Wind } from "lucide-react";
+import type { Weather } from "@/lib/pbp/weather";
+import { cn } from "@/lib/utils";
+
+/*
+ * Conditions chip (A5).
+ *
+ * Two very different callers, and the difference matters:
+ *
+ * - The schedule shows a FORECAST for a game nobody has played. It is derived
+ *   from season, week and venue, and it is stable, so it is a real prediction
+ *   rather than a guess.
+ * - The Gamecast shows what a game was ACTUALLY played in, read off the stored
+ *   log.
+ *
+ * These must never be interchanged. Substituting the forecast for a completed
+ * v1 game would assert that a game was played in conditions the engine never
+ * modelled — the same fabricated-fact problem as reporting 0 penalties for a
+ * game nobody counted.
+ */
+
+function WeatherIcon({ weather }: { weather: Weather }) {
+  const className = "h-3.5 w-3.5 shrink-0";
+  if (weather.precipitation !== "none") {
+    return weather.temperatureF <= 32 ? (
+      <CloudSnow className={className} aria-hidden />
+    ) : (
+      <CloudRain className={className} aria-hidden />
+    );
+  }
+  if (weather.windMph >= 18) return <Wind className={className} aria-hidden />;
+  if (weather.temperatureF <= 32) {
+    return <Snowflake className={className} aria-hidden />;
+  }
+  return <Sun className={className} aria-hidden />;
+}
+
+export function WeatherChip({
+  weather,
+  variant = "forecast",
+  className,
+}: {
+  weather: Weather;
+  /** `forecast` for an unplayed game, `actual` for what a game was played in. */
+  variant?: "forecast" | "actual";
+  className?: string;
+}) {
+  const label = `${weather.condition}, ${weather.temperatureF}°F, wind ${weather.windMph} mph`;
+  return (
+    <span
+      data-testid="weather-chip"
+      data-weather-variant={variant}
+      title={variant === "forecast" ? `Forecast: ${label}` : label}
+      aria-label={variant === "forecast" ? `Forecast: ${label}` : label}
+      className={cn(
+        "inline-flex items-center gap-1 whitespace-nowrap text-caption-12 text-text-muted",
+        className,
+      )}
+    >
+      <WeatherIcon weather={weather} />
+      <span>{weather.temperatureF}°</span>
+    </span>
+  );
+}
+
+/** Full-width conditions strip for the Gamecast. */
+export function WeatherStrip({ weather }: { weather: Weather }) {
+  return (
+    <div
+      data-testid="gamecast-weather"
+      className="flex flex-wrap items-center gap-3 rounded-control border border-border bg-surface-2 px-3 py-2 text-caption-12 text-text-muted"
+    >
+      <span className="inline-flex items-center gap-1.5 text-foreground">
+        <WeatherIcon weather={weather} />
+        {weather.condition}
+      </span>
+      <span>{weather.temperatureF}°F</span>
+      <span>Wind {weather.windMph} mph</span>
+      {weather.precipitation === "none" ? null : (
+        <span className="capitalize">{weather.precipitation} precipitation</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/gamecast/GamecastView.tsx
+++ b/apps/web/src/components/gamecast/GamecastView.tsx
@@ -45,6 +45,7 @@ import type { GamecastPanelSlots } from "./layouts/GamecastPanelSlots";
 import type { GamecastMode } from "./gamecast-transport-logic";
 import type { GamecastSpeed } from "./useAutoAdvance";
 import GamecastDynastyBanner from "./GamecastDynastyBanner";
+import { WeatherStrip } from "@/components/dynasty/WeatherChip";
 
 export interface GamecastDynastyCta {
   leagueId: string;
@@ -400,9 +401,27 @@ export default function GamecastView({
     </GamecastPlayByPlayCard>
   );
 
-  const postScoreboardBanner = dynastyCta ? (
-    <GamecastDynastyBanner leagueId={dynastyCta.leagueId} />
+  /*
+   * Conditions the game was ACTUALLY played in (A5).
+   *
+   * Read straight off the stored log, and rendered only when it is there. A v1
+   * log — or a v2 log simulated with the weather gate off — has no `weather`,
+   * and the strip stays hidden rather than falling back to the schedule's
+   * derived forecast. Absence means "not modelled", not "clear and mild".
+   */
+  const weatherStrip = log.weather ? (
+    <WeatherStrip weather={log.weather} />
   ) : null;
+
+  const postScoreboardBanner =
+    weatherStrip || dynastyCta ? (
+      <div className="space-y-2">
+        {weatherStrip}
+        {dynastyCta ? (
+          <GamecastDynastyBanner leagueId={dynastyCta.leagueId} />
+        ) : null}
+      </div>
+    ) : null;
 
   const panels: GamecastPanelSlots = {
       scoreboard: <GamecastScoreboard {...scoreboardProps} />,

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -8,6 +8,8 @@ import type { GameDrawerProjection } from "@/lib/game-drawer-projection";
 import { gameDrawerMatchupLabel } from "@/lib/game-drawer-projection";
 import { GameContextDrawer } from "@/components/games/GameContextDrawer";
 import { StatusBadge } from "@/components/status-badge";
+import { WeatherChip } from "@/components/dynasty/WeatherChip";
+import { deriveWeather } from "@/lib/pbp/weather";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
@@ -89,6 +91,24 @@ export function ScheduleFixtureRow({
   const scoreDisplay =
     result != null ? `${result.homeScore} – ${result.awayScore}` : "—";
 
+  /*
+   * Forecast conditions for a game that has not been played (A5).
+   *
+   * Deliberately NOT shown once a fixture is final. The derived forecast is a
+   * prediction about a scheduled game; a completed game was played in whatever
+   * its stored log recorded, and showing the forecast next to a final score
+   * would assert conditions the engine may never have modelled. The Gamecast
+   * reads the real thing off the log.
+   */
+  const forecast =
+    fixture.status !== "final" && fixture.week !== null
+      ? deriveWeather({
+          seasonId: fixture.seasonId,
+          week: fixture.week,
+          venueId: fixture.homeTeamId,
+        })
+      : null;
+
   return (
     <tr
       data-testid={`schedule-fixture-${fixture.id}`}
@@ -98,6 +118,9 @@ export function ScheduleFixtureRow({
           <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>
             {formatFixtureWhen(fixture.scheduledAt)}
           </MatchupCell>
+          {forecast ? (
+            <WeatherChip weather={forecast} className="mt-0.5" />
+          ) : null}
         </td>
         <td className="px-4 py-2 text-foreground">
           <MatchupCell onOpen={openDrawer} ariaLabel={drawerLabel}>

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2818,3 +2818,42 @@ export async function setDynastyConfig(input: {
     input,
   );
 }
+
+/*
+ * Rivalries (A5). Same compile-checked-ref discipline as the settings above.
+ */
+
+export interface RivalryDto {
+  id: string;
+  leagueId: string;
+  teamAId: string;
+  teamBId: string;
+  pairKey: string;
+  name: string | null;
+  intensity: number;
+  createdAt: string;
+}
+
+export async function listRivalries(leagueId: string): Promise<RivalryDto[]> {
+  const client = getConvexClient();
+  return client.query(simRef.query<RivalryDto[]>("listRivalries"), {
+    leagueId,
+  });
+}
+
+export async function upsertRivalry(input: {
+  leagueId: string;
+  actorUserId: string;
+  teamAId: string;
+  teamBId: string;
+  name?: string;
+  intensity?: number;
+}): Promise<RivalryDto> {
+  const client = getConvexClient();
+  return client.mutation(simRef.mutation<RivalryDto>("upsertRivalry"), input);
+}
+
+export async function deleteRivalry(rivalryId: string): Promise<null> {
+  const client = getConvexClient();
+  return client.mutation(simRef.mutation<null>("deleteRivalry"), { rivalryId });
+}

--- a/apps/web/src/lib/pbp/__tests__/weather.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/weather.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import {
+  homeFieldEdge,
+  isRivalry,
+  rivalryPairKey,
+  NEUTRAL_PRESTIGE,
+} from "../crowd";
+import {
+  CLEAR_WEATHER,
+  deriveWeather,
+  isFairWeather,
+  NEUTRAL_MODIFIERS,
+  weatherModifiers,
+  type Weather,
+} from "../weather";
+import type {
+  PbpGameInput,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2], ["RB", 3], ["WR", 5], ["TE", 2], ["DE", 2], ["DT", 2],
+    ["OLB", 2], ["MLB", 2], ["CB", 3], ["S", 2], ["K", 1], ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return players;
+}
+
+const buildTeam = (teamId: string, strength: number): TeamSimProfile => ({
+  teamId,
+  strength,
+  players: buildRoster(teamId, strength),
+});
+
+function gameInput(overrides: Partial<PbpGameInput> = {}): PbpGameInput {
+  return {
+    home: buildTeam("home", 70),
+    away: buildTeam("away", 70),
+    seed: 4242,
+    flavor: "balanced",
+    ...overrides,
+  };
+}
+
+const BLIZZARD: Weather = {
+  temperatureF: 24,
+  windMph: 26,
+  precipitation: "heavy",
+  condition: "Heavy snow",
+};
+
+describe("deriveWeather", () => {
+  it("is deterministic — same season, week and venue, same weather", () => {
+    const input = { seasonId: "season_a", week: 6, venueId: "team_b" };
+    const first = deriveWeather(input);
+    for (let i = 0; i < 20; i++) {
+      expect(deriveWeather(input)).toEqual(first);
+    }
+  });
+
+  it("varies by week and by venue", () => {
+    const base = { seasonId: "season_a", week: 6, venueId: "team_b" };
+    expect(deriveWeather({ ...base, week: 7 })).not.toEqual(deriveWeather(base));
+    expect(deriveWeather({ ...base, venueId: "team_c" })).not.toEqual(
+      deriveWeather(base),
+    );
+  });
+
+  it("skews colder and windier late in the season", () => {
+    // 500 venues per week, so this is a distribution claim rather than a lucky
+    // pair of samples.
+    const sample = (week: number) => {
+      let temp = 0;
+      let wind = 0;
+      for (let i = 0; i < 500; i++) {
+        const w = deriveWeather({
+          seasonId: "season_a",
+          week,
+          venueId: `venue_${i}`,
+        });
+        temp += w.temperatureF;
+        wind += w.windMph;
+      }
+      return { temp: temp / 500, wind: wind / 500 };
+    };
+    const early = sample(2);
+    const late = sample(13);
+    expect(late.temp).toBeLessThan(early.temp - 20);
+    expect(late.wind).toBeGreaterThan(early.wind);
+  });
+
+  it("rains more often late than early", () => {
+    const wetCount = (week: number) => {
+      let wet = 0;
+      for (let i = 0; i < 500; i++) {
+        const w = deriveWeather({
+          seasonId: "season_a",
+          week,
+          venueId: `venue_${i}`,
+        });
+        if (w.precipitation !== "none") wet += 1;
+      }
+      return wet;
+    };
+    expect(wetCount(13)).toBeGreaterThan(wetCount(2));
+  });
+
+  it("never calls freezing precipitation rain, or warm precipitation snow", () => {
+    for (let week = 1; week <= 14; week++) {
+      for (let i = 0; i < 60; i++) {
+        const w = deriveWeather({
+          seasonId: "s",
+          week,
+          venueId: `venue_${i}`,
+        });
+        if (w.precipitation === "none") continue;
+        if (w.temperatureF <= 32) expect(w.condition).toMatch(/snow/i);
+        else expect(w.condition).toMatch(/rain/i);
+      }
+    }
+  });
+
+  it("keeps a venue's climate stable across the season", () => {
+    /*
+     * A warm-climate program should stay relatively warm all year. Without a
+     * per-venue offset the model would randomly make the same stadium the
+     * coldest in week 3 and the warmest in week 12, which reads as noise rather
+     * than as geography.
+     */
+    const weeks = [2, 5, 8, 11];
+    const ranks = weeks.map((week) => {
+      const temps = Array.from({ length: 12 }, (_, i) => ({
+        venue: `venue_${i}`,
+        t: deriveWeather({ seasonId: "s", week, venueId: `venue_${i}` })
+          .temperatureF,
+      }));
+      temps.sort((a, b) => b.t - a.t);
+      return temps.map((x) => x.venue);
+    });
+    // The warmest venue in one week should be in the warm half in the others.
+    const warmest = ranks[0][0];
+    for (const order of ranks.slice(1)) {
+      expect(order.indexOf(warmest)).toBeLessThan(9);
+    }
+  });
+});
+
+describe("weatherModifiers", () => {
+  it("is exactly the identity in clear weather", () => {
+    // Exactly 1 matters: the engine multiplies unconditionally, and only an
+    // exact 1 keeps the gate-off path bit-identical to v1.
+    expect(weatherModifiers(CLEAR_WEATHER)).toEqual(NEUTRAL_MODIFIERS);
+    expect(isFairWeather(CLEAR_WEATHER)).toBe(true);
+  });
+
+  it("makes throwing, kicking and holding onto the ball all harder in a blizzard", () => {
+    const m = weatherModifiers(BLIZZARD);
+    expect(m.passAccuracy).toBeLessThan(1);
+    expect(m.kickDistance).toBeLessThan(1);
+    expect(m.explosiveRate).toBeLessThan(1);
+    expect(m.fumbleRate).toBeGreaterThan(1);
+  });
+
+  it("compounds stressors rather than taking the worst one", () => {
+    const windy: Weather = { ...CLEAR_WEATHER, windMph: 26, condition: "Windy" };
+    const wet: Weather = {
+      ...CLEAR_WEATHER,
+      precipitation: "heavy",
+      condition: "Heavy rain",
+    };
+    const both: Weather = { ...windy, precipitation: "heavy" };
+    const m = (w: Weather) => weatherModifiers(w).passAccuracy;
+    expect(m(both)).toBeLessThan(Math.min(m(windy), m(wet)));
+  });
+
+  it("stays inside bounds no matter how extreme the input", () => {
+    const absurd: Weather = {
+      temperatureF: -80,
+      windMph: 200,
+      precipitation: "heavy",
+      condition: "Apocalypse",
+    };
+    const m = weatherModifiers(absurd);
+    expect(m.passAccuracy).toBeGreaterThanOrEqual(0.6);
+    expect(m.kickDistance).toBeGreaterThanOrEqual(0.7);
+    expect(m.fumbleRate).toBeLessThanOrEqual(2.5);
+    expect(m.explosiveRate).toBeGreaterThanOrEqual(0.55);
+  });
+
+  it("leaves kicking alone in the cold but punishes it in the wind", () => {
+    const cold: Weather = { ...CLEAR_WEATHER, temperatureF: 10 };
+    const windy: Weather = { ...CLEAR_WEATHER, windMph: 28 };
+    expect(weatherModifiers(cold).kickDistance).toBe(1);
+    expect(weatherModifiers(windy).kickDistance).toBeLessThan(0.85);
+  });
+});
+
+describe("homeFieldEdge", () => {
+  it("returns the base edge exactly with neutral prestige and no rivalry", () => {
+    // The contract that makes this slice safe to enable: a league that has
+    // configured nothing behaves exactly as it did before.
+    for (const base of [2.5, 0.75, 1.2]) {
+      expect(homeFieldEdge({ base })).toBe(base);
+      expect(
+        homeFieldEdge({
+          base,
+          venuePrestige: NEUTRAL_PRESTIGE,
+          rivalryIntensity: 0,
+        }),
+      ).toBe(base);
+    }
+  });
+
+  it("amplifies with venue prestige and shrinks without it", () => {
+    expect(homeFieldEdge({ base: 1, venuePrestige: 95 })).toBeGreaterThan(1);
+    expect(homeFieldEdge({ base: 1, venuePrestige: 10 })).toBeLessThan(1);
+  });
+
+  it("damps home field in a rivalry", () => {
+    // The interesting behavior: a rivalry is the one night nobody is
+    // intimidated, so it is NOT just "more home field".
+    expect(homeFieldEdge({ base: 1, rivalryIntensity: 100 })).toBeLessThan(
+      homeFieldEdge({ base: 1, rivalryIntensity: 0 }),
+    );
+  });
+
+  it("clamps out-of-range inputs rather than producing nonsense", () => {
+    expect(homeFieldEdge({ base: 1, rivalryIntensity: 400 })).toBe(
+      homeFieldEdge({ base: 1, rivalryIntensity: 100 }),
+    );
+    expect(homeFieldEdge({ base: 1, venuePrestige: -50 })).toBe(
+      homeFieldEdge({ base: 1, venuePrestige: 0 }),
+    );
+  });
+
+  it("treats a pairing as one rivalry whichever way round it is named", () => {
+    expect(rivalryPairKey("team_b", "team_a")).toBe(
+      rivalryPairKey("team_a", "team_b"),
+    );
+    expect(isRivalry(0)).toBe(false);
+    expect(isRivalry(undefined)).toBe(false);
+    expect(isRivalry(40)).toBe(true);
+  });
+});
+
+describe("weather gate in the engine", () => {
+  it("ignores conditions entirely while the gate is off", () => {
+    // Passing weather without enabling it must change nothing — that is what
+    // lets a caller derive conditions for display without simulating in them.
+    const withWeather = simulateGameLog(gameInput({ weather: BLIZZARD }));
+    const without = simulateGameLog(gameInput());
+    expect(withWeather).toEqual(without);
+    expect(withWeather.weather).toBeUndefined();
+  });
+
+  it("records the conditions it actually played in", () => {
+    const log = simulateGameLog(
+      gameInput({ weather: BLIZZARD, features: { weather: true } }),
+    );
+    expect(log.weather).toEqual(BLIZZARD);
+  });
+
+  it("does not record weather it was not given, even with the gate on", () => {
+    // Absence must mean "not modelled". Substituting a default would be a
+    // fabricated fact about a real game.
+    const log = simulateGameLog(gameInput({ features: { weather: true } }));
+    expect(log.weather).toBeUndefined();
+  });
+
+  it("reproduces the ungated log when the conditions are clear", () => {
+    const clear = simulateGameLog(
+      gameInput({ weather: CLEAR_WEATHER, features: { weather: true } }),
+    );
+    const v1 = simulateGameLog(gameInput());
+    expect(clear.drives).toEqual(v1.drives);
+    expect(clear.homeScore).toBe(v1.homeScore);
+  });
+
+  it("lowers completion percentage and raises fumbles in bad weather", () => {
+    const measure = (weather: Weather | undefined) => {
+      let complete = 0;
+      let attempts = 0;
+      let fumbles = 0;
+      for (let i = 0; i < 120; i++) {
+        const log = simulateGameLog(
+          gameInput({
+            seed: 31000 + i,
+            weather,
+            features: weather ? { weather: true } : undefined,
+          }),
+        );
+        for (const drive of log.drives) {
+          for (const play of drive.plays) {
+            if (play.playType === "pass_complete") {
+              complete += 1;
+              attempts += 1;
+            } else if (play.playType === "pass_incomplete") {
+              attempts += 1;
+            }
+            if (play.participants.some((p) => p.role === "fumbler")) {
+              fumbles += 1;
+            }
+          }
+        }
+      }
+      return { pct: complete / attempts, fumbles };
+    };
+
+    const fair = measure(CLEAR_WEATHER);
+    const foul = measure(BLIZZARD);
+    expect(foul.pct).toBeLessThan(fair.pct);
+    expect(foul.fumbles).toBeGreaterThan(fair.fumbles);
+  });
+
+  it("blends crowd inputs into the home edge only under the gate", () => {
+    const rivalryOn = simulateGameLog(
+      gameInput({ rivalryIntensity: 100, features: { weather: true } }),
+    );
+    const rivalryIgnored = simulateGameLog(
+      gameInput({ rivalryIntensity: 100 }),
+    );
+    const plain = simulateGameLog(gameInput());
+    expect(rivalryIgnored).toEqual(plain);
+    expect(rivalryOn).not.toEqual(plain);
+  });
+});

--- a/apps/web/src/lib/pbp/crowd.ts
+++ b/apps/web/src/lib/pbp/crowd.ts
@@ -1,0 +1,78 @@
+/*
+ * Crowd, venue and rivalry (Dynasty Mode A5).
+ *
+ * Pure, deterministic, and — like `situational.ts` — it draws no random number.
+ * Home-field advantage is a property of the matchup, not a die roll.
+ *
+ * ## The contract that keeps this safe to add
+ *
+ * `homeFieldEdge` with neutral inputs returns the base edge EXACTLY. Venue
+ * prestige is an optional input that stays neutral until Epic C2 ships
+ * `teamSeasonPrograms`, and rivalry intensity is zero for every pair nobody has
+ * declared a rivalry for — which is almost all of them. So the common case is
+ * the identity, and enabling this slice cannot silently re-tune a league that
+ * has configured nothing.
+ */
+
+/** Prestige with no program data behind it. Returns the base edge unchanged. */
+export const NEUTRAL_PRESTIGE = 50;
+
+export interface HomeFieldEdgeInput {
+  /**
+   * The engine's own home-field constant, already resolved for the `balance`
+   * gate. This module scales it; it does not own it.
+   */
+  base: number;
+  /**
+   * 0-100 venue/program prestige. Absent or 50 is neutral. A blue-blood
+   * program in a full stadium is worth more than an empty one.
+   */
+  venuePrestige?: number;
+  /**
+   * 0-100 rivalry intensity for this specific pairing, 0 when the teams are not
+   * rivals.
+   */
+  rivalryIntensity?: number;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/**
+ * The home team's edge for this matchup.
+ *
+ * Prestige scales the edge multiplicatively — a loud, storied venue amplifies
+ * whatever home field is already worth. Rivalry works the OTHER way and damps
+ * it: a rivalry game is the one night a year the visitors travel well and
+ * nobody is intimidated. That is the interesting behavior, and it is why
+ * rivalry is not just "more home field".
+ */
+export function homeFieldEdge(input: HomeFieldEdgeInput): number {
+  const prestige = input.venuePrestige ?? NEUTRAL_PRESTIGE;
+  const rivalry = clamp(input.rivalryIntensity ?? 0, 0, 100);
+
+  const prestigeScale = 1 + (clamp(prestige, 0, 100) - NEUTRAL_PRESTIGE) / 125;
+  const rivalryScale = 1 - (rivalry / 100) * 0.6;
+
+  return input.base * prestigeScale * rivalryScale;
+}
+
+/**
+ * Does this matchup carry extra weight?
+ *
+ * Used for narrative and UI, not for play outcomes — a rivalry badge on a
+ * fixture is worth showing even when the intensity is low enough that the edge
+ * barely moves.
+ */
+export function isRivalry(rivalryIntensity: number | undefined): boolean {
+  return typeof rivalryIntensity === "number" && rivalryIntensity > 0;
+}
+
+/*
+ * The pair key is defined in `convex/lib/rivalries.ts` and re-exported here
+ * rather than reimplemented. The database deduplicates rivalries on this key
+ * and the engine looks them up with it — if the two ever drifted, a declared
+ * rivalry would silently stop being found at simulation time.
+ */
+export { rivalryPairKey } from "@/lib/rivalries";

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -17,6 +17,12 @@ import {
   shouldUseTimeout,
   type ClockStrategy,
 } from "./situational";
+import { homeFieldEdge as crowdHomeFieldEdge } from "./crowd";
+import {
+  NEUTRAL_MODIFIERS,
+  weatherModifiers,
+  type WeatherModifiers,
+} from "./weather";
 import type {
   PbpFeatureGates,
   PbpDrive,
@@ -96,6 +102,15 @@ interface GameState {
   edgeScale: number;
   /** `HOME_FIELD_EDGE`, or the recalibrated value under `features.balance`. */
   homeFieldEdge: number;
+  /**
+   * Weather multipliers (A5), or `NEUTRAL_MODIFIERS` when the gate is off.
+   *
+   * Held as resolved multipliers rather than as the `Weather` itself so the
+   * play functions multiply unconditionally instead of branching. Every neutral
+   * value is exactly 1, and multiplying by 1 is exact in floating point, so the
+   * gate-off path is bit-identical to v1 without a single `if`.
+   */
+  weatherMods: WeatherModifiers;
   decisive: boolean;
   quarter: number;
   clockSeconds: number;
@@ -618,7 +633,17 @@ function doFieldGoalAttempt(state: GameState): void {
   const kicker = selectPlayer(off, "K", state.rand);
   const dist = yardsToGoal(state) + 17;
   const edge = matchupEdge(state);
-  const makeProb = clamp(0.92 - (dist - 30) * 0.02 + edge * 0.08, 0.35, 0.95);
+  /*
+   * Wind and wet do not move the uprights, they shorten the leg — so a 40-yard
+   * try into a gale is modelled as a longer kick rather than as a flat accuracy
+   * penalty. Dividing by a neutral 1 is exact, so v1 is untouched.
+   */
+  const effectiveDist = dist / state.weatherMods.kickDistance;
+  const makeProb = clamp(
+    0.92 - (effectiveDist - 30) * 0.02 + edge * 0.08,
+    0.35,
+    0.95,
+  );
   const made = state.rand() < makeProb;
   const playType: PbpPlayType = made ? "field_goal" : "field_goal_miss";
 
@@ -664,7 +689,10 @@ function doPunt(state: GameState): void {
   const def = defenseTeam(state);
   const punter = selectPlayer(off, "P", state.rand);
   const returner = selectPlayer(def, "WR", state.rand, true);
-  const gross = Math.round(38 + state.rand() * 12 - matchupEdge(state) * 10);
+  const gross = Math.round(
+    (38 + state.rand() * 12 - matchupEdge(state) * 10) *
+      state.weatherMods.kickDistance,
+  );
   const net = clamp(gross - Math.round(state.rand() * 8), 25, 55);
   /*
    * Where the receiving team starts (v2 widens the floor).
@@ -709,9 +737,11 @@ function doRush(state: GameState): void {
   const def = defenseTeam(state);
   const rusher = selectPlayer(off, "RB", state.rand, true);
   const edge = matchupEdge(state);
-  const fumbleProb = clamp(0.01 - edge * 0.003, 0.003, 0.015);
+  const fumbleProb =
+    clamp(0.01 - edge * 0.003, 0.003, 0.015) * state.weatherMods.fumbleRate;
   const tdProb = clamp(0.055 + edge * 0.08, 0.02, 0.15);
-  const explosive = state.rand() < 0.08 + edge * 0.05;
+  const explosive =
+    state.rand() < (0.08 + edge * 0.05) * state.weatherMods.explosiveRate;
   let yards = explosive
     ? Math.round(12 + state.rand() * 18)
     : Math.round(2 + state.rand() * 5 + edge * 4);
@@ -805,7 +835,10 @@ function doPass(state: GameState): void {
      * non-rush fumble in the sport. Gated, and the draw happens ONLY inside
      * the gate so v1's PRNG sequence is untouched.
      */
-    if (state.features.scoringV2 && state.rand() < 0.12) {
+    if (
+      state.features.scoringV2 &&
+      state.rand() < 0.12 * state.weatherMods.fumbleRate
+    ) {
       const recoverer = selectDefender(def, state.rand, "tackle");
       play.isTurnover = true;
       play.participants.push(participant(passer, off.teamId, "fumbler"));
@@ -874,7 +907,13 @@ function doPass(state: GameState): void {
     return;
   }
 
-  const completeProb = clamp(0.6 + edge * 0.14, 0.45, 0.8);
+  /*
+   * Weather is applied AFTER the clamp on purpose. The 0.45 floor is a v1
+   * balance guard, not a law of physics — a sleet game should be allowed to
+   * push completion percentage below it.
+   */
+  const completeProb =
+    clamp(0.6 + edge * 0.14, 0.45, 0.8) * state.weatherMods.passAccuracy;
   const complete = state.rand() < completeProb;
   if (!complete) {
     const pd = state.rand() < 0.12 ? selectDefender(def, state.rand, "coverage") : null;
@@ -906,7 +945,8 @@ function doPass(state: GameState): void {
     return;
   }
 
-  const explosive = state.rand() < 0.1 + edge * 0.06;
+  const explosive =
+    state.rand() < (0.1 + edge * 0.06) * state.weatherMods.explosiveRate;
   let yards = explosive
     ? Math.round(15 + state.rand() * 25)
     : Math.round(4 + state.rand() * 9 + edge * 5);
@@ -1487,13 +1527,34 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
       penalties: input.features?.penalties === true,
       situational: input.features?.situational === true,
       balance: input.features?.balance === true,
+      weather: input.features?.weather === true,
     },
     home: input.home,
     away: input.away,
     strengthWeight: weights.strengthWeight,
     edgeScale: weights.edgeScale,
+    /*
+     * Crowd blending is a no-op with neutral inputs: `crowdHomeFieldEdge`
+     * multiplies by exactly 1 when prestige is 50 and rivalry is 0, which is
+     * every matchup nobody has configured.
+     */
     homeFieldEdge:
-      input.features?.balance === true ? HOME_FIELD_EDGE_V2 : HOME_FIELD_EDGE,
+      input.features?.weather === true
+        ? crowdHomeFieldEdge({
+            base:
+              input.features?.balance === true
+                ? HOME_FIELD_EDGE_V2
+                : HOME_FIELD_EDGE,
+            venuePrestige: input.venuePrestige,
+            rivalryIntensity: input.rivalryIntensity,
+          })
+        : input.features?.balance === true
+          ? HOME_FIELD_EDGE_V2
+          : HOME_FIELD_EDGE,
+    weatherMods:
+      input.features?.weather === true && input.weather
+        ? weatherModifiers(input.weather)
+        : NEUTRAL_MODIFIERS,
     decisive: input.decisive ?? false,
     quarter: 1,
     clockSeconds: QUARTER_SECONDS,
@@ -1550,6 +1611,15 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
     homeScore: state.homeScore,
     awayScore: state.awayScore,
     drives: state.drives,
+    /*
+     * Record the conditions the game was ACTUALLY played under — only when the
+     * gate was on. Absence means "not modelled", and a reader must not fill it
+     * in from the derived forecast: the forecast is what a scheduled game shows,
+     * not evidence about a game that has already happened.
+     */
+    ...(state.features.weather && input.weather
+      ? { weather: input.weather }
+      : {}),
   };
 }
 

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -48,6 +48,7 @@ export interface TeamSimProfile {
 }
 
 import type { SimulationFlavor } from "@/lib/simulation-flavor";
+import type { Weather } from "./weather";
 
 export interface PbpGameInput {
   home: TeamSimProfile;
@@ -63,6 +64,23 @@ export interface PbpGameInput {
    * byte-for-byte for the same seed — see `PbpFeatureGates`.
    */
   features?: PbpFeatureGates;
+  /**
+   * Conditions this game is played in (A5), derived by the caller from season,
+   * week and venue. The engine does not compute it, because the engine does not
+   * know what week it is.
+   *
+   * Read only under `features.weather`. Passing it with the gate off changes
+   * nothing — which is what lets a caller derive conditions for display without
+   * committing to simulating under them.
+   */
+  weather?: Weather;
+  /**
+   * Crowd context (A5). Both fields optional and neutral by default, so a
+   * league that has declared no rivalries and has no program data behaves
+   * exactly as it did before this slice.
+   */
+  venuePrestige?: number;
+  rivalryIntensity?: number;
 }
 
 export type PbpPlayType =
@@ -218,6 +236,17 @@ export interface PbpGameLog {
   awayScore: number;
   drives: PbpDrive[];
 
+  /**
+   * Conditions the game was actually played in (A5).
+   *
+   * Written only when the `weather` gate was on. Its ABSENCE means the game was
+   * not simulated under modelled conditions — which is not the same as fair
+   * weather, and a reader must not substitute the derived forecast for it. The
+   * forecast is what the schedule shows for a game nobody has played; this is
+   * what history reads.
+   */
+  weather?: Weather;
+
   /*
    * ── v2 additions (engine 2.0.0) ───────────────────────────────────────
    *
@@ -245,6 +274,14 @@ export interface PbpFeatureGates {
   scoringV2?: boolean;
   /** A2 — penalties, with accept/decline. */
   penalties?: boolean;
+  /**
+   * A5 — weather, venue prestige and rivalry.
+   *
+   * Maps to `dynastyConfig.weatherEnabled` once the gates are wired. With it
+   * off the engine ignores `PbpGameInput.weather` entirely and consumes no
+   * extra draws, so the pre-A5 log reproduces byte-for-byte.
+   */
+  weather?: boolean;
   /**
    * A3 — situational decisions and clock management: a 4th-down chart in place
    * of a coin flip, timeouts, the two-minute drill, spikes and onside kicks.

--- a/apps/web/src/lib/pbp/weather.ts
+++ b/apps/web/src/lib/pbp/weather.ts
@@ -1,0 +1,206 @@
+import { mulberry32, seedFor } from "@/lib/rng";
+
+/*
+ * Game conditions (Dynasty Mode A5).
+ *
+ * Pure and deterministic. Weather for a fixture is a FUNCTION of the season,
+ * the week and the venue — never of wall-clock time, never of an external
+ * forecast API, and never of the game's own PRNG.
+ *
+ * ## Why it uses its own seed stream
+ *
+ * `deriveWeather` draws from `seedFor("weather", ...)`, which is a different
+ * stream from the engine's `seedFor("pbp", fixtureId)`. That separation is
+ * load-bearing in two directions:
+ *
+ * - Deriving weather costs the game engine ZERO random draws, so the golden-log
+ *   parity fixture is unaffected whether or not a caller computed conditions.
+ * - Weather cannot correlate with what happens in the game. If both came off
+ *   the same stream, a cold week would systematically also be a fumble-heavy
+ *   week for reasons having nothing to do with the cold.
+ *
+ * ## Why it is derived and not stored
+ *
+ * A schedule shows conditions for games that have not been played. Storing a
+ * row per fixture would mean writing rows for a schedule that can still be
+ * regenerated. Deriving means the forecast is stable, free, and available
+ * before a game exists — and once a game IS played under the `weather` gate,
+ * the conditions it actually played in are recorded on its log, which is the
+ * copy history reads.
+ */
+
+export type Precipitation = "none" | "light" | "heavy";
+
+export interface Weather {
+  /** Fahrenheit. */
+  temperatureF: number;
+  /** Sustained wind, mph. */
+  windMph: number;
+  precipitation: Precipitation;
+  /** Short label for UI: "Clear", "Windy", "Rain", "Snow", … */
+  condition: string;
+}
+
+/**
+ * Neutral conditions: a mild, still, clear day.
+ *
+ * `weatherModifiers(CLEAR_WEATHER)` is the identity, which is what lets the
+ * gate be a no-op rather than a subtle re-tune.
+ */
+export const CLEAR_WEATHER: Readonly<Weather> = Object.freeze({
+  temperatureF: 68,
+  windMph: 4,
+  precipitation: "none",
+  condition: "Clear",
+});
+
+/**
+ * A high-school season runs roughly August to December, so week number is a
+ * decent proxy for the calendar. Week 1 is late summer; by week 14 it is
+ * playoff weather.
+ */
+const SEASON_WEEKS = 14;
+
+function seasonProgress(week: number): number {
+  if (!Number.isFinite(week)) return 0;
+  const clamped = Math.max(1, Math.min(SEASON_WEEKS, Math.round(week)));
+  return (clamped - 1) / (SEASON_WEEKS - 1);
+}
+
+export interface DeriveWeatherInput {
+  /** Stable id for the season — its Convex id in production. */
+  seasonId: string;
+  week: number;
+  /**
+   * Stable id for the place the game is played. The home team's id is the
+   * natural choice: a program plays its home games in one climate.
+   */
+  venueId: string;
+}
+
+/**
+ * Conditions for one fixture.
+ *
+ * Same inputs always produce the same weather, so a schedule page, a Gamecast
+ * and a re-simulation all agree without anyone storing anything.
+ */
+export function deriveWeather(input: DeriveWeatherInput): Weather {
+  const rand = mulberry32(
+    seedFor("weather", input.seasonId, String(input.week), input.venueId),
+  );
+  const progress = seasonProgress(input.week);
+
+  /*
+   * Temperature falls through the season. The venue draw is applied as a fixed
+   * offset per venue so a warm-climate program stays warm all year rather than
+   * being randomly cold in week 3 and hot in week 12.
+   */
+  const venueOffset = (rand() - 0.5) * 24;
+  const seasonal = 82 - progress * 42;
+  const daily = (rand() - 0.5) * 18;
+  const temperatureF = Math.round(seasonal + venueOffset + daily);
+
+  // Wind picks up as the season goes on, with a long tail for the rare gale.
+  const windRoll = rand();
+  const windMph = Math.round(
+    3 + progress * 6 + windRoll * windRoll * (14 + progress * 12),
+  );
+
+  /*
+   * Precipitation chance also rises late. Whether it falls as snow is decided
+   * by the temperature, not by another draw — sleet at 70 degrees would be a
+   * tell that the model is a lookup table rather than a climate.
+   */
+  const precipRoll = rand();
+  const precipChance = 0.14 + progress * 0.2;
+  let precipitation: Precipitation = "none";
+  if (precipRoll < precipChance * 0.35) precipitation = "heavy";
+  else if (precipRoll < precipChance) precipitation = "light";
+
+  return {
+    temperatureF,
+    windMph,
+    precipitation,
+    condition: describeConditions(temperatureF, windMph, precipitation),
+  };
+}
+
+function describeConditions(
+  temperatureF: number,
+  windMph: number,
+  precipitation: Precipitation,
+): string {
+  const freezing = temperatureF <= 32;
+  if (precipitation === "heavy") return freezing ? "Heavy snow" : "Heavy rain";
+  if (precipitation === "light") return freezing ? "Snow" : "Rain";
+  if (windMph >= 18) return freezing ? "Bitter wind" : "Windy";
+  if (freezing) return "Freezing";
+  if (temperatureF >= 88) return "Hot";
+  return "Clear";
+}
+
+/**
+ * How conditions change play.
+ *
+ * Multipliers, all 1 in clear weather. Returning multipliers rather than
+ * absolute rates means this module never has to know the engine's baseline
+ * numbers, and the engine never has to know what a "heavy rain" is.
+ */
+export interface WeatherModifiers {
+  /** Scales completion probability. */
+  passAccuracy: number;
+  /** Scales field-goal and punt distance. */
+  kickDistance: number;
+  /** Scales fumble probability. */
+  fumbleRate: number;
+  /** Scales the chance of an explosive play. */
+  explosiveRate: number;
+}
+
+export const NEUTRAL_MODIFIERS: Readonly<WeatherModifiers> = Object.freeze({
+  passAccuracy: 1,
+  kickDistance: 1,
+  fumbleRate: 1,
+  explosiveRate: 1,
+});
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+export function weatherModifiers(weather: Weather): WeatherModifiers {
+  /*
+   * Three independent stressors — wind, wet, cold — that compound. A freezing
+   * night with heavy snow and a 25 mph wind should be genuinely miserable to
+   * throw in, which only happens if the factors multiply rather than the model
+   * picking whichever is worst.
+   */
+  const wind = clamp((weather.windMph - 8) / 22, 0, 1);
+  const wet =
+    weather.precipitation === "heavy"
+      ? 1
+      : weather.precipitation === "light"
+        ? 0.5
+        : 0;
+  // Cold hands, hard ball. Below about 40F it starts to matter.
+  const cold = clamp((40 - weather.temperatureF) / 40, 0, 1);
+
+  return {
+    passAccuracy: clamp(1 - wind * 0.16 - wet * 0.12 - cold * 0.08, 0.6, 1),
+    // Wind dominates kicking, and it is the one place cold barely matters.
+    kickDistance: clamp(1 - wind * 0.2 - wet * 0.05, 0.7, 1),
+    fumbleRate: clamp(1 + wet * 0.7 + cold * 0.5, 1, 2.5),
+    explosiveRate: clamp(1 - wind * 0.15 - wet * 0.2 - cold * 0.1, 0.55, 1),
+  };
+}
+
+/** True when conditions are neutral enough to leave play untouched. */
+export function isFairWeather(weather: Weather): boolean {
+  const m = weatherModifiers(weather);
+  return (
+    m.passAccuracy === 1 &&
+    m.kickDistance === 1 &&
+    m.fumbleRate === 1 &&
+    m.explosiveRate === 1
+  );
+}

--- a/apps/web/src/lib/rivalries.ts
+++ b/apps/web/src/lib/rivalries.ts
@@ -1,0 +1,23 @@
+/*
+ * Rivalry pairing rules (A5) — Next-layer entry point.
+ *
+ * The definition lives in `convex/lib/rivalries.ts` because the Convex bundler
+ * can only reach files under `convex/`, while `src/` can reach both. Same
+ * arrangement as `src/lib/dynasty-config.ts`, and for the same reason: this is
+ * a re-export, NOT a copy.
+ *
+ * The stake here is the pair key. Convex deduplicates rivalries on it and the
+ * engine looks rivalries up with it — two implementations that drifted would
+ * make a declared rivalry silently stop being found at simulation time.
+ *
+ * Import from here in Next code; import from `convex/lib/rivalries` inside
+ * Convex functions.
+ */
+export {
+  RIVALRY_INTENSITY_DEFAULT,
+  RIVALRY_INTENSITY_MAX,
+  RIVALRY_INTENSITY_MIN,
+  normalizeIntensity,
+  rivalryPairKey,
+  sortRivalryTeams,
+} from "../../convex/lib/rivalries";


### PR DESCRIPTION
## Summary

Weather derived from the schedule, venue prestige and rivalry blended into home-field advantage,
a `rivalries` table with an admin surface on League Settings, and conditions shown on both the
schedule and the Gamecast.

Closes #613. Part of #605.

## The rule that shaped it: forecast is not evidence

Two things look like "weather" and must never be swapped.

**The schedule shows a forecast.** It is derived from `(seasonId, week, venueId)`, so it is stable
and available before a game exists — a real prediction, not a guess, and nothing is stored for it.

**The Gamecast shows what a game was actually played in**, read off the stored log, and only when
the log has it.

Substituting the forecast for a completed v1 game would assert conditions the engine never
modelled. So `ScheduleFixtureRow` renders the chip **only while a fixture is not final**, and
`GamecastView` renders the strip **only when `log.weather` is present** — no fallback. Same
honest-absence reasoning as A1's `returnYards` and A2's `penalties: number | null`.

## Determinism, and why weather has its own seed stream

`deriveWeather` draws from `seedFor("weather", …)`, never the engine's `seedFor("pbp", fixtureId)`.
That separation does two jobs:

- Deriving conditions costs the engine **zero random draws**, so a caller can compute weather for
  display without touching golden parity.
- Weather cannot correlate with what happens in the game. Off one stream, a cold week would
  systematically also be a fumble-heavy week for reasons having nothing to do with the cold.

Venue temperature is a **fixed per-venue offset**, not a fresh draw each week — otherwise the same
stadium would be the coldest in week 3 and the warmest in week 12, which reads as noise rather than
geography. There is a test for it.

## Rivalry damps home field — it is not "more home field"

`crowd.ts` blends prestige and rivalry into the base edge. Prestige **amplifies** it; rivalry
**shrinks** it, because a rivalry game is the one night a year the visitors travel well and nobody
is intimidated. That asymmetry is the interesting part, and the reason rivalry needed its own input
rather than a prestige bump.

**The contract that makes this safe to enable:** `homeFieldEdge` with neutral prestige and zero
rivalry returns the base **exactly** — asserted with `toBe`, not `toBeCloseTo`. That is every
matchup nobody has configured, which is nearly all of them.

## Why multiplying by 1 is the whole design

Every weather effect is a multiplier held on the engine state, resolved once to `NEUTRAL_MODIFIERS`
when the gate is off. Each neutral value is exactly `1`, and multiplication by 1 is exact in
floating point — so the play functions multiply **unconditionally**, with no `if` in any hot path,
and the gate-off log is still bit-identical to v1. The field goal takes the same trick: wind
lengthens the effective kick via `dist / kickDistance`, and dividing by a neutral 1 is exact.

A test asserts a game simulated *with the gate on and clear weather* reproduces the ungated drives.

## What changed

- **`pbp/weather.ts`** — `deriveWeather`, `weatherModifiers`, `CLEAR_WEATHER`, `isFairWeather`.
  Three independent stressors (wind, wet, cold) that **compound rather than max**, so a freezing
  night with snow and a 25 mph wind is genuinely miserable to throw in.
- **`pbp/crowd.ts`** — `homeFieldEdge`, `isRivalry`, and a re-export of `rivalryPairKey`.
- **`convex/lib/rivalries.ts`** — canonical pair-key and bounds. `src/lib/rivalries.ts` re-exports
  it, same arrangement as `dynastyConfig` (F5). **The stake is the key**: Convex deduplicates on it
  and the engine looks rivalries up with it, so two implementations that drifted would make a
  declared rivalry silently stop being found at simulation time.
- **`rivalries` table** — symmetric, stored with a sorted `pairKey` and upserted on it, so
  declaring "A vs B" after "B vs A" adjusts one rivalry instead of creating two rows that disagree
  about how big the game is.
- **`sim.ts`** — `listRivalries` query plus `upsertRivalry` / `deleteRivalry` **internalMutations**
  (WSM-000096), reached through the compile-checked `simRef` helpers. `AllowedPublicSimReads`
  widened to `"moduleStatus" | "listRivalries"` — a deliberate, reviewed act.
- **Admin surface** on League Settings, gated at **org-settings** level: a rivalry changes how a
  game between two *other* teams plays, so it is not something one coach declares unilaterally,
  even once multi-coach lands.
- **`resetCanonicalFixture` clears `rivalries`** in the same PR that adds the table (roadmap risk
  #5). Without it the rivalry spec would pass on a second run purely because the first run's row
  survived.

## Verification

- [x] `tsc --noEmit` clean (turbo type-check, 7/7)
- [x] `test:unit` — **192 files / 1437 tests pass** (was 191/1415)
- [x] `next build` succeeds
- [x] `turbo lint` clean
- [x] **Golden parity holds byte-for-byte** — all A1/A2/A3 tests pass unchanged
- [x] `dist-check.ts` unchanged: all A gates still 56.7% home / 32.3 total

22 new unit tests. The ones that earn their place:

- **Neutral inputs return the base edge exactly** (`toBe`), for three different base constants.
- **Passing weather with the gate off changes nothing** — full deep-equal against the ungated log.
- **The gate on with clear weather reproduces the ungated drives.**
- **Weather is never recorded that was not supplied**, even with the gate on.
- Over 120 games each, a blizzard **lowers completion percentage and raises fumbles** against clear
  weather with the same seeds.
- Late-season weeks are **>20°F colder and windier** than early weeks over 500 venues per week.
- **Freezing precipitation is never called rain** and warm precipitation never snow, across all 14
  weeks.
- A venue's climate **stays stable across the season** (the per-venue offset test above).
- Extreme inputs stay inside bounds — a −80°F, 200 mph game is miserable, not degenerate.

**One gap I want to flag rather than paper over: I did not run the Playwright spec.** Running it
needs a Convex backend with the new `rivalries` table pushed, and the recorded guidance for this
repo is never to run `convex dev` from a worktree. The spec is written and type-checks; CI's
Playwright job is its first real execution. If it fails I will fix it rather than quarantine it.

## Out of scope

- Wiring the gate to `dynastyConfig.weatherEnabled` and populating `PbpGameInput.weather` /
  `rivalryIntensity` in `simulateAndPersistFixture`. **Production behavior is unchanged**, as with
  A1, A2 and A3 — that is now four slices shipped dark, and turning them on needs to be somebody's
  explicit slice.
- Venue prestige has no producer until C2 ships `teamSeasonPrograms`; the input exists and degrades
  to neutral, exactly as #613 anticipated.
- A rivalry badge on the fixture row itself. `isRivalry` is exported for it, but the schedule does
  not load rivalries today and adding that read is a separate change.
