### PR TITLE
feat: heal lingering injuries as a rollover stage (#620)

### DIFF
--- a/apps/web/convex/__tests__/playerInjuries.test.ts
+++ b/apps/web/convex/__tests__/playerInjuries.test.ts
@@ -299,3 +299,238 @@ describe("recordGameInjuries", () => {
     ).toHaveLength(1);
   });
 });
+
+describe("healSeasonInjuries (B2)", () => {
+  /** Put one open injury on the board for `teamId`, owing `gamesOut` games. */
+  async function openInjury(
+    t: ReturnType<typeof convexTest>,
+    s: Awaited<ReturnType<typeof seed>>,
+    input: {
+      teamId: typeof s.homeTeamId;
+      playerId: typeof s.playerId;
+      fixtureId: typeof s.fixtures[number];
+      gamesOut: number;
+      seasonId?: typeof s.seasonId;
+    },
+  ) {
+    await t.run(async (ctx) => {
+      const now = new Date().toISOString();
+      await ctx.db.insert("playerInjuries", {
+        leagueId: s.leagueId,
+        seasonId: input.seasonId ?? s.seasonId,
+        teamId: input.teamId,
+        playerId: input.playerId,
+        fixtureId: input.fixtureId,
+        severity: "major",
+        label: "Season ending",
+        gamesOut: input.gamesOut,
+        initialGamesOut: input.gamesOut,
+        weekOccurred: 9,
+        returnsAfterWeek: 9 + input.gamesOut,
+        status: "out",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+  }
+
+  it("closes every open injury for the season and leaves none out", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[0],
+      gamesOut: 6,
+    });
+    await openInjury(t, s, {
+      teamId: s.thirdTeamId,
+      playerId: s.byePlayerId,
+      fixtureId: s.fixtures[1],
+      gamesOut: 2,
+    });
+
+    const result = await t.mutation(internal.sim.healSeasonInjuries, {
+      seasonId: s.seasonId,
+    });
+
+    expect(result.healed).toBe(2);
+    expect(
+      await t.query(api.sim.listActiveInjuries, { seasonId: s.seasonId }),
+    ).toHaveLength(0);
+  });
+
+  it("preserves gamesOut so an offseason heal stays distinguishable", async () => {
+    /*
+     * The whole audit trail. A row healed by PLAYING reaches zero games owed;
+     * a row healed by the OFFSEASON still owes six. Zeroing the countdown would
+     * erase the difference and make a season-ending injury indistinguishable
+     * from one the player came back from in Week 12.
+     */
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[0],
+      gamesOut: 6,
+    });
+
+    await t.mutation(internal.sim.healSeasonInjuries, { seasonId: s.seasonId });
+
+    const rows = await t.query(api.sim.listTeamInjuries, {
+      teamId: s.homeTeamId,
+      seasonId: s.seasonId,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("healed");
+    expect(rows[0].gamesOut).toBe(6);
+    expect(rows[0].initialGamesOut).toBe(6);
+  });
+
+  it("is idempotent — a second run heals nothing and changes nothing", async () => {
+    /*
+     * The stage runs under a 60-second lease, so a lost response is retried.
+     * Re-running must be a no-op rather than a second pass that re-stamps
+     * `updatedAt` on rows it already closed.
+     */
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[0],
+      gamesOut: 4,
+    });
+
+    const first = await t.mutation(internal.sim.healSeasonInjuries, {
+      seasonId: s.seasonId,
+    });
+    const afterFirst = await t.query(api.sim.listTeamInjuries, {
+      teamId: s.homeTeamId,
+      seasonId: s.seasonId,
+    });
+
+    const second = await t.mutation(internal.sim.healSeasonInjuries, {
+      seasonId: s.seasonId,
+    });
+    const afterSecond = await t.query(api.sim.listTeamInjuries, {
+      teamId: s.homeTeamId,
+      seasonId: s.seasonId,
+    });
+
+    expect(first.healed).toBe(1);
+    expect(second.healed).toBe(0);
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  it("leaves another season's open injuries alone", async () => {
+    /*
+     * Healing is scoped to the season being closed. A league mid-rollover on
+     * its 2027 season must not clear injuries a 2028 season already carries.
+     */
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const otherSeasonId = await t.run(async (ctx) =>
+      ctx.db.insert("seasons", {
+        leagueId: s.leagueId,
+        name: "2028",
+        status: "upcoming",
+        startDate: null,
+        endDate: null,
+        rosterLocked: false,
+      }),
+    );
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[0],
+      gamesOut: 3,
+    });
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[1],
+      gamesOut: 5,
+      seasonId: otherSeasonId,
+    });
+
+    const result = await t.mutation(internal.sim.healSeasonInjuries, {
+      seasonId: s.seasonId,
+    });
+
+    expect(result.healed).toBe(1);
+    expect(
+      await t.query(api.sim.listActiveInjuries, { seasonId: otherSeasonId }),
+    ).toHaveLength(1);
+  });
+
+  it("leaves a season-ending injury rostered and available in the new season", async () => {
+    /*
+     * The claim the stage exists to make. A player who tore an ACL in Week 3
+     * carries a six-game debt into an archive that will never play those games;
+     * next season he is on the roster and the sim sees nobody owing anything.
+     *
+     * Availability is read from the TARGET season's open injuries, which is why
+     * this asserts on `listActiveInjuries(next)` rather than on the row itself:
+     * that query is exactly what `loadSeasonSimContext` calls before it picks
+     * participants.
+     */
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    await openInjury(t, s, {
+      teamId: s.homeTeamId,
+      playerId: s.playerId,
+      fixtureId: s.fixtures[0],
+      gamesOut: 6,
+    });
+
+    const nextSeasonId = await t.run(async (ctx) => {
+      const next = await ctx.db.insert("seasons", {
+        leagueId: s.leagueId,
+        name: "2028",
+        status: "upcoming",
+        startDate: null,
+        endDate: null,
+        rosterLocked: false,
+      });
+      // What the `rosters_copied` stage produces: the player carried forward.
+      await ctx.db.insert("rosterAssignments", {
+        seasonId: next,
+        teamId: s.homeTeamId,
+        playerId: s.playerId,
+        leagueId: s.leagueId,
+        depthRank: 1,
+        positionSlot: "RB",
+        status: "active",
+        assignedAt: new Date().toISOString(),
+        assignedBy: "test",
+      });
+      return next;
+    });
+
+    await t.mutation(internal.sim.healSeasonInjuries, { seasonId: s.seasonId });
+
+    expect(
+      await t.query(api.sim.listActiveInjuries, { seasonId: nextSeasonId }),
+    ).toHaveLength(0);
+    const roster = await t.run(async (ctx) =>
+      ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", nextSeasonId).eq("teamId", s.homeTeamId),
+        )
+        .collect(),
+    );
+    expect(roster.map((row) => row.playerId)).toContain(s.playerId);
+  });
+
+  it("heals nothing when a season had no injuries", async () => {
+    const t = convexTest(schema, modules);
+    const s = await seed(t);
+    const result = await t.mutation(internal.sim.healSeasonInjuries, {
+      seasonId: s.seasonId,
+    });
+    expect(result.healed).toBe(0);
+  });
+});

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -193,6 +193,20 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
+  // Player injuries (A4). An injury left behind makes a player unavailable to
+  // every later run — the sim reads open rows for the season before it picks
+  // participants — so a spec that simulates would silently sim a short roster
+  // purely because an earlier spec's game hurt someone.
+  for (const team of teams as Array<{ _id: Id<"teams"> }>) {
+    const injuryRows = (await ctx.db
+      .query("playerInjuries")
+      .withIndex("by_teamId_seasonId", (q: any) => q.eq("teamId", team._id))
+      .collect()) as Array<{ _id: Id<"playerInjuries"> }>;
+    for (const row of injuryRows) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+  }
   // Team programs (A6). A stored scheme changes how every later run simulates
   // that team, so leaving one behind would make a distribution assertion depend
   // on which spec ran first.

--- a/apps/web/convex/sim.ts
+++ b/apps/web/convex/sim.ts
@@ -382,3 +382,45 @@ export const recordGameInjuries = internalMutation({
     return { recorded: args.injuries.length, healed };
   },
 });
+
+/**
+ * Close out every open injury for a season (B2).
+ *
+ * Runs as the `injuries_healed` rollover stage, against the SOURCE season. A
+ * season's injuries belong to that season — the new season's roster starts with
+ * no rows at all — so this is not what makes a player available next year. It
+ * is what stops the year that just ended from being archived with players still
+ * listed as owing games they will now never miss.
+ *
+ * `gamesOut` is deliberately PRESERVED rather than zeroed. The row then reads
+ * "healed with three games still owed", which is the only record that this
+ * injury was ended by the offseason rather than by playing through it. Nothing
+ * decides availability from the countdown alone — `isAvailable` in
+ * `pbp/injuries.ts` returns early on any status but "out", and every UI filter
+ * is an AND on both fields — so keeping it costs nothing and buys the audit.
+ *
+ * NOT gated on `injuriesEnabled`. A league that switches injuries off mid-
+ * dynasty still has rows on the board, and leaving them open would make the
+ * kill switch a way to strand data rather than a way to stop generating it.
+ *
+ * Idempotent by construction: it only touches rows the `by_seasonId_status`
+ * index still reports as "out", so a second run finds none and heals zero.
+ * That is what makes it safe to retry under the rollover's stage lease.
+ */
+export const healSeasonInjuries = internalMutation({
+  args: { seasonId: v.id("seasons") },
+  returns: v.object({ healed: v.number() }),
+  handler: async (ctx, args) => {
+    const now = new Date().toISOString();
+    const open = await ctx.db
+      .query("playerInjuries")
+      .withIndex("by_seasonId_status", (q) =>
+        q.eq("seasonId", args.seasonId).eq("status", "out"),
+      )
+      .collect();
+    for (const row of open) {
+      await ctx.db.patch(row._id, { status: "healed", updatedAt: now });
+    }
+    return { healed: open.length };
+  },
+});

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2346,12 +2346,23 @@ export const beginSeasonRollover = internalMutationGeneric({
   },
 });
 
+/*
+ * Rollover stage order — the SERVER half of the contract.
+ *
+ * `advanceSeasonRollover` enforces `requested === current + 1`, so this list
+ * and `ROLLOVER_STAGES` in `_actions/dynasty.ts` must stay identical and in the
+ * same order. Adding a stage is safe for a rollover that has not started and
+ * for one that has already completed; the only exposed window is a rollover
+ * paused mid-flight across the deploy that adds the stage, which is documented
+ * and accepted (#620) — the affected rollover retries from its checkpoint.
+ */
 const rolloverStageOrder = [
   "target_created",
   "players_progressed",
   "attributes_copied",
   "rosters_copied",
   "freshmen_created",
+  "injuries_healed",
   "completed",
 ] as const;
 

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -19,6 +19,7 @@ const {
   mockGetTeamsByLeague,
   mockGetPlayersByTeam,
   mockCreateRolloverFreshmenForTeam,
+  mockHealSeasonInjuries,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockResolveOrgContext: vi.fn(),
@@ -38,6 +39,7 @@ const {
   mockGetTeamsByLeague: vi.fn(),
   mockGetPlayersByTeam: vi.fn(),
   mockCreateRolloverFreshmenForTeam: vi.fn(),
+  mockHealSeasonInjuries: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
@@ -61,6 +63,7 @@ vi.mock("@/lib/data-api", () => ({
   getTeamsByLeague: mockGetTeamsByLeague,
   getPlayersByTeam: mockGetPlayersByTeam,
   createRolloverFreshmenForTeam: mockCreateRolloverFreshmenForTeam,
+  healSeasonInjuries: mockHealSeasonInjuries,
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
@@ -94,6 +97,7 @@ const completedSummary = {
     removedDepthEntries: 1,
   },
   recruiting: { freshmen: 47, toPool: false },
+  healing: { injuries: 3 },
 };
 
 beforeEach(() => {
@@ -148,7 +152,9 @@ beforeEach(() => {
                 ? "attributes_copied"
                 : stage === "freshmen_created"
                   ? "rosters_copied"
-                  : "freshmen_created",
+                  : stage === "injuries_healed"
+                    ? "freshmen_created"
+                    : "injuries_healed",
         status: "in_progress",
         graduatedPlayerIds: [],
         advancedPlayerIds: ["p1"],
@@ -157,6 +163,7 @@ beforeEach(() => {
       }),
   );
   mockReleaseSeasonRolloverStage.mockResolvedValue(null);
+  mockHealSeasonInjuries.mockResolvedValue({ healed: 0 });
   mockRollover.mockResolvedValue({
     graduatedPlayerIds: [],
     advancedPlayerIds: ["p1"],
@@ -598,5 +605,71 @@ describe("startNextSeasonAction success path", () => {
     });
     expect(mockRollover).not.toHaveBeenCalled();
     expect(mockCopySeasonRosters).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Injury healing (B2, #620). The stage sits between freshmen and completion
+   * and reaches BACK into the season being closed, which is what these assert:
+   * the source season id, not the target's.
+   */
+  describe("injuries_healed stage", () => {
+    it("heals the source season and records the count in the summary", async () => {
+      mockHealSeasonInjuries.mockResolvedValue({ healed: 5 });
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockHealSeasonInjuries).toHaveBeenCalledWith({
+        // The season being CLOSED. Healing the target would clear injuries
+        // that have not been sustained yet.
+        seasonId: ACTIVE.id,
+      });
+      expect(mockAdvanceSeasonRollover).toHaveBeenCalledWith({
+        rolloverId: "rollover_1",
+        stage: "injuries_healed",
+        summaryJson: expect.stringContaining('"injuries":5'),
+        ownerId: expect.any(String),
+      });
+      expect(res).toMatchObject({ ok: true });
+      expect((res as { summary: { healing: { injuries: number } } }).summary
+        .healing.injuries).toBe(5);
+    });
+
+    it("still completes the rollover when healing fails", async () => {
+      /*
+       * The next season already exists by this point. Aborting here would
+       * leave a league with a built roster and no completed rollover, which is
+       * strictly worse than a season archived with a few injuries still open.
+       */
+      mockHealSeasonInjuries.mockRejectedValue(new Error("convex_down"));
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(res).toMatchObject({ ok: true, seasonId: "season_next" });
+      expect(mockAdvanceSeasonRollover).toHaveBeenLastCalledWith(
+        expect.objectContaining({ stage: "completed" }),
+      );
+      expect(mockReleaseSeasonRolloverStage).not.toHaveBeenCalled();
+    });
+
+    it("does not re-heal a rollover resumed past the stage", async () => {
+      mockBeginSeasonRollover.mockResolvedValue({
+        rolloverId: "rollover_1",
+        sourceSeasonId: ACTIVE.id,
+        sourceSeasonName: ACTIVE.name,
+        targetSeasonId: "season_next",
+        targetSeasonName: "2027",
+        resumed: true,
+        stage: "injuries_healed",
+        status: "in_progress",
+        graduatedPlayerIds: [],
+        advancedPlayerIds: ["p1"],
+        summaryJson: JSON.stringify(completedSummary),
+      });
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockHealSeasonInjuries).not.toHaveBeenCalled();
+      expect(res).toMatchObject({ ok: true });
+    });
   });
 });

--- a/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/*
+ * The rollover stage list is written down TWICE — once in the server action
+ * that walks it (`ROLLOVER_STAGES`) and once in Convex, which enforces
+ * `requested === current + 1` (`rolloverStageOrder` in `sports.ts`). Neither
+ * can import the other: the action is a Next server module and Convex bundles
+ * only what lives under `convex/`.
+ *
+ * So the lists are checked by reading both files. A stage added to one and not
+ * the other is not a type error — it is a `rollover_stage_out_of_order` throw
+ * that only appears when a real league rolls over, halfway through a rollover
+ * that has already created the next season.
+ */
+
+const ROOT = join(__dirname, "..", "..", "..", "..", "..");
+
+function stageList(relativePath: string, constName: string): string[] {
+  const source = readFileSync(join(ROOT, relativePath), "utf8");
+  const match = new RegExp(`${constName} = \\[([^\\]]*)\\]`).exec(source);
+  if (!match) throw new Error(`no ${constName} in ${relativePath}`);
+  return Array.from(match[1].matchAll(/"([a-z_]+)"/g)).map((m) => m[1]);
+}
+
+const clientStages = stageList(
+  "src/app/dashboard/_actions/dynasty.ts",
+  "ROLLOVER_STAGES",
+);
+const serverStages = stageList("convex/sports.ts", "rolloverStageOrder");
+
+describe("rollover stage order", () => {
+  it("is identical on both sides of the Convex boundary", () => {
+    expect(clientStages).toEqual(serverStages);
+  });
+
+  it("keeps the pre-B2 stages in their original relative order", () => {
+    /*
+     * Adding a stage is safe. REORDERING one is not — a rollover checkpointed
+     * at `rosters_copied` under the old order would be asked to advance to a
+     * stage that is no longer its successor.
+     */
+    const original = [
+      "target_created",
+      "players_progressed",
+      "attributes_copied",
+      "rosters_copied",
+      "freshmen_created",
+      "completed",
+    ];
+    expect(clientStages.filter((s) => original.includes(s))).toEqual(original);
+  });
+
+  it("heals injuries after the new roster exists and before completion", () => {
+    expect(clientStages.indexOf("injuries_healed")).toBeGreaterThan(
+      clientStages.indexOf("freshmen_created"),
+    );
+    expect(clientStages.indexOf("injuries_healed")).toBeLessThan(
+      clientStages.indexOf("completed"),
+    );
+  });
+
+  it("keeps `completed` terminal", () => {
+    expect(clientStages.at(-1)).toBe("completed");
+    expect(serverStages.at(-1)).toBe("completed");
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -20,6 +20,7 @@ import {
   copySeasonRosters,
   removePlayersFromSeasonRoster,
   createRolloverFreshmenForTeam,
+  healSeasonInjuries,
 } from "@/lib/data-api";
 import { activeNonGraduatedNames } from "@/lib/dynasty";
 import { computeProgressedAttributes } from "@/lib/dynasty-progression";
@@ -43,6 +44,7 @@ const ROLLOVER_STAGES = [
   "attributes_copied",
   "rosters_copied",
   "freshmen_created",
+  "injuries_healed",
   "completed",
 ] as const;
 
@@ -73,6 +75,7 @@ function createRolloverSummary(input: {
       removedDepthEntries: 0,
     },
     recruiting: { freshmen: 0, toPool: input.freshmenToPool },
+    healing: { injuries: 0 },
   };
 }
 
@@ -91,6 +94,9 @@ function parseRolloverSummary(
       progression: parsed.progression ?? fallback.progression,
       carryover: parsed.carryover ?? fallback.carryover,
       recruiting: parsed.recruiting ?? fallback.recruiting,
+      // Summaries persisted before B2 have no `healing` key. Falling back keeps
+      // a rollover that started on the old code renderable on the new.
+      healing: parsed.healing ?? fallback.healing,
     };
   } catch {
     return fallback;
@@ -449,6 +455,43 @@ export async function startNextSeasonAction(input: {
           summary = parseRolloverSummary(checkpoint.summaryJson, summary);
         } catch (err) {
           await releaseClaimedStage("freshmen_created", err);
+          throw err;
+        }
+      }
+    }
+
+    /*
+     * Heal the SOURCE season's open injuries (B2).
+     *
+     * Last before `completed` on purpose: it is the only stage that reaches
+     * back into the season being closed rather than forward into the one being
+     * built, so running it after the new roster exists keeps the "everything
+     * that touches the target season" block contiguous.
+     *
+     * `healSeasonInjuries` is idempotent, so unlike the freshmen stage this
+     * needs no per-item progress record — a retry after a lost response finds
+     * zero open rows and reports zero. A failure to heal must not abort a
+     * rollover that has already built the next season, so the count falls back
+     * to whatever the summary already held rather than throwing.
+     */
+    if (!hasReachedRolloverStage(stage, "injuries_healed")) {
+      const acquired = await claimStage("injuries_healed");
+      if (acquired) {
+        try {
+          const healed = await healSeasonInjuries({
+            seasonId: summary.sourceSeason.id,
+          }).catch(() => null);
+          if (healed) summary.healing.injuries = healed.healed;
+          const checkpoint = await advanceSeasonRollover({
+            rolloverId: rollover.rolloverId,
+            stage: "injuries_healed",
+            summaryJson: serializeRolloverSummary(summary),
+            ownerId,
+          });
+          stage = checkpoint.stage;
+          summary = parseRolloverSummary(checkpoint.summaryJson, summary);
+        } catch (err) {
+          await releaseClaimedStage("injuries_healed", err);
           throw err;
         }
       }

--- a/apps/web/src/components/dynasty/__tests__/DynastyPanel.test.ts
+++ b/apps/web/src/components/dynasty/__tests__/DynastyPanel.test.ts
@@ -103,6 +103,7 @@ const summary: RolloverOperationSummary = {
     removedDepthEntries: 4,
   },
   recruiting: { freshmen: 47, toPool: false },
+  healing: { injuries: 2 },
 };
 
 const baseProps = {

--- a/apps/web/src/lib/__tests__/process-stages.test.ts
+++ b/apps/web/src/lib/__tests__/process-stages.test.ts
@@ -59,6 +59,7 @@ describe("process stage builders", () => {
       "progress",
       "carryover",
       "freshmen",
+      "healing",
     ]);
     expect(pending[0]?.status).toBe("in_progress");
     // Stage list stays stable (identical ids/order) across outcomes.
@@ -79,6 +80,7 @@ describe("process stage builders", () => {
         removedDepthEntries: 6,
       },
       recruiting: { freshmen: 48, toPool: true },
+      healing: { injuries: 3 },
     });
     expect(success.map((stage) => stage.id)).toEqual([
       "rollover",
@@ -87,6 +89,7 @@ describe("process stage builders", () => {
       "progress",
       "carryover",
       "freshmen",
+      "healing",
     ]);
     expect(success.find((stage) => stage.id === "rollover")?.detail).toBe(
       "2026 → 2027",

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2919,6 +2919,17 @@ export async function recordGameInjuries(input: {
   );
 }
 
+/** Close out a finished season's open injuries — the B2 rollover stage. */
+export async function healSeasonInjuries(input: {
+  seasonId: string;
+}): Promise<{ healed: number }> {
+  const client = getConvexClient();
+  return client.mutation(
+    simRef.mutation<{ healed: number }>("healSeasonInjuries"),
+    input,
+  );
+}
+
 /*
  * Team programs (A6, extended by C3). Same compile-checked-ref discipline as
  * the dynasty settings above.

--- a/apps/web/src/lib/process-stages.ts
+++ b/apps/web/src/lib/process-stages.ts
@@ -188,6 +188,20 @@ export function dynastyRolloverProcessStages(
       }`
     : undefined;
 
+  /*
+   * Read through optionally. `healing` is required on the type, but a summary
+   * persisted before B2 predates the field, and a display builder that throws
+   * on a missing count would take the whole panel down over a stage detail.
+   * No count is honest absence — better than inventing a zero.
+   */
+  const healedInjuries = withSummary?.healing?.injuries;
+  const healingDetail =
+    healedInjuries === undefined
+      ? undefined
+      : healedInjuries === 0
+        ? "No lingering injuries"
+        : `${players(healedInjuries)} cleared`;
+
   return [
     stage("rollover", "Start next season", outcome, rolloverDetail),
     terminalStage("graduate", "Graduate seniors", terminalOutcome, graduateDetail),
@@ -210,5 +224,11 @@ export function dynastyRolloverProcessStages(
       carryoverDetail,
     ),
     terminalStage("freshmen", "Generate freshmen", terminalOutcome, freshmanDetail),
+    terminalStage(
+      "healing",
+      "Heal lingering injuries",
+      terminalOutcome,
+      healingDetail,
+    ),
   ];
 }

--- a/apps/web/src/lib/rollover-summary.ts
+++ b/apps/web/src/lib/rollover-summary.ts
@@ -19,4 +19,9 @@ export interface RolloverOperationSummary {
     removedDepthEntries: number;
   };
   recruiting: { freshmen: number; toPool: boolean };
+  /**
+   * Injuries closed out by the `injuries_healed` stage (B2). Zero is a real
+   * answer — a season nobody got hurt in — and is why this is not optional.
+   */
+  healing: { injuries: number };
 }


### PR DESCRIPTION
Closes #620. Dynasty Mode B2 — Wave 2.

## What this does

Adds `injuries_healed` to the rollover stage machine, between `freshmen_created` and `completed`. It is the only stage that reaches *back* into the season being closed rather than forward into the one being built, which is why it runs last.

## The design decision worth reviewing

`healSeasonInjuries` **preserves `gamesOut` rather than zeroing it.**

A row healed by *playing* reaches zero games owed. A row healed by the *offseason* still owes six. Keeping the countdown is the only record of which one happened — zeroing it would make a season-ending ACL indistinguishable from an ankle the player came back from in Week 12.

This is safe because nothing decides availability from the countdown alone. `isAvailable` in `pbp/injuries.ts` returns early on any status but `"out"`, and every UI filter (`InjuryReportCard`, the depth chart) is an AND on both fields. Verified each consumer before relying on it.

**Not gated on `injuriesEnabled`.** A league that switches injuries off mid-dynasty still has open rows on the board; leaving them would make the kill switch a way to strand data rather than a way to stop generating new data.

## The drift guard

The stage list is written down twice — `ROLLOVER_STAGES` in the server action that walks it, and `rolloverStageOrder` in `convex/sports.ts`, which enforces `requested === current + 1`. Neither can import the other: the action is a Next server module and Convex bundles only what lives under `convex/`.

`rollover-stages.test.ts` reads both files and compares them. A stage added to one and not the other is **not** a type error — it is a `rollover_stage_out_of_order` throw that first appears halfway through a real league's rollover, after the next season already exists.

## Two things found on the way

- **`resetCanonicalFixture` never cleared `playerInjuries`** — missed when A4 added the table. A leaked injury makes a player unavailable to every later spec, so a suite that simulates would quietly sim a short roster because an earlier spec's game hurt someone. Fixed here; this is the per-PR cleanup item the roadmap calls for.
- **`dynastyRolloverProcessStages` crashed the whole panel** on a summary missing the new field. Now reads through optionally — no count is honest absence, and a display builder should not take down a page over a stage detail.

## Failure behavior

Healing failure does **not** abort the rollover. The next season already exists by this point; aborting would leave a league with a built roster and no completed rollover, which is strictly worse than a season archived with a few injuries still open.

## Verification

- `pnpm exec vitest run` — **1576 passed, 202 files.** 13 new: 6 on `healSeasonInjuries` (scoping, idempotency, `gamesOut` preservation, carry-forward availability), 3 on the action stage, 4 on stage-order drift.
- `pnpm turbo type-check` — clean (the real CI gate; vitest does not run in CI).
- `pnpm --filter @sports-management/web lint` — clean.
- Idempotency is structural, not conditional: the mutation only touches rows the `by_seasonId_status` index still reports as `"out"`, so a retry under the 60-second lease finds none and heals zero.

## Accepted risk

A rollover paused mid-flight across the deploy that adds this stage. Documented in #620 and in a comment on `rolloverStageOrder`; the affected rollover retries from its checkpoint.