### PR TITLE
feat: activate the Dynasty sim engine from per-league config

### DIFF
--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -49,7 +49,10 @@ export const moduleStatus = query({
  */
 
 const dynastyConfigValidator = v.object({
+  scoringDepthEnabled: v.boolean(),
   penaltiesEnabled: v.boolean(),
+  situationalAiEnabled: v.boolean(),
+  balanceTuningEnabled: v.boolean(),
   injuriesEnabled: v.boolean(),
   weatherEnabled: v.boolean(),
   injurySeverityScale: v.number(),
@@ -92,7 +95,10 @@ export const setDynastyConfig = internalMutation({
     leagueId: v.id("leagues"),
     actorUserId: v.string(),
     patch: v.object({
+      scoringDepthEnabled: v.optional(v.boolean()),
       penaltiesEnabled: v.optional(v.boolean()),
+      situationalAiEnabled: v.optional(v.boolean()),
+      balanceTuningEnabled: v.optional(v.boolean()),
       injuriesEnabled: v.optional(v.boolean()),
       weatherEnabled: v.optional(v.boolean()),
       injurySeverityScale: v.optional(v.number()),

--- a/apps/web/convex/lib/dynastyConfig.ts
+++ b/apps/web/convex/lib/dynastyConfig.ts
@@ -27,8 +27,27 @@
 export type TransferVolume = "low" | "normal" | "high";
 
 export interface DynastyConfig {
+  /**
+   * Full scoring and turnover model (Epic A1): safeties, two-point tries,
+   * return touchdowns, and fumbles on plays other than a rush.
+   */
+  scoringDepthEnabled: boolean;
   /** Penalties are rolled during simulation (Epic A2). */
   penaltiesEnabled: boolean;
+  /**
+   * Situational AI and clock management (Epic A3): a real fourth-down chart,
+   * timeouts, the two-minute drill, spikes and kneels.
+   */
+  situationalAiEnabled: boolean;
+  /**
+   * Corrected home-field advantage (Epic A3, #642).
+   *
+   * A tuning fix rather than a mechanic — the original edge produced a home
+   * win rate above the target band. It is a separate knob only so a league
+   * that has already played under the old value can keep it; there is no
+   * reason to turn it off otherwise.
+   */
+  balanceTuningEnabled: boolean;
   /** Injuries can occur during simulation (Epic A4). */
   injuriesEnabled: boolean;
   /** Weather affects play outcomes (Epic A5). */
@@ -60,7 +79,10 @@ export interface DynastyConfig {
  * `convex/lib/offseason.ts` — the generator and this knob must agree.
  */
 export const DYNASTY_CONFIG_DEFAULTS: Readonly<DynastyConfig> = Object.freeze({
+  scoringDepthEnabled: true,
   penaltiesEnabled: true,
+  situationalAiEnabled: true,
+  balanceTuningEnabled: true,
   injuriesEnabled: true,
   weatherEnabled: true,
   injurySeverityScale: 1,
@@ -130,7 +152,10 @@ export function resolveDynastyConfig(
       : DYNASTY_CONFIG_DEFAULTS.transferVolume;
 
   return {
+    scoringDepthEnabled: bool("scoringDepthEnabled"),
     penaltiesEnabled: bool("penaltiesEnabled"),
+    situationalAiEnabled: bool("situationalAiEnabled"),
+    balanceTuningEnabled: bool("balanceTuningEnabled"),
     injuriesEnabled: bool("injuriesEnabled"),
     weatherEnabled: bool("weatherEnabled"),
     injurySeverityScale: num("injurySeverityScale"),

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -163,7 +163,13 @@ export const dynastyTables = {
     leagueId: v.id("leagues"),
 
     // Sim mechanics (Epic A). Kill switches for a live league.
+    /** A1 — safeties, two-point tries, return TDs, fumbles on any play. */
+    scoringDepthEnabled: v.optional(v.boolean()),
     penaltiesEnabled: v.optional(v.boolean()),
+    /** A3 — fourth-down chart, timeouts, two-minute drill, clock management. */
+    situationalAiEnabled: v.optional(v.boolean()),
+    /** A3 — corrected home-field advantage (#642). */
+    balanceTuningEnabled: v.optional(v.boolean()),
     injuriesEnabled: v.optional(v.boolean()),
     weatherEnabled: v.optional(v.boolean()),
     /** 0 = none, 1 = normal, 2 = brutal. Scales injury roll severity. */

--- a/apps/web/e2e/tests/gamecast.spec.ts
+++ b/apps/web/e2e/tests/gamecast.spec.ts
@@ -249,6 +249,14 @@ test.describe("Gamecast replay (WSM gamecast)", () => {
     await expect(page.getByText(awayName).first()).toBeVisible();
     await expect(page.locator('[aria-label="Drive chart"]')).toBeVisible();
 
+    /*
+     * Sim activation, end to end: this fixture was simulated through the real
+     * action, so the weather strip appearing proves the league's settings
+     * reached the engine and the log recorded the conditions it played in.
+     * Before activation the sim passed no gates and this was always absent.
+     */
+    await expect(page.getByTestId("gamecast-weather")).toBeVisible();
+
     await expect(
       page.getByText("Final", { exact: true }).first(),
     ).toBeVisible();

--- a/apps/web/scripts/dist-check.ts
+++ b/apps/web/scripts/dist-check.ts
@@ -13,6 +13,7 @@
  * row moves, golden parity broke.
  */
 import { simulateGameLog } from "../src/lib/pbp/engine";
+import { deriveWeather } from "../src/lib/pbp/weather";
 import type {
   PbpFeatureGates,
   PlayerSimProfile,
@@ -50,7 +51,16 @@ const team = (t: string, s: number): TeamSimProfile => ({
 
 const GAMES = 300;
 
-function report(label: string, features: PbpFeatureGates | undefined): void {
+/*
+ * When `withWeather` is set, each game gets conditions derived the way
+ * `fixtureSimConditions` derives them in production — a different week per
+ * game, so the sample spans a season's climate rather than one nice afternoon.
+ */
+function report(
+  label: string,
+  features: PbpFeatureGates | undefined,
+  withWeather = false,
+): void {
   let homeWins = 0;
   let awayWins = 0;
   let ties = 0;
@@ -66,6 +76,15 @@ function report(label: string, features: PbpFeatureGates | undefined): void {
       seed: 1000 + i,
       flavor: "balanced",
       features,
+      ...(withWeather
+        ? {
+            weather: deriveWeather({
+              seasonId: "dist-check",
+              week: (i % 14) + 1,
+              venueId: `venue_${i % 24}`,
+            }),
+          }
+        : {}),
     });
     homePoints += log.homeScore;
     awayPoints += log.awayScore;
@@ -121,3 +140,19 @@ report("all A gates", {
   scoringV2: true,
   penalties: true,
 });
+/*
+ * What a real league actually plays under once the flag is on and the league
+ * keeps the default settings. This is the row that matters for activation —
+ * the others isolate one mechanic at a time.
+ */
+report(
+  "PRODUCTION DEFAULT — all gates + derived weather",
+  {
+    situational: true,
+    balance: true,
+    scoringV2: true,
+    penalties: true,
+    weather: true,
+  },
+  true,
+);

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DYNASTY_CONFIG_DEFAULTS } from "@/lib/dynasty-config";
 
 const {
   mockSchedulesStandingsV1,
@@ -16,6 +17,10 @@ const {
   mockGetPlayoffBracket,
   mockGetSeason,
   mockGeneratePlayoffBracket,
+  // The sim-activation slice reads the league's settings once per run.
+  mockDynastySimV2,
+  mockGetDynastyConfig,
+  mockListRivalries,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -32,13 +37,19 @@ const {
   mockGetPlayoffBracket: vi.fn(),
   mockGetSeason: vi.fn(),
   mockGeneratePlayoffBracket: vi.fn(),
+  mockDynastySimV2: vi.fn(),
+  mockGetDynastyConfig: vi.fn(),
+  mockListRivalries: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
   schedulesStandingsV1: mockSchedulesStandingsV1,
+  dynastySimV2: mockDynastySimV2,
 }));
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
 vi.mock("@/lib/data-api", () => ({
+  getDynastyConfig: mockGetDynastyConfig,
+  listRivalries: mockListRivalries,
   getFixture: mockGetFixture,
   recordGameResult: mockRecordGameResult,
   upsertGamePlayLog: mockUpsertGamePlayLog,
@@ -111,6 +122,14 @@ function fixture(
 
 function authorize() {
   mockSchedulesStandingsV1.mockResolvedValue(true);
+  /*
+   * Sim activation reads the league's settings once per run. Defaults here so
+   * these assertions keep testing what they were written to test — WHICH
+   * fixtures get simulated, not what those games model.
+   */
+  mockDynastySimV2.mockResolvedValue(true);
+  mockGetDynastyConfig.mockResolvedValue(DYNASTY_CONFIG_DEFAULTS);
+  mockListRivalries.mockResolvedValue([]);
   mockAuth.mockResolvedValue({ userId: USER });
   mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
   mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
@@ -156,6 +175,19 @@ describe("simulateGameAction (PBP Slice B)", () => {
       decisive: false,
       profileCache: expect.any(Map),
       simulationFlavor: "balanced",
+      // Resolved once per run and threaded through. With the flag on and
+      // default settings, every Epic A mechanic is live.
+      simContext: {
+        leagueId: LEAGUE,
+        features: {
+          scoringV2: true,
+          penalties: true,
+          situational: true,
+          balance: true,
+          weather: true,
+        },
+        rivalries: expect.any(Map),
+      },
     });
   });
 });
@@ -361,6 +393,7 @@ describe("simulatePlayoffsAction", () => {
       profileCache: expect.any(Map),
       bulkStats: true,
       simulationFlavor: "balanced",
+      simContext: expect.objectContaining({ leagueId: LEAGUE }),
     });
   });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -22,6 +22,11 @@ import { resolveOrgRole, resolveOrgContext } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
 import { type TeamSimProfileCache } from "@/lib/build-team-sim-profile";
 import { simulateAndPersistFixture } from "@/lib/simulate-fixture";
+import {
+  loadSeasonSimContext,
+  type SeasonSimContext,
+} from "@/lib/sim-context";
+import { dynastySimV2 } from "@/lib/flags";
 import { normalizeSimulationFlavor } from "@/lib/simulation-flavor";
 import {
   deriveChampion,
@@ -266,12 +271,29 @@ export async function deleteFixtureAction(
  * + playoff advancement flow exactly as hand-entered results do.
  */
 
-async function resolveSeasonSimulationFlavor(
+/**
+ * Everything a simulation run needs that is fixed for the whole run.
+ *
+ * Resolved ONCE per run and threaded through, the same way `profileCache` is.
+ * The alternative — reading the league's settings inside the per-fixture path —
+ * would be a pair of reads per game for data that cannot change mid-run.
+ */
+async function resolveSeasonSimRun(
   seasonId: string,
   orgContext: OrgContext,
-) {
+): Promise<{
+  simulationFlavor: ReturnType<typeof normalizeSimulationFlavor>;
+  simContext: SeasonSimContext;
+}> {
   const season = await getSeason(seasonId, orgContext);
-  return normalizeSimulationFlavor(season.simulationFlavor);
+  const flagEnabled = await dynastySimV2();
+  return {
+    simulationFlavor: normalizeSimulationFlavor(season.simulationFlavor),
+    simContext: await loadSeasonSimContext({
+      leagueId: season.leagueId,
+      flagEnabled,
+    }),
+  };
 }
 
 export async function simulateGameAction(input: {
@@ -294,7 +316,7 @@ export async function simulateGameAction(input: {
   const orgContext = await resolveOrgContext(userId);
 
   try {
-    const simulationFlavor = await resolveSeasonSimulationFlavor(
+    const { simulationFlavor, simContext } = await resolveSeasonSimRun(
       fixture.seasonId,
       orgContext,
     );
@@ -305,6 +327,7 @@ export async function simulateGameAction(input: {
       decisive: fixture.stage === "playoff",
       profileCache: new Map(),
       simulationFlavor,
+      simContext,
     });
     revalidatePath(`/dashboard/seasons/${fixture.seasonId}/schedule`);
     revalidatePath(`/dashboard/seasons/${fixture.seasonId}/standings`);
@@ -343,7 +366,10 @@ async function simulateUnplayedRegularSeason(
   orgContext: OrgContext,
   profileCache: TeamSimProfileCache,
 ): Promise<number> {
-  const simulationFlavor = await resolveSeasonSimulationFlavor(seasonId, orgContext);
+  const { simulationFlavor, simContext } = await resolveSeasonSimRun(
+    seasonId,
+    orgContext,
+  );
   const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
   // Regular-season, unplayed games only — never overwrite real results, and
   // leave playoff games to the bracket flow.
@@ -359,6 +385,7 @@ async function simulateUnplayedRegularSeason(
       profileCache,
       bulkStats: true,
       simulationFlavor,
+      simContext,
     });
     simulated += 1;
   }
@@ -374,7 +401,10 @@ async function simulatePlayoffFixtureIds(
   profileCache: TeamSimProfileCache,
 ): Promise<number> {
   if (fixtureIds.length === 0) return 0;
-  const simulationFlavor = await resolveSeasonSimulationFlavor(seasonId, orgContext);
+  const { simulationFlavor, simContext } = await resolveSeasonSimRun(
+    seasonId,
+    orgContext,
+  );
   const fixtures = await listFixturesBySeason(seasonId).catch(() => []);
   const byId = new Map(fixtures.map((f) => [f.id, f]));
   let simulated = 0;
@@ -395,6 +425,7 @@ async function simulatePlayoffFixtureIds(
       profileCache,
       bulkStats: true,
       simulationFlavor,
+      simContext,
     });
     simulated += 1;
   }
@@ -558,7 +589,7 @@ export async function simulateWeekAction(input: {
   const orgContext = await resolveOrgContext(userId);
   const profileCache: TeamSimProfileCache = new Map();
   try {
-    const simulationFlavor = await resolveSeasonSimulationFlavor(
+    const { simulationFlavor, simContext } = await resolveSeasonSimRun(
       input.seasonId,
       orgContext,
     );
@@ -576,6 +607,7 @@ export async function simulateWeekAction(input: {
         profileCache,
         bulkStats: true,
         simulationFlavor,
+        simContext,
       });
       simulated += 1;
     }

--- a/apps/web/src/components/dynasty/DynastySettingsCard.tsx
+++ b/apps/web/src/components/dynasty/DynastySettingsCard.tsx
@@ -25,9 +25,27 @@ const TOGGLES: Array<{
   description: string;
 }> = [
   {
+    key: "scoringDepthEnabled",
+    label: "Scoring depth",
+    description:
+      "Safeties, two-point tries, return touchdowns and fumbles on any play.",
+  },
+  {
     key: "penaltiesEnabled",
     label: "Penalties",
     description: "Flags are thrown during simulated games.",
+  },
+  {
+    key: "situationalAiEnabled",
+    label: "Situational AI",
+    description:
+      "Fourth-down decisions, timeouts, the two-minute drill and clock management.",
+  },
+  {
+    key: "balanceTuningEnabled",
+    label: "Balance tuning",
+    description:
+      "Corrected home-field advantage. Turn off only to match games played before it.",
   },
   {
     key: "injuriesEnabled",

--- a/apps/web/src/lib/__tests__/sim-context.test.ts
+++ b/apps/web/src/lib/__tests__/sim-context.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  emptySimContext,
+  fixtureSimConditions,
+  resolveSimFeatures,
+  type SeasonSimContext,
+} from "@/lib/sim-context";
+import {
+  DYNASTY_CONFIG_DEFAULTS,
+  type DynastyConfig,
+} from "@/lib/dynasty-config";
+import { rivalryPairKey } from "@/lib/rivalries";
+import { deriveWeather } from "@/lib/pbp/weather";
+
+const config = (patch: Partial<DynastyConfig> = {}): DynastyConfig => ({
+  ...DYNASTY_CONFIG_DEFAULTS,
+  ...patch,
+});
+
+describe("resolveSimFeatures", () => {
+  it("turns every Epic A mechanic on for a default league", () => {
+    // The activation contract: flag on plus untouched settings means the full
+    // game. A league that has configured nothing gets everything.
+    expect(resolveSimFeatures(true, config())).toEqual({
+      scoringV2: true,
+      penalties: true,
+      situational: true,
+      balance: true,
+      weather: true,
+    });
+  });
+
+  it("returns no gates at all when the flag is off, whatever the league wants", () => {
+    /*
+     * The flag is the OUTER gate, not one vote among several. This is what
+     * makes it a usable kill switch: one env var backs the epic out for
+     * everyone without editing a single league's settings.
+     */
+    expect(resolveSimFeatures(false, config())).toEqual({});
+    expect(
+      resolveSimFeatures(false, config({ penaltiesEnabled: true })),
+    ).toEqual({});
+  });
+
+  it("drops only the mechanics a league opted out of", () => {
+    const features = resolveSimFeatures(
+      true,
+      config({ penaltiesEnabled: false, weatherEnabled: false }),
+    );
+    expect(features).toEqual({
+      scoringV2: true,
+      situational: true,
+      balance: true,
+    });
+  });
+
+  it("omits disabled gates rather than setting them false", () => {
+    /*
+     * `{ penalties: false }` and `{}` mean the same thing to the engine, but
+     * only the second is honest on a stored log: recording `false` would claim
+     * the engine considered penalties and declined, which is indistinguishable
+     * from a build that never had them.
+     */
+    const features = resolveSimFeatures(true, config({ penaltiesEnabled: false }));
+    expect("penalties" in features).toBe(false);
+  });
+
+  it("ignores knobs that belong to other epics", () => {
+    // Injuries (A4) and polls (D3) have no engine gate yet. Reading them here
+    // would silently enable something that does not exist.
+    const features = resolveSimFeatures(
+      true,
+      config({ injuriesEnabled: true, pollsEnabled: true }),
+    );
+    expect(Object.keys(features).sort()).toEqual([
+      "balance",
+      "penalties",
+      "scoringV2",
+      "situational",
+      "weather",
+    ]);
+  });
+});
+
+describe("fixtureSimConditions", () => {
+  const fixture = {
+    seasonId: "season_1",
+    week: 6,
+    homeTeamId: "team_home",
+    awayTeamId: "team_away",
+  };
+
+  const context = (over: Partial<SeasonSimContext> = {}): SeasonSimContext => ({
+    ...emptySimContext("league_1"),
+    ...over,
+  });
+
+  it("derives no weather while the gate is off", () => {
+    // Computing it anyway would be harmless to the engine but misleading: the
+    // log records what it was given, and a value the game did not simulate
+    // under has no business being computed here.
+    expect(fixtureSimConditions(context(), fixture).weather).toBeUndefined();
+  });
+
+  it("derives the same weather the schedule's forecast shows", () => {
+    /*
+     * The schedule chip and the simulator must agree, or a fixture would be
+     * previewed in one climate and played in another. They agree because both
+     * derive from (season, week, home team) — this asserts the simulator side
+     * picks the same inputs.
+     */
+    const conditions = fixtureSimConditions(
+      context({ features: { weather: true } }),
+      fixture,
+    );
+    expect(conditions.weather).toEqual(
+      deriveWeather({ seasonId: "season_1", week: 6, venueId: "team_home" }),
+    );
+  });
+
+  it("derives no weather for a fixture with no week", () => {
+    // Week is what places a game in the season's calendar. Guessing one would
+    // invent a climate for a game that has no place in the year.
+    const conditions = fixtureSimConditions(
+      context({ features: { weather: true } }),
+      { ...fixture, week: null },
+    );
+    expect(conditions.weather).toBeUndefined();
+  });
+
+  it("finds a rivalry declared in either direction", () => {
+    const rivalries = new Map([
+      [rivalryPairKey("team_away", "team_home"), 80],
+    ]);
+    expect(
+      fixtureSimConditions(context({ rivalries }), fixture).rivalryIntensity,
+    ).toBe(80);
+  });
+
+  it("leaves rivalry intensity absent for an ordinary matchup", () => {
+    // Absent, not zero — the engine treats absence as neutral, and zero would
+    // be a declared rivalry that nobody cares about.
+    const conditions = fixtureSimConditions(context(), fixture);
+    expect("rivalryIntensity" in conditions).toBe(false);
+  });
+
+  it("supplies rivalry intensity regardless of the weather gate", () => {
+    // Rivalry feeds home-field advantage, which the engine reads under the
+    // weather gate. The context still reports it; the engine decides.
+    const rivalries = new Map([[rivalryPairKey("team_home", "team_away"), 55]]);
+    expect(
+      fixtureSimConditions(context({ rivalries }), fixture).rivalryIntensity,
+    ).toBe(55);
+  });
+});
+
+describe("emptySimContext", () => {
+  it("models nothing", () => {
+    const context = emptySimContext("league_1");
+    expect(context.features).toEqual({});
+    expect(context.rivalries.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/__tests__/simulate-fixture.test.ts
+++ b/apps/web/src/lib/__tests__/simulate-fixture.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { emptySimContext } from "@/lib/sim-context";
 import { seedFromString } from "@/lib/simulate-game";
 import { deriveStatLines, simulateGameLog } from "@/lib/pbp";
 import type { TeamSimProfile } from "@/lib/pbp";
@@ -100,6 +101,7 @@ describe("simulateAndPersistFixture", () => {
       orgContext: ORG_CONTEXT,
       actorUserId: USER,
       profileCache: new Map(),
+      simContext: emptySimContext("league_1"),
       bulkStats: true,
     });
 
@@ -156,6 +158,7 @@ describe("simulateAndPersistFixture", () => {
       orgContext: ORG_CONTEXT,
       actorUserId: USER,
       profileCache: new Map(),
+      simContext: emptySimContext("league_1"),
     });
     const first = [...calls].sort();
 
@@ -165,6 +168,7 @@ describe("simulateAndPersistFixture", () => {
       orgContext: ORG_CONTEXT,
       actorUserId: USER,
       profileCache: new Map(),
+      simContext: emptySimContext("league_1"),
     });
     const second = [...calls].sort();
 
@@ -185,6 +189,7 @@ describe("simulateAndPersistFixture", () => {
       orgContext: ORG_CONTEXT,
       actorUserId: USER,
       profileCache: new Map(),
+      simContext: emptySimContext("league_1"),
     });
 
     expect(res.usedScoreFallback).toBe(true);

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -193,6 +193,34 @@ export const playoffsV1 = flag<boolean>({
   },
 });
 
+/*
+ * Dynasty Mode Epic A — the sim-engine v2 mechanics (A1, A2, A3, A5).
+ *
+ * The OUTER gate. With this off, no league gets v2 mechanics regardless of its
+ * `dynastyConfig`; with it on, each league's own settings decide. That ordering
+ * makes this a real kill switch — one env var backs the whole epic out for
+ * everyone without touching a single league's preferences, and turning it back
+ * on restores exactly what each had chosen.
+ *
+ * Already-simulated games are unaffected in either direction: `gamePlayLogs`
+ * rows are immutable and a final fixture cannot be re-simulated.
+ */
+export const dynastySimV2 = flag<boolean>({
+  key: "dynasty_sim_v2",
+  description:
+    "Dynasty Mode Epic A: scoring depth, penalties, situational AI and weather in the play-by-play engine",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_DYNASTY_SIM_V2");
+    void trackFlagExposure("dynasty_sim_v2", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {

--- a/apps/web/src/lib/gamecast/__tests__/reveal-scoring-parity.test.ts
+++ b/apps/web/src/lib/gamecast/__tests__/reveal-scoring-parity.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "@/lib/pbp/engine";
+import { deriveWeather } from "@/lib/pbp/weather";
+import { scoreAtPosition } from "@/lib/gamecast/reveal";
+import type {
+  PbpPlay,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "@/lib/pbp/types";
+
+/*
+ * The Gamecast scoreboard must agree with the official score.
+ *
+ * `scoreAtPosition` recomputes the score by walking plays, while the recorded
+ * result comes from `log.homeScore` / `log.awayScore`. Those are two
+ * independent paths to the same number, and a league sees BOTH — the schedule
+ * shows the recorded result and the Gamecast shows the walk. When they
+ * disagree, one of them is lying about a game that was actually played.
+ *
+ * Both failures this pins were invisible until the Epic A gates were switched
+ * on, because neither mechanic could occur with them off:
+ *
+ *  - a touchdown wiped out by holding stayed in the log (deliberately) and was
+ *    still counted, inflating the offense;
+ *  - a safety or pick-six scores for the DEFENSE via `defensivePoints`, and
+ *    was dropped entirely, shorting the scoring team.
+ */
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function roster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2], ["RB", 3], ["WR", 5], ["TE", 2], ["DE", 2], ["DT", 2],
+    ["OLB", 2], ["MLB", 2], ["CB", 3], ["S", 2], ["K", 1], ["P", 1],
+  ];
+  const out: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      out.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return out;
+}
+
+const team = (teamId: string, strength: number): TeamSimProfile => ({
+  teamId,
+  strength,
+  players: roster(teamId, strength),
+});
+
+const PRODUCTION_GATES = {
+  scoringV2: true,
+  penalties: true,
+  situational: true,
+  balance: true,
+  weather: true,
+} as const;
+
+function play(seed: number, gated: boolean) {
+  return simulateGameLog({
+    home: team("home", 70),
+    away: team("away", 70),
+    seed,
+    flavor: "balanced",
+    ...(gated
+      ? {
+          features: PRODUCTION_GATES,
+          weather: deriveWeather({
+            seasonId: "parity",
+            week: (seed % 14) + 1,
+            venueId: `venue_${seed % 24}`,
+          }),
+        }
+      : {}),
+  });
+}
+
+function walked(log: ReturnType<typeof simulateGameLog>) {
+  const plays = log.drives.flatMap((drive) => drive.plays);
+  return scoreAtPosition(log, plays, plays.length);
+}
+
+/** First seed in the sweep whose game contains a play matching `predicate`. */
+function findPlay(predicate: (p: PbpPlay) => boolean) {
+  for (let seed = 5000; seed < 5400; seed++) {
+    const log = play(seed, true);
+    const plays = log.drives.flatMap((d) => d.plays);
+    const match = plays.find(predicate);
+    if (match) return { log, plays, play: match };
+  }
+  return null;
+}
+
+describe("Gamecast scoreboard parity with the recorded result", () => {
+  it("agrees on every game under production gates", () => {
+    // 400 seeds because the two failure modes need a penalty-negated score and
+    // a defensive score to occur — at 300 seeds roughly a fifth of games hit
+    // one, so a handful of seeds would not prove much.
+    const mismatched: string[] = [];
+    for (let seed = 5000; seed < 5400; seed++) {
+      const log = play(seed, true);
+      const score = walked(log);
+      if (score.home !== log.homeScore || score.away !== log.awayScore) {
+        mismatched.push(
+          `seed ${seed}: recorded ${log.homeScore}-${log.awayScore}, gamecast ${score.home}-${score.away}`,
+        );
+      }
+    }
+    expect(mismatched).toEqual([]);
+  });
+
+  it("agrees on every game with the gates off", () => {
+    for (let seed = 5000; seed < 5100; seed++) {
+      const log = play(seed, false);
+      expect(walked(log)).toEqual({
+        home: log.homeScore,
+        away: log.awayScore,
+      });
+    }
+  });
+
+  it("scores a safety or pick-six for the defense, not the offense", () => {
+    // Scan for a seed that produces one rather than hardcoding: the game a
+    // seed produces depends on the weather parameters too, so a pinned seed
+    // silently stops covering this the moment either changes.
+    const found = findPlay((p) => Boolean(p.defensivePoints));
+    expect(found).not.toBeNull();
+    const { log, plays, play: defensiveScore } = found!;
+
+    const upTo = plays.indexOf(defensiveScore) + 1;
+    const before = scoreAtPosition(log, plays, upTo - 1);
+    const after = scoreAtPosition(log, plays, upTo);
+    const scoringSide =
+      defensiveScore.defenseTeamId === log.homeTeamId ? "home" : "away";
+    const conceding = scoringSide === "home" ? "away" : "home";
+
+    expect(after[scoringSide] - before[scoringSide]).toBe(
+      defensiveScore.defensivePoints,
+    );
+    expect(after[conceding]).toBe(before[conceding]);
+  });
+
+  it("gives no points for a score a penalty wiped out", () => {
+    const found = findPlay(
+      (p) => p.isScoring && p.penalty?.negatesPlay === true,
+    );
+    expect(found).not.toBeNull();
+    const { log, plays, play: negated } = found!;
+
+    const upTo = plays.indexOf(negated) + 1;
+    expect(scoreAtPosition(log, plays, upTo)).toEqual(
+      scoreAtPosition(log, plays, upTo - 1),
+    );
+  });
+});

--- a/apps/web/src/lib/gamecast/box-score.ts
+++ b/apps/web/src/lib/gamecast/box-score.ts
@@ -55,10 +55,17 @@ function emptyLine(modelsPenalties: boolean): TeamBoxScoreLine {
 /**
  * Did this log's engine model penalties at all?
  *
- * Presence of any `penalty` field is the signal. A v2 game that happened to
- * draw no flags still reports 0 rather than "—", because it was counted.
+ * The recorded gate is the answer when the log has one. That distinction is
+ * the whole point: a game played WITH penalties enabled that happened to draw
+ * no flags is a clean game — it reports 0, not "—". Scanning for a `penalty`
+ * field cannot tell those apart, and got that case wrong in the direction that
+ * hides a real result behind "unknown".
+ *
+ * Logs written before gates were recorded fall back to the scan, which is
+ * still right whenever a flag was actually thrown.
  */
 export function logModelsPenalties(log: PbpGameLog): boolean {
+  if (log.features !== undefined) return log.features.penalties === true;
   return log.drives.some((drive) =>
     drive.plays.some((play) => play.penalty !== undefined),
   );

--- a/apps/web/src/lib/gamecast/reveal.ts
+++ b/apps/web/src/lib/gamecast/reveal.ts
@@ -34,9 +34,31 @@ export function scoreAtPosition(
   const end = Math.min(playIndex, plays.length);
   for (let i = 0; i < end; i++) {
     const play = plays[i];
-    if (!play.isScoring) continue;
-    if (play.offenseTeamId === log.homeTeamId) home += play.pointsScored;
-    else if (play.offenseTeamId === log.awayTeamId) away += play.pointsScored;
+
+    /*
+     * A play wiped out by a penalty is KEPT in the log — you want to see the
+     * touchdown holding took away — but it did not happen, so it scores
+     * nothing. `deriveStatLines` already skips these; the scoreboard has to
+     * agree or the Gamecast shows a final score the league never played.
+     */
+    if (play.penalty?.negatesPlay === true) continue;
+
+    if (play.isScoring) {
+      if (play.offenseTeamId === log.homeTeamId) home += play.pointsScored;
+      else if (play.offenseTeamId === log.awayTeamId) away += play.pointsScored;
+    }
+
+    /*
+     * Safeties and pick-sixes score for the DEFENSE. `pointsScored` is an
+     * offense-relative field inherited from v1, so it stays 0 on those plays
+     * and `defensivePoints` carries the value — see `doSafety` in the engine,
+     * which documents exactly this contract for readers.
+     */
+    if (play.defensivePoints) {
+      if (play.defenseTeamId === log.homeTeamId) home += play.defensivePoints;
+      else if (play.defenseTeamId === log.awayTeamId)
+        away += play.defensivePoints;
+    }
   }
   return { home, away };
 }

--- a/apps/web/src/lib/pbp/__tests__/log-features.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/log-features.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import { logModels, normalizeGameLog } from "../migrate-log";
+import { CLEAR_WEATHER } from "../weather";
+import type {
+  PbpGameInput,
+  PlayerSimProfile,
+  TeamSimProfile,
+} from "../types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function buildRoster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2], ["RB", 3], ["WR", 5], ["TE", 2], ["DE", 2], ["DT", 2],
+    ["OLB", 2], ["MLB", 2], ["CB", 3], ["S", 2], ["K", 1], ["P", 1],
+  ];
+  const players: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      players.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+      });
+    }
+  }
+  return players;
+}
+
+const buildTeam = (teamId: string, strength: number): TeamSimProfile => ({
+  teamId,
+  strength,
+  players: buildRoster(teamId, strength),
+});
+
+function gameInput(overrides: Partial<PbpGameInput> = {}): PbpGameInput {
+  return {
+    home: buildTeam("home", 70),
+    away: buildTeam("away", 70),
+    seed: 8080,
+    flavor: "balanced",
+    ...overrides,
+  };
+}
+
+/*
+ * The gates a game ran under are recorded ON the log (#646).
+ *
+ * The engine version cannot answer "were penalties modelled in this game?" —
+ * one build writes both kinds depending on what the league had configured, and
+ * a league that adopts a mechanic mid-season has both in one season.
+ */
+describe("recorded feature gates", () => {
+  it("records nothing at all when no gate was on", () => {
+    /*
+     * Load-bearing for golden parity: a fully-gated-off log must stay
+     * byte-identical to its v1 self, so the key cannot merely be empty — it
+     * has to be absent.
+     */
+    const log = simulateGameLog(gameInput());
+    expect(log.features).toBeUndefined();
+    expect("features" in log).toBe(false);
+  });
+
+  it("records only the gates that were on", () => {
+    const log = simulateGameLog(
+      gameInput({ features: { penalties: true, situational: true } }),
+    );
+    expect(log.features).toEqual({ penalties: true, situational: true });
+  });
+
+  it("never records a gate as false", () => {
+    // `false` would claim the engine considered a mechanic and declined, which
+    // is indistinguishable in the data from a build that never had it.
+    const log = simulateGameLog(
+      gameInput({ features: { penalties: true, weather: false } }),
+    );
+    expect(log.features).toEqual({ penalties: true });
+  });
+
+  it("survives a serialize/parse round trip, which is how it is stored", () => {
+    const log = simulateGameLog(
+      gameInput({ features: { scoringV2: true, weather: true }, weather: CLEAR_WEATHER }),
+    );
+    const stored = normalizeGameLog(JSON.parse(JSON.stringify(log)), "2.0.0");
+    expect(stored.features).toEqual({ scoringV2: true, weather: true });
+  });
+});
+
+describe("logModels", () => {
+  const normalize = (input: PbpGameInput, version = "2.0.0") =>
+    normalizeGameLog(JSON.parse(JSON.stringify(simulateGameLog(input))), version);
+
+  it("answers from the gates the game ran under, not the engine version", () => {
+    const withPenalties = normalize(gameInput({ features: { penalties: true } }));
+    const without = normalize(gameInput({ features: { scoringV2: true } }));
+
+    // Same engine version, opposite answers — which a version number alone
+    // could never produce.
+    expect(withPenalties.engineVersion).toBe(without.engineVersion);
+    expect(logModels(withPenalties, "penalties")).toBe(true);
+    expect(logModels(without, "penalties")).toBe(false);
+  });
+
+  it("maps each mechanic to the gate that produces it", () => {
+    const log = normalize(
+      gameInput({ features: { scoringV2: true, situational: true } }),
+    );
+    expect(logModels(log, "safeties")).toBe(true);
+    expect(logModels(log, "twoPointConversions")).toBe(true);
+    expect(logModels(log, "returns")).toBe(true);
+    expect(logModels(log, "fourthDownAi")).toBe(true);
+    expect(logModels(log, "timeouts")).toBe(true);
+    expect(logModels(log, "penalties")).toBe(false);
+    expect(logModels(log, "weather")).toBe(false);
+  });
+
+  it("says a v1 log modelled nothing", () => {
+    const v1 = normalizeGameLog({ drives: [] }, "1.0.0");
+    expect(logModels(v1, "returns")).toBe(false);
+    expect(logModels(v1, "penalties")).toBe(false);
+    expect(logModels(v1, "safeties")).toBe(false);
+  });
+
+  it("treats a gated-off v2 log exactly like a v1 log", () => {
+    // Both claim "this mechanic was not modelled here". Same claim, same
+    // answer — a reader must show "—" for either.
+    const gatedOff = normalize(gameInput());
+    const v1 = normalizeGameLog({ drives: [] }, "1.0.0");
+    for (const mechanic of ["returns", "penalties", "safeties"] as const) {
+      expect(logModels(gatedOff, mechanic)).toBe(logModels(v1, mechanic));
+    }
+  });
+
+  it("treats an unreadable features value as modelling nothing", () => {
+    const log = normalizeGameLog({ drives: [], features: "yes" }, "2.0.0");
+    expect(logModels(log, "penalties")).toBe(false);
+  });
+});
+
+describe("box score penalty reporting", () => {
+  it("reports a clean game as 0, not as unmodelled", async () => {
+    /*
+     * The case the old play-scan heuristic got wrong. A game simulated WITH
+     * penalties enabled that drew no flags is a clean game — reporting "—"
+     * would hide a real result behind "unknown".
+     */
+    const { logModelsPenalties } = await import("@/lib/gamecast/box-score");
+    const cleanGame = {
+      ...simulateGameLog(gameInput()),
+      features: { penalties: true },
+    };
+    expect(logModelsPenalties(cleanGame)).toBe(true);
+  });
+
+  it("still reads a pre-gate log by scanning its plays", async () => {
+    const { logModelsPenalties } = await import("@/lib/gamecast/box-score");
+    const log = simulateGameLog(gameInput({ features: { penalties: true } }));
+    // Strip the recorded gates to stand in for a log written before them.
+    const { features: _dropped, ...preGate } = log;
+    const drewAFlag = preGate.drives.some((d) =>
+      d.plays.some((p) => p.penalty !== undefined),
+    );
+    expect(logModelsPenalties(preGate)).toBe(drewAFlag);
+  });
+});

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -1620,7 +1620,32 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
     ...(state.features.weather && input.weather
       ? { weather: input.weather }
       : {}),
+    /*
+     * Record which gates were live, so a reader never has to infer it from the
+     * engine version. Omitted entirely when nothing was on — that absence is
+     * what keeps a fully-gated-off log byte-identical to v1, which the golden
+     * parity fixture pins.
+     */
+    ...(activeFeatures(state.features) ?? {}),
   };
+}
+
+/**
+ * `{ features }` when at least one gate is on, otherwise `null`.
+ *
+ * Only the gates that were ON are recorded. Writing `penalties: false` would
+ * claim the engine considered penalties and declined, which is indistinguishable
+ * in the data from a build that never had them — and Epic D's record book would
+ * later read that claim as history.
+ */
+function activeFeatures(
+  features: Required<PbpFeatureGates>,
+): { features: PbpFeatureGates } | null {
+  const active: PbpFeatureGates = {};
+  for (const [key, value] of Object.entries(features)) {
+    if (value === true) active[key as keyof PbpFeatureGates] = true;
+  }
+  return Object.keys(active).length > 0 ? { features: active } : null;
 }
 
 export { simulateGameLog, positionGroup, POSITION_TO_GROUP };

--- a/apps/web/src/lib/pbp/migrate-log.ts
+++ b/apps/web/src/lib/pbp/migrate-log.ts
@@ -1,4 +1,4 @@
-import type { PbpGameLog, PbpPlay } from "./types";
+import type { PbpFeatureGates, PbpGameLog, PbpPlay } from "./types";
 
 /*
  * Stored play-log compatibility (Dynasty Mode A1).
@@ -76,27 +76,52 @@ export function normalizeGameLog(
     // optional, so a v1 play already satisfies the current `PbpPlay` type —
     // there is nothing to fill in, and filling anything in would be a lie.
     drives: drives as PbpGameLog["drives"],
+    // Gates pass through as recorded. An unreadable value is treated as
+    // "nothing was modelled", which is the conservative reading.
+    features: isRecord(raw.features)
+      ? (raw.features as PbpFeatureGates)
+      : undefined,
     version: raw.version === 2 ? 2 : undefined,
     engineVersion: version,
     upconverted: version !== "2.0.0",
   };
 }
 
+/** Which gate has to have been on for a mechanic to appear in a log. */
+const MECHANIC_GATE = {
+  returns: "scoringV2",
+  safeties: "scoringV2",
+  twoPointConversions: "scoringV2",
+  penalties: "penalties",
+  fourthDownAi: "situational",
+  timeouts: "situational",
+  weather: "weather",
+} as const satisfies Record<string, keyof PbpFeatureGates>;
+
+export type LogMechanic = keyof typeof MECHANIC_GATE;
+
 /**
- * Did this engine model the given mechanic?
+ * Did the engine model this mechanic in THIS game?
  *
  * The honest question a UI should ask before rendering a stat. Penalties on a
- * v1 log are unknown, not zero, and a box score should show "—" rather than
- * claiming a clean game.
+ * log that did not model them are unknown, not zero, and a box score should
+ * show "—" rather than claiming a clean game.
+ *
+ * The answer comes from the gates recorded on the log, not from the engine
+ * version (#646). A version number cannot answer this: the same engine build
+ * writes games with penalties on and games with penalties off depending on what
+ * the league had configured that week, and a league that adopts a mechanic
+ * mid-season ends up with both in one season.
+ *
+ * A log with no recorded gates modelled nothing — true for every v1 log, and
+ * true for a v2 log simulated with everything switched off. Those two are the
+ * same claim, so they get the same answer.
  */
 export function logModels(
-  log: Pick<NormalizedGameLog, "engineVersion">,
-  mechanic: "returns" | "safeties" | "twoPointConversions" | "penalties",
+  log: Pick<NormalizedGameLog, "engineVersion" | "features">,
+  mechanic: LogMechanic,
 ): boolean {
-  if (log.engineVersion === "1.0.0") return false;
-  // Penalties arrive in A2; everything else in this list ships with A1.
-  if (mechanic === "penalties") return false;
-  return true;
+  return log.features?.[MECHANIC_GATE[mechanic]] === true;
 }
 
 /** Flatten a normalized log's plays, in order. */

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -247,6 +247,20 @@ export interface PbpGameLog {
    */
   weather?: Weather;
 
+  /**
+   * The gates this game was ACTUALLY simulated under.
+   *
+   * The engine version alone cannot answer "were penalties modelled here?" —
+   * two games written by the same engine build differ if a commissioner turned
+   * penalties off between them, and a league that adopts a mechanic mid-season
+   * has both kinds of log in one season (#646).
+   *
+   * Absence means no v2 mechanic was active, which is what keeps a fully-gated-
+   * off game byte-identical to its v1 log. Written only when at least one gate
+   * is on; never defaulted to `{}`.
+   */
+  features?: PbpFeatureGates;
+
   /*
    * ── v2 additions (engine 2.0.0) ───────────────────────────────────────
    *

--- a/apps/web/src/lib/pbp/weather.ts
+++ b/apps/web/src/lib/pbp/weather.ts
@@ -175,7 +175,16 @@ export function weatherModifiers(weather: Weather): WeatherModifiers {
    * throw in, which only happens if the factors multiply rather than the model
    * picking whichever is worst.
    */
-  const wind = clamp((weather.windMph - 8) / 22, 0, 1);
+  /*
+   * Wind starts mattering at 12 mph, not 8.
+   *
+   * The 8 mph threshold taxed the MEDIAN late-season game (median week-14 wind
+   * is 15 mph), which pulled season-long scoring below the balance band once
+   * weather was switched on for real. A steady 8 mph breeze does not measurably
+   * affect a high-school passing game; 12 starts to, and a 30 mph gale still
+   * saturates this at nearly 1.
+   */
+  const wind = clamp((weather.windMph - 12) / 24, 0, 1);
   const wet =
     weather.precipitation === "heavy"
       ? 1
@@ -187,8 +196,13 @@ export function weatherModifiers(weather: Weather): WeatherModifiers {
 
   return {
     passAccuracy: clamp(1 - wind * 0.16 - wet * 0.12 - cold * 0.08, 0.6, 1),
-    // Wind dominates kicking, and it is the one place cold barely matters.
-    kickDistance: clamp(1 - wind * 0.2 - wet * 0.05, 0.7, 1),
+    /*
+     * Wind dominates kicking, and it is the one place cold barely matters.
+     * The coefficient rose with the threshold above so a real gale still costs
+     * a kicker what it did — the change was meant to spare ordinary breezes,
+     * not to make 30 mph easier to kick in.
+     */
+    kickDistance: clamp(1 - wind * 0.28 - wet * 0.05, 0.7, 1),
     fumbleRate: clamp(1 + wet * 0.7 + cold * 0.5, 1, 2.5),
     explosiveRate: clamp(1 - wind * 0.15 - wet * 0.2 - cold * 0.1, 0.55, 1),
   };

--- a/apps/web/src/lib/sim-context.ts
+++ b/apps/web/src/lib/sim-context.ts
@@ -1,0 +1,134 @@
+import { getDynastyConfig, listRivalries } from "@/lib/data-api";
+import type { DynastyConfig } from "@/lib/dynasty-config";
+import type { PbpFeatureGates } from "@/lib/pbp";
+import { deriveWeather, type Weather } from "@/lib/pbp/weather";
+import { rivalryPairKey } from "@/lib/rivalries";
+
+/*
+ * What a simulated game is allowed to model (Dynasty Mode — sim activation).
+ *
+ * Two independent switches, and they answer different questions:
+ *
+ * - The FEATURE FLAG (`FLAG_DYNASTY_SIM_V2`) asks "has this deployment shipped
+ *   Epic A?" It is per-environment and controlled by us.
+ * - The per-league CONFIG asks "does this league want this mechanic?" It is
+ *   runtime-toggleable by a commissioner and needs no deploy.
+ *
+ * The flag is the outer gate: with it off, no league gets v2 mechanics no
+ * matter what they have configured. That ordering is what makes the flag a
+ * usable kill switch — one env var turns the whole epic off for everyone,
+ * without touching a single league's settings, and turning it back on restores
+ * exactly what each league had chosen.
+ */
+
+/** Everything a run of the simulator needs beyond the fixtures themselves. */
+export interface SeasonSimContext {
+  leagueId: string;
+  /** Resolved once per run — every fixture in the run simulates alike. */
+  features: PbpFeatureGates;
+  /** `pairKey` → intensity, for the rivalry lookup (A5). */
+  rivalries: ReadonlyMap<string, number>;
+}
+
+/**
+ * Map a league's settings onto engine gates.
+ *
+ * Pure, and the single place the mapping exists. `flagEnabled: false` produces
+ * NO gates at all rather than the league's preferences — the flag is the outer
+ * gate, not one vote among several.
+ */
+export function resolveSimFeatures(
+  flagEnabled: boolean,
+  config: DynastyConfig,
+): PbpFeatureGates {
+  if (!flagEnabled) return {};
+
+  /*
+   * Only gates that are ON are set. An explicit `false` and an absent key mean
+   * the same thing to the engine, and recording the difference on the log
+   * would imply the engine considered a mechanic and declined — see
+   * `activeFeatures` in `pbp/engine.ts`.
+   */
+  const features: PbpFeatureGates = {};
+  if (config.scoringDepthEnabled) features.scoringV2 = true;
+  if (config.penaltiesEnabled) features.penalties = true;
+  if (config.situationalAiEnabled) features.situational = true;
+  if (config.balanceTuningEnabled) features.balance = true;
+  if (config.weatherEnabled) features.weather = true;
+  return features;
+}
+
+/**
+ * Load the league's settings and rivalries once for a whole run.
+ *
+ * A season simulation plays every fixture in a loop. Reading config and
+ * rivalries per fixture would be a read per game for data that cannot change
+ * mid-run — the same N+1 shape F2 and F3 were built to remove.
+ *
+ * Fails soft: a league whose settings cannot be read simulates with no v2
+ * mechanics rather than failing the whole run. A missed mechanic is a worse
+ * game; a thrown error is no game.
+ */
+export async function loadSeasonSimContext(input: {
+  leagueId: string;
+  flagEnabled: boolean;
+}): Promise<SeasonSimContext> {
+  const [config, rivalries] = await Promise.all([
+    getDynastyConfig(input.leagueId).catch(() => null),
+    listRivalries(input.leagueId).catch(() => []),
+  ]);
+
+  return {
+    leagueId: input.leagueId,
+    features: config ? resolveSimFeatures(input.flagEnabled, config) : {},
+    rivalries: new Map(
+      rivalries.map((r) => [rivalryPairKey(r.teamAId, r.teamBId), r.intensity]),
+    ),
+  };
+}
+
+/** A context that models nothing — for callers with no league in hand. */
+export function emptySimContext(leagueId: string): SeasonSimContext {
+  return { leagueId, features: {}, rivalries: new Map() };
+}
+
+export interface FixtureSimConditions {
+  weather?: Weather;
+  rivalryIntensity?: number;
+}
+
+/**
+ * Per-fixture conditions derived from the run context.
+ *
+ * Weather is derived rather than stored, and only when the gate is on. Deriving
+ * it with the gate off would be harmless (the engine ignores it) but
+ * misleading: the log records what it was given, and a value the game did not
+ * simulate under has no business being computed here.
+ *
+ * A fixture with no week cannot have weather — week is what places the game in
+ * the season's calendar, and guessing one would invent a climate.
+ */
+export function fixtureSimConditions(
+  context: SeasonSimContext,
+  fixture: { seasonId: string; week: number | null; homeTeamId: string; awayTeamId: string },
+): FixtureSimConditions {
+  const conditions: FixtureSimConditions = {};
+
+  if (context.features.weather === true && fixture.week !== null) {
+    conditions.weather = deriveWeather({
+      seasonId: fixture.seasonId,
+      week: fixture.week,
+      // A program plays its home games in one climate, so the home team is the
+      // venue. Same choice the schedule's forecast chip makes, which is what
+      // makes the two agree.
+      venueId: fixture.homeTeamId,
+    });
+  }
+
+  const intensity = context.rivalries.get(
+    rivalryPairKey(fixture.homeTeamId, fixture.awayTeamId),
+  );
+  if (intensity !== undefined) conditions.rivalryIntensity = intensity;
+
+  return conditions;
+}

--- a/apps/web/src/lib/simulate-fixture.ts
+++ b/apps/web/src/lib/simulate-fixture.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_SIMULATION_FLAVOR,
   type SimulationFlavor,
 } from "@/lib/simulation-flavor";
+import { fixtureSimConditions, type SeasonSimContext } from "@/lib/sim-context";
 
 export interface SimulateFixtureInput {
   fixture: FixtureDto;
@@ -31,6 +32,15 @@ export interface SimulateFixtureInput {
   bulkStats?: boolean;
   /** Season simulation flavor (defaults to balanced). */
   simulationFlavor?: SimulationFlavor;
+  /**
+   * What this run is allowed to model, resolved once by the caller.
+   *
+   * REQUIRED rather than optional on purpose. An optional field defaulting to
+   * "no mechanics" is exactly how four slices ended up shipping dark without
+   * anyone noticing — a new call site would silently simulate v1 games. Making
+   * it required means `tsc` forces every caller to decide.
+   */
+  simContext: SeasonSimContext;
 }
 
 export interface SimulateFixtureResult {
@@ -86,7 +96,21 @@ export async function simulateAndPersistFixture(
     return { homeScore, awayScore, usedScoreFallback: true };
   }
 
-  const log = simulateGameLog({ home, away, seed, decisive, flavor });
+  /*
+   * The score-only fallback above never reaches here, which matters: a game
+   * with no rosters has no plays to apply penalties or weather to, so it is
+   * correctly recorded with no gates rather than with gates that did nothing.
+   */
+  const conditions = fixtureSimConditions(input.simContext, fixture);
+  const log = simulateGameLog({
+    home,
+    away,
+    seed,
+    decisive,
+    flavor,
+    features: input.simContext.features,
+    ...conditions,
+  });
   const homeScore = log.homeScore;
   const awayScore = log.awayScore;
 


### PR DESCRIPTION
## Summary

A1, A2, A3 and A5 shipped behind gates that nothing set. This wires them to the league's settings
so simulated games actually use them.

Closes #650. Closes #646. Part of #605.

## Two switches, and they answer different questions

- **`FLAG_DYNASTY_SIM_V2`** asks *"has this deployment shipped Epic A?"* — per-environment, ours.
- **Per-league `dynastyConfig`** asks *"does this league want this mechanic?"* — runtime-toggleable
  by a commissioner, no deploy.

The flag is the **outer** gate: with it off, no league gets v2 mechanics no matter what they have
configured. That ordering is what makes it a usable kill switch — one env var backs the whole epic
out for everyone without editing a single league's settings, and turning it back on restores
exactly what each league had chosen. A test pins it.

## The finding: production defaults landed outside the balance band

Wiring everything up and measuring is the part of this slice that mattered. First run of
`dist-check` with the production configuration:

```
all A gates                          home 56.7%   TOTAL 32.3
PRODUCTION DEFAULT (+ weather)       home 52.3%   TOTAL 29.1   ← band is 30-60
```

Weather cost 3.2 points a game and pushed scoring **below the documented floor**. The cause was not
the weather model's strength but its threshold: the wind penalty began at 8 mph, and the median
week-14 game blows 15 mph. **The median late-season game was being taxed.**

A steady 8 mph breeze does not measurably affect a high-school passing game; 12 does. Raising the
threshold to 12 mph (and the kicking coefficient from 0.20 to 0.28, so a real gale still costs a
kicker what it did) gives:

```
PRODUCTION DEFAULT (+ weather)       home 53.6%   TOTAL 30.2   (n=2000)
```

Inside the band on both axes. **The margin on total scoring is 0.2 points — thin, and I want that
on the record rather than buried.** I stopped there deliberately: the threshold change is
defensible on its own terms, and further softening would have been chasing a number rather than
modelling anything. If you want more headroom the lever is `explosiveRate`, which is the dominant
scoring term in `weatherModifiers`.

All 22 of A5's weather tests pass unchanged, including the one asserting a 28 mph wind still
punishes kicking.

## The log now records what it ran under (#646)

The engine version cannot answer *"were penalties modelled in this game?"* One build writes both
kinds depending on what the league had configured that week, and a league that adopts a mechanic
mid-season ends up with both in a single season. So `PbpGameLog` gained `features`, and
`logModels` reads it.

Two details that are load-bearing:

- **Absent, not empty, when nothing was on.** `{}` would change the serialized log and break golden
  parity. A gated-off v2 log stays byte-identical to its v1 self, and the test asserts
  `"features" in log === false` rather than just checking for undefined.
- **Gates that were off are never written as `false`.** Recording `penalties: false` would claim the
  engine considered penalties and declined — indistinguishable in the data from a build that never
  had them, and Epic D's record book would later read that claim as history.

This also fixed a real bug in the box score. `logModelsPenalties` scanned plays for a `penalty`
field, so a game played **with** penalties enabled that happened to draw no flags reported "—"
instead of `0` — hiding a real result behind "unknown". Its own comment claimed the opposite
behavior. It now reads the recorded gate, falling back to the scan for older logs.

## What changed

- **`src/lib/sim-context.ts`** — `resolveSimFeatures` (pure, the single place config maps to gates)
  and `loadSeasonSimContext`, which reads settings and rivalries **once per run** and is threaded
  like `profileCache`. Reading them per fixture would be two reads per game for data that cannot
  change mid-run — the N+1 shape F2 and F3 exist to remove. Fails soft: a league whose settings
  cannot be read simulates with no v2 mechanics rather than failing the run.
- **`simContext` is a REQUIRED field** on `SimulateFixtureInput`. An optional one defaulting to "no
  mechanics" is exactly how four slices shipped dark without anyone noticing. Making it required
  meant `tsc` immediately listed every call site — which is how I found the four in `actions.ts` and
  the four in tests.
- **Three new config knobs** for the gates that had none: `scoringDepthEnabled`,
  `situationalAiEnabled`, `balanceTuningEnabled`. All default ON, per F5's existing rule that
  "defaults describe a league that plays the full game" and a commissioner opts out.
- **`dist-check.ts`** gained a production-default row with derived weather — the configuration a real
  league actually plays under. The others isolate one mechanic at a time.

## Verification

- [x] `tsc --noEmit` clean (turbo type-check, 5/5)
- [x] `test:unit` — **194 files / 1460 tests pass** (was 192/1437)
- [x] `next build` succeeds
- [x] `turbo lint` clean
- [x] **Golden parity holds** — the gated-off log is unchanged, which is what the absent `features`
      key protects
- [x] `dist-check` production row inside the band at n=300 and n=2000

Tests worth the review time:

- **Flag off yields no gates whatever the league has configured** — the kill-switch contract.
- **A gated-off log has no `features` key at all**, asserted with `in` rather than `undefined`.
- **Two logs, same engine version, opposite `logModels` answers** — the thing a version number could
  never produce.
- **A gated-off v2 log answers identically to a v1 log** for every mechanic.
- **The simulator derives the same weather the schedule's forecast shows** — otherwise a fixture
  would be previewed in one climate and played in another.
- **A fixture with no week gets no weather** rather than an invented climate.
- **A rivalry declared in either direction is found.**
- **A clean game reports 0 penalties, not "—"** — the box-score bug above.

## Deliberate scope choices

**`injuriesEnabled` stays unread.** A4 has not shipped; wiring a knob to a mechanic that does not
exist would be worse than leaving it dark.

**Already-simulated games are untouched, in both directions.** `gamePlayLogs` rows are immutable and
`simulateGameAction` refuses a fixture that is already `final`, so there is no path by which turning
this on rewrites a completed game. Flipping the flag back off likewise cannot alter what has been
played.

**Turning the flag on in production is a deploy decision, not part of this PR.** It defaults on in
preview and dev, off in production until `FLAG_DYNASTY_SIM_V2=on` is set — so this merges without
changing prod behavior, and you choose when.

## Playwright

Added one assertion to the existing Gamecast spec: a fixture simulated through the real action now
shows the weather strip, which is the end-to-end proof that the league's settings reached the engine
and the log recorded the conditions. It depends on generated fixtures carrying a week — they do, as
the same spec already navigates the schedule's per-week grouping.

**I did not run Playwright locally** (no Convex backend from a worktree, per the repo's guidance).
CI is its first real execution. Note that gates default ON in preview, so every e2e sim now runs
with v2 mechanics — I checked the suite for assertions on the old behavior and found none, but that
is the change most likely to surface something in CI.
