### PR TITLE
feat: persist the offseason phase machine and add the Season offseason route

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,10 @@ _Avoid_: Seasons Home, league schedule
 The single Season currently in progress for a League and the primary seasonal destination linked from League Home.
 _Avoid_: Viewed season, selected year
 
+**Offseason Hub**:
+The phase-machine surface for one upcoming Season at `/dashboard/seasons/[seasonId]/offseason`, where an administrator moves the league through Rollover, Draft, Free agency and Activate.
+_Avoid_: Offseason page, preseason, transfer window
+
 **Resource Header**:
 The orientation and sibling-navigation surface shared by a Home and its child pages without using breadcrumb trails.
 _Avoid_: Breadcrumb, back-link row
@@ -97,6 +101,7 @@ _Avoid_: Playbook, formation, strategy, system
 - Opening an accessible Team, Player, Season, or child deep link makes its owning League the **Active League** before rendering
 - Selecting an **Active League** from the switcher or **League Directory** navigates directly to its **League Home**
 - Global league switching replaces the current history entry so Back does not reopen a page implicitly scoped to the previous **Active League**
+- An upcoming **Season** has at most one **Offseason Hub**, and a Season that is active or completed has none
 - The league switcher links to the **League Directory** for cross-league administration
 - **League Home** is the root of the Active League workspace; desktop and mobile sidebar destinations Overview, Teams, Players, Seasons, and Settings are its primary branches
 - **League Home** does not duplicate those branches in a local tab bar; its header exposes only contextual actions

--- a/apps/web/convex/__tests__/offseasonPhases.test.ts
+++ b/apps/web/convex/__tests__/offseasonPhases.test.ts
@@ -1,0 +1,248 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { OFFSEASON_PHASES, phaseGate } from "../lib/offseasonPhases";
+import {
+  OFFSEASON_PHASES as NEXT_PHASES,
+  phaseGate as nextPhaseGate,
+} from "../../src/lib/dynasty/offseason-phases";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_admin";
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Offseason League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2027",
+      status: "upcoming",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+    return { leagueId, seasonId };
+  });
+}
+
+describe("offseason phase machine — one definition, two import paths", () => {
+  it("gives the Convex side and the Next side the same rules", () => {
+    // `src/lib/dynasty/offseason-phases.ts` re-exports rather than mirroring.
+    // If someone forks it into a copy, the button the UI enables and the
+    // advance the mutation permits could silently disagree.
+    expect(NEXT_PHASES).toEqual(OFFSEASON_PHASES);
+    expect(
+      nextPhaseGate({ from: "draft", to: "free_agency", draftStatus: "active" }),
+    ).toEqual(
+      phaseGate({ from: "draft", to: "free_agency", draftStatus: "active" }),
+    );
+  });
+});
+
+describe("beginOffseason", () => {
+  it("opens at draft with the rollover already recorded", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seed(t);
+    const opened = await t.mutation(internal.dynasty.beginOffseason, {
+      seasonId,
+      actorUserId: ACTOR,
+    });
+    expect(opened.phase).toBe("draft");
+    expect(opened.completedPhases).toEqual(["rollover"]);
+  });
+
+  it("is idempotent — a second call returns the same row", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seed(t);
+    const first = await t.mutation(internal.dynasty.beginOffseason, {
+      seasonId,
+      actorUserId: ACTOR,
+    });
+    const second = await t.mutation(internal.dynasty.beginOffseason, {
+      seasonId,
+      actorUserId: ACTOR,
+    });
+    expect(second.id).toBe(first.id);
+  });
+
+  it("snapshots the league's point budgets at open", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seed(t);
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId,
+      actorUserId: ACTOR,
+      patch: { scoutingPointsPerOffseason: 40 },
+    });
+    const opened = await t.mutation(internal.dynasty.beginOffseason, {
+      seasonId,
+      actorUserId: ACTOR,
+    });
+    expect(opened.scoutingPointsTotal).toBe(40);
+
+    // Raising the knob afterwards must not retroactively change a budget that
+    // an offseason may already have spent against.
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId,
+      actorUserId: ACTOR,
+      patch: { scoutingPointsPerOffseason: 99 },
+    });
+    const reread = await t.query(api.dynasty.getOffseason, { seasonId });
+    expect(reread?.scoutingPointsTotal).toBe(40);
+  });
+
+  it("refuses to open on a season that has already started", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seed(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(seasonId, { status: "active" } as never);
+    });
+    await expect(
+      t.mutation(internal.dynasty.beginOffseason, {
+        seasonId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/season_not_upcoming/);
+  });
+});
+
+describe("getOffseason", () => {
+  it("returns null for a season that never opened one", async () => {
+    // Honest absence: defaulting here would hide which leagues still need a
+    // row, and the stepper's bridge is where absence becomes renderable.
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seed(t);
+    expect(await t.query(api.dynasty.getOffseason, { seasonId })).toBeNull();
+  });
+});
+
+describe("advanceOffseasonPhase", () => {
+  async function opened() {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seed(t);
+    await t.mutation(internal.dynasty.beginOffseason, {
+      seasonId,
+      actorUserId: ACTOR,
+    });
+    return { t, seasonId };
+  }
+
+  const advance = (
+    t: ReturnType<typeof convexTest>,
+    seasonId: never,
+    args: Partial<{
+      expectedPhase: string;
+      to: string;
+      ownerId: string;
+      draftStatus: string;
+    }> = {},
+  ) =>
+    t.mutation(internal.dynasty.advanceOffseasonPhase, {
+      seasonId,
+      expectedPhase: args.expectedPhase ?? "draft",
+      to: args.to ?? "free_agency",
+      ownerId: args.ownerId ?? "owner_a",
+      actorUserId: ACTOR,
+      draftStatus: args.draftStatus ?? "none",
+    });
+
+  it("moves forward and records the phase it left", async () => {
+    const { t, seasonId } = await opened();
+    const result = await advance(t, seasonId as never);
+    expect(result.changed).toBe(true);
+    expect(result.offseason.phase).toBe("free_agency");
+    expect(result.offseason.completedPhases).toEqual(["rollover", "draft"]);
+  });
+
+  it("advancing twice with the same payload produces one state change", async () => {
+    const { t, seasonId } = await opened();
+    const first = await advance(t, seasonId as never);
+    const second = await advance(t, seasonId as never);
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(second.offseason.completedPhases).toEqual(
+      first.offseason.completedPhases,
+    );
+    expect(second.offseason.phase).toBe("free_agency");
+  });
+
+  it("rejects a backward request as phase_regression", async () => {
+    const { t, seasonId } = await opened();
+    await advance(t, seasonId as never);
+    await expect(
+      advance(t, seasonId as never, {
+        expectedPhase: "free_agency",
+        to: "draft",
+      }),
+    ).rejects.toThrow(/phase_regression/);
+  });
+
+  it("resolves two concurrent advances to one winner and one phase_busy", async () => {
+    const { t, seasonId } = await opened();
+    /*
+     * Both callers read phase `draft` and both send `expectedPhase: "draft"`.
+     * Convex serializes them, so the loser finds its expectation stale — it
+     * asked to move an offseason that someone else already moved.
+     */
+    const results = await Promise.allSettled([
+      advance(t, seasonId as never, { ownerId: "owner_a" }),
+      advance(t, seasonId as never, { ownerId: "owner_b" }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(String((rejected[0] as PromiseRejectedResult).reason)).toMatch(
+      /phase_busy/,
+    );
+
+    const final = await t.query(api.dynasty.getOffseason, { seasonId });
+    expect(final?.phase).toBe("free_agency");
+    expect(final?.completedPhases).toEqual(["rollover", "draft"]);
+  });
+
+  it("refuses to leave the draft phase while a draft is mid-pick", async () => {
+    const { t, seasonId } = await opened();
+    await expect(
+      advance(t, seasonId as never, { draftStatus: "active" }),
+    ).rejects.toThrow(/draft_in_progress/);
+  });
+
+  it("reports an invalid request as invalid rather than as a conflict", async () => {
+    // A skipped phase sent with a stale expectation is still out-of-order.
+    // Masking it as phase_busy would send an admin looking for a second admin
+    // who does not exist.
+    const { t, seasonId } = await opened();
+    await expect(
+      advance(t, seasonId as never, {
+        expectedPhase: "activate",
+        to: "activate",
+      }),
+    ).rejects.toThrow(/phase_out_of_order/);
+  });
+
+  it("walks the whole machine to the end", async () => {
+    const { t, seasonId } = await opened();
+    for (let i = 1; i < OFFSEASON_PHASES.length - 1; i++) {
+      await advance(t, seasonId as never, {
+        expectedPhase: OFFSEASON_PHASES[i],
+        to: OFFSEASON_PHASES[i + 1],
+      });
+    }
+    const final = await t.query(api.dynasty.getOffseason, { seasonId });
+    expect(final?.phase).toBe("activate");
+    expect(final?.completedPhases).toEqual([
+      "rollover",
+      "draft",
+      "free_agency",
+    ]);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -226,7 +226,10 @@ void api.sim.moduleStatus;
 void api.program.moduleStatus;
 void api.history.moduleStatus;
 
-type AllowedPublicDynastyReads = "moduleStatus" | "getDynastyConfig";
+type AllowedPublicDynastyReads =
+  | "moduleStatus"
+  | "getDynastyConfig"
+  | "getOffseason";
 type AllowedPublicSimReads =
   | "moduleStatus"
   | "listRivalries"

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -1,4 +1,5 @@
-import { v } from "convex/values";
+import { v, type Infer } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
 import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
 import {
@@ -6,6 +7,12 @@ import {
   resolveDynastyConfig,
   type DynastyConfig,
 } from "./lib/dynastyConfig";
+import {
+  INITIAL_OFFSEASON_PHASE,
+  completePhase,
+  phaseGate,
+  type DraftPhaseStatus,
+} from "./lib/offseasonPhases";
 
 /*
  * Dynasty Mode — offseason pipeline (Epic B).
@@ -144,5 +151,214 @@ export const setDynastyConfig = internalMutation({
     }
 
     return merged;
+  },
+});
+
+/*
+ * ── Persisted offseason phase machine (B1) ──────────────────────────────────
+ */
+
+const offseasonValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  phase: v.string(),
+  completedPhases: v.array(v.string()),
+  scoutingPointsTotal: v.number(),
+  scoutingPointsSpent: v.number(),
+  trainingPointsTotal: v.number(),
+  trainingPointsSpent: v.number(),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+});
+
+type OffseasonDoc = Doc<"offseasons">;
+
+/**
+ * `Infer` pins the mapper's return to the validator (WSM-000166). If a field
+ * is added to one and not the other this stops compiling, rather than throwing
+ * a data-dependent 500 the first time a row happens to carry the new field.
+ */
+function toOffseasonDto(row: OffseasonDoc): Infer<typeof offseasonValidator> {
+  return {
+    id: row._id as string,
+    leagueId: row.leagueId as string,
+    seasonId: row.seasonId as string,
+    phase: row.phase,
+    completedPhases: row.completedPhases,
+    scoutingPointsTotal: row.scoutingPointsTotal,
+    scoutingPointsSpent: row.scoutingPointsSpent,
+    trainingPointsTotal: row.trainingPointsTotal,
+    trainingPointsSpent: row.trainingPointsSpent,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * The stored offseason for a season, or `null` if one was never opened.
+ *
+ * Null is honest here and the caller must handle it: a league that entered its
+ * offseason before this table existed has no row, and `resolveOffseasonState`
+ * in `lib/offseasonPhases.ts` is where that absence is turned into something
+ * renderable. Defaulting here would hide which leagues still need opening.
+ */
+export const getOffseason = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.union(offseasonValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("offseasons")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    return row ? toOffseasonDto(row) : null;
+  },
+});
+
+/**
+ * Open the offseason for a season, or return the one already open.
+ *
+ * Idempotent by design — it is safe to call on every admin page load, which is
+ * what makes the row's existence something the UI never has to orchestrate.
+ */
+export const beginOffseason = internalMutation({
+  args: { seasonId: v.id("seasons"), actorUserId: v.string() },
+  returns: offseasonValidator,
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("offseasons")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (existing) return toOffseasonDto(existing);
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    /*
+     * An offseason prepares a season that has not started. Opening one on an
+     * active or completed season would let phase actions mutate rosters that
+     * results have already been recorded against.
+     */
+    if (season.status !== "upcoming") throw new Error("season_not_upcoming");
+
+    const configRow = await ctx.db
+      .query("dynastyConfig")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .first();
+    const config = resolveDynastyConfig(configRow);
+
+    const now = new Date().toISOString();
+    const id = await ctx.db.insert("offseasons", {
+      leagueId: season.leagueId,
+      seasonId: args.seasonId,
+      phase: INITIAL_OFFSEASON_PHASE,
+      completedPhases: ["rollover"],
+      scoutingPointsTotal: config.scoutingPointsPerOffseason,
+      scoutingPointsSpent: 0,
+      trainingPointsTotal: config.trainingPointsPerOffseason,
+      trainingPointsSpent: 0,
+      configJson: JSON.stringify(config),
+      createdAt: now,
+      updatedAt: now,
+      updatedBy: args.actorUserId,
+    });
+    const row = await ctx.db.get(id);
+    if (!row) throw new Error("offseason_not_found");
+    return toOffseasonDto(row);
+  },
+});
+
+const OFFSEASON_LEASE_MS = 30_000;
+
+/**
+ * Move an offseason to its next phase.
+ *
+ * Compare-and-set on `expectedPhase`. Convex serializes concurrent mutations,
+ * so two admins who both read phase `draft` and both click Advance arrive here
+ * one after the other: the first commits, and the second finds its
+ * `expectedPhase` stale. That second caller is told `phase_busy` rather than
+ * being silently no-opped, because it did not get what it asked for — someone
+ * else moved the offseason underneath it.
+ *
+ * The exception is a caller whose target is already the current phase. That is
+ * a retry of a request that landed, so it returns `changed: false` instead of
+ * erroring, and `completedPhases` behaves as a set either way.
+ */
+export const advanceOffseasonPhase = internalMutation({
+  args: {
+    seasonId: v.id("seasons"),
+    expectedPhase: v.string(),
+    to: v.string(),
+    ownerId: v.string(),
+    actorUserId: v.string(),
+    draftStatus: v.string(),
+  },
+  returns: v.object({
+    changed: v.boolean(),
+    offseason: offseasonValidator,
+  }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("offseasons")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .first();
+    if (!row) throw new Error("offseason_not_found");
+
+    /*
+     * Already where the caller wants to be. A retry and a lost race send
+     * BYTE-IDENTICAL payloads — same `expectedPhase`, same `to` — so the only
+     * thing that separates them is who asked. `leaseOwnerId` records who made
+     * the move, which is what earns the lease its place on the row today
+     * rather than only in B2+.
+     *
+     * No recorded owner means nobody claims to have moved it (a fresh row
+     * asked to stay where it is), which is a no-op, not a conflict.
+     */
+    if (row.phase === args.to) {
+      if (
+        row.leaseOwnerId === undefined ||
+        row.leaseOwnerId === args.ownerId
+      ) {
+        return { changed: false, offseason: toOffseasonDto(row) };
+      }
+      throw new Error("phase_busy");
+    }
+
+    const decision = phaseGate({
+      from: row.phase,
+      to: args.to,
+      draftStatus: args.draftStatus as DraftPhaseStatus,
+    });
+    if (!decision.ok) throw new Error(decision.reason);
+
+    /*
+     * The CAS. Checked AFTER the gate so a genuinely invalid request (a
+     * backward phase, a skipped phase) reports what is wrong with it rather
+     * than being masked as a concurrency loss.
+     */
+    if (row.phase !== args.expectedPhase) throw new Error("phase_busy");
+
+    const now = Date.now();
+    const leaseExpiresAt = row.leaseExpiresAt
+      ? Date.parse(row.leaseExpiresAt)
+      : 0;
+    const foreignLease =
+      row.leaseOwnerId !== undefined &&
+      row.leaseOwnerId !== args.ownerId &&
+      Number.isFinite(leaseExpiresAt) &&
+      leaseExpiresAt > now;
+    if (foreignLease) throw new Error("phase_busy");
+
+    await ctx.db.patch(row._id, {
+      phase: args.to,
+      completedPhases: completePhase(row.completedPhases, row.phase),
+      leasePhase: args.to,
+      leaseOwnerId: args.ownerId,
+      leaseExpiresAt: new Date(now + OFFSEASON_LEASE_MS).toISOString(),
+      updatedAt: new Date(now).toISOString(),
+      updatedBy: args.actorUserId,
+    });
+    const updated = await ctx.db.get(row._id);
+    if (!updated) throw new Error("offseason_not_found");
+    return { changed: true, offseason: toOffseasonDto(updated) };
   },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -153,6 +153,16 @@ async function cascadeDeleteLeague(
       deleted += 1;
     }
   }
+  // Persisted offseason phase machine (B1). Left behind, a row would carry one
+  // run's phase into the next and make the stepper assertions order-dependent.
+  const offseasonRows = (await ctx.db
+    .query("offseasons")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"offseasons"> }>;
+  for (const row of offseasonRows) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
   // Dynasty feed (F4) — league-scoped, so cleared once rather than per season.
   const events = (await ctx.db
     .query("dynastyEvents")

--- a/apps/web/convex/lib/offseasonPhases.ts
+++ b/apps/web/convex/lib/offseasonPhases.ts
@@ -1,0 +1,228 @@
+/*
+ * The offseason phase machine (Dynasty Mode B1).
+ *
+ * Pure and Convex-free. Every rule about what an offseason may do next lives
+ * here; the Convex mutation adds only concurrency. That split is deliberate —
+ * the rules are the part worth testing exhaustively, and they are the part
+ * later slices (B2–B6) extend.
+ *
+ * ## Why this table exists at all when `seasonRollovers` already has stages
+ *
+ * `seasonRollovers` owns the AUTOMATIC stages: six mechanical steps that run
+ * back-to-back inside one server action under a 60-second lease. This machine
+ * owns the HUMAN-PACED ones: an admin can sit in the draft phase for three
+ * days. Modelling both with one lease would make the lease meaningless — a
+ * 60-second timeout on a phase measured in days either expires constantly or
+ * has to be so long it stops protecting anything.
+ *
+ * ## Adding a phase later
+ *
+ * Insert it into `OFFSEASON_PHASES` in position. `completedPhases` is a SET of
+ * names rather than a high-water index, so an offseason already in flight when
+ * a new phase is inserted behind it simply never has that name in its set. It
+ * reads as "skipped", which is exactly what happened, and no migration is
+ * forced. `hasReachedPhase` is the only thing that depends on order.
+ */
+
+export const OFFSEASON_PHASES = [
+  "rollover",
+  "draft",
+  "free_agency",
+  "activate",
+] as const;
+
+export type OffseasonPhase = (typeof OFFSEASON_PHASES)[number];
+
+export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
+  rollover: "Rollover",
+  draft: "Draft",
+  free_agency: "Free agency",
+  activate: "Activate",
+};
+
+/**
+ * Phases an admin may pass through without doing anything in them.
+ *
+ * The draft is genuinely optional — a league that does not run one still has
+ * to leave the phase, so "optional" means "advanceable while empty", not
+ * "skippable in the ordering".
+ */
+const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set(["draft"]);
+
+/*
+ * A new offseason opens at `draft`, not at `rollover`.
+ *
+ * `rollover` is in the machine as a completed marker only. By the time an
+ * offseason row can exist the mechanical rollover has already run — it is what
+ * created the target season — and it is owned by `seasonRollovers`, not by
+ * this machine. Opening at `rollover` would show an admin a phase they cannot
+ * act on and have already finished.
+ */
+export const INITIAL_OFFSEASON_PHASE: OffseasonPhase = "draft";
+
+export type DraftPhaseStatus = "none" | "active" | "complete";
+
+export interface OffseasonState {
+  phase: OffseasonPhase;
+  completedPhases: OffseasonPhase[];
+}
+
+export function isOffseasonPhase(value: string): value is OffseasonPhase {
+  return (OFFSEASON_PHASES as readonly string[]).includes(value);
+}
+
+export function phaseIndex(phase: string): number {
+  return (OFFSEASON_PHASES as readonly string[]).indexOf(phase);
+}
+
+/** The phase after `phase`, or `null` at the end of the machine. */
+export function nextPhase(phase: OffseasonPhase): OffseasonPhase | null {
+  const index = phaseIndex(phase);
+  if (index < 0 || index >= OFFSEASON_PHASES.length - 1) return null;
+  return OFFSEASON_PHASES[index + 1];
+}
+
+/**
+ * True when `phase` is at or past `expected`.
+ *
+ * Mirrors `hasReachedRolloverStage` in `_actions/dynasty.ts` on purpose: two
+ * different comparison idioms for two different phase machines in the same
+ * feature would be a reliable source of off-by-one bugs.
+ */
+export function hasReachedPhase(phase: string, expected: string): boolean {
+  const current = phaseIndex(phase);
+  const target = phaseIndex(expected);
+  if (current < 0 || target < 0) return false;
+  return current >= target;
+}
+
+export type AdvanceRejection =
+  | "phase_regression"
+  | "phase_out_of_order"
+  | "unknown_phase"
+  | "draft_in_progress";
+
+export type AdvanceDecision =
+  | { ok: true; kind: "advance" }
+  /** Already at `to` — a retry of a request that landed. */
+  | { ok: true; kind: "noop" }
+  | { ok: false; reason: AdvanceRejection };
+
+export interface PhaseGateInput {
+  from: string;
+  to: string;
+  draftStatus: DraftPhaseStatus;
+}
+
+/**
+ * Whether an offseason at `from` may move to `to`.
+ *
+ * The single decision function for an advance. It returns a `noop` rather than
+ * an error when the offseason is already at `to`, which is what makes a
+ * double-submitted advance safe: the second one is not a failure, it is a
+ * request that was already satisfied.
+ */
+export function phaseGate(input: PhaseGateInput): AdvanceDecision {
+  if (!isOffseasonPhase(input.from) || !isOffseasonPhase(input.to)) {
+    return { ok: false, reason: "unknown_phase" };
+  }
+  if (input.to === input.from) return { ok: true, kind: "noop" };
+  if (hasReachedPhase(input.from, input.to)) {
+    return { ok: false, reason: "phase_regression" };
+  }
+  if (input.to !== nextPhase(input.from)) {
+    return { ok: false, reason: "phase_out_of_order" };
+  }
+
+  /*
+   * The one real gameplay gate today. A draft that is mid-pick holds roster
+   * moves that free agency would otherwise contradict, so the phase cannot be
+   * left until it is finished. `none` is fine — an unstarted draft is the
+   * league declining to run one.
+   */
+  if (input.from === "draft" && input.draftStatus === "active") {
+    return { ok: false, reason: "draft_in_progress" };
+  }
+
+  return { ok: true, kind: "advance" };
+}
+
+/**
+ * Add `phase` to `completed` without duplicating it, in machine order.
+ *
+ * Takes a plain string and filters against the machine, so a name that is not
+ * a phase — a stored value from a future version, a typo — is dropped rather
+ * than persisted. That also makes the result self-repairing: a row that
+ * somehow accumulated junk is cleaned the next time it advances.
+ */
+export function completePhase(
+  completed: readonly string[],
+  phase: string,
+): OffseasonPhase[] {
+  const set = new Set<string>([...completed, phase]);
+  return OFFSEASON_PHASES.filter((candidate) => set.has(candidate));
+}
+
+export type PhaseStepState = "complete" | "active" | "upcoming" | "optional";
+
+export interface PhaseStep {
+  id: OffseasonPhase;
+  label: string;
+  state: PhaseStepState;
+}
+
+/**
+ * The stepper's view of an offseason.
+ *
+ * Reads only persisted state. A phase is `complete` because it is IN
+ * `completedPhases`, not because the current phase happens to be past it —
+ * those differ for an offseason that was migrated or had a phase inserted
+ * behind it, and the set is the honest answer.
+ */
+export function buildPhaseSteps(state: OffseasonState): PhaseStep[] {
+  const completed = new Set<string>(state.completedPhases);
+  return OFFSEASON_PHASES.map((phase) => {
+    const state_: PhaseStepState =
+      phase === state.phase
+        ? "active"
+        : completed.has(phase)
+          ? "complete"
+          : OPTIONAL_PHASES.has(phase) && hasReachedPhase(state.phase, phase)
+            ? "optional"
+            : "upcoming";
+    return { id: phase, label: OFFSEASON_PHASE_LABELS[phase], state: state_ };
+  });
+}
+
+/**
+ * A usable state for a season with no stored row.
+ *
+ * Two callers need this and they need different things from it:
+ *
+ * - A season that just rolled over has genuinely completed `rollover` and
+ *   nothing else. That is the default.
+ * - A league that entered its offseason BEFORE this table existed has real
+ *   draft progress that no row records. Inferring the phase from draft status
+ *   is a one-way bridge for those leagues, not a parallel source of truth: it
+ *   is consulted only when the row is absent, and the row wins the moment one
+ *   exists. It can be deleted once every live league has been through an
+ *   offseason under B1.
+ */
+export function resolveOffseasonState(
+  row: { phase: string; completedPhases: string[] } | null | undefined,
+  bridge: { draftStatus: DraftPhaseStatus } = { draftStatus: "none" },
+): OffseasonState {
+  if (row && isOffseasonPhase(row.phase)) {
+    return {
+      phase: row.phase,
+      completedPhases: row.completedPhases.filter(isOffseasonPhase),
+    };
+  }
+  if (bridge.draftStatus === "active") {
+    return { phase: "draft", completedPhases: ["rollover"] };
+  }
+  if (bridge.draftStatus === "complete") {
+    return { phase: "free_agency", completedPhases: ["rollover", "draft"] };
+  }
+  return { phase: INITIAL_OFFSEASON_PHASE, completedPhases: ["rollover"] };
+}

--- a/apps/web/convex/tables/offseason.ts
+++ b/apps/web/convex/tables/offseason.ts
@@ -9,6 +9,57 @@ import { v } from "convex/values";
  */
 export const offseasonTables = {
   /*
+   * Persisted offseason phase machine (Dynasty Mode B1).
+   *
+   * One row per target season. The phase used to be DERIVED from draft status
+   * in the stepper, which made it unresumable, ungateable and invisible to any
+   * audit — and would have had to be rewritten once phases outnumbered the
+   * draft.
+   *
+   * `seasonRollovers` still owns the automatic, lease-protected mechanical
+   * stages. This table owns the human-paced ones. The two are separate because
+   * a 60-second lease is coherent for a stage that runs in one server action
+   * and incoherent for a phase an admin sits in for three days.
+   *
+   * `completedPhases` is a SET, not a high-water mark, so inserting a phase
+   * into the middle of the machine later never forces a migration.
+   */
+  offseasons: defineTable({
+    leagueId: v.id("leagues"),
+    /** The UPCOMING season being prepared, not the one that just finished. */
+    seasonId: v.id("seasons"),
+    phase: v.string(),
+    completedPhases: v.array(v.string()),
+    /*
+     * Budgets are SNAPSHOT at open, alongside `configJson`. An admin who
+     * raises `scoutingPointsPerOffseason` halfway through must not retroactively
+     * refund an offseason that has already been half spent under the old value.
+     * B3 and B6 are the consumers; nothing spends them yet.
+     */
+    scoutingPointsTotal: v.number(),
+    scoutingPointsSpent: v.number(),
+    trainingPointsTotal: v.number(),
+    trainingPointsSpent: v.number(),
+    /** `DynastyConfig` as of open — see the budget note above. */
+    configJson: v.string(),
+    /*
+     * Advance lease. Short-lived and held only across an advance, never across
+     * phase occupancy. B2+ phases do real work between claim and commit; today
+     * it exists so a second admin clicking Advance loses cleanly rather than
+     * double-running that work.
+     */
+    leasePhase: v.optional(v.string()),
+    leaseOwnerId: v.optional(v.string()),
+    leaseExpiresAt: v.optional(v.string()),
+    lastError: v.optional(v.string()),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    updatedBy: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  /*
    * Offseason snake draft (WSM-000233). One draft per target season; order is
    * reverse final standings. Writes are internalMutation only.
    */

--- a/apps/web/e2e/tests/offseason-phases.spec.ts
+++ b/apps/web/e2e/tests/offseason-phases.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { acceptBrowserConfirms } from "../helpers/sim-league-setup";
+
+/*
+ * Persisted offseason phase machine (Dynasty Mode B1, #618).
+ *
+ * Runs in its own fixture league. The canonical shared league's season
+ * statuses churn across CI runs, and the whole point of this suite is that the
+ * Offseason link appears for an UPCOMING season and not for an active one —
+ * an assertion that is meaningless if another spec can flip the status.
+ *
+ * A newly created season is upcoming, which is a far cheaper way to get one
+ * than simulating a full season to a champion and rolling over.
+ */
+test.describe("Offseason phase machine (B1)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "offseason-phases";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E OP Home",
+      awayTeamName: "E2E OP Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("an upcoming season exposes the Offseason hub and advances a phase", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    const seasonName = `E2E Offseason ${Date.now()}`;
+    await dialog.getByLabel("Season name").fill(seasonName);
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+
+    // Take the new season's id off the schedule shortcut rather than hunting
+    // for its row — the seasons list sorts by status and date, so a name match
+    // there is order-dependent in a way this suite has no reason to depend on.
+    const href = await success
+      .getByTestId("create-season-generate-schedule")
+      .getAttribute("href");
+    const seasonId = href?.split("/")[3];
+    expect(seasonId).toBeTruthy();
+    await success.getByRole("button", { name: "Done" }).click();
+
+    await page.goto(`/dashboard/seasons/${seasonId}`);
+
+    /*
+     * The sibling link is the flag-gated entry added to buildSeasonSiblingLinks.
+     *
+     * Scoped to the Resource Header rather than the page: accessible-name
+     * matching is a SUBSTRING match, and this spec names its season "E2E
+     * Offseason …", so a bare page-level "Offseason" also matches the "View E2E
+     * Offseason …" link on the season card.
+     */
+    const offseasonLink = page
+      .getByTestId("resource-header-season")
+      .getByRole("link", { name: "Offseason" });
+    await expect(offseasonLink).toBeVisible({ timeout: 30_000 });
+    await offseasonLink.click();
+    await expect(page).toHaveURL(/\/dashboard\/seasons\/[^/]+\/offseason$/);
+
+    // A freshly opened offseason sits at `draft` with the rollover recorded.
+    const stepper = page.getByTestId("offseason-phase-stepper");
+    await expect(stepper).toHaveAttribute("data-phase", "draft");
+    await expect(page.getByTestId("offseason-phase-rollover")).toHaveAttribute(
+      "data-state",
+      "complete",
+    );
+
+    await page.getByTestId("offseason-advance").click();
+    await expect(page.getByTestId("offseason-phase-message")).toContainText(
+      "Free agency",
+      { timeout: 30_000 },
+    );
+
+    // The phase is PERSISTED, which is the whole slice — a reload has to keep it.
+    await page.reload();
+    await expect(page.getByTestId("offseason-phase-stepper")).toHaveAttribute(
+      "data-phase",
+      "free_agency",
+    );
+    await expect(page.getByTestId("offseason-phase-draft")).toHaveAttribute(
+      "data-state",
+      "complete",
+    );
+  });
+
+  test("an active season has no Offseason link and no hub page", async ({
+    page,
+  }) => {
+    const active = fixture;
+    if (!active) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${active.seasonId}`);
+    // Scoped to the Resource Header for the same reason as the test above:
+    // accessible-name matching is a case-insensitive SUBSTRING match, and this
+    // fixture's league is called "E2E:offseason-phases".
+    await expect(
+      page
+        .getByTestId("resource-header-season")
+        .getByRole("link", { name: "Offseason" }),
+    ).toHaveCount(0);
+
+    /*
+     * The route itself refuses too, not just the link — an offseason prepares a
+     * season that has not started, and this one has.
+     *
+     * Asserted on what RENDERS, not on the HTTP status. `/dashboard/*` streams
+     * its shell before a page's guard runs, so the response headers go out as
+     * 200 even when the page then calls `notFound()` (WSM-000190) — the same
+     * caveat `schedules-standings.spec.ts` records for its own 404 checks,
+     * which target fully server-rendered `/leagues/*` routes instead.
+     */
+    await page.goto(`/dashboard/seasons/${active.seasonId}/offseason`);
+    await expect(page.getByTestId("offseason-phase-stepper")).toHaveCount(0);
+    await expect(page.getByTestId("offseason-advance")).toHaveCount(0);
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/offseason-phases.ts
+++ b/apps/web/src/app/dashboard/_actions/offseason-phases.ts
@@ -1,0 +1,131 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  advanceOffseasonPhase,
+  beginOffseason,
+  getDraft,
+  getLeagueOrgId,
+  type OffseasonDto,
+} from "@/lib/data-api";
+import type { DraftPhaseStatus } from "@/lib/dynasty/offseason-phases";
+
+/*
+ * Advancing the offseason is an ORG-ADMIN action (B1).
+ *
+ * A phase change moves every team in the league at once — it closes the draft
+ * window on all of them, or opens free agency for all of them. It is not a
+ * per-team action, so it does not route through `authorizeTeamMutation`. The
+ * per-team authorization the roadmap requires is for the phase CONTENTS
+ * (scouting, training, promotions) that B3–B6 add, where each coach acts on
+ * their own roster.
+ */
+
+export type OffseasonActionResult =
+  | { ok: true; offseason: OffseasonDto; changed: boolean }
+  | { ok: false; error: string };
+
+async function requireLeagueAdmin(leagueId: string): Promise<string | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (!canManageOrgSettings(role)) return null;
+  const orgContext = await resolveOrgContext(userId);
+  if (!orgContext.visibleLeagueIds.includes(leagueId)) return null;
+  return userId;
+}
+
+function draftStatusFor(
+  draft: { status: string } | null,
+): DraftPhaseStatus {
+  if (!draft) return "none";
+  return draft.status === "complete" ? "complete" : "active";
+}
+
+export async function openOffseasonAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<OffseasonActionResult> {
+  const userId = await requireLeagueAdmin(input.leagueId);
+  if (!userId) return { ok: false, error: "not_authorized" };
+
+  try {
+    const offseason = await beginOffseason({
+      seasonId: input.seasonId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    return { ok: true, offseason, changed: true };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}
+
+export async function advanceOffseasonPhaseAction(input: {
+  leagueId: string;
+  seasonId: string;
+  expectedPhase: string;
+  to: string;
+}): Promise<OffseasonActionResult> {
+  const userId = await requireLeagueAdmin(input.leagueId);
+  if (!userId) return { ok: false, error: "not_authorized" };
+
+  try {
+    /*
+     * Open on demand so the row's existence is never something the UI has to
+     * orchestrate. `beginOffseason` is idempotent, so this is a no-op for every
+     * season that already has one.
+     */
+    await beginOffseason({ seasonId: input.seasonId, actorUserId: userId });
+
+    /*
+     * Draft status is read HERE and passed in, rather than read inside the
+     * mutation. The gate needs it, and `drafts` is queried by season through a
+     * function the Next layer already owns — reaching into it from the dynasty
+     * module would couple two Convex modules for one boolean.
+     */
+    const draft = await getDraft(input.seasonId).catch(() => null);
+
+    const result = await advanceOffseasonPhase({
+      seasonId: input.seasonId,
+      expectedPhase: input.expectedPhase,
+      to: input.to,
+      // Identifies this attempt, so a retry by the same admin is not mistaken
+      // for a second admin racing them.
+      ownerId: `${userId}:${input.expectedPhase}:${input.to}`,
+      actorUserId: userId,
+      draftStatus: draftStatusFor(draft),
+    });
+
+    revalidatePath(`/dashboard/seasons/${input.seasonId}`);
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    return { ok: true, offseason: result.offseason, changed: result.changed };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}
+
+/**
+ * Convex wraps a thrown `Error` in its own message, so the bare reason a
+ * caller needs (`phase_busy`, `draft_in_progress`) has to be recovered from
+ * the text rather than read off a field.
+ */
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const known = [
+    "phase_busy",
+    "phase_regression",
+    "phase_out_of_order",
+    "draft_in_progress",
+    "unknown_phase",
+    "offseason_not_found",
+    "season_not_upcoming",
+    "season_not_found",
+  ];
+  return known.find((code) => raw.includes(code)) ?? "advance_failed";
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
@@ -1,0 +1,93 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { dynastyOffseasonV2 } from "@/lib/flags";
+import {
+  getDraft,
+  getLeague,
+  getOffseason,
+  getSeason,
+  getTeamsByLeague,
+} from "@/lib/data-api";
+import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import { Card, CardContent } from "@/components/ui/card";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import { seasonHomeHref } from "@/components/workspace/resource-navigation";
+import { OffseasonPhaseControls } from "@/components/offseason/OffseasonPhaseControls";
+import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+
+/*
+ * Offseason Hub (Dynasty Mode B1).
+ *
+ * A dedicated surface for the phase machine, separate from the Offseason card
+ * on Season Home. Season Home shows an admin where the offseason IS; this page
+ * is where they move it, and where B2–B6 hang the per-phase panels.
+ */
+export default async function SeasonOffseasonPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const enabled = await dynastyOffseasonV2();
+  if (!enabled) notFound();
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: seasonId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const season = await getSeason(seasonId, orgContext).catch(() => null);
+  if (!season) notFound();
+
+  /*
+   * An offseason prepares a season that has not started. On an active or
+   * completed season there is nothing here to do, and showing the controls
+   * would imply a roster window that results have already closed.
+   */
+  if (season.status !== "upcoming") notFound();
+
+  const league = await getLeague(season.leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+  await syncActiveLeagueForResource(league.id);
+
+  const [offseason, draft, teams] = await Promise.all([
+    getOffseason(season.id).catch(() => null),
+    getDraft(season.id).catch(() => null),
+    getTeamsByLeague(league.id, orgContext).catch(() => []),
+  ]);
+
+  const role = league.orgId ? await resolveOrgRole(league.orgId, userId) : null;
+  const isAdmin = canManageOrgSettings(role);
+
+  const draftStatus = !draft
+    ? ("none" as const)
+    : draft.status === "complete"
+      ? ("complete" as const)
+      : ("active" as const);
+  const state = resolveOffseasonState(offseason, { draftStatus });
+
+  return (
+    <div className="mx-auto max-w-[960px] space-y-4">
+      <ResourceHeader
+        kind="season"
+        title="Offseason"
+        homeHref={seasonHomeHref(season.id)}
+        context={`${season.name} · ${league.name}`}
+      />
+
+      <Card data-testid="offseason-hub-page">
+        <CardContent className="space-y-6 p-5">
+          <OffseasonPhaseControls
+            leagueId={league.id}
+            seasonId={season.id}
+            state={state}
+            draftStatus={draftStatus}
+            isAdmin={isAdmin}
+            teamCount={teams.length}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   schedulesStandingsV1,
   playoffsV1,
   statKeepingV1,
+  dynastyOffseasonV2,
 } from "@/lib/flags";
 import {
   computeStandings,
@@ -18,6 +19,7 @@ import {
   listFixturesBySeason,
   listFreeAgents,
   getDraft,
+  getOffseason,
 } from "@/lib/data-api";
 import { canManageTeam } from "@/lib/authorization";
 import { resolveOrgContext, requireOrgAdmin, resolveOrgRole } from "@/lib/org-context";
@@ -85,7 +87,7 @@ export default async function SeasonHubPage({
     seasons.filter((s) => s.status === "completed"),
   );
 
-  const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
+  const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, offseasonEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
     await Promise.all([
       listFixturesBySeason(season.id),
       computeStandings(season.id),
@@ -93,6 +95,7 @@ export default async function SeasonHubPage({
       schedulesStandingsV1(),
       playoffsV1(),
       statKeepingV1(),
+      dynastyOffseasonV2(),
       activeSeason
         ? listFixturesBySeason(activeSeason.id).catch(() => [])
         : Promise.resolve([]),
@@ -159,17 +162,20 @@ export default async function SeasonHubPage({
   let offseasonOrgRole: Awaited<ReturnType<typeof resolveOrgRole>> | null =
     null;
   let draft: Awaited<ReturnType<typeof getDraft>> = null;
+  let offseason: Awaited<ReturnType<typeof getOffseason>> = null;
   let playerNames: Record<string, string> = {};
 
   if (isUpcomingSeason) {
-    [freeAgents, offseasonTeams, offseasonOrgRole, draft] = await Promise.all([
-      listFreeAgents(league.id).catch(() => []),
-      getTeamsByLeague(league.id, orgContext).catch(() => []),
-      league.orgId
-        ? resolveOrgRole(league.orgId, userId).catch(() => null)
-        : Promise.resolve(null),
-      getDraft(season.id).catch(() => null),
-    ]);
+    [freeAgents, offseasonTeams, offseasonOrgRole, draft, offseason] =
+      await Promise.all([
+        listFreeAgents(league.id).catch(() => []),
+        getTeamsByLeague(league.id, orgContext).catch(() => []),
+        league.orgId
+          ? resolveOrgRole(league.orgId, userId).catch(() => null)
+          : Promise.resolve(null),
+        getDraft(season.id).catch(() => null),
+        getOffseason(season.id).catch(() => null),
+      ]);
 
     const leaguePlayers = await getPlayers([league.id]).catch(() => []);
     playerNames = Object.fromEntries(
@@ -227,6 +233,8 @@ export default async function SeasonHubPage({
           scheduleEnabled,
           playoffsEnabled,
           statsEnabled,
+          // Only an upcoming season has an offseason to prepare.
+          offseasonEnabled: offseasonEnabled && isUpcomingSeason,
         })}
       />
       <WorkspaceNav links={links} />
@@ -243,6 +251,7 @@ export default async function SeasonHubPage({
           coachTeam={coachTeam}
           draft={draft}
           playerNames={playerNames}
+          offseason={offseason}
         />
       )}
 

--- a/apps/web/src/components/offseason/OffseasonHub.tsx
+++ b/apps/web/src/components/offseason/OffseasonHub.tsx
@@ -2,7 +2,11 @@ import { CalendarClock } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { DraftDto } from "@/lib/data-api";
 import type { FreeAgentRow } from "@/lib/offseason-free-agency";
-import type { DraftPhaseStatus } from "./OffseasonPhaseStepper";
+import type { OffseasonDto } from "@/lib/data-api";
+import {
+  resolveOffseasonState,
+  type DraftPhaseStatus,
+} from "@/lib/dynasty/offseason-phases";
 import { DraftBoard } from "./DraftBoard";
 import { DraftStartToggle } from "./DraftStartToggle";
 import { FreeAgencyPanel } from "./FreeAgencyPanel";
@@ -25,6 +29,8 @@ export interface OffseasonHubProps {
   coachTeam: { id: string; name: string } | null;
   draft: DraftDto | null;
   playerNames: Record<string, string>;
+  /** Persisted phase state (B1); `null` for a season opened before the table. */
+  offseason?: OffseasonDto | null;
 }
 
 export function OffseasonHub({
@@ -38,8 +44,10 @@ export function OffseasonHub({
   coachTeam,
   draft,
   playerNames,
+  offseason = null,
 }: OffseasonHubProps) {
   const draftStatus = draftPhaseStatus(draft);
+  const phaseState = resolveOffseasonState(offseason, { draftStatus });
 
   return (
     <Card className="mb-6" data-testid="offseason-hub">
@@ -54,7 +62,7 @@ export function OffseasonHub({
         </p>
       </CardHeader>
       <CardContent className="space-y-6">
-        <OffseasonPhaseStepper draftStatus={draftStatus} />
+        <OffseasonPhaseStepper state={phaseState} />
 
         {isAdmin && !draft && (
           <DraftStartToggle leagueId={leagueId} seasonId={seasonId} />

--- a/apps/web/src/components/offseason/OffseasonPhaseControls.tsx
+++ b/apps/web/src/components/offseason/OffseasonPhaseControls.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { advanceOffseasonPhaseAction } from "@/app/dashboard/_actions/offseason-phases";
+import {
+  OFFSEASON_PHASE_LABELS,
+  nextPhase,
+  phaseGate,
+  type DraftPhaseStatus,
+  type OffseasonState,
+} from "@/lib/dynasty/offseason-phases";
+import { OffseasonPhaseStepper } from "./OffseasonPhaseStepper";
+
+const REASON_COPY: Record<string, string> = {
+  draft_in_progress:
+    "Finish or end the draft before leaving the draft phase.",
+  phase_busy:
+    "Another admin advanced this offseason first. Reload to see where it is now.",
+  phase_regression: "The offseason cannot move backwards.",
+  phase_out_of_order: "Phases have to be completed in order.",
+  not_authorized: "You do not have permission to advance the offseason.",
+  season_not_upcoming: "This season has already started.",
+};
+
+function copyFor(reason: string): string {
+  return REASON_COPY[reason] ?? "Could not advance the offseason.";
+}
+
+export interface OffseasonPhaseControlsProps {
+  leagueId: string;
+  seasonId: string;
+  state: OffseasonState;
+  draftStatus: DraftPhaseStatus;
+  isAdmin: boolean;
+  teamCount: number;
+}
+
+export function OffseasonPhaseControls({
+  leagueId,
+  seasonId,
+  state,
+  draftStatus,
+  isAdmin,
+  teamCount,
+}: OffseasonPhaseControlsProps) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const target = nextPhase(state.phase);
+  /*
+   * The SAME gate the mutation runs (`phaseGate` is shared through
+   * `convex/lib/offseasonPhases.ts`). Deciding here whether the button is
+   * enabled and there whether the advance commits keeps the two answers from
+   * drifting into a button that is clickable and an action that always fails.
+   */
+  const decision = target
+    ? phaseGate({ from: state.phase, to: target, draftStatus })
+    : null;
+  const blockedReason =
+    decision && !decision.ok ? decision.reason : null;
+
+  function advance() {
+    if (!target) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await advanceOffseasonPhaseAction({
+        leagueId,
+        seasonId,
+        expectedPhase: state.phase,
+        to: target,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      setMessage(
+        result.changed
+          ? `Advanced to ${OFFSEASON_PHASE_LABELS[target]}.`
+          : `Already in ${OFFSEASON_PHASE_LABELS[target]}.`,
+      );
+    });
+  }
+
+  return (
+    <div className="space-y-5" data-testid="offseason-phase-controls">
+      <OffseasonPhaseStepper state={state} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <p className="text-sm text-muted-foreground" data-testid="offseason-phase-summary">
+          {teamCount} team{teamCount === 1 ? "" : "s"} in this offseason ·
+          currently in {OFFSEASON_PHASE_LABELS[state.phase]}.
+        </p>
+
+        {isAdmin && target && (
+          <Button
+            size="sm"
+            className="ml-auto"
+            disabled={pending || blockedReason !== null}
+            data-testid="offseason-advance"
+            onClick={advance}
+          >
+            Advance to {OFFSEASON_PHASE_LABELS[target]}
+          </Button>
+        )}
+      </div>
+
+      {blockedReason && (
+        <p className="text-sm text-muted-foreground" data-testid="offseason-phase-blocked">
+          {copyFor(blockedReason)}
+        </p>
+      )}
+
+      {message && (
+        <p className="text-sm text-foreground" data-testid="offseason-phase-message">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/offseason/OffseasonPhaseStepper.tsx
+++ b/apps/web/src/components/offseason/OffseasonPhaseStepper.tsx
@@ -1,47 +1,35 @@
 import { Check, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  buildPhaseSteps,
+  type OffseasonState,
+  type PhaseStep,
+} from "@/lib/dynasty/offseason-phases";
 
-export type DraftPhaseStatus = "none" | "active" | "complete";
+export type { DraftPhaseStatus } from "@/lib/dynasty/offseason-phases";
 
-interface PhaseDef {
-  id: string;
-  label: string;
-  state: "complete" | "active" | "upcoming" | "disabled";
-}
-
-function buildPhases(draftStatus: DraftPhaseStatus): PhaseDef[] {
-  const draftState: PhaseDef["state"] =
-    draftStatus === "none"
-      ? "disabled"
-      : draftStatus === "active"
-        ? "active"
-        : "complete";
-
-  const freeAgencyState: PhaseDef["state"] =
-    draftStatus === "active" ? "upcoming" : "active";
-
-  return [
-    { id: "rollover", label: "Rollover", state: "complete" },
-    { id: "draft", label: "Draft", state: draftState },
-    { id: "free_agency", label: "Free agency", state: freeAgencyState },
-    { id: "activate", label: "Activate", state: "upcoming" },
-  ];
-}
-
+/*
+ * The stepper reads PERSISTED state (B1).
+ *
+ * It used to compute four phases from draft status, which meant the offseason
+ * had no memory: nothing was resumable, nothing could be gated, and every
+ * phase added after the draft would have needed another derived rule. The
+ * phase now comes from the `offseasons` row; `resolveOffseasonState` is where
+ * a season without one is turned into something renderable.
+ */
 export interface OffseasonPhaseStepperProps {
-  draftStatus?: DraftPhaseStatus;
+  state: OffseasonState;
 }
 
-export function OffseasonPhaseStepper({
-  draftStatus = "none",
-}: OffseasonPhaseStepperProps) {
-  const phases = buildPhases(draftStatus);
+export function OffseasonPhaseStepper({ state }: OffseasonPhaseStepperProps) {
+  const phases = buildPhaseSteps(state);
 
   return (
     <nav
       aria-label="Offseason phases"
       className="w-full min-w-0"
       data-testid="offseason-phase-stepper"
+      data-phase={state.phase}
     >
       <ol className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-stretch">
         {phases.map((phase, index) => (
@@ -51,20 +39,10 @@ export function OffseasonPhaseStepper({
               "flex min-w-0 flex-1 items-center gap-2",
               index < phases.length - 1 && "sm:pr-2",
             )}
+            data-testid={`offseason-phase-${phase.id}`}
+            data-state={phase.state}
           >
-            <div
-              className={cn(
-                "flex min-w-0 flex-1 items-center gap-2 rounded-control border px-3 py-2 text-sm",
-                phase.state === "complete" &&
-                  "border-primary/30 bg-primary/5 text-foreground",
-                phase.state === "active" &&
-                  "border-primary bg-primary/10 text-foreground",
-                phase.state === "disabled" &&
-                  "border-border bg-muted/40 text-muted-foreground",
-                phase.state === "upcoming" &&
-                  "border-border bg-card text-muted-foreground",
-              )}
-            >
+            <div className={stepClass(phase.state)}>
               <span className="shrink-0" aria-hidden>
                 {phase.state === "complete" ? (
                   <Check className="h-4 w-4 text-primary" />
@@ -80,9 +58,9 @@ export function OffseasonPhaseStepper({
                 )}
               </span>
               <span className="min-w-0 truncate font-medium">{phase.label}</span>
-              {phase.state === "disabled" && (
+              {phase.state === "optional" && (
                 <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                  Optional
+                  Skipped
                 </span>
               )}
             </div>
@@ -98,5 +76,15 @@ export function OffseasonPhaseStepper({
         ))}
       </ol>
     </nav>
+  );
+}
+
+function stepClass(state: PhaseStep["state"]): string {
+  return cn(
+    "flex min-w-0 flex-1 items-center gap-2 rounded-control border px-3 py-2 text-sm",
+    state === "complete" && "border-primary/30 bg-primary/5 text-foreground",
+    state === "active" && "border-primary bg-primary/10 text-foreground",
+    state === "optional" && "border-border bg-muted/40 text-muted-foreground",
+    state === "upcoming" && "border-border bg-card text-muted-foreground",
   );
 }

--- a/apps/web/src/components/offseason/__tests__/offseason-phase-stepper.test.ts
+++ b/apps/web/src/components/offseason/__tests__/offseason-phase-stepper.test.ts
@@ -2,30 +2,62 @@ import { createElement } from "react";
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { OffseasonPhaseStepper } from "@/components/offseason/OffseasonPhaseStepper";
+import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
 
+/*
+ * These assertions moved from draft status to persisted state in B1. The
+ * stepper no longer infers anything — it renders the row.
+ */
 describe("OffseasonPhaseStepper", () => {
-  it("renders free agency active when no draft exists", () => {
+  it("renders the persisted phase as active and completed phases as complete", () => {
     const html = renderToStaticMarkup(
-      createElement(OffseasonPhaseStepper, { draftStatus: "none" }),
+      createElement(OffseasonPhaseStepper, {
+        state: {
+          phase: "free_agency",
+          completedPhases: ["rollover", "draft"],
+        },
+      }),
     );
     expect(html).toContain('data-testid="offseason-phase-stepper"');
-    expect(html).toContain("Free agency");
-    expect(html).toContain("Draft");
-    expect(html).toContain("Optional");
+    expect(html).toContain('data-phase="free_agency"');
+    expect(html).toContain('data-testid="offseason-phase-draft" data-state="complete"');
+    expect(html).toContain(
+      'data-testid="offseason-phase-free_agency" data-state="active"',
+    );
+    expect(html).toContain(
+      'data-testid="offseason-phase-activate" data-state="upcoming"',
+    );
   });
 
-  it("marks draft active when a draft is in progress", () => {
+  it("marks a passed-over draft as skipped rather than complete", () => {
+    // The distinction is real: a league that never ran a draft did not
+    // complete that phase, it declined it.
     const html = renderToStaticMarkup(
-      createElement(OffseasonPhaseStepper, { draftStatus: "active" }),
+      createElement(OffseasonPhaseStepper, {
+        state: { phase: "free_agency", completedPhases: ["rollover"] },
+      }),
     );
-    expect(html).toContain("border-primary bg-primary/10");
-    expect(html).not.toContain("Optional");
+    expect(html).toContain(
+      'data-testid="offseason-phase-draft" data-state="optional"',
+    );
+    expect(html).toContain("Skipped");
   });
 
-  it("marks draft complete when the draft has finished", () => {
+  it("renders a season with no stored row from the draft-status bridge", () => {
     const html = renderToStaticMarkup(
-      createElement(OffseasonPhaseStepper, { draftStatus: "complete" }),
+      createElement(OffseasonPhaseStepper, {
+        state: resolveOffseasonState(null, { draftStatus: "active" }),
+      }),
     );
-    expect(html).toContain("border-primary/30 bg-primary/5");
+    expect(html).toContain('data-phase="draft"');
+  });
+
+  it("prefers the stored row over the bridge when both are available", () => {
+    // The bridge is a migration path, not a parallel source of truth.
+    const state = resolveOffseasonState(
+      { phase: "activate", completedPhases: ["rollover", "draft", "free_agency"] },
+      { draftStatus: "active" },
+    );
+    expect(state.phase).toBe("activate");
   });
 });

--- a/apps/web/src/components/workspace/resource-navigation.ts
+++ b/apps/web/src/components/workspace/resource-navigation.ts
@@ -104,7 +104,7 @@ export function seasonHomeHref(seasonId: string): string {
  */
 export function seasonSubpageHref(
   seasonId: string,
-  subpage: "schedule" | "standings" | "playoffs" | "stats",
+  subpage: "schedule" | "standings" | "playoffs" | "stats" | "offseason",
 ): string {
   return `/dashboard/seasons/${seasonId}/${subpage}`;
 }
@@ -186,14 +186,25 @@ export function buildSeasonSiblingLinks({
   scheduleEnabled,
   playoffsEnabled,
   statsEnabled,
+  offseasonEnabled = false,
 }: {
   seasonId: string;
   scheduleEnabled: boolean;
   playoffsEnabled: boolean;
   statsEnabled: boolean;
+  /**
+   * Offseason Hub (B1). The caller passes `flag && season.status === "upcoming"`
+   * — the hub prepares a season that has not started, so on an active or
+   * completed season the link would lead to a page with nothing to do.
+   */
+  offseasonEnabled?: boolean;
 }): ResourceSiblingLink[] {
   const links: (ResourceSiblingLink | false)[] = [
     { label: "Overview", href: seasonHomeHref(seasonId) },
+    offseasonEnabled && {
+      label: "Offseason",
+      href: seasonSubpageHref(seasonId, "offseason"),
+    },
     scheduleEnabled && {
       label: "Schedule",
       href: seasonSubpageHref(seasonId, "schedule"),

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2974,3 +2974,60 @@ export async function setTeamProgram(input: {
     input,
   );
 }
+
+/*
+ * Persisted offseason phase machine (B1). Same typed-ref discipline as the
+ * config functions above.
+ */
+
+export interface OffseasonDto {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  phase: string;
+  completedPhases: string[];
+  scoutingPointsTotal: number;
+  scoutingPointsSpent: number;
+  trainingPointsTotal: number;
+  trainingPointsSpent: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** `null` when no offseason was ever opened for the season — see the query. */
+export async function getOffseason(
+  seasonId: string,
+): Promise<OffseasonDto | null> {
+  const client = getConvexClient();
+  return client.query(dynastyRef.query<OffseasonDto | null>("getOffseason"), {
+    seasonId,
+  });
+}
+
+export async function beginOffseason(input: {
+  seasonId: string;
+  actorUserId: string;
+}): Promise<OffseasonDto> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<OffseasonDto>("beginOffseason"),
+    input,
+  );
+}
+
+export async function advanceOffseasonPhase(input: {
+  seasonId: string;
+  expectedPhase: string;
+  to: string;
+  ownerId: string;
+  actorUserId: string;
+  draftStatus: string;
+}): Promise<{ changed: boolean; offseason: OffseasonDto }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{ changed: boolean; offseason: OffseasonDto }>(
+      "advanceOffseasonPhase",
+    ),
+    input,
+  );
+}

--- a/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  INITIAL_OFFSEASON_PHASE,
+  OFFSEASON_PHASES,
+  buildPhaseSteps,
+  completePhase,
+  hasReachedPhase,
+  isOffseasonPhase,
+  nextPhase,
+  phaseGate,
+  resolveOffseasonState,
+  type OffseasonPhase,
+} from "@/lib/dynasty/offseason-phases";
+
+const gate = (
+  from: string,
+  to: string,
+  draftStatus: "none" | "active" | "complete" = "none",
+) => phaseGate({ from, to, draftStatus });
+
+describe("phase ordering", () => {
+  it("walks the machine forward and stops at the end", () => {
+    let phase: OffseasonPhase = OFFSEASON_PHASES[0];
+    const walked: OffseasonPhase[] = [phase];
+    for (;;) {
+      const next = nextPhase(phase);
+      if (!next) break;
+      phase = next;
+      walked.push(phase);
+    }
+    expect(walked).toEqual([...OFFSEASON_PHASES]);
+    expect(nextPhase("activate")).toBeNull();
+  });
+
+  it("compares phases by position, not by name", () => {
+    expect(hasReachedPhase("free_agency", "draft")).toBe(true);
+    expect(hasReachedPhase("draft", "draft")).toBe(true);
+    expect(hasReachedPhase("draft", "free_agency")).toBe(false);
+  });
+
+  it("returns false rather than a wrong answer for an unknown phase", () => {
+    // -1 indexes would otherwise compare as "reached", which is the classic
+    // way a phase machine silently lets an unknown value through.
+    expect(hasReachedPhase("nonsense", "draft")).toBe(false);
+    expect(hasReachedPhase("draft", "nonsense")).toBe(false);
+    expect(isOffseasonPhase("nonsense")).toBe(false);
+  });
+
+  it("opens at draft, because the rollover has already happened", () => {
+    expect(INITIAL_OFFSEASON_PHASE).toBe("draft");
+    expect(resolveOffseasonState(null).completedPhases).toContain("rollover");
+  });
+});
+
+describe("phaseGate", () => {
+  it("allows a forward advance to the immediate next phase", () => {
+    expect(gate("draft", "free_agency")).toEqual({ ok: true, kind: "advance" });
+  });
+
+  it("treats a repeat advance as a landed retry, not a failure", () => {
+    // A double-clicked Advance must not surface an error to an admin who did
+    // nothing wrong.
+    expect(gate("free_agency", "free_agency")).toEqual({
+      ok: true,
+      kind: "noop",
+    });
+  });
+
+  it("rejects a backward advance as a regression", () => {
+    expect(gate("free_agency", "draft")).toEqual({
+      ok: false,
+      reason: "phase_regression",
+    });
+  });
+
+  it("rejects skipping a phase", () => {
+    expect(gate("draft", "activate")).toEqual({
+      ok: false,
+      reason: "phase_out_of_order",
+    });
+  });
+
+  it("gates leaving the draft while it is mid-pick", () => {
+    expect(gate("draft", "free_agency", "active")).toEqual({
+      ok: false,
+      reason: "draft_in_progress",
+    });
+  });
+
+  it("lets an unstarted or finished draft be left", () => {
+    // "none" is a league declining to run one — not a reason to be stuck.
+    expect(gate("draft", "free_agency", "none").ok).toBe(true);
+    expect(gate("draft", "free_agency", "complete").ok).toBe(true);
+  });
+
+  it("rejects a phase name it does not know", () => {
+    expect(gate("draft", "recruiting")).toEqual({
+      ok: false,
+      reason: "unknown_phase",
+    });
+  });
+});
+
+describe("completePhase", () => {
+  it("behaves as a set — advancing twice records one entry", () => {
+    const once = completePhase(["rollover"], "draft");
+    const twice = completePhase(once, "draft");
+    expect(once).toEqual(["rollover", "draft"]);
+    expect(twice).toEqual(once);
+  });
+
+  it("keeps machine order regardless of insertion order", () => {
+    expect(completePhase(["free_agency", "rollover"], "draft")).toEqual([
+      "rollover",
+      "draft",
+      "free_agency",
+    ]);
+  });
+
+  it("drops names that are not phases instead of persisting them", () => {
+    expect(completePhase(["rollover", "recruiting"], "draft")).toEqual([
+      "rollover",
+      "draft",
+    ]);
+  });
+});
+
+describe("buildPhaseSteps", () => {
+  it("derives step state from the completed set, not from position", () => {
+    const steps = buildPhaseSteps({
+      phase: "activate",
+      completedPhases: ["rollover", "free_agency"],
+    });
+    const byId = Object.fromEntries(steps.map((s) => [s.id, s.state]));
+    // `draft` is behind the current phase but was never completed.
+    expect(byId.draft).toBe("optional");
+    expect(byId.free_agency).toBe("complete");
+    expect(byId.activate).toBe("active");
+  });
+
+  it("labels every phase in the machine exactly once", () => {
+    const steps = buildPhaseSteps({ phase: "draft", completedPhases: [] });
+    expect(steps.map((s) => s.id)).toEqual([...OFFSEASON_PHASES]);
+    expect(steps.filter((s) => s.state === "active")).toHaveLength(1);
+  });
+});
+
+describe("resolveOffseasonState", () => {
+  it("uses the stored row whenever there is one", () => {
+    expect(
+      resolveOffseasonState({ phase: "activate", completedPhases: ["draft"] }),
+    ).toEqual({ phase: "activate", completedPhases: ["draft"] });
+  });
+
+  it("falls back to draft status only when the row is absent", () => {
+    expect(resolveOffseasonState(null, { draftStatus: "complete" })).toEqual({
+      phase: "free_agency",
+      completedPhases: ["rollover", "draft"],
+    });
+  });
+
+  it("ignores a stored phase it cannot interpret", () => {
+    // A row written by a future version must not put the stepper into a state
+    // with no active phase.
+    const state = resolveOffseasonState(
+      { phase: "recruiting", completedPhases: ["rollover"] },
+      { draftStatus: "none" },
+    );
+    expect(state.phase).toBe(INITIAL_OFFSEASON_PHASE);
+  });
+
+  it("filters unknown names out of the completed set", () => {
+    const state = resolveOffseasonState({
+      phase: "free_agency",
+      completedPhases: ["rollover", "recruiting"],
+    });
+    expect(state.completedPhases).toEqual(["rollover"]);
+  });
+});

--- a/apps/web/src/lib/dynasty/offseason-phases.ts
+++ b/apps/web/src/lib/dynasty/offseason-phases.ts
@@ -1,0 +1,41 @@
+/*
+ * Offseason phase machine (B1) — Next-layer entry point.
+ *
+ * The definition lives in `convex/lib/offseasonPhases.ts` because the Convex
+ * bundler can only reach files under `convex/`, while `src/` can reach both.
+ * Same arrangement as `src/lib/dynasty-config.ts` and `src/lib/rivalries.ts`,
+ * and for the same reason: this is a re-export, NOT a copy.
+ *
+ * The stake here is `phaseGate`. It is the single decision function for an
+ * advance, and it runs on both sides — the server action uses it to decide
+ * whether to show the button, the mutation uses it to decide whether to commit.
+ * Two implementations that drifted would produce a button that is enabled and
+ * an advance that always fails.
+ *
+ * Import from here in Next code; import from `convex/lib/offseasonPhases`
+ * inside Convex functions.
+ */
+export {
+  INITIAL_OFFSEASON_PHASE,
+  OFFSEASON_PHASES,
+  OFFSEASON_PHASE_LABELS,
+  buildPhaseSteps,
+  completePhase,
+  hasReachedPhase,
+  isOffseasonPhase,
+  nextPhase,
+  phaseGate,
+  phaseIndex,
+  resolveOffseasonState,
+} from "../../../convex/lib/offseasonPhases";
+
+export type {
+  AdvanceDecision,
+  AdvanceRejection,
+  DraftPhaseStatus,
+  OffseasonPhase,
+  OffseasonState,
+  PhaseGateInput,
+  PhaseStep,
+  PhaseStepState,
+} from "../../../convex/lib/offseasonPhases";

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -221,6 +221,22 @@ export const dynastySimV2 = flag<boolean>({
   },
 });
 
+export const dynastyOffseasonV2 = flag<boolean>({
+  key: "dynasty_offseason_v2",
+  description:
+    "Dynasty Mode Epic B: persisted offseason phase machine and the Season offseason route (#618)",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_DYNASTY_OFFSEASON_V2");
+    void trackFlagExposure("dynasty_offseason_v2", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
## Summary

The offseason phase becomes a stored row instead of something the stepper inferred from draft
status, plus a dedicated Offseason Hub route for an upcoming season.

Closes #618. Part of #606.

Zero new gameplay, as the slice intends. This is the structural change that stops the stepper
having to be rewritten once phases outnumber the draft.

## The distinction that shaped the mutation

A **retry** and a **lost race** send byte-identical payloads. Two admins who both load the page at
phase `draft` and both click Advance send exactly what one admin double-clicking sends: same
`expectedPhase`, same `to`. Nothing in the request separates them.

So `leaseOwnerId` does: it records *who* made the move. Arriving at a phase you already asked for,
having been the one who moved it, is a landed retry (`changed: false`). Arriving there when someone
else moved it is `phase_busy`. That is what earns the lease its place on the row now rather than
only in B2+, and it is why the concurrency test asserts one fulfilled and one rejected rather than
two silent successes — which is what the first implementation did.

Ordering is checked **before** the compare-and-set, so a genuinely invalid request (backward,
skipped) reports what is wrong with it instead of being masked as a concurrency loss. Telling an
admin to go look for another admin who does not exist is a worse failure than the original error.

## Why `seasonRollovers` is left alone

It keeps owning the six automatic mechanical stages. `offseasons` owns the human-paced ones. A
60-second lease is coherent for a stage that runs inside one server action and incoherent for a
phase an admin sits in for three days — long enough to be useless, or short enough to expire
constantly. Two machines, two lease semantics, no merge.

## `completedPhases` is a set, not a high-water mark

B2–B6 insert phases into the middle of the machine. With a set, an offseason already in flight when
a phase is inserted behind it simply never has that name — it reads as "skipped", which is exactly
what happened, and no migration is ever forced. `hasReachedPhase` is the only thing that depends on
order.

That also makes the stepper honest about a passed-over draft: a league that never ran one did not
*complete* that phase, it *declined* it, and those render differently.

## One definition, two import paths

`phaseGate` is the single decision function for an advance and it runs on both sides — the client
uses it to decide whether the Advance button is enabled, the mutation uses it to decide whether to
commit. Two implementations that drifted would produce a button that is clickable and an action
that always fails. So it lives in `convex/lib/offseasonPhases.ts` (the Convex bundler can only
reach `convex/`) and `src/lib/dynasty/offseason-phases.ts` re-exports it — same arrangement as
`dynasty-config` (F5) and `rivalries` (A5). A test asserts the two import paths agree.

## What changed

- **`convex/lib/offseasonPhases.ts`** — `OFFSEASON_PHASES`, `nextPhase`, `hasReachedPhase`,
  `phaseGate`, `completePhase`, `buildPhaseSteps`, `resolveOffseasonState`.
- **`offseasons` table** — phase, completed set, scouting/training budgets, config snapshot, lease.
  Budgets and config are **snapshotted at open**: an admin who raises
  `scoutingPointsPerOffseason` halfway through must not retroactively refund an offseason that has
  already been half spent under the old value.
- **`convex/dynasty.ts`** — `getOffseason` (query), `beginOffseason` and `advanceOffseasonPhase`
  (**internalMutations**, WSM-000096), reached through the compile-checked `dynastyRef` helpers.
  `AllowedPublicDynastyReads` widened to include `getOffseason` — a deliberate, reviewed act.
- **`OffseasonPhaseStepper`** now takes persisted state. The shipped draft and free-agency phases
  are entries in the machine.
- **New route** `/dashboard/seasons/[id]/offseason` behind `FLAG_DYNASTY_OFFSEASON_V2`, with
  `seasonSubpageHref` extended and the sibling link shown only when the season is `upcoming`. The
  route itself 404s on a non-upcoming season, not just the link — an offseason prepares a season
  that has not started.
- **`resetCanonicalFixture` clears `offseasons`** in the same PR that adds the table (roadmap risk
  #5).
- **`CONTEXT.md`** gains an **Offseason Hub** entry with `_Avoid_` and a Relationships line.

## Deliberate scope choices

**Advancing is an org-admin action, not a per-team one.** A phase change closes the draft window on
every team at once, so it does not route through `authorizeTeamMutation`. The per-team
authorization the roadmap requires is for the phase *contents* — scouting, training, promotions —
that B3–B6 add, where each coach acts on their own roster. That path is untouched and still open.

**`getOffseason` returns `null` rather than a default.** Defaulting in the query would hide which
leagues still need a row. `resolveOffseasonState` is the single place absence becomes renderable,
and it prefers a stored row whenever there is one — the draft-status fallback is a one-way bridge
for leagues that entered their offseason before this table existed, not a parallel source of truth.
It can be deleted once every live league has been through an offseason under B1.

## Verification

- [x] `tsc --noEmit` clean (turbo type-check, 5/5)
- [x] `test:unit` — **193 files / 1449 tests pass** (was 192/1437)
- [x] `next build` succeeds; `/dashboard/seasons/[id]/offseason` present in the route manifest
- [x] `turbo lint` clean
- [x] `offseason-draft.spec.ts` and `offseason-free-agency.spec.ts` unmodified

New tests worth the review time:

- **Two concurrent advances → one winner, one `phase_busy`**, with the final row asserted so a
  double-apply would fail even if both calls resolved.
- **Advancing twice with the same payload produces one state change.**
- **A backward request is `phase_regression`; a skipped phase is `phase_out_of_order`** — the second
  asserted specifically so it is not silently reclassified as a conflict.
- **Leaving the draft mid-pick is `draft_in_progress`**, and an unstarted draft is not a trap.
- **Raising a config knob after open does not change an open offseason's budget.**
- **The Convex and Next import paths return identical rules** — fails loudly if the re-export is
  ever forked into a copy.
- **A phase behind the current one but never completed renders as skipped, not complete.**
- **An unknown stored phase does not leave the stepper with no active phase.**

## Playwright

`e2e/tests/offseason-phases.spec.ts` covers the AC directly: the Offseason link appears for an
upcoming season and is absent for an active one, the phase advances, and **a reload keeps it** —
which is the whole slice. It runs in its own fixture league, because the assertion is about season
status and the canonical league's statuses churn across runs.

**I did not run it locally** — it needs a Convex backend with the new `offseasons` table pushed, and
the recorded guidance for this repo is never to run `convex dev` from a worktree. It type-checks;
CI's Playwright job is its first real execution, and I will fix rather than quarantine if it fails.

## Out of scope

- The B2–B6 phases (`injuries_healed`, scouting, transfers, promotions, training) and the panels
  that go in them. The machine is built to have them inserted.
- Spending the scouting and training budgets. They are snapshotted and carried; nothing reads them
  yet.
- Wiring the Dynasty sim gates on. Still four A slices shipping dark and now one B slice behind a
  flag; turning them on remains unassigned.
