### PR TITLE
feat: add fatigue, durability and injuries to the sim engine

### DIFF
--- a/apps/web/convex/__tests__/playerInjuries.test.ts
+++ b/apps/web/convex/__tests__/playerInjuries.test.ts
@@ -1,0 +1,301 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Injury League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2027",
+      status: "active",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+    const mkTeam = (name: string) =>
+      ctx.db.insert("teams", {
+        name,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "City",
+        logoUrl: null,
+        rosterLimit: 53,
+      } as never);
+    const homeTeamId = await mkTeam("Home");
+    const awayTeamId = await mkTeam("Away");
+    const thirdTeamId = await mkTeam("Bye");
+    const mkPlayer = (name: string, teamId: typeof homeTeamId) =>
+      ctx.db.insert("players", {
+        name,
+        leagueId,
+        teamId,
+        position: "RB",
+        positionGroup: "RB",
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      } as never);
+    const playerId = await mkPlayer("Hurt Player", homeTeamId);
+    const byePlayerId = await mkPlayer("Bye Player", thirdTeamId);
+    const mkFixture = async (week: number) =>
+      ctx.db.insert("fixtures", {
+        seasonId,
+        homeTeamId,
+        awayTeamId,
+        scheduledAt: null,
+        week,
+        venue: null,
+        status: "scheduled",
+        stage: "regular",
+        createdAt: new Date(0).toISOString(),
+        createdBy: "test",
+      } as never);
+    return {
+      leagueId,
+      seasonId,
+      homeTeamId,
+      awayTeamId,
+      thirdTeamId,
+      playerId,
+      byePlayerId,
+      fixtures: [await mkFixture(1), await mkFixture(2), await mkFixture(3), await mkFixture(4)],
+    };
+  });
+}
+
+describe("recordGameInjuries", () => {
+  it("records an injury and projects a return week", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const result = await t.mutation(internal.sim.recordGameInjuries, {
+      fixtureId: s.fixtures[0],
+      seasonId: s.seasonId,
+      leagueId: s.leagueId,
+      week: 1,
+      homeTeamId: s.homeTeamId,
+      awayTeamId: s.awayTeamId,
+      injuries: [
+        {
+          playerId: s.playerId,
+          teamId: s.homeTeamId,
+          severity: "major",
+          label: "Out multiple weeks",
+          gamesOut: 3,
+        },
+      ],
+    });
+    expect(result.recorded).toBe(1);
+
+    const rows = await t.query(api.sim.listActiveInjuries, {
+      seasonId: s.seasonId,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].gamesOut).toBe(3);
+    expect(rows[0].initialGamesOut).toBe(3);
+    expect(rows[0].returnsAfterWeek).toBe(4);
+    expect(rows[0].status).toBe("out");
+  });
+
+  it("decrements exactly once per team game, and heals on the right one", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const record = (fixtureIndex: number, week: number, injuries: unknown[] = []) =>
+      t.mutation(internal.sim.recordGameInjuries, {
+        fixtureId: s.fixtures[fixtureIndex],
+        seasonId: s.seasonId,
+        leagueId: s.leagueId,
+        week,
+        homeTeamId: s.homeTeamId,
+        awayTeamId: s.awayTeamId,
+        injuries: injuries as never,
+      });
+
+    await record(0, 1, [
+      {
+        playerId: s.playerId,
+        teamId: s.homeTeamId,
+        severity: "moderate",
+        label: "Week to week",
+        gamesOut: 2,
+      },
+    ]);
+
+    const remaining = async () => {
+      const rows = await t.query(api.sim.listActiveInjuries, {
+        seasonId: s.seasonId,
+      });
+      return rows[0]?.gamesOut ?? null;
+    };
+
+    expect(await remaining()).toBe(2);
+    await record(1, 2);
+    expect(await remaining()).toBe(1);
+    const second = await record(2, 3);
+    // The game that takes him to zero is the one that heals him.
+    expect(second.healed).toBe(1);
+    expect(await remaining()).toBeNull();
+
+    // And he does not go negative on subsequent games.
+    const fourth = await record(3, 4);
+    expect(fourth.healed).toBe(0);
+  });
+
+  it("does not tick the countdown twice when a game is re-simulated", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const injure = () =>
+      t.mutation(internal.sim.recordGameInjuries, {
+        fixtureId: s.fixtures[0],
+        seasonId: s.seasonId,
+        leagueId: s.leagueId,
+        week: 1,
+        homeTeamId: s.homeTeamId,
+        awayTeamId: s.awayTeamId,
+        injuries: [
+          {
+            playerId: s.playerId,
+            teamId: s.homeTeamId,
+            severity: "major",
+            label: "Out multiple weeks",
+            gamesOut: 4,
+          },
+        ],
+      });
+
+    await injure();
+    await injure();
+    await injure();
+
+    const rows = await t.query(api.sim.listActiveInjuries, {
+      seasonId: s.seasonId,
+    });
+    // Replaced, not accumulated — and the countdown untouched by the replays.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].gamesOut).toBe(4);
+  });
+
+  it("does not heal a team that did not play", async () => {
+    /*
+     * The games-not-weeks rule. A team on a bye keeps its injured players out —
+     * decrementing league-wide would quietly shorten every absence.
+     */
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.run(async (ctx) => {
+      const now = new Date().toISOString();
+      await ctx.db.insert("playerInjuries", {
+        leagueId: s.leagueId,
+        seasonId: s.seasonId,
+        teamId: s.thirdTeamId,
+        playerId: s.byePlayerId,
+        fixtureId: s.fixtures[3],
+        severity: "moderate",
+        label: "Week to week",
+        gamesOut: 2,
+        initialGamesOut: 2,
+        weekOccurred: 1,
+        returnsAfterWeek: 3,
+        status: "out",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.mutation(internal.sim.recordGameInjuries, {
+      fixtureId: s.fixtures[0],
+      seasonId: s.seasonId,
+      leagueId: s.leagueId,
+      week: 1,
+      homeTeamId: s.homeTeamId,
+      awayTeamId: s.awayTeamId,
+      injuries: [],
+    });
+
+    const bye = await t.query(api.sim.listTeamInjuries, {
+      teamId: s.thirdTeamId,
+      seasonId: s.seasonId,
+    });
+    expect(bye[0].gamesOut).toBe(2);
+  });
+
+  it("emits exactly one event per injury, and none on a re-sim", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const injure = () =>
+      t.mutation(internal.sim.recordGameInjuries, {
+        fixtureId: s.fixtures[0],
+        seasonId: s.seasonId,
+        leagueId: s.leagueId,
+        week: 1,
+        homeTeamId: s.homeTeamId,
+        awayTeamId: s.awayTeamId,
+        injuries: [
+          {
+            playerId: s.playerId,
+            teamId: s.homeTeamId,
+            severity: "major",
+            label: "Out multiple weeks",
+            gamesOut: 3,
+          },
+        ],
+      });
+
+    await injure();
+    await injure();
+
+    const events = await t.run(async (ctx) =>
+      ctx.db.query("dynastyEvents").collect(),
+    );
+    const injuryEvents = events.filter((e) => e.eventType === "player_injured");
+    expect(injuryEvents).toHaveLength(1);
+    expect(injuryEvents[0].headline).toContain("Hurt Player");
+  });
+
+  it("records a day-to-day knock as already healed", async () => {
+    // gamesOut 0 means he is available next week — it should never sit in the
+    // active list waiting for a decrement that would take it negative.
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await t.mutation(internal.sim.recordGameInjuries, {
+      fixtureId: s.fixtures[0],
+      seasonId: s.seasonId,
+      leagueId: s.leagueId,
+      week: 1,
+      homeTeamId: s.homeTeamId,
+      awayTeamId: s.awayTeamId,
+      injuries: [
+        {
+          playerId: s.playerId,
+          teamId: s.homeTeamId,
+          severity: "minor",
+          label: "Day to day",
+          gamesOut: 0,
+        },
+      ],
+    });
+
+    expect(
+      await t.query(api.sim.listActiveInjuries, { seasonId: s.seasonId }),
+    ).toHaveLength(0);
+    expect(
+      await t.query(api.sim.listTeamInjuries, {
+        teamId: s.homeTeamId,
+        seasonId: s.seasonId,
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -227,7 +227,11 @@ void api.program.moduleStatus;
 void api.history.moduleStatus;
 
 type AllowedPublicDynastyReads = "moduleStatus" | "getDynastyConfig";
-type AllowedPublicSimReads = "moduleStatus" | "listRivalries";
+type AllowedPublicSimReads =
+  | "moduleStatus"
+  | "listRivalries"
+  | "listActiveInjuries"
+  | "listTeamInjuries";
 type AllowedPublicProgramReads = "moduleStatus";
 type AllowedPublicHistoryReads = "moduleStatus";
 

--- a/apps/web/convex/lib/narrative.ts
+++ b/apps/web/convex/lib/narrative.ts
@@ -44,6 +44,14 @@ export type NarrativeInput =
       type: "season_completed";
       seasonName: string;
       championName: string | null;
+    }
+  | {
+      type: "player_injured";
+      playerName: string;
+      teamName: string;
+      label: string;
+      gamesOut: number;
+      week: number | null;
     };
 
 export type NarrativeEventType = NarrativeInput["type"];
@@ -74,6 +82,13 @@ export function renderHeadline(input: NarrativeInput): string {
         ? `${input.seasonName}: ${input.championName} wins the championship`
         : `${input.seasonName} is in the books`;
     }
+    case "player_injured": {
+      const duration =
+        input.gamesOut <= 0
+          ? "and is day to day"
+          : `and is out ${input.gamesOut} game${input.gamesOut === 1 ? "" : "s"}`;
+      return `${weekPrefix(input.week)}${input.teamName}'s ${input.playerName} was hurt ${duration}`;
+    }
     default: {
       // Exhaustiveness guard: adding a NarrativeInput variant without a case
       // here fails `tsc`, so a new event type cannot ship copy-less.
@@ -91,6 +106,9 @@ export function defaultSeverity(type: NarrativeEventType): EventSeverity {
       return "info";
     case "season_completed":
       return "headline";
+    case "player_injured":
+      // A knock is background; anything costing games is worth surfacing.
+      return "info";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;
@@ -106,6 +124,8 @@ export function categoryFor(type: NarrativeEventType): EventCategory {
       return "game";
     case "season_completed":
       return "program";
+    case "player_injured":
+      return "game";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;

--- a/apps/web/convex/sim.ts
+++ b/apps/web/convex/sim.ts
@@ -1,12 +1,13 @@
-import { v } from "convex/values";
+import { v, type Infer } from "convex/values";
 import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
+import { emitDynastyEvent } from "./lib/events";
 import {
   normalizeIntensity,
   rivalryPairKey,
   sortRivalryTeams,
 } from "./lib/rivalries";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 
 /*
  * Dynasty Mode — simulation persistence (Epic A).
@@ -184,5 +185,200 @@ export const deleteRivalry = internalMutation({
     const existing = await ctx.db.get(args.rivalryId);
     if (existing) await ctx.db.delete(args.rivalryId);
     return null;
+  },
+});
+
+/*
+ * ── Player injuries (A4) ────────────────────────────────────────────────────
+ */
+
+const injuryValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  teamId: v.string(),
+  playerId: v.string(),
+  fixtureId: v.string(),
+  severity: v.string(),
+  label: v.string(),
+  gamesOut: v.number(),
+  initialGamesOut: v.number(),
+  weekOccurred: v.union(v.number(), v.null()),
+  returnsAfterWeek: v.union(v.number(), v.null()),
+  status: v.string(),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+});
+
+function toInjuryDto(
+  row: Doc<"playerInjuries">,
+): Infer<typeof injuryValidator> {
+  return {
+    id: row._id as string,
+    leagueId: row.leagueId as string,
+    seasonId: row.seasonId as string,
+    teamId: row.teamId as string,
+    playerId: row.playerId as string,
+    fixtureId: row.fixtureId as string,
+    severity: row.severity,
+    label: row.label,
+    gamesOut: row.gamesOut,
+    initialGamesOut: row.initialGamesOut,
+    weekOccurred: row.weekOccurred,
+    returnsAfterWeek: row.returnsAfterWeek,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Every injury still costing a player games, for one season. */
+export const listActiveInjuries = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(injuryValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerInjuries")
+      .withIndex("by_seasonId_status", (q) =>
+        q.eq("seasonId", args.seasonId).eq("status", "out"),
+      )
+      .collect();
+    return rows.map(toInjuryDto);
+  },
+});
+
+/** Injuries for one team's season, healed ones included, newest first. */
+export const listTeamInjuries = query({
+  args: { teamId: v.id("teams"), seasonId: v.id("seasons") },
+  returns: v.array(injuryValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerInjuries")
+      .withIndex("by_teamId_seasonId", (q) =>
+        q.eq("teamId", args.teamId).eq("seasonId", args.seasonId),
+      )
+      .collect();
+    return rows
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .map(toInjuryDto);
+  },
+});
+
+/**
+ * Record a game's injuries and tick everyone else's countdown.
+ *
+ * Both halves belong in ONE mutation because they are one event: a game was
+ * played. Splitting them would let a crash between the two leave a season where
+ * an injury was recorded but nobody healed, and re-running would then
+ * double-decrement.
+ *
+ * Idempotent on `fixtureId`: re-simulating a game replaces its injuries rather
+ * than adding a second set, and does not tick the countdown twice.
+ */
+export const recordGameInjuries = internalMutation({
+  args: {
+    fixtureId: v.id("fixtures"),
+    seasonId: v.id("seasons"),
+    leagueId: v.id("leagues"),
+    week: v.union(v.number(), v.null()),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+    injuries: v.array(
+      v.object({
+        playerId: v.id("players"),
+        teamId: v.id("teams"),
+        severity: v.string(),
+        label: v.string(),
+        gamesOut: v.number(),
+      }),
+    ),
+  },
+  returns: v.object({ recorded: v.number(), healed: v.number() }),
+  handler: async (ctx, args) => {
+    const now = new Date().toISOString();
+
+    const already = await ctx.db
+      .query("playerInjuries")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    const isResim = already.length > 0;
+    for (const row of already) await ctx.db.delete(row._id);
+
+    /*
+     * Only the two teams that just played tick down. A league-wide decrement
+     * would heal players on teams with a bye, which is precisely the case the
+     * games-not-weeks rule exists to get right.
+     */
+    let healed = 0;
+    if (!isResim) {
+      for (const teamId of [args.homeTeamId, args.awayTeamId]) {
+        const open = await ctx.db
+          .query("playerInjuries")
+          .withIndex("by_teamId_seasonId", (q) =>
+            q.eq("teamId", teamId).eq("seasonId", args.seasonId),
+          )
+          .collect();
+        for (const row of open) {
+          if (row.status !== "out" || row.gamesOut <= 0) continue;
+          const remaining = row.gamesOut - 1;
+          await ctx.db.patch(row._id, {
+            gamesOut: remaining,
+            status: remaining <= 0 ? "healed" : "out",
+            updatedAt: now,
+          });
+          if (remaining <= 0) healed += 1;
+        }
+      }
+    }
+
+    for (const injury of args.injuries) {
+      /*
+       * One event per injury, deduped on the fixture and player rather than on
+       * anything version-derived. Re-simulating a game must not republish the
+       * news — `emitDynastyEvent` no-ops on a key it has already seen.
+       */
+      const [player, team] = await Promise.all([
+        ctx.db.get(injury.playerId),
+        ctx.db.get(injury.teamId),
+      ]);
+      await emitDynastyEvent(ctx, {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        week: args.week,
+        teamId: injury.teamId,
+        playerId: injury.playerId,
+        fixtureId: args.fixtureId,
+        dedupeKey: `injury:${args.fixtureId}:${injury.playerId}`,
+        narrative: {
+          type: "player_injured",
+          playerName: player?.name ?? "A player",
+          teamName: team?.name ?? "A team",
+          label: injury.label,
+          gamesOut: injury.gamesOut,
+          week: args.week,
+        },
+        severity: injury.gamesOut >= 3 ? "notable" : "info",
+      });
+
+      await ctx.db.insert("playerInjuries", {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        teamId: injury.teamId,
+        playerId: injury.playerId,
+        fixtureId: args.fixtureId,
+        severity: injury.severity,
+        label: injury.label,
+        gamesOut: injury.gamesOut,
+        initialGamesOut: injury.gamesOut,
+        weekOccurred: args.week,
+        returnsAfterWeek:
+          args.week === null ? null : args.week + Math.max(0, injury.gamesOut),
+        status: injury.gamesOut > 0 ? "out" : "healed",
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    return { recorded: args.injuries.length, healed };
   },
 });

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -159,6 +159,39 @@ export const dynastyTables = {
    * because `resolveDynastyConfig` fills defaults for anything missing. Read it
    * through that resolver, never off the raw document.
    */
+  /*
+   * Player injuries (A4).
+   *
+   * `gamesOut` is the AUTHORITATIVE countdown, decremented once per team game
+   * played. `returnsAfterWeek` is the projection shown in the UI — a bye or a
+   * rescheduled fixture moves the real return date, and the countdown follows
+   * while the projection does not.
+   */
+  playerInjuries: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    playerId: v.id("players"),
+    /** The fixture the injury happened in — also the dedupe key for a re-sim. */
+    fixtureId: v.id("fixtures"),
+    severity: v.string(),
+    label: v.string(),
+    /** Team games still to miss. 0 means available. */
+    gamesOut: v.number(),
+    /** What it was when it happened, so the UI can say "a 4-game injury". */
+    initialGamesOut: v.number(),
+    weekOccurred: v.union(v.number(), v.null()),
+    returnsAfterWeek: v.union(v.number(), v.null()),
+    /** "out" | "healed" */
+    status: v.string(),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_seasonId_status", ["seasonId", "status"])
+    .index("by_playerId_seasonId", ["playerId", "seasonId"])
+    .index("by_teamId_seasonId", ["teamId", "seasonId"])
+    .index("by_fixtureId", ["fixtureId"]),
+
   dynastyConfig: defineTable({
     leagueId: v.id("leagues"),
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -21,6 +21,7 @@ const {
   mockDynastySimV2,
   mockGetDynastyConfig,
   mockListRivalries,
+  mockListActiveInjuries,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -40,6 +41,7 @@ const {
   mockDynastySimV2: vi.fn(),
   mockGetDynastyConfig: vi.fn(),
   mockListRivalries: vi.fn(),
+  mockListActiveInjuries: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
@@ -50,6 +52,7 @@ vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
 vi.mock("@/lib/data-api", () => ({
   getDynastyConfig: mockGetDynastyConfig,
   listRivalries: mockListRivalries,
+  listActiveInjuries: mockListActiveInjuries,
   getFixture: mockGetFixture,
   recordGameResult: mockRecordGameResult,
   upsertGamePlayLog: mockUpsertGamePlayLog,
@@ -130,6 +133,7 @@ function authorize() {
   mockDynastySimV2.mockResolvedValue(true);
   mockGetDynastyConfig.mockResolvedValue(DYNASTY_CONFIG_DEFAULTS);
   mockListRivalries.mockResolvedValue([]);
+  mockListActiveInjuries.mockResolvedValue([]);
   mockAuth.mockResolvedValue({ userId: USER });
   mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
   mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
@@ -185,8 +189,11 @@ describe("simulateGameAction (PBP Slice B)", () => {
           situational: true,
           balance: true,
           weather: true,
+          injuries: true,
         },
         rivalries: expect.any(Map),
+        injurySeverityScale: 1,
+        unavailablePlayerIds: expect.any(Set),
       },
     });
   });

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -291,6 +291,7 @@ async function resolveSeasonSimRun(
     simulationFlavor: normalizeSimulationFlavor(season.simulationFlavor),
     simContext: await loadSeasonSimContext({
       leagueId: season.leagueId,
+      seasonId,
       flagEnabled,
     }),
   };

--- a/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/depth-chart/page.tsx
@@ -6,6 +6,7 @@ import {
   getTeamLeagueId,
   getPlayersByTeam,
   getSeasons,
+  listTeamInjuries,
   getDepthChartByTeamSeason,
   getLeagueOrgId,
 } from "@/lib/data-api";
@@ -83,6 +84,20 @@ export default async function DepthChartPage({
     );
   }
 
+  /*
+   * Injured players are marked ON the depth chart (A4), because that is where
+   * a coach decides who starts — a separate report is easy to miss.
+   */
+  const injuries = await listTeamInjuries({
+    teamId: teamId,
+    seasonId: activeSeason.id,
+  }).catch(() => []);
+  const outPlayers = new Map(
+    injuries
+      .filter((injury) => injury.status === "out" && injury.gamesOut > 0)
+      .map((injury) => [injury.playerId, injury.gamesOut] as const),
+  );
+
   const [players, entries] = await Promise.all([
     getPlayersByTeam(teamId, {
       userId,
@@ -108,6 +123,7 @@ export default async function DepthChartPage({
         })}
       />
       <DepthChartBoard
+        outPlayers={outPlayers}
         teamId={teamId}
         teamName={team.name}
         leagueId={team.leagueId}

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   getTeamMaddenOveralls,
   getLeagueClaimable,
   getSeasons,
+  listTeamInjuries,
   listFixturesBySeason,
 } from "@/lib/data-api";
 import { isSeasonStarted } from "@/lib/season-started";
@@ -23,6 +24,7 @@ import type { PlayerSnapshot } from "@/lib/attributes/headline-columns";
 import TeamManagement from "./team-management";
 import { ClaimTeamButton } from "./claim-team-button";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import { InjuryReportCard } from "@/components/dynasty/InjuryReportCard";
 import {
   buildTeamSiblingLinks,
   teamHomeHref,
@@ -83,6 +85,17 @@ export default async function TeamDetailPage({
       )
     : false;
 
+  /*
+   * Injury report (A4). Season-scoped, and only when there is a season — a
+   * team with no season has no games to be out of. Failure must never take
+   * down Team Home, so the card simply does not render.
+   */
+  const injuries = activeSeason
+    ? await listTeamInjuries({ teamId: id, seasonId: activeSeason.id }).catch(
+        () => [],
+      )
+    : [];
+
   // WSM-000090: attribute snapshots feed the SPRT stat columns. Phase 2-gated;
   // the season is resolved server-side — including workspace forks, which read
   // their source league's current season (WSM-000122). Failure here must never
@@ -113,6 +126,15 @@ export default async function TeamDetailPage({
         homeHref={teamHomeHref(id)}
         siblings={siblingLinks}
       />
+
+      {injuries.length > 0 && (
+        <InjuryReportCard
+          injuries={injuries}
+          playerNames={Object.fromEntries(
+            players.map((player) => [player.id, player.name]),
+          )}
+        />
+      )}
 
       {offerFork && (
         <div className="mb-4 rounded-md border border-primary/40 bg-primary/5 p-4">

--- a/apps/web/src/components/depth-chart/DepthChartBoard.tsx
+++ b/apps/web/src/components/depth-chart/DepthChartBoard.tsx
@@ -21,6 +21,8 @@ interface DepthChartBoardProps {
   /** Admin or coach: can reorder the depth chart. Viewers are read-only
    *  (WSM-000121). Defaults true to preserve existing callers. */
   canEdit?: boolean;
+  /** Player ids serving an injury (A4) → games remaining. */
+  outPlayers?: ReadonlyMap<string, number>;
 }
 
 export default function DepthChartBoard({
@@ -32,6 +34,7 @@ export default function DepthChartBoard({
   entries,
   isAdmin,
   canEdit = true,
+  outPlayers,
 }: DepthChartBoardProps) {
   const [rosterLocked, setRosterLocked] = useState(season.rosterLocked);
 
@@ -108,6 +111,7 @@ export default function DepthChartBoard({
               positionSlot={positionSlot}
               players={slotPlayers}
               disabled={rosterLocked || !canEdit}
+              outPlayers={outPlayers}
             />
           ))}
         </div>

--- a/apps/web/src/components/depth-chart/PositionColumn.tsx
+++ b/apps/web/src/components/depth-chart/PositionColumn.tsx
@@ -31,6 +31,8 @@ interface PositionColumnProps {
   positionSlot: string;
   players: PlayerDto[];
   disabled: boolean;
+  /** Player ids serving an injury (A4), with games remaining. */
+  outPlayers?: ReadonlyMap<string, number>;
 }
 
 export default function PositionColumn({
@@ -40,6 +42,7 @@ export default function PositionColumn({
   positionSlot,
   players,
   disabled,
+  outPlayers,
 }: PositionColumnProps) {
   const [items, setItems] = useState<PlayerDto[]>(players);
   const [pending, startTransition] = useTransition();
@@ -124,6 +127,7 @@ export default function PositionColumn({
                   player={player}
                   rank={index + 1}
                   disabled={disabled || pending}
+                  gamesOut={outPlayers?.get(player.id)}
                 />
               ))}
             </ol>
@@ -138,10 +142,13 @@ function SortableRow({
   player,
   rank,
   disabled,
+  gamesOut,
 }: {
   player: PlayerDto;
   rank: number;
   disabled: boolean;
+  /** Games still to miss (A4). Undefined means available. */
+  gamesOut?: number;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: player.id, disabled });
@@ -174,6 +181,20 @@ function SortableRow({
       </button>
       <span className="w-6 font-mono text-xs text-muted-foreground">{rank}</span>
       <span className="flex-1 text-sm text-foreground">{player.name}</span>
+      {gamesOut !== undefined && (
+        /*
+         * The depth chart is where a coach decides who plays, so an injured
+         * starter has to be visible AT the decision rather than on a separate
+         * report they might not open.
+         */
+        <span
+          className="shrink-0 rounded-control border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-destructive"
+          data-testid="depth-chart-out-badge"
+          title={`Out ${gamesOut} more game${gamesOut === 1 ? "" : "s"}`}
+        >
+          Out
+        </span>
+      )}
       {player.jerseyNumber !== null && (
         <span className="font-mono text-xs text-muted-foreground">
           #{player.jerseyNumber}

--- a/apps/web/src/components/dynasty/InjuryReportCard.tsx
+++ b/apps/web/src/components/dynasty/InjuryReportCard.tsx
@@ -1,0 +1,98 @@
+import { HeartPulse } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { InjuryDto } from "@/lib/data-api";
+
+/*
+ * Injury report (Dynasty Mode A4).
+ *
+ * Shows what a coach needs before setting a lineup: who is out, for how many
+ * more games, and who has come back. `gamesOut` is the countdown, not the
+ * projected week — a bye moves the date but not the number of games owed.
+ */
+
+export interface InjuryReportCardProps {
+  injuries: InjuryDto[];
+  playerNames: Record<string, string>;
+}
+
+function describe(injury: InjuryDto): string {
+  if (injury.status !== "out") return "Available";
+  if (injury.gamesOut <= 0) return "Available";
+  return `Out ${injury.gamesOut} more game${injury.gamesOut === 1 ? "" : "s"}`;
+}
+
+export function InjuryReportCard({
+  injuries,
+  playerNames,
+}: InjuryReportCardProps) {
+  const out = injuries.filter(
+    (injury) => injury.status === "out" && injury.gamesOut > 0,
+  );
+  const returned = injuries.filter(
+    (injury) => injury.status !== "out" || injury.gamesOut <= 0,
+  );
+
+  return (
+    <Card className="mb-6" data-testid="injury-report">
+      <CardHeader>
+        <CardTitle className="inline-flex items-center gap-2 text-xl">
+          <HeartPulse className="h-5 w-5 text-primary" aria-hidden />
+          Injury report
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {injuries.length === 0 ? (
+          <p
+            className="text-caption-12 text-text-muted"
+            data-testid="injury-report-empty"
+          >
+            No injuries this season.
+          </p>
+        ) : (
+          <>
+            {out.length > 0 && (
+              <ul className="divide-y divide-border" data-testid="injury-report-out">
+                {out.map((injury) => (
+                  <li
+                    key={injury.id}
+                    className="flex flex-wrap items-center justify-between gap-3 py-3"
+                    data-testid="injury-row"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-label-14 text-foreground">
+                        {playerNames[injury.playerId] ?? "Unknown player"}
+                      </p>
+                      <p className="text-caption-12 text-text-muted">
+                        {injury.label}
+                        {injury.weekOccurred !== null
+                          ? ` · hurt in Week ${injury.weekOccurred}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span
+                      className="shrink-0 rounded-control border border-border px-2 py-1 text-caption-12 text-text-muted"
+                      data-testid="injury-status"
+                    >
+                      {describe(injury)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {returned.length > 0 && (
+              <div data-testid="injury-report-returned">
+                <p className="text-caption-12 text-text-muted">
+                  Back from injury:{" "}
+                  {returned
+                    .map((injury) => playerNames[injury.playerId] ?? "Unknown")
+                    .join(", ")}
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/__tests__/sim-context.test.ts
+++ b/apps/web/src/lib/__tests__/sim-context.test.ts
@@ -27,6 +27,7 @@ describe("resolveSimFeatures", () => {
       situational: true,
       balance: true,
       weather: true,
+      injuries: true,
     });
   });
 
@@ -51,6 +52,7 @@ describe("resolveSimFeatures", () => {
       scoringV2: true,
       situational: true,
       balance: true,
+      injuries: true,
     });
   });
 
@@ -65,20 +67,28 @@ describe("resolveSimFeatures", () => {
     expect("penalties" in features).toBe(false);
   });
 
-  it("ignores knobs that belong to other epics", () => {
-    // Injuries (A4) and polls (D3) have no engine gate yet. Reading them here
+  it("ignores knobs that belong to epics with no engine gate", () => {
+    // Polls (D3) and transfers (B4) have no engine gate. Reading them here
     // would silently enable something that does not exist.
     const features = resolveSimFeatures(
       true,
-      config({ injuriesEnabled: true, pollsEnabled: true }),
+      config({ pollsEnabled: true, transfersEnabled: true }),
     );
     expect(Object.keys(features).sort()).toEqual([
       "balance",
+      "injuries",
       "penalties",
       "scoringV2",
       "situational",
       "weather",
     ]);
+  });
+
+  it("carries the injury dial without letting it enable the gate", () => {
+    // The dial scales severity; the knob decides whether injuries happen at
+    // all. A brutal dial on a league that disabled injuries changes nothing.
+    expect(resolveSimFeatures(true, config({ injuriesEnabled: false })))
+      .not.toHaveProperty("injuries");
   });
 });
 

--- a/apps/web/src/lib/build-team-sim-profile.ts
+++ b/apps/web/src/lib/build-team-sim-profile.ts
@@ -99,6 +99,9 @@ export async function buildTeamSimProfile(
       // no attribute snapshot, in which case `meanAwareness` falls back to
       // overall rather than assuming a value.
       awareness: snaps.get(p.id)?.attributes?.AWR,
+      // Stamina and injury resistance (A4). Absent means average — never zero,
+      // which would gas an unrated player inside a quarter.
+      endurance: snaps.get(p.id)?.attributes?.STA,
     };
   });
 

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2857,3 +2857,64 @@ export async function deleteRivalry(rivalryId: string): Promise<null> {
   const client = getConvexClient();
   return client.mutation(simRef.mutation<null>("deleteRivalry"), { rivalryId });
 }
+
+/*
+ * Player injuries (A4). Same typed-ref discipline as the config functions.
+ */
+
+export interface InjuryDto {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  fixtureId: string;
+  severity: string;
+  label: string;
+  gamesOut: number;
+  initialGamesOut: number;
+  weekOccurred: number | null;
+  returnsAfterWeek: number | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listActiveInjuries(
+  seasonId: string,
+): Promise<InjuryDto[]> {
+  const client = getConvexClient();
+  return client.query(simRef.query<InjuryDto[]>("listActiveInjuries"), {
+    seasonId,
+  });
+}
+
+export async function listTeamInjuries(input: {
+  teamId: string;
+  seasonId: string;
+}): Promise<InjuryDto[]> {
+  const client = getConvexClient();
+  return client.query(simRef.query<InjuryDto[]>("listTeamInjuries"), input);
+}
+
+export async function recordGameInjuries(input: {
+  fixtureId: string;
+  seasonId: string;
+  leagueId: string;
+  week: number | null;
+  homeTeamId: string;
+  awayTeamId: string;
+  injuries: Array<{
+    playerId: string;
+    teamId: string;
+    severity: string;
+    label: string;
+    gamesOut: number;
+  }>;
+}): Promise<{ recorded: number; healed: number }> {
+  const client = getConvexClient();
+  return client.mutation(
+    simRef.mutation<{ recorded: number; healed: number }>("recordGameInjuries"),
+    input,
+  );
+}

--- a/apps/web/src/lib/pbp/__tests__/attrition.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/attrition.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import { simulateGameLog } from "../engine";
+import {
+  chargeSnap,
+  effectiveOverall,
+  snapCost,
+  staminaDecay,
+  substitutionCandidate,
+  type SnapLedger,
+} from "../fatigue";
+import { INJURY_TABLE, contactFactor, isAvailable, projectedReturnWeek, rollInjury } from "../injuries";
+import type { PbpGameInput, PlayerSimProfile, TeamSimProfile } from "../types";
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function roster(teamId: string, strength: number): PlayerSimProfile[] {
+  const specs: Array<[string, number]> = [
+    ["QB", 2], ["RB", 3], ["WR", 5], ["TE", 2], ["DE", 2], ["DT", 2],
+    ["OLB", 2], ["MLB", 2], ["CB", 3], ["S", 2], ["K", 1], ["P", 1],
+  ];
+  const out: PlayerSimProfile[] = [];
+  for (const [pos, count] of specs) {
+    for (let i = 1; i <= count; i++) {
+      const jitter = ((i * 7 + strength) % 11) - 5;
+      out.push({
+        playerId: `${teamId}-${pos}-${i}`,
+        position: pos,
+        overall: clamp(strength + jitter, 40, 99),
+        depthRank: i,
+        positionSlot: pos,
+        endurance: 70,
+      });
+    }
+  }
+  return out;
+}
+
+const team = (teamId: string, strength: number): TeamSimProfile => ({
+  teamId,
+  strength,
+  players: roster(teamId, strength),
+});
+
+function gameInput(overrides: Partial<PbpGameInput> = {}): PbpGameInput {
+  return {
+    home: team("home", 70),
+    away: team("away", 70),
+    seed: 9100,
+    flavor: "balanced",
+    ...overrides,
+  };
+}
+
+describe("fatigue", () => {
+  it("drains stamina monotonically as snaps accumulate", () => {
+    let previous = 1;
+    for (let snaps = 0; snaps <= 60; snaps += 5) {
+      const stamina = staminaDecay(snaps);
+      expect(stamina).toBeLessThanOrEqual(previous);
+      previous = stamina;
+    }
+    expect(staminaDecay(0)).toBe(1);
+    expect(staminaDecay(1000)).toBe(0);
+  });
+
+  it("lowers effective overall monotonically with accumulated snaps", () => {
+    let previous = Infinity;
+    for (let snaps = 0; snaps <= 60; snaps += 5) {
+      const value = effectiveOverall(80, staminaDecay(snaps));
+      expect(value).toBeLessThanOrEqual(previous);
+      previous = value;
+    }
+  });
+
+  it("never drops a player below a floor", () => {
+    // A gassed starter is still a varsity player. Approaching zero would make
+    // weighted selection behave as if he had left the field.
+    expect(effectiveOverall(45, 0)).toBeGreaterThanOrEqual(40);
+    expect(effectiveOverall(99, 0)).toBeGreaterThan(80);
+  });
+
+  it("lets a high-endurance player last longer at the same workload", () => {
+    expect(staminaDecay(30, 95)).toBeGreaterThan(staminaDecay(30, 45));
+  });
+
+  it("charges a carry more than an incompletion, and nothing for a timeout", () => {
+    expect(snapCost("rush")).toBeGreaterThan(snapCost("pass_incomplete"));
+    expect(snapCost("timeout")).toBe(0);
+    expect(snapCost("penalty")).toBe(0);
+  });
+});
+
+describe("substitutionCandidate", () => {
+  const players = roster("home", 70).filter((p) => p.position === "RB");
+
+  it("leaves a fresh starter alone", () => {
+    expect(substitutionCandidate(players, () => 1)).toBeNull();
+  });
+
+  it("does not sub in someone worse, even for an exhausted starter", () => {
+    // A team with no depth plays its tired starter. That consequence is the
+    // whole reason the mechanic exists — rotating to a worse player would
+    // quietly remove it.
+    const ledger: SnapLedger = new Map();
+    chargeSnap(ledger, players[0].playerId, 100);
+    const onlyStarter = [players[0]];
+    expect(
+      substitutionCandidate(onlyStarter, (p) =>
+        staminaDecay(ledger.get(p.playerId) ?? 0, p.endurance),
+      ),
+    ).toBeNull();
+  });
+
+  it("brings on a fresh backup who is better right now", () => {
+    const gassed = { ...players[0], overall: 75 };
+    const fresh = { ...players[1], overall: 70 };
+    const relief = substitutionCandidate([gassed, fresh], (p) =>
+      p.playerId === gassed.playerId ? 0 : 1,
+    );
+    expect(relief?.playerId).toBe(fresh.playerId);
+  });
+});
+
+describe("rollInjury", () => {
+  const roll = (over: Partial<Parameters<typeof rollInjury>[0]> = {}) =>
+    rollInjury({
+      playType: "rush",
+      stamina: 1,
+      severityScale: 1,
+      rolls: [0, 0.5],
+      ...over,
+    });
+
+  it("never injures anyone when the league dial is zero", () => {
+    // A true off switch, not a rare-events mode.
+    for (let i = 0; i < 200; i++) {
+      expect(roll({ severityScale: 0, rolls: [0, i / 200] })).toBeNull();
+    }
+  });
+
+  it("cannot injure anyone on a play with no contact", () => {
+    expect(roll({ playType: "timeout" })).toBeNull();
+    expect(roll({ playType: "penalty" })).toBeNull();
+  });
+
+  it("hurts tired players more often than fresh ones", () => {
+    const rate = (stamina: number) => {
+      let hurt = 0;
+      for (let i = 0; i < 4000; i++) {
+        if (roll({ stamina, rolls: [i / 4000, 0.5] })) hurt += 1;
+      }
+      return hurt;
+    };
+    expect(rate(0)).toBeGreaterThan(rate(1));
+  });
+
+  it("hurts people more on violent plays than on gentle ones", () => {
+    const rate = (playType: Parameters<typeof contactFactor>[0]) => {
+      let hurt = 0;
+      for (let i = 0; i < 4000; i++) {
+        if (roll({ playType, rolls: [i / 4000, 0.5] })) hurt += 1;
+      }
+      return hurt;
+    };
+    expect(rate("sack")).toBeGreaterThan(rate("rush"));
+    expect(rate("rush")).toBeGreaterThan(rate("pass_incomplete"));
+    expect(rate("pass_incomplete")).toBeGreaterThan(rate("extra_point"));
+  });
+
+  it("keeps gamesOut inside the band its severity declares", () => {
+    for (let i = 0; i < 500; i++) {
+      const outcome = roll({ rolls: [0, i / 500] });
+      if (!outcome) continue;
+      const spec = INJURY_TABLE[outcome.severity];
+      expect(outcome.gamesOut).toBeGreaterThanOrEqual(spec.minGames);
+      expect(outcome.gamesOut).toBeLessThanOrEqual(spec.maxGames);
+    }
+  });
+
+  it("skews a brutal league toward worse injuries, not just more of them", () => {
+    const severeShare = (severityScale: number) => {
+      let severe = 0;
+      let total = 0;
+      for (let i = 0; i < 2000; i++) {
+        const outcome = roll({ severityScale, rolls: [0, i / 2000] });
+        if (!outcome) continue;
+        total += 1;
+        if (outcome.severity === "major" || outcome.severity === "severe") severe += 1;
+      }
+      return severe / total;
+    };
+    expect(severeShare(2)).toBeGreaterThan(severeShare(1));
+  });
+});
+
+describe("availability", () => {
+  it("counts games, not weeks", () => {
+    // A bye heals nobody. The player misses the games he was given, whenever
+    // those games happen.
+    expect(isAvailable({ gamesOut: 2, status: "out" })).toBe(false);
+    expect(isAvailable({ gamesOut: 0, status: "out" })).toBe(true);
+    expect(isAvailable({ gamesOut: 3, status: "healed" })).toBe(true);
+    expect(isAvailable(null)).toBe(true);
+  });
+
+  it("projects a return week without deciding anything from it", () => {
+    expect(projectedReturnWeek(6, 3)).toBe(9);
+    expect(projectedReturnWeek(6, 0)).toBe(6);
+  });
+});
+
+describe("the injuries gate", () => {
+  it("reproduces the pre-A4 log byte for byte when disabled", () => {
+    // Parity is the contract every Epic A slice inherits: with the gate off the
+    // engine must draw the same numbers in the same order as before it existed.
+    const before = simulateGameLog(
+      gameInput({ features: { scoringV2: true, penalties: true, situational: true } }),
+    );
+    const withDialButNoGate = simulateGameLog(
+      gameInput({
+        features: { scoringV2: true, penalties: true, situational: true },
+        injurySeverityScale: 2,
+      }),
+    );
+    expect(withDialButNoGate).toEqual(before);
+    expect(before.injuries).toBeUndefined();
+  });
+
+  it("records an empty list rather than nothing when it modelled no injuries", () => {
+    // Absence means "not modelled"; an empty array means "modelled, nobody
+    // got hurt". A reader must be able to tell those apart.
+    const log = simulateGameLog(
+      gameInput({ features: { injuries: true }, injurySeverityScale: 0 }),
+    );
+    expect(log.injuries).toEqual([]);
+  });
+
+  it("keeps a knocked-out player off the field for the rest of the game", () => {
+    for (let seed = 9000; seed < 9120; seed++) {
+      const log = simulateGameLog(
+        gameInput({ seed, features: { injuries: true }, injurySeverityScale: 2 }),
+      );
+      const plays = log.drives.flatMap((d) => d.plays);
+      for (const injury of log.injuries ?? []) {
+        if (injury.gamesOut <= 0) continue;
+        const at = plays.findIndex(
+          (p) =>
+            p.injury?.playerId === injury.playerId &&
+            p.injury?.gamesOut === injury.gamesOut &&
+            p.injury?.severity === injury.severity,
+        );
+        const playedAgain = plays
+          .slice(at + 1)
+          .some((p) => p.participants.some((q) => q.playerId === injury.playerId));
+        expect(playedAgain).toBe(false);
+      }
+    }
+  });
+
+  it("stays inside the balance band of 0-2 injuries per game", () => {
+    let total = 0;
+    const games = 200;
+    for (let seed = 9000; seed < 9000 + games; seed++) {
+      const log = simulateGameLog(
+        gameInput({ seed, features: { injuries: true } }),
+      );
+      total += (log.injuries ?? []).length;
+    }
+    const perGame = total / games;
+    expect(perGame).toBeGreaterThan(0);
+    expect(perGame).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -6,6 +6,15 @@ import {
 } from "@/lib/simulation-flavor";
 import { acceptOrDecline, meanAwareness, rollPenalty } from "./penalties";
 import {
+  chargeSnap,
+  snapCost,
+  staminaDecay,
+  staminaFor,
+  substitutionCandidate,
+  type SnapLedger,
+} from "./fatigue";
+import { contactFactor, rollInjury } from "./injuries";
+import {
   NEUTRAL_AGGRESSION,
   clockStrategy,
   fourthDownDecision,
@@ -24,6 +33,7 @@ import {
   type WeatherModifiers,
 } from "./weather";
 import type {
+  GameInjury,
   PbpFeatureGates,
   PbpDrive,
   PbpDriveEndReason,
@@ -96,6 +106,14 @@ interface GameState {
    * golden-parity test exists to catch exactly that.
    */
   features: Required<PbpFeatureGates>;
+  /** Accumulated snap cost per player for this game (A4). */
+  snaps: SnapLedger;
+  /** Players whose game ended through injury (A4). */
+  unavailable: Set<string>;
+  /** Injuries sustained in this game, in order (A4). */
+  injuries: GameInjury[];
+  /** League severity dial, 0 disables injuries entirely (A4). */
+  injurySeverityScale: number;
   home: TeamSimProfile;
   away: TeamSimProfile;
   strengthWeight: number;
@@ -307,9 +325,12 @@ function weightedPick(
 function playersInGroup(
   team: TeamSimProfile,
   group: SimPositionGroup,
+  unavailable?: ReadonlySet<string>,
 ): PlayerSimProfile[] {
   return team.players
     .filter((p) => positionGroup(p.position) === group)
+    // A player whose game ended cannot take another snap (A4).
+    .filter((p) => !unavailable?.has(p.playerId))
     .sort((a, b) => {
       const da = a.depthRank ?? 99;
       const db = b.depthRank ?? 99;
@@ -318,13 +339,22 @@ function playersInGroup(
     });
 }
 
+/*
+ * Takes the whole `state`, not just `rand` (A4).
+ *
+ * Selection now depends on who is still standing and how tired they are, both
+ * of which live on the state. Threading them as extra optional arguments left
+ * every existing call site silently opting out — which is exactly what happened
+ * on the first attempt, and injured players kept taking snaps.
+ */
 function selectPlayer(
   team: TeamSimProfile,
   group: SimPositionGroup,
-  rand: () => number,
+  state: GameState,
   distribute = false,
 ): PlayerSimProfile {
-  const candidates = playersInGroup(team, group);
+  const rand = state.rand;
+  const candidates = playersInGroup(team, group, state.unavailable);
   if (candidates.length === 0) {
     return {
       playerId: `${team.teamId}-unknown-${group}`,
@@ -335,12 +365,27 @@ function selectPlayer(
   if (distribute && candidates.length > 1) {
     return weightedPick(candidates.slice(0, Math.min(4, candidates.length)), rand);
   }
+
+  /*
+   * A tired starter gets spelled — but only by someone who is actually better
+   * right now (A4). `substitutionCandidate` returns null when the bench is
+   * worse, so a team with no depth plays its exhausted starter, which is the
+   * consequence this mechanic exists to create.
+   *
+   * Consumes no randomness, so it cannot shift the draw sequence.
+   */
+  if (state.features.injuries) {
+    const relief = substitutionCandidate(candidates, (player) =>
+      staminaFor(state.snaps, player),
+    );
+    if (relief) return relief;
+  }
   return candidates[0];
 }
 
 function selectDefender(
   team: TeamSimProfile,
-  rand: () => number,
+  state: GameState,
   kind: "tackle" | "sack" | "coverage",
 ): PlayerSimProfile {
   const weights =
@@ -349,12 +394,12 @@ function selectDefender(
       : kind === "coverage"
         ? { DL: 0.1, LB: 0.25, DB: 0.65 }
         : { DL: 0.35, LB: 0.35, DB: 0.3 };
-  const r = rand();
+  const r = state.rand();
   let group: SimPositionGroup = "LB";
   if (r < weights.DL) group = "DL";
   else if (r < weights.DL + weights.LB) group = "LB";
   else group = "DB";
-  return selectPlayer(team, group, rand, true);
+  return selectPlayer(team, group, state, true);
 }
 
 function participant(
@@ -396,6 +441,84 @@ function endDrive(state: GameState, reason: PbpDriveEndReason): void {
   state.currentDrivePlays = [];
 }
 
+/*
+ * Fatigue and injury both hang off `recordPlay` (A4).
+ *
+ * It is the one choke point every play passes through, so charging snaps here
+ * means no play type can be forgotten. The PRNG cost is a function of the play
+ * TYPE only — three draws on a contact play, none otherwise — so the number of
+ * draws depends on the sequence of plays and never on their outcomes. A roll
+ * that cost draws only when someone got hurt would make every later play
+ * depend on whether anyone did.
+ */
+function applyAttrition(state: GameState, play: PbpPlay): void {
+  if (!state.features.injuries) return;
+
+  const cost = snapCost(play.playType);
+  for (const participant of play.participants) {
+    chargeSnap(state.snaps, participant.playerId, cost);
+  }
+
+  if (contactFactor(play.playType) <= 0) return;
+  if (play.participants.length === 0) return;
+
+  const whoRoll = state.rand();
+  const whetherRoll = state.rand();
+  const severityRoll = state.rand();
+
+  const victim =
+    play.participants[
+      Math.min(
+        play.participants.length - 1,
+        Math.floor(whoRoll * play.participants.length),
+      )
+    ];
+  const profile = profileFor(state, victim.teamId, victim.playerId);
+
+  const outcome = rollInjury({
+    playType: play.playType,
+    stamina: staminaDecay(
+      state.snaps.get(victim.playerId) ?? 0,
+      profile?.endurance,
+    ),
+    severityScale: state.injurySeverityScale,
+    rolls: [whetherRoll, severityRoll],
+  });
+  if (!outcome) return;
+
+  play.injury = {
+    playerId: victim.playerId,
+    teamId: victim.teamId,
+    severity: outcome.severity,
+    gamesOut: outcome.gamesOut,
+    label: outcome.label,
+  };
+  state.injuries.push({
+    playerId: victim.playerId,
+    teamId: victim.teamId,
+    severity: outcome.severity,
+    gamesOut: outcome.gamesOut,
+    label: outcome.label,
+    quarter: play.quarter,
+  });
+
+  /*
+   * Anything worse than a knock ends this player's game. That is what forces
+   * the next man up and makes roster depth matter WITHIN a game, not only in
+   * the weeks after it. A `minor` injury does not — he is shaken up and returns.
+   */
+  if (outcome.gamesOut > 0) state.unavailable.add(victim.playerId);
+}
+
+function profileFor(
+  state: GameState,
+  teamId: string,
+  playerId: string,
+): PlayerSimProfile | undefined {
+  const team = state.home.teamId === teamId ? state.home : state.away;
+  return team.players.find((p) => p.playerId === playerId);
+}
+
 function recordPlay(state: GameState, play: PbpPlay): void {
   if (state.pendingTempo) {
     play.tempo = state.pendingTempo;
@@ -403,6 +526,7 @@ function recordPlay(state: GameState, play: PbpPlay): void {
     // pulls in behind it.
     state.pendingTempo = null;
   }
+  applyAttrition(state, play);
   state.currentDrivePlays.push(play);
   state.playId += 1;
 }
@@ -499,7 +623,7 @@ function checkPeriodEnd(state: GameState): void {
 function doOnsideKick(state: GameState, kicking: "home" | "away"): void {
   const kickingTeam = kicking === "home" ? state.home : state.away;
   const receiving = kicking === "home" ? state.away : state.home;
-  const kicker = selectPlayer(kickingTeam, "K", state.rand);
+  const kicker = selectPlayer(kickingTeam, "K", state);
   const recovered = state.rand() < 0.15;
 
   startDrive(state, kickingTeam.teamId, 35);
@@ -556,8 +680,8 @@ function doKickoff(state: GameState, kicking: "home" | "away"): void {
 
   const kickingTeam = kicking === "home" ? state.home : state.away;
   const receiving = kicking === "home" ? state.away : state.home;
-  const kicker = selectPlayer(kickingTeam, "K", state.rand);
-  const returner = selectPlayer(receiving, "RB", state.rand, true);
+  const kicker = selectPlayer(kickingTeam, "K", state);
+  const returner = selectPlayer(receiving, "RB", state, true);
   const edge = matchupEdge(state);
   const returnYards = Math.round(18 + state.rand() * 22 + edge * 8);
   const startField = clamp(returnYards, 15, 40);
@@ -595,7 +719,7 @@ function doKickoff(state: GameState, kicking: "home" | "away"): void {
 function doExtraPoint(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const kicker = selectPlayer(off, "K", state.rand);
+  const kicker = selectPlayer(off, "K", state);
   const edge = matchupEdge(state);
   const makeProb = clamp(0.94 + edge * 0.03, 0.88, 0.99);
   const made = state.rand() < makeProb;
@@ -630,7 +754,7 @@ function doExtraPoint(state: GameState): void {
 function doFieldGoalAttempt(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const kicker = selectPlayer(off, "K", state.rand);
+  const kicker = selectPlayer(off, "K", state);
   const dist = yardsToGoal(state) + 17;
   const edge = matchupEdge(state);
   /*
@@ -687,8 +811,8 @@ function doFieldGoalAttempt(state: GameState): void {
 function doPunt(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const punter = selectPlayer(off, "P", state.rand);
-  const returner = selectPlayer(def, "WR", state.rand, true);
+  const punter = selectPlayer(off, "P", state);
+  const returner = selectPlayer(def, "WR", state, true);
   const gross = Math.round(
     (38 + state.rand() * 12 - matchupEdge(state) * 10) *
       state.weatherMods.kickDistance,
@@ -735,7 +859,7 @@ function doPunt(state: GameState): void {
 function doRush(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const rusher = selectPlayer(off, "RB", state.rand, true);
+  const rusher = selectPlayer(off, "RB", state, true);
   const edge = matchupEdge(state);
   const fumbleProb =
     clamp(0.01 - edge * 0.003, 0.003, 0.015) * state.weatherMods.fumbleRate;
@@ -750,10 +874,10 @@ function doRush(state: GameState): void {
   const participants: PbpParticipant[] = [
     participant(rusher, off.teamId, "rusher"),
   ];
-  const tackler = selectDefender(def, state.rand, "tackle");
+  const tackler = selectDefender(def, state, "tackle");
   participants.push(participant(tackler, def.teamId, "tackler_solo"));
   if (state.rand() < 0.35) {
-    const ast = selectDefender(def, state.rand, "tackle");
+    const ast = selectDefender(def, state, "tackle");
     participants.push(participant(ast, def.teamId, "tackler_ast"));
   }
 
@@ -765,7 +889,7 @@ function doRush(state: GameState): void {
     isTurnover = true;
     yards = 0;
     const fumbler = rusher;
-    const recoverer = selectDefender(def, state.rand, "tackle");
+    const recoverer = selectDefender(def, state, "tackle");
     participants.push(participant(fumbler, off.teamId, "fumbler"));
     participants.push(participant(recoverer, def.teamId, "recoverer"));
   } else if (state.fieldPosition + yards >= 100 && state.rand() < tdProb + (yards >= 15 ? 0.15 : 0)) {
@@ -799,14 +923,14 @@ function doRush(state: GameState): void {
 function doPass(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const passer = selectPlayer(off, "QB", state.rand);
-  const receiver = selectPlayer(off, "WR", state.rand, true);
+  const passer = selectPlayer(off, "QB", state);
+  const receiver = selectPlayer(off, "WR", state, true);
   const edge = matchupEdge(state);
   const sackProb = clamp(0.07 - edge * 0.03, 0.03, 0.12);
   const intProb = clamp(0.025 - edge * 0.01, 0.008, 0.04);
 
   if (state.rand() < sackProb) {
-    const sacker = selectDefender(def, state.rand, "sack");
+    const sacker = selectDefender(def, state, "sack");
     const yards = -Math.round(3 + state.rand() * 6);
     const play: PbpPlay = {
       playId: state.playId,
@@ -839,7 +963,7 @@ function doPass(state: GameState): void {
       state.features.scoringV2 &&
       state.rand() < 0.12 * state.weatherMods.fumbleRate
     ) {
-      const recoverer = selectDefender(def, state.rand, "tackle");
+      const recoverer = selectDefender(def, state, "tackle");
       play.isTurnover = true;
       play.participants.push(participant(passer, off.teamId, "fumbler"));
       play.participants.push(participant(recoverer, def.teamId, "recoverer"));
@@ -856,7 +980,7 @@ function doPass(state: GameState): void {
   }
 
   if (state.rand() < intProb) {
-    const interceptor = selectDefender(def, state.rand, "coverage");
+    const interceptor = selectDefender(def, state, "coverage");
     const returnYards = Math.round(state.rand() * 20);
     const play: PbpPlay = {
       playId: state.playId,
@@ -916,7 +1040,7 @@ function doPass(state: GameState): void {
     clamp(0.6 + edge * 0.14, 0.45, 0.8) * state.weatherMods.passAccuracy;
   const complete = state.rand() < completeProb;
   if (!complete) {
-    const pd = state.rand() < 0.12 ? selectDefender(def, state.rand, "coverage") : null;
+    const pd = state.rand() < 0.12 ? selectDefender(def, state, "coverage") : null;
     const participants: PbpParticipant[] = [
       participant(passer, off.teamId, "passer"),
       participant(receiver, off.teamId, "receiver"),
@@ -956,11 +1080,11 @@ function doPass(state: GameState): void {
     participant(passer, off.teamId, "passer"),
     participant(receiver, off.teamId, "receiver"),
   ];
-  const tackler = selectDefender(def, state.rand, "tackle");
+  const tackler = selectDefender(def, state, "tackle");
   participants.push(participant(tackler, def.teamId, "tackler_solo"));
   if (state.rand() < 0.3) {
     participants.push(
-      participant(selectDefender(def, state.rand, "tackle"), def.teamId, "tackler_ast"),
+      participant(selectDefender(def, state, "tackle"), def.teamId, "tackler_ast"),
     );
   }
 
@@ -995,7 +1119,7 @@ function doPass(state: GameState): void {
 function doKneel(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const rusher = selectPlayer(off, "QB", state.rand);
+  const rusher = selectPlayer(off, "QB", state);
   const play: PbpPlay = {
     playId: state.playId,
     driveId: state.driveId,
@@ -1037,7 +1161,7 @@ function awardDefensivePoints(state: GameState, points: number): void {
 function doSafety(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const tackler = selectDefender(def, state.rand, "tackle");
+  const tackler = selectDefender(def, state, "tackle");
 
   awardDefensivePoints(state, 2);
 
@@ -1089,8 +1213,8 @@ function shouldGoForTwo(state: GameState): boolean {
 function doTwoPointConversion(state: GameState): void {
   const off = offenseTeam(state);
   const def = defenseTeam(state);
-  const passer = selectPlayer(off, "QB", state.rand);
-  const target = selectPlayer(off, "WR", state.rand, true);
+  const passer = selectPlayer(off, "QB", state);
+  const target = selectPlayer(off, "WR", state, true);
   const edge = matchupEdge(state);
   const success = state.rand() < clamp(0.45 + edge * 0.1, 0.3, 0.62);
 
@@ -1528,7 +1652,17 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
       situational: input.features?.situational === true,
       balance: input.features?.balance === true,
       weather: input.features?.weather === true,
+      injuries: input.features?.injuries === true,
     },
+    snaps: new Map(),
+    unavailable: new Set(),
+    injuries: [],
+    /*
+     * Default 1 (normal) rather than 0. A caller that enabled the gate but did
+     * not pass a dial wants injuries at the usual rate — reading absence as
+     * "off" would make the gate silently do nothing.
+     */
+    injurySeverityScale: input.injurySeverityScale ?? 1,
     home: input.home,
     away: input.away,
     strengthWeight: weights.strengthWeight,
@@ -1627,6 +1761,12 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
      * parity fixture pins.
      */
     ...(activeFeatures(state.features) ?? {}),
+    /*
+     * An empty array is not the same as absence here: it says injuries WERE
+     * modelled and nobody got hurt, which a reader must be able to distinguish
+     * from a game that never rolled for them.
+     */
+    ...(state.features.injuries ? { injuries: state.injuries } : {}),
   };
 }
 

--- a/apps/web/src/lib/pbp/fatigue.ts
+++ b/apps/web/src/lib/pbp/fatigue.ts
@@ -1,0 +1,166 @@
+import type { PbpPlayType, PlayerSimProfile } from "./types";
+
+/*
+ * Fatigue and durability (Dynasty Mode A4).
+ *
+ * Pure, and deliberately CONSUMES NO RANDOMNESS. Fatigue is a function of the
+ * snaps a player has already taken, so it can be recomputed at any point in a
+ * game without touching the PRNG. That matters more than it looks: the engine's
+ * random sequence is shared by every mechanic, so a single stray `rand()` here
+ * would shift every later draw and break golden parity for reasons that have
+ * nothing to do with fatigue.
+ *
+ * ## What this models
+ *
+ * A workhorse back who carries 25 times is worse in the fourth quarter than he
+ * was in the first, and a team with no second back has no way out of that. The
+ * point is not the tiredness itself — it is that ROSTER DEPTH becomes a real
+ * decision instead of a number nobody reads.
+ */
+
+/**
+ * How much a snap costs the players involved in it.
+ *
+ * A carry costs more than a pass drop-back because someone hits you at the end
+ * of it. These are relative weights, not seconds or calories — only their ratio
+ * matters, and `STAMINA_BUDGET` sets the absolute scale.
+ */
+const SNAP_COSTS: Partial<Record<PbpPlayType, number>> = {
+  rush: 1.35,
+  pass_complete: 1,
+  pass_incomplete: 0.8,
+  sack: 1.25,
+  interception: 1.1,
+  kickoff: 0.9,
+  punt: 0.6,
+  field_goal: 0.3,
+  extra_point: 0.2,
+  two_point_convert: 1,
+  two_point_fail: 1,
+  onside_kick: 0.9,
+  kneel: 0.3,
+  spike: 0.2,
+};
+
+/** Plays with no snap of their own cost nothing. */
+const FREE_PLAYS: ReadonlySet<PbpPlayType> = new Set([
+  "timeout",
+  "penalty",
+  "safety",
+]);
+
+export function snapCost(playType: PbpPlayType): number {
+  if (FREE_PLAYS.has(playType)) return 0;
+  return SNAP_COSTS[playType] ?? 1;
+}
+
+/**
+ * Accumulated snap cost at which an average player is fully gassed.
+ *
+ * Tuned against a real workload: a feature back sees roughly 25 carries plus a
+ * dozen pass snaps in a full game, which lands near this budget — so the
+ * heaviest-used player on a team finishes tired and everyone else does not.
+ */
+const STAMINA_BUDGET = 46;
+
+/** Endurance below which a player tires faster; above which, slower. */
+const NEUTRAL_ENDURANCE = 70;
+
+/**
+ * Remaining stamina in `[0, 1]` after `accumulated` snap cost.
+ *
+ * Linear rather than exponential on purpose. An exponential curve spends most
+ * of its range in a region nobody reaches and then falls off a cliff, which
+ * reads as a bug when a starter collapses in one drive.
+ *
+ * `endurance` is the player's rating when known. Absence means average — never
+ * zero, which would make an unrated player tire instantly.
+ */
+export function staminaDecay(
+  accumulated: number,
+  endurance?: number,
+): number {
+  const rating = endurance ?? NEUTRAL_ENDURANCE;
+  // A 99-endurance player lasts about 40% longer than a 40-endurance one.
+  const budget = STAMINA_BUDGET * (0.7 + (clamp(rating, 0, 99) / 99) * 0.6);
+  return clamp(1 - accumulated / budget, 0, 1);
+}
+
+/** The most an exhausted player loses off their rating. */
+const MAX_FATIGUE_PENALTY = 14;
+
+/**
+ * A player's rating adjusted for how tired they are.
+ *
+ * Never drops below 40: a gassed starter is still a varsity player, and letting
+ * this approach zero would make the engine's weighted selection behave as if he
+ * had left the field.
+ */
+export function effectiveOverall(
+  overall: number,
+  stamina: number,
+): number {
+  const penalty = (1 - clamp(stamina, 0, 1)) * MAX_FATIGUE_PENALTY;
+  return Math.max(40, Math.round(overall - penalty));
+}
+
+/** Stamina below which the engine looks for a fresh body. */
+const SUB_THRESHOLD = 0.55;
+
+/**
+ * Who should come in for a tired starter, if anyone.
+ *
+ * Returns `null` when the starter is fine OR when there is nobody better to
+ * bring on — a team with no depth simply plays its tired starter, which is the
+ * whole consequence this mechanic exists to create. It does NOT return a worse
+ * player just to rotate.
+ *
+ * `candidates` must be in depth order, which is how `playersInGroup` supplies
+ * them.
+ */
+export function substitutionCandidate(
+  candidates: readonly PlayerSimProfile[],
+  staminaOf: (player: PlayerSimProfile) => number,
+): PlayerSimProfile | null {
+  if (candidates.length < 2) return null;
+
+  const starter = candidates[0];
+  const starterStamina = staminaOf(starter);
+  if (starterStamina >= SUB_THRESHOLD) return null;
+
+  const starterEffective = effectiveOverall(starter.overall, starterStamina);
+  let best: PlayerSimProfile | null = null;
+  let bestEffective = starterEffective;
+
+  for (const candidate of candidates.slice(1)) {
+    const effective = effectiveOverall(candidate.overall, staminaOf(candidate));
+    if (effective > bestEffective) {
+      best = candidate;
+      bestEffective = effective;
+    }
+  }
+  return best;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/** Running snap-cost totals for one game, keyed by player id. */
+export type SnapLedger = Map<string, number>;
+
+export function chargeSnap(
+  ledger: SnapLedger,
+  playerId: string,
+  cost: number,
+): void {
+  if (cost <= 0) return;
+  ledger.set(playerId, (ledger.get(playerId) ?? 0) + cost);
+}
+
+export function staminaFor(
+  ledger: SnapLedger,
+  player: PlayerSimProfile,
+): number {
+  return staminaDecay(ledger.get(player.playerId) ?? 0, player.endurance);
+}

--- a/apps/web/src/lib/pbp/injuries.ts
+++ b/apps/web/src/lib/pbp/injuries.ts
@@ -1,0 +1,201 @@
+import type { PbpPlayType } from "./types";
+
+/*
+ * Injuries (Dynasty Mode A4).
+ *
+ * Pure. The caller supplies the random draws, which keeps this module testable
+ * without a PRNG and — more importantly — keeps the number of draws an injury
+ * roll costs VISIBLE at the call site. The engine's random sequence is shared,
+ * so a mechanic that quietly draws a variable number of values would make every
+ * later play depend on whether someone got hurt.
+ *
+ * Exactly two draws per roll, always: one for whether, one for how bad.
+ */
+
+export type InjurySeverity = "minor" | "moderate" | "major" | "severe";
+
+export interface InjurySpec {
+  /** Share of injuries at this severity. Weights sum to 1. */
+  weight: number;
+  /** Inclusive range of TEAM GAMES missed. */
+  minGames: number;
+  maxGames: number;
+  label: string;
+}
+
+/**
+ * Severity distribution.
+ *
+ * Weighted hard toward the low end because that is what a season looks like:
+ * mostly knocks that cost a week, occasionally something that ends a year. A
+ * flat distribution would retire half a roster by Week 8.
+ *
+ * `minor` costs ZERO games — the player is shaken up, leaves the field, and is
+ * back next week. It exists so the news feed and the Gamecast have something to
+ * report that is not a catastrophe.
+ */
+export const INJURY_TABLE: Record<InjurySeverity, InjurySpec> = {
+  minor: { weight: 0.55, minGames: 0, maxGames: 0, label: "Day to day" },
+  moderate: { weight: 0.28, minGames: 1, maxGames: 2, label: "Week to week" },
+  major: { weight: 0.13, minGames: 3, maxGames: 6, label: "Out multiple weeks" },
+  severe: { weight: 0.04, minGames: 7, maxGames: 12, label: "Out for the season" },
+};
+
+const SEVERITY_ORDER: readonly InjurySeverity[] = [
+  "minor",
+  "moderate",
+  "major",
+  "severe",
+];
+
+/**
+ * Base chance that a play produces an injury, before fatigue and contact.
+ *
+ * Calibrated for the balance band's 0–2 injuries per game: roughly 110 plays a
+ * game, so a base near 0.008 lands about one injury per game once the contact
+ * and fatigue multipliers are applied.
+ */
+const BASE_INJURY_RATE = 0.008;
+
+/** How violent a play is, relative to a normal snap. */
+const CONTACT_MULTIPLIER: Partial<Record<PbpPlayType, number>> = {
+  rush: 1.3,
+  sack: 2.1,
+  pass_complete: 1.1,
+  pass_incomplete: 0.45,
+  interception: 1.2,
+  kickoff: 1.6,
+  punt: 0.9,
+  two_point_convert: 1.3,
+  two_point_fail: 1.3,
+  onside_kick: 1.8,
+  field_goal: 0.2,
+  extra_point: 0.15,
+  kneel: 0.05,
+  spike: 0.05,
+};
+
+export function contactFactor(playType: PbpPlayType): number {
+  return CONTACT_MULTIPLIER[playType] ?? 0;
+}
+
+export interface InjuryRollInput {
+  playType: PbpPlayType;
+  /** Remaining stamina of the player exposed, in `[0, 1]`. */
+  stamina: number;
+  /**
+   * League severity dial (`dynastyConfig.injurySeverityScale`): 0 none,
+   * 1 normal, 2 brutal. At 0 this function can never return an injury, which
+   * is what makes the knob a true off switch rather than a rare-events mode.
+   */
+  severityScale: number;
+  /** Two draws in `[0, 1)`: whether, then how bad. */
+  rolls: readonly [number, number];
+}
+
+export interface InjuryOutcome {
+  severity: InjurySeverity;
+  gamesOut: number;
+  label: string;
+}
+
+/**
+ * Did this play hurt someone, and how badly?
+ *
+ * Tired players get hurt more — the fatigue multiplier reaches 2.2x at zero
+ * stamina. That link is the reason fatigue is worth modelling at all: without
+ * it, running a back into the ground has no cost beyond a few rating points.
+ */
+export function rollInjury(input: InjuryRollInput): InjuryOutcome | null {
+  if (input.severityScale <= 0) return null;
+
+  const contact = contactFactor(input.playType);
+  if (contact <= 0) return null;
+
+  const fatigue = 1 + (1 - clamp(input.stamina, 0, 1)) * 1.2;
+  const chance = BASE_INJURY_RATE * contact * fatigue * clamp(input.severityScale, 0, 2);
+
+  if (input.rolls[0] >= chance) return null;
+
+  const severity = pickSeverity(input.rolls[1], input.severityScale);
+  const spec = INJURY_TABLE[severity];
+  /*
+   * `gamesOut` is drawn from the SAME roll that chose the severity rather than
+   * a third draw. Two draws per roll keeps the PRNG cost of an injury check
+   * constant whether or not anyone gets hurt — a variable cost would make every
+   * subsequent play depend on the injury outcome.
+   */
+  const spread = spec.maxGames - spec.minGames;
+  const within = spread === 0 ? 0 : Math.round(fractional(input.rolls[1]) * spread);
+  return {
+    severity,
+    gamesOut: spec.minGames + within,
+    label: spec.label,
+  };
+}
+
+/**
+ * Choose a severity band.
+ *
+ * A brutal league (`severityScale` 2) shifts weight toward the top of the table
+ * rather than merely producing more injuries — otherwise "brutal" would just
+ * mean "more day-to-day knocks", which nobody would notice.
+ */
+function pickSeverity(roll: number, severityScale: number): InjurySeverity {
+  const skew = clamp(severityScale, 0, 2) - 1; // -1 gentle, 0 normal, +1 brutal
+  let cumulative = 0;
+  const weights = SEVERITY_ORDER.map((severity, index) => {
+    // Later (worse) bands get more weight as `skew` rises.
+    const tilt = 1 + skew * (index / (SEVERITY_ORDER.length - 1) - 0.35);
+    return INJURY_TABLE[severity].weight * Math.max(0.05, tilt);
+  });
+  const total = weights.reduce((a, b) => a + b, 0);
+  const target = clamp(roll, 0, 0.999999) * total;
+  for (let i = 0; i < SEVERITY_ORDER.length; i++) {
+    cumulative += weights[i];
+    if (target < cumulative) return SEVERITY_ORDER[i];
+  }
+  return "minor";
+}
+
+/** The fractional part, used to reuse one draw for two independent choices. */
+function fractional(n: number): number {
+  return (n * 997) % 1;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+export interface InjuryRecord {
+  /** Team games still to be missed. The authoritative countdown. */
+  gamesOut: number;
+  status: string;
+}
+
+/**
+ * Is a player available?
+ *
+ * Availability counts GAMES, not weeks. A team with a bye does not heal anyone
+ * — the player misses the number of games he was given, whenever those games
+ * happen. `returnsAfterWeek` is stored alongside as the projection shown in the
+ * UI ("back after Week 9"), but it is a forecast, not the rule: a bye or a
+ * rescheduled fixture moves the real return date and the countdown follows.
+ */
+export function isAvailable(
+  injury: InjuryRecord | null | undefined,
+): boolean {
+  if (!injury) return true;
+  if (injury.status !== "out") return true;
+  return injury.gamesOut <= 0;
+}
+
+/**
+ * Projected return week for an injury sustained in `week`.
+ *
+ * Assumes no byes, which is why it is a projection. Nothing decides
+ * availability from it.
+ */
+export function projectedReturnWeek(week: number, gamesOut: number): number {
+  return week + Math.max(0, gamesOut);
+}

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -18,6 +18,11 @@ export interface PlayerSimProfile {
   overall: number;
   /** From depthChartEntries/rosterAssignments when available. */
   positionSlot?: string;
+  /**
+   * Endurance rating, when the player has an attribute snapshot (A4). Absent
+   * means average — never zero, which would gas an unrated player instantly.
+   */
+  endurance?: number;
   depthRank?: number;
   /**
    * Awareness (AWR) 0-99, when the player has an attribute snapshot. Drives
@@ -81,6 +86,22 @@ export interface PbpGameInput {
    */
   venuePrestige?: number;
   rivalryIntensity?: number;
+  /**
+   * League injury dial (A4), 0–2. Read only under `features.injuries`.
+   * Defaults to 1 (normal) when the gate is on and this is absent — a caller
+   * that enabled injuries wants them at the usual rate.
+   */
+  injurySeverityScale?: number;
+}
+
+/** An injury sustained during a simulated game (A4). */
+export interface GameInjury {
+  playerId: string;
+  teamId: string;
+  severity: string;
+  gamesOut: number;
+  label: string;
+  quarter: number;
 }
 
 export type PbpPlayType =
@@ -180,6 +201,21 @@ export interface PbpPlay {
   defensivePoints?: number;
 
   /**
+   * Someone was hurt on this play (A4).
+   *
+   * Absent means nobody was — which, on a log whose `features.injuries` is
+   * unset, is indistinguishable from "this engine did not model injuries". The
+   * recorded gate is what tells those apart.
+   */
+  injury?: {
+    playerId: string;
+    teamId: string;
+    severity: string;
+    gamesOut: number;
+    label: string;
+  };
+
+  /**
    * The flag on this play (A2), if any.
    *
    * A play carrying `negatesPlay: true` is KEPT in the log — you want to see
@@ -261,6 +297,14 @@ export interface PbpGameLog {
    */
   features?: PbpFeatureGates;
 
+  /**
+   * Everyone hurt in this game (A4), in the order it happened.
+   *
+   * Absent when the gate was off. An EMPTY array is different and meaningful:
+   * injuries were modelled and nobody got hurt.
+   */
+  injuries?: GameInjury[];
+
   /*
    * ── v2 additions (engine 2.0.0) ───────────────────────────────────────
    *
@@ -288,6 +332,14 @@ export interface PbpFeatureGates {
   scoringV2?: boolean;
   /** A2 — penalties, with accept/decline. */
   penalties?: boolean;
+  /**
+   * A4 — fatigue, durability and injuries.
+   *
+   * One gate for both halves on purpose: fatigue with no injury risk is a
+   * rating tweak nobody would notice, and injuries with no fatigue lose the
+   * link that makes riding a starter cost something.
+   */
+  injuries?: boolean;
   /**
    * A5 — weather, venue prestige and rivalry.
    *

--- a/apps/web/src/lib/sim-context.ts
+++ b/apps/web/src/lib/sim-context.ts
@@ -1,4 +1,8 @@
-import { getDynastyConfig, listRivalries } from "@/lib/data-api";
+import {
+  getDynastyConfig,
+  listActiveInjuries,
+  listRivalries,
+} from "@/lib/data-api";
 import type { DynastyConfig } from "@/lib/dynasty-config";
 import type { PbpFeatureGates } from "@/lib/pbp";
 import { deriveWeather, type Weather } from "@/lib/pbp/weather";
@@ -28,6 +32,15 @@ export interface SeasonSimContext {
   features: PbpFeatureGates;
   /** `pairKey` → intensity, for the rivalry lookup (A5). */
   rivalries: ReadonlyMap<string, number>;
+  /** League injury dial, 0–2 (A4). */
+  injurySeverityScale: number;
+  /**
+   * Players who cannot play (A4), resolved once for the run.
+   *
+   * Read per season rather than per team: one indexed query answers for every
+   * fixture in the run, where a per-team read would be two more reads a game.
+   */
+  unavailablePlayerIds: ReadonlySet<string>;
 }
 
 /**
@@ -55,6 +68,7 @@ export function resolveSimFeatures(
   if (config.situationalAiEnabled) features.situational = true;
   if (config.balanceTuningEnabled) features.balance = true;
   if (config.weatherEnabled) features.weather = true;
+  if (config.injuriesEnabled) features.injuries = true;
   return features;
 }
 
@@ -71,25 +85,43 @@ export function resolveSimFeatures(
  */
 export async function loadSeasonSimContext(input: {
   leagueId: string;
+  seasonId: string;
   flagEnabled: boolean;
 }): Promise<SeasonSimContext> {
-  const [config, rivalries] = await Promise.all([
+  const [config, rivalries, injuries] = await Promise.all([
     getDynastyConfig(input.leagueId).catch(() => null),
     listRivalries(input.leagueId).catch(() => []),
+    listActiveInjuries(input.seasonId).catch(() => []),
   ]);
 
+  const features = config ? resolveSimFeatures(input.flagEnabled, config) : {};
   return {
     leagueId: input.leagueId,
-    features: config ? resolveSimFeatures(input.flagEnabled, config) : {},
+    features,
+    injurySeverityScale: config?.injurySeverityScale ?? 1,
     rivalries: new Map(
       rivalries.map((r) => [rivalryPairKey(r.teamAId, r.teamBId), r.intensity]),
+    ),
+    /*
+     * Only benches anyone when the gate is on. With injuries disabled a stored
+     * injury is history, not a rule — a league that switches the mechanic off
+     * mid-season gets everyone back rather than carrying invisible absences.
+     */
+    unavailablePlayerIds: new Set(
+      features.injuries === true ? injuries.map((i) => i.playerId) : [],
     ),
   };
 }
 
 /** A context that models nothing — for callers with no league in hand. */
 export function emptySimContext(leagueId: string): SeasonSimContext {
-  return { leagueId, features: {}, rivalries: new Map() };
+  return {
+    leagueId,
+    features: {},
+    rivalries: new Map(),
+    injurySeverityScale: 1,
+    unavailablePlayerIds: new Set(),
+  };
 }
 
 export interface FixtureSimConditions {

--- a/apps/web/src/lib/simulate-fixture.ts
+++ b/apps/web/src/lib/simulate-fixture.ts
@@ -1,6 +1,7 @@
 import type { FixtureDto } from "@sports-management/shared-types";
 import {
   bulkUpsertPlayerGameStats,
+  recordGameInjuries,
   recordGameResult,
   upsertGamePlayLog,
   upsertPlayerGameStats,
@@ -77,12 +78,29 @@ export async function simulateAndPersistFixture(
     buildTeamSimProfile(fixture.awayTeamId, fixture.seasonId, orgContext, profileCache),
   ]);
 
-  const rosterEmpty = home.players.length === 0 || away.players.length === 0;
+  /*
+   * Bench anyone still serving an injury (A4).
+   *
+   * Filtered HERE rather than inside `buildTeamSimProfile` because that is
+   * cached per (team, season) and the unavailable set belongs to the run. A
+   * cached profile that had already dropped an injured player would keep
+   * dropping him after he healed.
+   */
+  const unavailable = input.simContext.unavailablePlayerIds;
+  const fit = (team: typeof home) =>
+    unavailable.size === 0
+      ? team
+      : { ...team, players: team.players.filter((p) => !unavailable.has(p.playerId)) };
+  const homeFit = fit(home);
+  const awayFit = fit(away);
+
+  const rosterEmpty =
+    homeFit.players.length === 0 || awayFit.players.length === 0;
 
   if (rosterEmpty) {
     const { homeScore, awayScore } = simulateScore({
-      homeStrength: home.strength,
-      awayStrength: away.strength,
+      homeStrength: homeFit.strength,
+      awayStrength: awayFit.strength,
       seed,
       decisive,
       flavor,
@@ -103,12 +121,13 @@ export async function simulateAndPersistFixture(
    */
   const conditions = fixtureSimConditions(input.simContext, fixture);
   const log = simulateGameLog({
-    home,
-    away,
+    home: homeFit,
+    away: awayFit,
     seed,
     decisive,
     flavor,
     features: input.simContext.features,
+    injurySeverityScale: input.simContext.injurySeverityScale,
     ...conditions,
   });
   const homeScore = log.homeScore;
@@ -122,7 +141,30 @@ export async function simulateAndPersistFixture(
     actorUserId,
   });
 
-  const rosterIds = knownPlayerIds(home.players, away.players);
+  /*
+   * Injuries are persisted BEFORE the result is recorded, so a failure leaves a
+   * game that has not been marked final — which the sim will retry — rather
+   * than a final game whose injuries were lost.
+   */
+  if (log.injuries !== undefined) {
+    await recordGameInjuries({
+      fixtureId: fixture.id,
+      seasonId: fixture.seasonId,
+      leagueId: input.simContext.leagueId,
+      week: fixture.week,
+      homeTeamId: fixture.homeTeamId,
+      awayTeamId: fixture.awayTeamId,
+      injuries: log.injuries.map((injury) => ({
+        playerId: injury.playerId,
+        teamId: injury.teamId,
+        severity: injury.severity,
+        label: injury.label,
+        gamesOut: injury.gamesOut,
+      })),
+    }).catch(() => null);
+  }
+
+  const rosterIds = knownPlayerIds(homeFit.players, awayFit.players);
   const statLines = deriveStatLines(log).filter((line) =>
     rosterIds.has(line.playerId),
   );


### PR DESCRIPTION
## Summary

Players tire as snaps accumulate, tired players get hurt more often, and anything worse than a
knock ends their game and costs them team games afterwards.

Closes #619. Part of #605.

**Stacked on #651** (sim activation) — that PR wires `injuriesEnabled` into the engine, and this one
is meaningless without it. Merge #651 first.

## Games, not weeks

The one decision everything else follows from. `gamesOut` is the authoritative countdown and it
ticks only for **the two teams that just played**. A team on a bye heals nobody.

The obvious implementation — store a return week, compare against the current week — is simpler and
wrong: a bye or a rescheduled fixture silently shortens every absence in the league. `returnsAfterWeek`
is still stored, but only as the projection the UI shows ("back after Week 9"). Nothing decides
availability from it, and the tests assert the countdown, not the date.

## Randomness discipline

The engine's PRNG is one shared sequence, so a mechanic that draws unpredictably corrupts every
later play for reasons unrelated to itself. Two rules:

- **`fatigue.ts` consumes no randomness at all.** Stamina is a function of snaps already taken, so
  it can be recomputed anywhere without touching the sequence.
- **`injuries.ts` takes its draws from the caller**, which makes the cost visible at the call site.
  `applyAttrition` draws a fixed three per contact play and none otherwise — so the draw count
  depends on the sequence of play *types* and never on their *outcomes*. A roll that cost draws only
  when someone got hurt would make every later play depend on whether anyone did.

Gate off reproduces the pre-A4 log byte for byte, including with an injury dial passed in.

## What the mechanic is actually for

Fatigue is not the point; **roster depth becoming a real decision** is. Two details carry that:

- `substitutionCandidate` returns `null` when the bench is worse than the tired starter. A team with
  no depth plays its exhausted starter — that consequence is the whole mechanic, and rotating to a
  worse player would quietly remove it.
- Anything above a knock puts a player out for the rest of the game, so the next man up plays *now*,
  not just next week.

Injury rate scales with fatigue (2.2x at zero stamina) and with contact — a sack is ~4.7x an
incompletion. That link is why fatigue is worth modelling: without it, riding a back into the ground
costs a few rating points and nothing else.

## Measured

```
dial 0:  0.00 injuries/game   (a true off switch, not a rare-events mode)
dial 1:  1.27 injuries/game   { minor 204, moderate 100, major 62, severe 15 }
dial 2:  2.59 injuries/game   { minor 324, moderate 240, major 156, severe 56 }
```

Normal sits inside the roadmap's 0–2 band. A brutal league shifts weight toward *worse* injuries
rather than merely more of them — otherwise "brutal" would just mean more day-to-day knocks, which
nobody would notice.

## Idempotency

`recordGameInjuries` records the game's injuries **and** ticks everyone else's countdown in one
mutation, because they are one event: a game was played. Split, a crash between them leaves a season
where an injury was recorded but nobody healed, and re-running double-decrements.

Both halves are idempotent on `fixtureId`: a re-simulated game replaces its injuries rather than
adding a second set, and does not tick the countdown twice. Verified by simulating the same fixture
three times and asserting the countdown is untouched.

## What changed

- **`pbp/fatigue.ts`** — `snapCost`, `staminaDecay`, `effectiveOverall`, `substitutionCandidate`.
- **`pbp/injuries.ts`** — `rollInjury`, `INJURY_TABLE`, `contactFactor`, `isAvailable`.
- **`playerInjuries` table** with the four indexes the issue names, plus `by_fixtureId` for the
  dedupe.
- **`sim.ts`** — `listActiveInjuries` / `listTeamInjuries` queries and `recordGameInjuries`
  (**internalMutation**, WSM-000096). `AllowedPublicSimReads` widened for the two reads.
- **One `dynastyEvents` row per injury**, deduped on `injury:{fixtureId}:{playerId}` — no engine
  version in the key, so a re-sim does not republish the news.
- **Injury report card** on Team Home and an **OUT badge on the depth chart** — the badge matters
  more, because the depth chart is where a coach decides who starts and a separate report is easy to
  miss.
- **`resetCanonicalFixture` clears `playerInjuries`** in the same PR that adds it.

## A correction I made mid-build

`state.unavailable` was threaded as an optional extra argument to `selectPlayer`, which meant every
existing call site silently opted out — injured players kept taking snaps (163 of 180 played on).
The fix was to make the selection functions take the whole `state` instead of a bare `rand`, so
there is no way to call them without it. A probe now asserts 0 of 177.

## Verification

- [x] `tsc --noEmit` clean (5/5), `turbo lint` clean, `next build` succeeds
- [x] `test:unit` — **197 files / 1491 tests pass** (was 195/1464)
- [x] Golden parity holds with the gate off
- [x] Injury rate inside the 0–2 band, asserted in a test rather than only measured

Tests worth the review time: effective overall decreases monotonically with snaps; a dial of 0 never
injures anyone across 200 rolls; a knocked-out player takes no further snap across 120 games; an
empty `injuries` array is recorded (modelled, nobody hurt) and distinguished from absence; the
countdown heals on exactly the right game and does not go negative; a team on a bye does not heal.

## Not done — flagging rather than implying otherwise

**No Playwright spec.** The issue asks for one asserting the report card and the OUT badge render
for an injured player. Getting an injured player through the UI needs a simulated game that happens
to produce an injury, which is not deterministic from the spec's side — it needs a seeded fixture or
a seed helper that injures someone directly. That is a real piece of work and I did not want to
fake it with a retry loop over simulations. Both surfaces are server components over a typed DTO and
are covered by unit tests; the gap is genuinely the browser-level assertion.

**`buildTeamSimProfile` does not itself exclude injured players** — `simulateAndPersistFixture`
filters after it. The issue names the former, but that function is cached per (team, season) while
the unavailable set belongs to a run: a cached profile that had already dropped an injured player
would keep dropping him after he healed. Same observable behavior, correct cache semantics.
