### PR TITLE
feat: incoming freshman class with scouting and genuine uncertainty (#621)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,8 +81,12 @@ The single Season currently in progress for a League and the primary seasonal de
 _Avoid_: Viewed season, selected year
 
 **Offseason Hub**:
-The phase-machine surface for one upcoming Season at `/dashboard/seasons/[seasonId]/offseason`, where an administrator moves the league through Rollover, Draft, Free agency and Activate.
+The phase-machine surface for one upcoming Season at `/dashboard/seasons/[seasonId]/offseason`, where an administrator moves the league through Rollover, Recruiting, Draft, Free agency and Activate.
 _Avoid_: Offseason page, preseason, transfer window
+
+**Prospect**:
+An incoming ninth-grader on the Recruiting class for one upcoming Season, shown as a projected range rather than a rating until a Team signs him. Scouting narrows the range and never removes it.
+_Avoid_: Recruit rating, star rating, draft prospect, blue-chip
 
 **Resource Header**:
 The orientation and sibling-navigation surface shared by a Home and its child pages without using breadcrumb trails.
@@ -110,6 +114,8 @@ _Avoid_: Playbook, formation, strategy, system
 - **League Settings** is exposed only when the operator is an Org Admin for the **Active League**
 - Coaches manage a Team from **Team Home**, not **League Settings**
 - A Team has at most one **Scheme** per Season, set from **Team Home** because a Scheme changes only that Team's own games
+- An upcoming **Season** has at most one recruiting class, and every **Prospect** in it belongs to exactly one Team once signed
+- A **Prospect** is scouted and signed from the **Offseason Hub**, because the class is shared by the whole League rather than owned by one Team
 - **Account Settings** contains cross-league **Import** and **Account Billing**
 - A successful **Import** may set the imported League as the **Active League** and offer navigation to its **League Home**
 - The **League Directory** provides access to **Discover**

--- a/apps/web/convex/__tests__/offseasonPhases.test.ts
+++ b/apps/web/convex/__tests__/offseasonPhases.test.ts
@@ -48,14 +48,14 @@ describe("offseason phase machine — one definition, two import paths", () => {
 });
 
 describe("beginOffseason", () => {
-  it("opens at draft with the rollover already recorded", async () => {
+  it("opens at recruiting with the rollover already recorded", async () => {
     const t = convexTest(schema, modules);
     const { seasonId } = await seed(t);
     const opened = await t.mutation(internal.dynasty.beginOffseason, {
       seasonId,
       actorUserId: ACTOR,
     });
-    expect(opened.phase).toBe("draft");
+    expect(opened.phase).toBe("recruiting");
     expect(opened.completedPhases).toEqual(["rollover"]);
   });
 
@@ -146,19 +146,31 @@ describe("advanceOffseasonPhase", () => {
   ) =>
     t.mutation(internal.dynasty.advanceOffseasonPhase, {
       seasonId,
-      expectedPhase: args.expectedPhase ?? "draft",
-      to: args.to ?? "free_agency",
+      // Defaults are the FIRST advance a fresh offseason can make. B3 inserted
+      // `recruiting` ahead of `draft`, so that is now recruiting → draft.
+      expectedPhase: args.expectedPhase ?? "recruiting",
+      to: args.to ?? "draft",
       ownerId: args.ownerId ?? "owner_a",
       actorUserId: ACTOR,
       draftStatus: args.draftStatus ?? "none",
     });
 
+  /** An offseason moved forward to the draft phase, for the draft-only gates. */
+  async function atDraft() {
+    const { t, seasonId } = await opened();
+    await advance(t, seasonId as never);
+    return { t, seasonId };
+  }
+
   it("moves forward and records the phase it left", async () => {
     const { t, seasonId } = await opened();
     const result = await advance(t, seasonId as never);
     expect(result.changed).toBe(true);
-    expect(result.offseason.phase).toBe("free_agency");
-    expect(result.offseason.completedPhases).toEqual(["rollover", "draft"]);
+    expect(result.offseason.phase).toBe("draft");
+    expect(result.offseason.completedPhases).toEqual([
+      "rollover",
+      "recruiting",
+    ]);
   });
 
   it("advancing twice with the same payload produces one state change", async () => {
@@ -170,16 +182,15 @@ describe("advanceOffseasonPhase", () => {
     expect(second.offseason.completedPhases).toEqual(
       first.offseason.completedPhases,
     );
-    expect(second.offseason.phase).toBe("free_agency");
+    expect(second.offseason.phase).toBe("draft");
   });
 
   it("rejects a backward request as phase_regression", async () => {
-    const { t, seasonId } = await opened();
-    await advance(t, seasonId as never);
+    const { t, seasonId } = await atDraft();
     await expect(
       advance(t, seasonId as never, {
-        expectedPhase: "free_agency",
-        to: "draft",
+        expectedPhase: "draft",
+        to: "recruiting",
       }),
     ).rejects.toThrow(/phase_regression/);
   });
@@ -187,7 +198,7 @@ describe("advanceOffseasonPhase", () => {
   it("resolves two concurrent advances to one winner and one phase_busy", async () => {
     const { t, seasonId } = await opened();
     /*
-     * Both callers read phase `draft` and both send `expectedPhase: "draft"`.
+     * Both callers read the opening phase and send the same `expectedPhase`.
      * Convex serializes them, so the loser finds its expectation stale — it
      * asked to move an offseason that someone else already moved.
      */
@@ -205,15 +216,31 @@ describe("advanceOffseasonPhase", () => {
     );
 
     const final = await t.query(api.dynasty.getOffseason, { seasonId });
-    expect(final?.phase).toBe("free_agency");
-    expect(final?.completedPhases).toEqual(["rollover", "draft"]);
+    expect(final?.phase).toBe("draft");
+    expect(final?.completedPhases).toEqual(["rollover", "recruiting"]);
   });
 
   it("refuses to leave the draft phase while a draft is mid-pick", async () => {
-    const { t, seasonId } = await opened();
+    const { t, seasonId } = await atDraft();
     await expect(
-      advance(t, seasonId as never, { draftStatus: "active" }),
+      advance(t, seasonId as never, {
+        expectedPhase: "draft",
+        to: "free_agency",
+        draftStatus: "active",
+      }),
     ).rejects.toThrow(/draft_in_progress/);
+  });
+
+  it("lets an offseason leave recruiting with nothing signed (B3)", async () => {
+    /*
+     * The recruiting phase is optional in the same sense the draft is: a
+     * league that ignores the class still has to get past it. A gate here
+     * would let an unsigned prospect trap an entire offseason.
+     */
+    const { t, seasonId } = await opened();
+    const result = await advance(t, seasonId as never);
+    expect(result.changed).toBe(true);
+    expect(result.offseason.phase).toBe("draft");
   });
 
   it("reports an invalid request as invalid rather than as a conflict", async () => {
@@ -241,6 +268,7 @@ describe("advanceOffseasonPhase", () => {
     expect(final?.phase).toBe("activate");
     expect(final?.completedPhases).toEqual([
       "rollover",
+      "recruiting",
       "draft",
       "free_agency",
     ]);

--- a/apps/web/convex/__tests__/recruitProspects.test.ts
+++ b/apps/web/convex/__tests__/recruitProspects.test.ts
@@ -1,0 +1,470 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { MAX_SCOUT_LEVEL, SCOUT_LEVEL_COST } from "../lib/scouting";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_admin";
+
+const ATTRIBUTES = { SPD: 80, STR: 70, AWR: 66, ACC: 74, AGI: 58 };
+
+function prospectInput(overrides: Partial<{ name: string; trueOverall: number }> = {}) {
+  return {
+    name: overrides.name ?? "Cam Whitfield",
+    position: "WR",
+    positionGroup: "WR",
+    archetype: "Deep Threat",
+    hometown: "Acworth, GA",
+    trueAttributesJson: JSON.stringify(ATTRIBUTES),
+    trueOverall: overrides.trueOverall ?? 70,
+    potentialTier: "riser",
+  };
+}
+
+async function seed(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Recruiting League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2027",
+      status: "upcoming",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+    const teamId = await ctx.db.insert("teams", {
+      leagueId,
+      name: "North HS",
+      city: "North",
+      stadium: "North Field",
+      location: "North, GA",
+      foundedYear: null,
+      divisionId: null,
+      rosterLimit: null,
+      logoUrl: null,
+    });
+    const otherTeamId = await ctx.db.insert("teams", {
+      leagueId,
+      name: "South HS",
+      city: "South",
+      stadium: "South Field",
+      location: "South, GA",
+      foundedYear: null,
+      divisionId: null,
+      rosterLimit: null,
+      logoUrl: null,
+    });
+    return { leagueId, seasonId, teamId, otherTeamId };
+  });
+}
+
+async function classOf(
+  t: ReturnType<typeof convexTest>,
+  ids: { leagueId: never; seasonId: never },
+  count = 1,
+) {
+  await t.mutation(internal.dynasty.createProspectClass, {
+    leagueId: ids.leagueId,
+    seasonId: ids.seasonId,
+    prospects: Array.from({ length: count }, (_, i) =>
+      prospectInput({ name: `Prospect ${i}`, trueOverall: 60 + i }),
+    ),
+  });
+  return t.query(api.dynasty.listProspects, { seasonId: ids.seasonId });
+}
+
+describe("listProspects hides the truth", () => {
+  it("never returns the hidden fields", async () => {
+    /*
+     * The mechanic in one assertion. If `trueOverall` or `potentialTier` ever
+     * reaches a page, a coach can rank the whole board exactly and scouting
+     * becomes a button nobody presses.
+     */
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const board = await classOf(t, ids as never, 3);
+    expect(board).toHaveLength(3);
+    for (const prospect of board) {
+      expect(prospect).not.toHaveProperty("trueAttributesJson");
+      expect(prospect).not.toHaveProperty("trueOverall");
+      expect(prospect).not.toHaveProperty("potentialTier");
+    }
+  });
+
+  it("keeps the hidden fields out of the source validator too", () => {
+    /*
+     * The runtime assertion above only sees the fields a fixture happens to
+     * exercise. This one reads the module and fails if any of the three names
+     * is ever added to `prospectValidator` — the change that would silently
+     * make the runtime test pass while leaking everything.
+     */
+    const source = readFileSync(
+      join(__dirname, "..", "dynasty.ts"),
+      "utf8",
+    );
+    const validator = /const prospectValidator = v\.object\(\{([\s\S]*?)\n\}\);/
+      .exec(source)?.[1];
+    expect(validator).toBeDefined();
+    for (const hidden of [
+      "trueAttributesJson",
+      "trueOverall",
+      "potentialTier",
+    ]) {
+      expect(validator).not.toContain(hidden);
+    }
+  });
+
+  it("shows a projected range instead, at level 0", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    expect(prospect.scoutLevel).toBe(0);
+    expect(prospect.projectedHigh).toBeGreaterThan(prospect.projectedLow);
+    expect(prospect.projectedLow).toBeLessThanOrEqual(60);
+    expect(prospect.projectedHigh).toBeGreaterThanOrEqual(60);
+  });
+});
+
+describe("createProspectClass", () => {
+  it("does not build a second class on a retry", async () => {
+    // The rollover stage can be retried after a lost response. Two classes on
+    // one board would look like a very good recruiting year.
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    await classOf(t, ids as never, 4);
+    const retry = await t.mutation(internal.dynasty.createProspectClass, {
+      leagueId: ids.leagueId,
+      seasonId: ids.seasonId,
+      prospects: [prospectInput({ name: "Late Addition" })],
+    });
+    expect(retry).toEqual({ created: 4, alreadyExisted: true });
+    const board = await t.query(api.dynasty.listProspects, {
+      seasonId: ids.seasonId,
+    });
+    expect(board).toHaveLength(4);
+    expect(board.map((p) => p.name)).not.toContain("Late Addition");
+  });
+
+  it("refuses a class whose season belongs to another league", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const otherLeagueId = await t.run(async (ctx) =>
+      ctx.db.insert("leagues", {
+        name: "Other",
+        orgId: "org_test",
+        isPublic: false,
+        inviteToken: null,
+      }),
+    );
+    await expect(
+      t.mutation(internal.dynasty.createProspectClass, {
+        leagueId: otherLeagueId,
+        seasonId: ids.seasonId,
+        prospects: [prospectInput()],
+      }),
+    ).rejects.toThrow(/season_league_mismatch/);
+  });
+});
+
+describe("scoutProspect", () => {
+  it("narrows the range and charges the league budget", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [before] = await classOf(t, ids as never);
+    const result = await t.mutation(internal.dynasty.scoutProspect, {
+      prospectId: before.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    expect(result.prospect.scoutLevel).toBe(1);
+    expect(
+      result.prospect.projectedHigh - result.prospect.projectedLow,
+    ).toBeLessThan(before.projectedHigh - before.projectedLow);
+    expect(result.scoutingPointsSpent).toBe(SCOUT_LEVEL_COST[1]);
+  });
+
+  it("opens the offseason on demand rather than requiring an admin first", async () => {
+    /*
+     * The budget lives on the offseason row. A coach spending points is not
+     * necessarily the person who opens the offseason, so making the budget's
+     * existence depend on someone else's page load would be a race.
+     */
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    expect(
+      await t.query(api.dynasty.getOffseason, { seasonId: ids.seasonId }),
+    ).toBeNull();
+    const [prospect] = await classOf(t, ids as never);
+    await t.mutation(internal.dynasty.scoutProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    const offseason = await t.query(api.dynasty.getOffseason, {
+      seasonId: ids.seasonId,
+    });
+    expect(offseason?.scoutingPointsSpent).toBe(SCOUT_LEVEL_COST[1]);
+  });
+
+  it("stops at the top level instead of charging for nothing", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    for (let level = 0; level < MAX_SCOUT_LEVEL; level++) {
+      await t.mutation(internal.dynasty.scoutProspect, {
+        prospectId: prospect.id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      });
+    }
+    await expect(
+      t.mutation(internal.dynasty.scoutProspect, {
+        prospectId: prospect.id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/prospect_fully_scouted/);
+  });
+
+  it("refuses to overspend the budget", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId: ids.leagueId,
+      actorUserId: ACTOR,
+      patch: { scoutingPointsPerOffseason: SCOUT_LEVEL_COST[1] },
+    });
+    const board = await classOf(t, ids as never, 2);
+    await t.mutation(internal.dynasty.scoutProspect, {
+      prospectId: board[0].id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    await expect(
+      t.mutation(internal.dynasty.scoutProspect, {
+        prospectId: board[1].id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/scouting_budget_exhausted/);
+  });
+
+  it("refuses a team from another league", async () => {
+    // The per-team argument is the Wave 5 hook; this is the check that makes
+    // it mean something today.
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    const foreignTeamId = await t.run(async (ctx) => {
+      const leagueId = await ctx.db.insert("leagues", {
+        name: "Other",
+        orgId: "org_test",
+        isPublic: false,
+        inviteToken: null,
+      });
+      return ctx.db.insert("teams", {
+        leagueId,
+        name: "Elsewhere HS",
+        city: "Elsewhere",
+        stadium: "Elsewhere Field",
+        location: "Elsewhere, GA",
+        foundedYear: null,
+        divisionId: null,
+        rosterLimit: null,
+        logoUrl: null,
+      });
+    });
+    await expect(
+      t.mutation(internal.dynasty.scoutProspect, {
+        prospectId: prospect.id as never,
+        teamId: foreignTeamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/team_league_mismatch/);
+  });
+});
+
+describe("signProspect", () => {
+  it("creates one grade-9 player with a roster spot and the TRUE ratings", async () => {
+    /*
+     * The moment of truth. The attribute snapshot has to be the real map, not
+     * the scouted one — otherwise the uncertainty becomes permanent and every
+     * downstream system reasons about a guess.
+     */
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    const result = await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    expect(result.alreadySigned).toBe(false);
+
+    await t.run(async (ctx) => {
+      const player = await ctx.db.get(result.playerId as never);
+      expect(player).toMatchObject({
+        name: prospect.name,
+        teamId: ids.teamId,
+        grade: 9,
+        status: "active",
+      });
+
+      const assignments = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_playerId", (q) =>
+          q.eq("playerId", result.playerId as never),
+        )
+        .collect();
+      expect(assignments).toHaveLength(1);
+      expect(assignments[0]).toMatchObject({
+        seasonId: ids.seasonId,
+        teamId: ids.teamId,
+        status: "active",
+      });
+
+      const attributes = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", result.playerId as never),
+        )
+        .collect();
+      expect(attributes).toHaveLength(1);
+      expect(JSON.parse(attributes[0].attributesJson)).toEqual(ATTRIBUTES);
+      expect(attributes[0].weightedOverall).toBe(60);
+    });
+  });
+
+  it("records who signed him on the class, not only on the player", async () => {
+    // A signed player can be released or traded later; the class should keep
+    // saying who actually recruited him.
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    const result = await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    expect(result.prospect.signedTeamId).toBe(ids.teamId);
+    expect(result.prospect.playerId).toBe(result.playerId);
+  });
+
+  it("is a no-op on re-invoke by the same team", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    const first = await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    const second = await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    expect(second.alreadySigned).toBe(true);
+    expect(second.playerId).toBe(first.playerId);
+
+    await t.run(async (ctx) => {
+      const players = await ctx.db
+        .query("players")
+        .withIndex("by_teamId", (q) => q.eq("teamId", ids.teamId))
+        .collect();
+      expect(players).toHaveLength(1);
+    });
+  });
+
+  it("tells a losing team it lost rather than handing it the player", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    await expect(
+      t.mutation(internal.dynasty.signProspect, {
+        prospectId: prospect.id as never,
+        teamId: ids.otherTeamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/prospect_already_signed/);
+  });
+
+  it("caps a team's class so one program cannot take the board", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const board = await classOf(t, ids as never, 12);
+    for (let i = 0; i < 6; i++) {
+      await t.mutation(internal.dynasty.signProspect, {
+        prospectId: board[i].id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      });
+    }
+    await expect(
+      t.mutation(internal.dynasty.signProspect, {
+        prospectId: board[6].id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/recruiting_class_full/);
+
+    // Another program is unaffected — the cap is per team, not per class.
+    const other = await t.mutation(internal.dynasty.signProspect, {
+      prospectId: board[6].id as never,
+      teamId: ids.otherTeamId,
+      actorUserId: ACTOR,
+    });
+    expect(other.alreadySigned).toBe(false);
+  });
+
+  it("refuses to sign into a locked roster", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.seasonId, { rosterLocked: true } as never);
+    });
+    await expect(
+      t.mutation(internal.dynasty.signProspect, {
+        prospectId: prospect.id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/season_locked/);
+  });
+
+  it("cannot be scouted after signing", async () => {
+    // Scouting resolves into a signing. Paying to narrow a range on a player
+    // whose real ratings are already on the roster would be selling nothing.
+    const t = convexTest(schema, modules);
+    const ids = await seed(t);
+    const [prospect] = await classOf(t, ids as never);
+    await t.mutation(internal.dynasty.signProspect, {
+      prospectId: prospect.id as never,
+      teamId: ids.teamId,
+      actorUserId: ACTOR,
+    });
+    await expect(
+      t.mutation(internal.dynasty.scoutProspect, {
+        prospectId: prospect.id as never,
+        teamId: ids.teamId,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/prospect_already_signed/);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -229,7 +229,14 @@ void api.history.moduleStatus;
 type AllowedPublicDynastyReads =
   | "moduleStatus"
   | "getDynastyConfig"
-  | "getOffseason";
+  | "getOffseason"
+  /*
+   * B3. Public, and safe to be public, because the hidden three
+   * (`trueAttributesJson`, `trueOverall`, `potentialTier`) are absent from its
+   * `returns:` validator — see `prospectsHideTruth.test.ts`, which is the test
+   * that makes this line reviewable rather than trusting.
+   */
+  | "listProspects";
 type AllowedPublicSimReads =
   | "moduleStatus"
   | "listRivalries"

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -1,6 +1,6 @@
 import { v, type Infer } from "convex/values";
-import type { Doc } from "./_generated/dataModel";
-import { internalMutation, query } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { internalMutation, query, type MutationCtx } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
 import {
   normalizeDynastyConfigPatch,
@@ -13,6 +13,13 @@ import {
   phaseGate,
   type DraftPhaseStatus,
 } from "./lib/offseasonPhases";
+import {
+  MIN_SCOUT_LEVEL,
+  RECRUITING_CLASS_PER_TEAM,
+  applyScoutingNoise,
+  isPotentialTier,
+  nextScoutCost,
+} from "./lib/scouting";
 
 /*
  * Dynasty Mode — offseason pipeline (Epic B).
@@ -64,6 +71,7 @@ const dynastyConfigValidator = v.object({
   schemesEnabled: v.boolean(),
   weatherEnabled: v.boolean(),
   injurySeverityScale: v.number(),
+  recruitingEnabled: v.boolean(),
   transfersEnabled: v.boolean(),
   transferVolume: v.string(),
   scoutingPointsPerOffseason: v.number(),
@@ -111,6 +119,7 @@ export const setDynastyConfig = internalMutation({
       schemesEnabled: v.optional(v.boolean()),
       weatherEnabled: v.optional(v.boolean()),
       injurySeverityScale: v.optional(v.number()),
+      recruitingEnabled: v.optional(v.boolean()),
       transfersEnabled: v.optional(v.boolean()),
       transferVolume: v.optional(v.string()),
       scoutingPointsPerOffseason: v.optional(v.number()),
@@ -225,47 +234,65 @@ export const beginOffseason = internalMutation({
   args: { seasonId: v.id("seasons"), actorUserId: v.string() },
   returns: offseasonValidator,
   handler: async (ctx, args) => {
-    const existing = await ctx.db
-      .query("offseasons")
-      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
-      .first();
-    if (existing) return toOffseasonDto(existing);
-
-    const season = await ctx.db.get(args.seasonId);
-    if (!season) throw new Error("season_not_found");
-    /*
-     * An offseason prepares a season that has not started. Opening one on an
-     * active or completed season would let phase actions mutate rosters that
-     * results have already been recorded against.
-     */
-    if (season.status !== "upcoming") throw new Error("season_not_upcoming");
-
-    const configRow = await ctx.db
-      .query("dynastyConfig")
-      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
-      .first();
-    const config = resolveDynastyConfig(configRow);
-
-    const now = new Date().toISOString();
-    const id = await ctx.db.insert("offseasons", {
-      leagueId: season.leagueId,
-      seasonId: args.seasonId,
-      phase: INITIAL_OFFSEASON_PHASE,
-      completedPhases: ["rollover"],
-      scoutingPointsTotal: config.scoutingPointsPerOffseason,
-      scoutingPointsSpent: 0,
-      trainingPointsTotal: config.trainingPointsPerOffseason,
-      trainingPointsSpent: 0,
-      configJson: JSON.stringify(config),
-      createdAt: now,
-      updatedAt: now,
-      updatedBy: args.actorUserId,
-    });
-    const row = await ctx.db.get(id);
-    if (!row) throw new Error("offseason_not_found");
+    const row = await ensureOffseason(ctx, args.seasonId, args.actorUserId);
     return toOffseasonDto(row);
   },
 });
+
+/**
+ * The offseason row for a season, opening one if it does not exist yet.
+ *
+ * Shared with `scoutProspect` (B3), which needs the budget on the row and
+ * cannot require that an admin visited the hub first — a coach spending
+ * scouting points is not necessarily the person who opens the offseason, and
+ * making the budget's existence depend on someone else's page load would turn
+ * a shared resource into a race.
+ */
+async function ensureOffseason(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+  actorUserId: string,
+): Promise<Doc<"offseasons">> {
+  const existing = await ctx.db
+    .query("offseasons")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .first();
+  if (existing) return existing;
+
+  const season = await ctx.db.get(seasonId);
+  if (!season) throw new Error("season_not_found");
+  /*
+   * An offseason prepares a season that has not started. Opening one on an
+   * active or completed season would let phase actions mutate rosters that
+   * results have already been recorded against.
+   */
+  if (season.status !== "upcoming") throw new Error("season_not_upcoming");
+
+  const configRow = await ctx.db
+    .query("dynastyConfig")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+    .first();
+  const config = resolveDynastyConfig(configRow);
+
+  const now = new Date().toISOString();
+  const id = await ctx.db.insert("offseasons", {
+    leagueId: season.leagueId,
+    seasonId,
+    phase: INITIAL_OFFSEASON_PHASE,
+    completedPhases: ["rollover"],
+    scoutingPointsTotal: config.scoutingPointsPerOffseason,
+    scoutingPointsSpent: 0,
+    trainingPointsTotal: config.trainingPointsPerOffseason,
+    trainingPointsSpent: 0,
+    configJson: JSON.stringify(config),
+    createdAt: now,
+    updatedAt: now,
+    updatedBy: actorUserId,
+  });
+  const row = await ctx.db.get(id);
+  if (!row) throw new Error("offseason_not_found");
+  return row;
+}
 
 const OFFSEASON_LEASE_MS = 30_000;
 
@@ -360,5 +387,421 @@ export const advanceOffseasonPhase = internalMutation({
     const updated = await ctx.db.get(row._id);
     if (!updated) throw new Error("offseason_not_found");
     return { changed: true, offseason: toOffseasonDto(updated) };
+  },
+});
+
+/*
+ * ── Incoming freshman class: scouting and signing (B3) ──────────────────────
+ */
+
+const prospectValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  name: v.string(),
+  position: v.string(),
+  positionGroup: v.string(),
+  archetype: v.string(),
+  hometown: v.union(v.string(), v.null()),
+  scoutLevel: v.number(),
+  projectedLow: v.number(),
+  projectedHigh: v.number(),
+  scoutedAttributesJson: v.string(),
+  signedTeamId: v.union(v.string(), v.null()),
+  playerId: v.union(v.string(), v.null()),
+});
+
+type ProspectDoc = Doc<"recruitProspects">;
+
+/**
+ * The public face of a prospect.
+ *
+ * Note what is NOT here: `trueAttributesJson`, `trueOverall`, `potentialTier`.
+ * Their absence is the entire mechanic, not an oversight, and it is asserted
+ * from two directions — `Infer` pins this mapper to the validator above
+ * (WSM-000166), and `__tests__/prospectsHideTruth.test.ts` fails if any of the
+ * three names ever appears in the validator. Adding one here would not be a
+ * leak of a private field; it would delete recruiting.
+ */
+function toProspectDto(row: ProspectDoc): Infer<typeof prospectValidator> {
+  return {
+    id: row._id as string,
+    leagueId: row.leagueId as string,
+    seasonId: row.seasonId as string,
+    name: row.name,
+    position: row.position,
+    positionGroup: row.positionGroup,
+    archetype: row.archetype,
+    hometown: row.hometown,
+    scoutLevel: row.scoutLevel,
+    projectedLow: row.projectedLow,
+    projectedHigh: row.projectedHigh,
+    scoutedAttributesJson: row.scoutedAttributesJson,
+    signedTeamId: (row.signedTeamId as string | undefined) ?? null,
+    playerId: (row.playerId as string | undefined) ?? null,
+  };
+}
+
+/** A season's recruiting board, blurred to each prospect's scout level. */
+export const listProspects = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(prospectValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("recruitProspects")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    return rows.map(toProspectDto);
+  },
+});
+
+/**
+ * Persist a generated class.
+ *
+ * Generation itself runs in the Next layer (`src/lib/dynasty/prospects.ts`)
+ * because it reuses the name and attribute generators that live under `src/`;
+ * this end owns storage and the level-0 band.
+ *
+ * Idempotent on the season, not on the rows: a class that already exists is
+ * returned untouched rather than appended to. The rollover stage that calls
+ * this can be retried after a lost response, and a second class on the same
+ * board would be indistinguishable from a very good recruiting year.
+ */
+export const createProspectClass = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    prospects: v.array(
+      v.object({
+        name: v.string(),
+        position: v.string(),
+        positionGroup: v.string(),
+        archetype: v.string(),
+        hometown: v.union(v.string(), v.null()),
+        trueAttributesJson: v.string(),
+        trueOverall: v.number(),
+        potentialTier: v.string(),
+      }),
+    ),
+  },
+  returns: v.object({ created: v.number(), alreadyExisted: v.boolean() }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("recruitProspects")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    if (existing.length > 0) {
+      return { created: existing.length, alreadyExisted: true };
+    }
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.leagueId !== args.leagueId) {
+      throw new Error("season_league_mismatch");
+    }
+
+    const now = new Date().toISOString();
+    let created = 0;
+    for (const p of args.prospects) {
+      /*
+       * The row's own id is the scouting seed, so the band cannot be computed
+       * until after the insert — hence insert-then-patch rather than a single
+       * write. Seeding from anything the caller supplies instead (a name, an
+       * index) would let two classes with the same shape share bands.
+       */
+      const id = await ctx.db.insert("recruitProspects", {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        name: p.name,
+        position: p.position,
+        positionGroup: p.positionGroup,
+        archetype: p.archetype,
+        hometown: p.hometown,
+        trueAttributesJson: p.trueAttributesJson,
+        trueOverall: p.trueOverall,
+        potentialTier: isPotentialTier(p.potentialTier)
+          ? p.potentialTier
+          : "steady",
+        scoutLevel: MIN_SCOUT_LEVEL,
+        scoutedAttributesJson: "{}",
+        projectedLow: 0,
+        projectedHigh: 0,
+        createdAt: now,
+      });
+      const report = applyScoutingNoise({
+        prospectId: id as string,
+        scoutLevel: MIN_SCOUT_LEVEL,
+        trueOverall: p.trueOverall,
+        trueAttributes: parseAttributes(p.trueAttributesJson),
+      });
+      await ctx.db.patch(id, {
+        scoutedAttributesJson: JSON.stringify(report.scoutedAttributes),
+        projectedLow: report.projectedLow,
+        projectedHigh: report.projectedHigh,
+      });
+      created += 1;
+    }
+    return { created, alreadyExisted: false };
+  },
+});
+
+function parseAttributes(json: string): Record<string, number> {
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const out: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Buy one more level of precision on a prospect.
+ *
+ * `teamId` is taken and validated even though the class and the budget are
+ * league-wide today. It is the multiplayer-critical detail from the roadmap:
+ * the same mutation has to serve a Wave 5 coach scoped to one team, and the
+ * argument that would make that possible cannot be retrofitted onto call sites
+ * that never passed it. What it buys today is that a coach of team A cannot
+ * spend team B's authority, which is the shape the later change needs.
+ *
+ * Scouting is shared: a league-wide budget on the offseason row, and a level
+ * that every team sees. Per-team scouting needs a `(prospectId, teamId)` join
+ * table, which is a Wave 5 addition to this row rather than a change to it.
+ */
+export const scoutProspect = internalMutation({
+  args: {
+    prospectId: v.id("recruitProspects"),
+    teamId: v.id("teams"),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    prospect: prospectValidator,
+    scoutingPointsSpent: v.number(),
+    scoutingPointsTotal: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const prospect = await ctx.db.get(args.prospectId);
+    if (!prospect) throw new Error("prospect_not_found");
+    if (prospect.playerId) throw new Error("prospect_already_signed");
+
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("team_not_found");
+    if (team.leagueId !== prospect.leagueId) {
+      throw new Error("team_league_mismatch");
+    }
+
+    const cost = nextScoutCost(prospect.scoutLevel);
+    if (cost === null) throw new Error("prospect_fully_scouted");
+
+    const offseason = await ensureOffseason(
+      ctx,
+      prospect.seasonId,
+      args.actorUserId,
+    );
+    if (offseason.scoutingPointsSpent + cost > offseason.scoutingPointsTotal) {
+      throw new Error("scouting_budget_exhausted");
+    }
+
+    const report = applyScoutingNoise({
+      prospectId: args.prospectId as string,
+      scoutLevel: prospect.scoutLevel + 1,
+      trueOverall: prospect.trueOverall,
+      trueAttributes: parseAttributes(prospect.trueAttributesJson),
+    });
+
+    await ctx.db.patch(args.prospectId, {
+      scoutLevel: report.scoutLevel,
+      scoutedAttributesJson: JSON.stringify(report.scoutedAttributes),
+      projectedLow: report.projectedLow,
+      projectedHigh: report.projectedHigh,
+    });
+    await ctx.db.patch(offseason._id, {
+      scoutingPointsSpent: offseason.scoutingPointsSpent + cost,
+      updatedAt: new Date().toISOString(),
+      updatedBy: args.actorUserId,
+    });
+
+    const updated = await ctx.db.get(args.prospectId);
+    if (!updated) throw new Error("prospect_not_found");
+    return {
+      prospect: toProspectDto(updated),
+      scoutingPointsSpent: offseason.scoutingPointsSpent + cost,
+      scoutingPointsTotal: offseason.scoutingPointsTotal,
+    };
+  },
+});
+
+/**
+ * Sign a prospect: he becomes a real grade-9 player on the team's roster.
+ *
+ * The attribute snapshot written here is the TRUE map, not the scouted one.
+ * That is the moment of truth the whole slice builds toward — a coach who
+ * signed on a 62–76 range finds out he got a 64. Writing the blurred numbers
+ * instead would make the uncertainty permanent rather than resolved, and every
+ * downstream system (depth chart, SPRT, progression) would be reasoning about
+ * a guess.
+ *
+ * Idempotent through `playerId`: set means signed, so a retry returns the
+ * existing player rather than creating a second one. This is checked before
+ * anything is written, because the failure it guards against — a duplicate
+ * player on a roster — is not something a later step could undo.
+ */
+export const signProspect = internalMutation({
+  args: {
+    prospectId: v.id("recruitProspects"),
+    teamId: v.id("teams"),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    prospect: prospectValidator,
+    playerId: v.string(),
+    alreadySigned: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const prospect = await ctx.db.get(args.prospectId);
+    if (!prospect) throw new Error("prospect_not_found");
+
+    if (prospect.playerId) {
+      /*
+       * Already signed. A retry by the SAME team is the request landing twice
+       * and gets the player back; a different team asking is a genuine loss —
+       * someone else got him — and has to be told so rather than handed a
+       * player it does not own.
+       */
+      if (prospect.signedTeamId !== args.teamId) {
+        throw new Error("prospect_already_signed");
+      }
+      return {
+        prospect: toProspectDto(prospect),
+        playerId: prospect.playerId as string,
+        alreadySigned: true,
+      };
+    }
+
+    const [team, season] = await Promise.all([
+      ctx.db.get(args.teamId),
+      ctx.db.get(prospect.seasonId),
+    ]);
+    if (!team) throw new Error("team_not_found");
+    if (!season) throw new Error("season_not_found");
+    if (team.leagueId !== prospect.leagueId) {
+      throw new Error("team_league_mismatch");
+    }
+    if (season.rosterLocked === true) throw new Error("season_locked");
+
+    /*
+     * The class holds exactly `RECRUITING_CLASS_PER_TEAM` names per team, so
+     * this cap is what keeps it a contest: without it one program could sign
+     * every prospect in the league and the board would be a queue.
+     */
+    const classRows = await ctx.db
+      .query("recruitProspects")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", prospect.seasonId))
+      .collect();
+    const signedByTeam = classRows.filter(
+      (row) => row.signedTeamId === args.teamId,
+    ).length;
+    if (signedByTeam >= RECRUITING_CLASS_PER_TEAM) {
+      throw new Error("recruiting_class_full");
+    }
+
+    const now = new Date().toISOString();
+    const playerId = await ctx.db.insert("players", {
+      name: prospect.name,
+      leagueId: prospect.leagueId,
+      teamId: args.teamId,
+      position: prospect.position,
+      positionGroup: null,
+      jerseyNumber: null,
+      dateOfBirth: null,
+      status: "active",
+      headshotUrl: null,
+      experienceYears: null,
+      grade: 9,
+      squad: "JV",
+      hometown: prospect.hometown,
+      synthetic: true,
+    });
+
+    /*
+     * Roster assignment written directly rather than through
+     * `assignPlayerToRosterCore` in `sports.ts`, which is module-private and
+     * carries guards a brand-new player cannot fail (already-on-roster,
+     * not-on-team). What IS reproduced is the part that matters: `depthRank`
+     * continues the slot's existing order instead of restarting at 1.
+     */
+    const teamAssignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", prospect.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+    const depthRank =
+      teamAssignments
+        .filter(
+          (row) =>
+            row.status === "active" && row.positionSlot === prospect.position,
+        )
+        .reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+
+    await ctx.db.insert("rosterAssignments", {
+      seasonId: prospect.seasonId,
+      teamId: args.teamId,
+      playerId,
+      leagueId: prospect.leagueId,
+      depthRank,
+      positionSlot: prospect.position,
+      status: "active",
+      assignedAt: now,
+      assignedBy: args.actorUserId,
+    });
+
+    await ctx.db.insert("playerAttributes", {
+      playerId,
+      seasonId: prospect.seasonId,
+      positionGroup: prospect.positionGroup,
+      attributesJson: prospect.trueAttributesJson,
+      pffSourceJson: null,
+      maddenSourceJson: null,
+      pffWeight: 0,
+      maddenWeight: 0,
+      weightedOverall: prospect.trueOverall,
+      ingestedAt: now,
+    });
+
+    await ctx.db.insert("rosterAuditLog", {
+      leagueId: prospect.leagueId,
+      teamId: args.teamId,
+      seasonId: prospect.seasonId,
+      actorUserId: args.actorUserId,
+      action: "sign_prospect",
+      beforeJson: null,
+      afterJson: JSON.stringify({
+        prospectId: args.prospectId as string,
+        playerId: playerId as string,
+        name: prospect.name,
+        position: prospect.position,
+        scoutLevel: prospect.scoutLevel,
+      }),
+      createdAt: now,
+    });
+
+    await ctx.db.patch(args.prospectId, {
+      signedTeamId: args.teamId,
+      playerId,
+      signedAt: now,
+    });
+
+    const updated = await ctx.db.get(args.prospectId);
+    if (!updated) throw new Error("prospect_not_found");
+    return {
+      prospect: toProspectDto(updated),
+      playerId: playerId as string,
+      alreadySigned: false,
+    };
   },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 /*
@@ -160,6 +161,18 @@ async function cascadeDeleteLeague(
     .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
     .collect()) as Array<{ _id: Id<"offseasons"> }>;
   for (const row of offseasonRows) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
+  // Recruiting classes (B3). A prospect left behind is worse than stale data:
+  // the class is generated once per season and then never regenerated, so a
+  // leaked row would make a later run's board a mix of two classes, and a
+  // prospect already signed by a deleted team would show as taken by nobody.
+  const prospectRows = (await ctx.db
+    .query("recruitProspects")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"recruitProspects"> }>;
+  for (const row of prospectRows) {
     await ctx.db.delete(row._id);
     deleted += 1;
   }
@@ -631,5 +644,62 @@ export const resetCanonicalFixture = internalMutation({
       deleted += await cascadeDeleteLeague(ctx, league._id);
     }
     return { deleted };
+  },
+});
+
+/*
+ * Seed a recruiting class onto an existing season (B3).
+ *
+ * Recruiting classes are normally built by the `prospects_generated` rollover
+ * stage, which needs a completed season to roll over FROM. Simulating one to a
+ * champion just to see a board would make the recruiting spec the slowest in
+ * the suite and would couple it to every earlier slice's behaviour.
+ *
+ * Routed through `internal.dynasty.createProspectClass` rather than inserting
+ * rows here, so the seeded board is built by the SAME code path production
+ * uses — including the level-0 band. A fixture that wrote its own rows could
+ * drift from the real one and quietly make the spec assert nothing.
+ */
+export const seedProspectClass = internalMutation({
+  args: {
+    seasonId: v.id("seasons"),
+    count: v.optional(v.number()),
+  },
+  returns: v.object({ created: v.number(), alreadyExisted: v.boolean() }),
+  handler: async (ctx, args): Promise<{ created: number; alreadyExisted: boolean }> => {
+    assertSeedEnabled();
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+
+    const count = Math.max(1, Math.min(args.count ?? 4, 20));
+    const positions = ["QB", "RB", "WR", "OL", "DL", "LB", "DB"];
+    const prospects = Array.from({ length: count }, (_, i) => {
+      const position = positions[i % positions.length] ?? "WR";
+      // Fixed ratings: a spec that asserted on a range needs the range to be
+      // the same on every run.
+      const base = 55 + ((i * 7) % 30);
+      return {
+        name: `E2E Prospect ${i + 1}`,
+        position,
+        positionGroup: position,
+        archetype: "Athlete",
+        hometown: "Acworth, GA",
+        trueAttributesJson: JSON.stringify({
+          SPD: base + 4,
+          STR: base - 3,
+          AWR: base,
+          ACC: base + 1,
+          AGI: base - 1,
+        }),
+        trueOverall: base,
+        potentialTier: "steady",
+      };
+    });
+
+    return ctx.runMutation(internal.dynasty.createProspectClass, {
+      leagueId: season.leagueId,
+      seasonId: args.seasonId,
+      prospects,
+    });
   },
 });

--- a/apps/web/convex/lib/dynastyConfig.ts
+++ b/apps/web/convex/lib/dynastyConfig.ts
@@ -62,6 +62,15 @@ export interface DynastyConfig {
   weatherEnabled: boolean;
   /** 0 = none, 1 = normal, 2 = brutal. Scales injury severity. */
   injurySeverityScale: number;
+  /**
+   * An incoming freshman class is generated and must be recruited (Epic B3).
+   *
+   * With this off the rollover skips the class entirely and the offseason's
+   * recruiting phase has nothing in it. Rosters are unaffected either way — the
+   * rollover's backfill still tops every team up to `targetRosterSize`, so this
+   * switch removes a mechanic rather than the players.
+   */
+  recruitingEnabled: boolean;
   /** Players may transfer in and out during the offseason (Epic B4). */
   transfersEnabled: boolean;
   /** How much roster churn an offseason produces. */
@@ -95,6 +104,7 @@ export const DYNASTY_CONFIG_DEFAULTS: Readonly<DynastyConfig> = Object.freeze({
   schemesEnabled: true,
   weatherEnabled: true,
   injurySeverityScale: 1,
+  recruitingEnabled: true,
   transfersEnabled: true,
   transferVolume: "normal",
   scoutingPointsPerOffseason: 100,
@@ -169,6 +179,7 @@ export function resolveDynastyConfig(
     schemesEnabled: bool("schemesEnabled"),
     weatherEnabled: bool("weatherEnabled"),
     injurySeverityScale: num("injurySeverityScale"),
+    recruitingEnabled: bool("recruitingEnabled"),
     transfersEnabled: bool("transfersEnabled"),
     transferVolume: volume,
     scoutingPointsPerOffseason: num("scoutingPointsPerOffseason"),

--- a/apps/web/convex/lib/offseasonPhases.ts
+++ b/apps/web/convex/lib/offseasonPhases.ts
@@ -26,6 +26,7 @@
 
 export const OFFSEASON_PHASES = [
   "rollover",
+  "recruiting",
   "draft",
   "free_agency",
   "activate",
@@ -35,6 +36,7 @@ export type OffseasonPhase = (typeof OFFSEASON_PHASES)[number];
 
 export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
   rollover: "Rollover",
+  recruiting: "Recruiting",
   draft: "Draft",
   free_agency: "Free agency",
   activate: "Activate",
@@ -46,8 +48,15 @@ export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
  * The draft is genuinely optional — a league that does not run one still has
  * to leave the phase, so "optional" means "advanceable while empty", not
  * "skippable in the ordering".
+ *
+ * Recruiting joined it in B3 for a stronger reason than convenience: a class
+ * left entirely unsigned must not be able to trap an offseason. The cost of
+ * skipping it is a roster of walk-ons, which is a consequence, not a block.
  */
-const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set(["draft"]);
+const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set([
+  "recruiting",
+  "draft",
+]);
 
 /*
  * A new offseason opens at `draft`, not at `rollover`.
@@ -57,8 +66,14 @@ const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set(["draft"]);
  * created the target season — and it is owned by `seasonRollovers`, not by
  * this machine. Opening at `rollover` would show an admin a phase they cannot
  * act on and have already finished.
+ *
+ * B3 moved the opening phase from `draft` to `recruiting` by inserting one in
+ * front of it. That is the migration-free insert this file's header describes:
+ * an offseason already sitting in `draft` when B3 deployed keeps its phase, and
+ * simply never has `recruiting` in its `completedPhases` set. The stepper reads
+ * that as skipped, which is exactly what happened to it.
  */
-export const INITIAL_OFFSEASON_PHASE: OffseasonPhase = "draft";
+export const INITIAL_OFFSEASON_PHASE: OffseasonPhase = "recruiting";
 
 export type DraftPhaseStatus = "none" | "active" | "complete";
 

--- a/apps/web/convex/lib/rng.ts
+++ b/apps/web/convex/lib/rng.ts
@@ -1,0 +1,96 @@
+/*
+ * Shared deterministic RNG for every seeded system in the app (Dynasty Mode F1).
+ *
+ * Moved here from `src/lib/rng.ts` in B3, unchanged. The Convex bundler can only
+ * reach files under `convex/`, while `src/` can reach both, so anything BOTH
+ * runtimes need has to live on this side — the same arrangement as
+ * `convex/lib/dynastyConfig.ts` and `convex/lib/offseasonPhases.ts`.
+ * `src/lib/rng.ts` re-exports this module, so no import site changed and the
+ * generated streams are byte-identical to before the move.
+ *
+ * Scouting is what forced it: `applyScoutingNoise` has to produce the SAME band
+ * whether it runs in the mutation that persists a scout or in the component that
+ * renders one, and two copies of a PRNG is exactly the drift this file exists to
+ * prevent.
+ *
+ * ## Why this matters
+ *
+ * "Same league, same actions => same dynasty" is only true if every seeded
+ * system derives its seed the same way and never collides with another system.
+ * Two subsystems that hash the same entity id produce the SAME stream — e.g.
+ * seeding both a player's progression and his scouting noise from a bare
+ * `playerId` would correlate them, so a player who develops well would always
+ * also scout well. The namespace convention below prevents that.
+ *
+ * ## Seed namespace convention
+ *
+ * Build every seed with `seedFor(domain, ...parts)`:
+ *
+ *   seedFor("pbp", fixtureId)                    // play-by-play engine
+ *   seedFor("progression", playerId, seasonId)   // offseason development
+ *   seedFor("scouting", prospectId, String(lvl)) // recruit scouting noise
+ *   seedFor("transfer", playerId, seasonId)      // transfer likelihood
+ *   seedFor("weather", seasonId, String(week))   // game conditions
+ *
+ * Rules:
+ * - The domain is always first and unique per subsystem.
+ * - Include every id the result should vary by, and nothing else. Adding a part
+ *   changes the stream, so adding one to an existing domain reshuffles history.
+ * - Never seed from wall-clock time or `Math.random()` — that breaks replay,
+ *   golden-log parity tests, and re-simulation.
+ */
+
+/** Domains registered with the seed-namespace convention. */
+export type SeedDomain =
+  | "pbp"
+  | "progression"
+  | "scouting"
+  | "prospects"
+  | "transfer"
+  | "training"
+  | "weather"
+  | "injury"
+  | "penalty"
+  | "goals"
+  | "roster";
+
+/**
+ * FNV-1a over the string, returned as an unsigned 32-bit int. Stable across
+ * runs and platforms — the same string always yields the same seed.
+ */
+export function seedFromString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Namespaced seed. Prefer this over calling `seedFromString` directly so two
+ * subsystems keyed on the same entity never share a stream.
+ */
+export function seedFor(domain: SeedDomain, ...parts: string[]): number {
+  return seedFromString([domain, ...parts].join(":"));
+}
+
+/**
+ * mulberry32 — small, fast, deterministic PRNG. Returns a generator producing
+ * numbers in [0, 1). Identical seed => identical sequence.
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Convenience: a generator seeded straight from a namespaced key. */
+export function rngFor(domain: SeedDomain, ...parts: string[]): () => number {
+  return mulberry32(seedFor(domain, ...parts));
+}

--- a/apps/web/convex/lib/scouting.ts
+++ b/apps/web/convex/lib/scouting.ts
@@ -1,0 +1,226 @@
+/*
+ * Recruit scouting (Dynasty Mode B3) — pure, Convex-free.
+ *
+ * A prospect has a true rating nobody can see. Scouting buys PRECISION, not
+ * truth: every level narrows the range you are shown, and level 3 still leaves
+ * a six-point window. Recruiting is a judgment call or it is a spreadsheet.
+ *
+ * ## The two things that could go wrong, and how the construction prevents them
+ *
+ * 1. **A band that lies.** If the range could exclude the true overall, a coach
+ *    who scouted to level 3 and signed the top-ranked kid could get someone
+ *    strictly worse than every number he was shown, and there would be no way to
+ *    tell an unlucky read from a bug. So the band ALWAYS contains the truth. The
+ *    uncertainty is in the width, never in the placement.
+ *
+ *    Bust risk lives somewhere honest instead: `potentialTier` is hidden at every
+ *    scout level and is what decides who a prospect BECOMES. You can know almost
+ *    exactly what a player is today and still be wrong about him.
+ *
+ * 2. **Bands that do not nest.** The obvious implementation draws an independent
+ *    range per level, and then level 3 can sit outside level 2 — so spending a
+ *    point can move the range AWAY from where it was, which reads as the game
+ *    lying to you. This builds the TIGHTEST band first and widens outward for
+ *    each lower level, so containment is structural rather than asserted:
+ *    band(3) ⊆ band(2) ⊆ band(1) ⊆ band(0) holds for every prospect by
+ *    construction, and the tests only have to confirm it survived clamping.
+ *
+ * Deterministic per `(prospectId, scoutLevel)` — see the seed convention in
+ * `convex/lib/rng.ts`. Re-reading a prospect never reshuffles his range.
+ */
+import { rngFor } from "./rng";
+
+/** Ratings live on the same 40–99 scale as `generateSyntheticAttributes`. */
+export const OVERALL_MIN = 40;
+export const OVERALL_MAX = 99;
+
+export const MIN_SCOUT_LEVEL = 0;
+export const MAX_SCOUT_LEVEL = 3;
+
+/**
+ * Width of the projected-overall band at each scout level.
+ *
+ * Strictly decreasing, and never zero: a fully scouted prospect is a six-point
+ * question, not an answer. 36 points at level 0 is deliberately close to
+ * useless — an unscouted board should feel like noise, because that is what
+ * makes spending the budget a decision.
+ */
+export const SCOUT_BAND_WIDTH: readonly number[] = [36, 24, 14, 6];
+
+/**
+ * Cost to move from level `i - 1` to level `i`. Index 0 is unused (everyone
+ * starts at level 0 for free).
+ *
+ * Rising costs mean a fixed budget buys either a broad look at the whole class
+ * or certainty about a few names, and never both.
+ */
+export const SCOUT_LEVEL_COST: readonly number[] = [0, 5, 10, 20];
+
+/**
+ * Prospects generated per team, and the most any one team may sign.
+ *
+ * One number for both on purpose. It makes the class exactly big enough for
+ * every program to fill its board and not one name bigger, so recruiting is a
+ * contest over WHICH six rather than a queue where the last team still gets its
+ * pick. A larger class would make the board a formality; a per-team cap above
+ * the class share would let one program take everything.
+ */
+export const RECRUITING_CLASS_PER_TEAM = 6;
+
+/** Hidden development ceiling. Drives who a prospect BECOMES, not who he is. */
+export type PotentialTier = "bust" | "steady" | "riser" | "star";
+
+export const POTENTIAL_TIERS: readonly PotentialTier[] = [
+  "bust",
+  "steady",
+  "riser",
+  "star",
+];
+
+export function isPotentialTier(value: string): value is PotentialTier {
+  return (POTENTIAL_TIERS as readonly string[]).includes(value);
+}
+
+/** Cost of the next scout, or `null` when the prospect is fully scouted. */
+export function nextScoutCost(scoutLevel: number): number | null {
+  const next = scoutLevel + 1;
+  if (next > MAX_SCOUT_LEVEL) return null;
+  return SCOUT_LEVEL_COST[next] ?? null;
+}
+
+export function clampScoutLevel(level: number): number {
+  if (!Number.isFinite(level)) return MIN_SCOUT_LEVEL;
+  return Math.max(MIN_SCOUT_LEVEL, Math.min(MAX_SCOUT_LEVEL, Math.round(level)));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export interface ScoutingBand {
+  /** Lowest overall the prospect could be, as shown to the coach. */
+  projectedLow: number;
+  /** Highest overall the prospect could be, as shown to the coach. */
+  projectedHigh: number;
+}
+
+/**
+ * Every level's band for one prospect, index 0..3.
+ *
+ * Computed together in a single RNG stream on purpose. Deriving level `n` from
+ * its own independent stream is what breaks nesting; deriving all four from one
+ * pass, tightest first, is what makes nesting free.
+ */
+export function scoutingBands(
+  prospectId: string,
+  trueOverall: number,
+): ScoutingBand[] {
+  const rand = rngFor("scouting", prospectId);
+  const truth = clamp(trueOverall, OVERALL_MIN, OVERALL_MAX);
+
+  /*
+   * Where truth sits inside the tightest band. Drawn once, so a prospect whose
+   * true rating sits at the top of his level-3 window keeps sitting there as
+   * the window widens — the band grows around a fixed point rather than
+   * jumping.
+   */
+  const tightest = SCOUT_BAND_WIDTH[MAX_SCOUT_LEVEL] ?? 6;
+  let low = truth - rand() * tightest;
+  let high = low + tightest;
+
+  const raw = SCOUT_BAND_WIDTH.map(() => ({ low, high }));
+  for (let level = MAX_SCOUT_LEVEL - 1; level >= MIN_SCOUT_LEVEL; level--) {
+    const width = SCOUT_BAND_WIDTH[level] ?? tightest;
+    const extra = Math.max(0, width - (high - low));
+    // Split the extra width between the two ends. Never symmetric, so a wider
+    // band is not a tell that the midpoint is the answer.
+    const below = extra * rand();
+    low -= below;
+    high += extra - below;
+    raw[level] = { low, high };
+  }
+
+  /*
+   * Clamp onto the ratings scale by sliding the window, not by squashing it.
+   * Squashing would let a prospect at 99 end up with a zero-width band at
+   * level 3 — an exact answer, handed out by an edge case. Sliding preserves
+   * both the width and the nesting (`min` and `max` are monotone, and the
+   * per-level cap `OVERALL_MAX - width` is larger for tighter bands).
+   */
+  return raw.map((band, level) => {
+    const width = SCOUT_BAND_WIDTH[level] ?? tightest;
+    const slid = clamp(band.low, OVERALL_MIN, OVERALL_MAX - width);
+    return {
+      projectedLow: Math.round(slid),
+      projectedHigh: Math.round(slid) + width,
+    };
+  });
+}
+
+/** The band shown at one scout level. */
+export function scoutingBand(
+  prospectId: string,
+  trueOverall: number,
+  scoutLevel: number,
+): ScoutingBand {
+  const level = clampScoutLevel(scoutLevel);
+  const bands = scoutingBands(prospectId, trueOverall);
+  return bands[level] ?? bands[MIN_SCOUT_LEVEL];
+}
+
+export interface ScoutingReport {
+  scoutLevel: number;
+  projectedLow: number;
+  projectedHigh: number;
+  /** Per-attribute reads, blurred by the same amount as the band. */
+  scoutedAttributes: Record<string, number>;
+}
+
+export interface ApplyScoutingNoiseInput {
+  prospectId: string;
+  scoutLevel: number;
+  trueOverall: number;
+  trueAttributes: Record<string, number>;
+}
+
+/**
+ * What a coach at `scoutLevel` is allowed to see.
+ *
+ * The ONLY function that turns hidden truth into shown numbers. Keeping it
+ * single means the rule "you never see the exact rating" is enforced in one
+ * place rather than re-derived at each call site — and it is why nothing but
+ * this file needs to touch `trueAttributesJson`.
+ *
+ * Per-attribute reads use a level-specific stream, so a prospect's blurred
+ * ratings genuinely change as he is scouted rather than converging along a
+ * path the previous read already revealed.
+ */
+export function applyScoutingNoise(
+  input: ApplyScoutingNoiseInput,
+): ScoutingReport {
+  const scoutLevel = clampScoutLevel(input.scoutLevel);
+  const band = scoutingBand(input.prospectId, input.trueOverall, scoutLevel);
+
+  /*
+   * Attribute blur is half the band's width. At level 3 that is ±3 — enough
+   * that a coach still cannot rank two similar prospects on a single attribute,
+   * which is the point of a scale that stops short of certainty.
+   */
+  const spread = (SCOUT_BAND_WIDTH[scoutLevel] ?? 36) / 2;
+  const rand = rngFor("scouting", input.prospectId, String(scoutLevel));
+  const scoutedAttributes: Record<string, number> = {};
+  for (const key of Object.keys(input.trueAttributes).sort()) {
+    const truth = input.trueAttributes[key] ?? OVERALL_MIN;
+    const offset = (rand() * 2 - 1) * spread;
+    scoutedAttributes[key] = Math.round(
+      clamp(truth + offset, OVERALL_MIN, OVERALL_MAX),
+    );
+  }
+
+  return {
+    scoutLevel,
+    projectedLow: band.projectedLow,
+    projectedHigh: band.projectedHigh,
+    scoutedAttributes,
+  };
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2363,6 +2363,7 @@ const rolloverStageOrder = [
   "rosters_copied",
   "freshmen_created",
   "injuries_healed",
+  "prospects_generated",
   "completed",
 ] as const;
 

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -211,6 +211,8 @@ export const dynastyTables = {
     injurySeverityScale: v.optional(v.number()),
 
     // Offseason economy (Epic B).
+    /** An incoming freshman class is generated and recruited (Epic B3). */
+    recruitingEnabled: v.optional(v.boolean()),
     transfersEnabled: v.optional(v.boolean()),
     /** "low" | "normal" | "high" — how much roster churn a offseason produces. */
     transferVolume: v.optional(v.string()),

--- a/apps/web/convex/tables/offseason.ts
+++ b/apps/web/convex/tables/offseason.ts
@@ -60,6 +60,66 @@ export const offseasonTables = {
     .index("by_leagueId", ["leagueId"]),
 
   /*
+   * Incoming freshman class (Dynasty Mode B3). One row per prospect, one class
+   * per target season, shared by every team in the league.
+   *
+   * ## The hidden/shown split is the table's whole reason for existing
+   *
+   * `trueAttributesJson`, `trueOverall` and `potentialTier` are the prospect.
+   * `scoutedAttributesJson`, `projectedLow` and `projectedHigh` are what a coach
+   * has earned the right to see. They are stored side by side rather than
+   * derived on read so that the shown numbers are STABLE — a range that
+   * recomputed on every page load would drift under the coach even though the
+   * generator is deterministic, and any future change to the noise function
+   * would silently rewrite history for classes already scouted.
+   *
+   * Nothing outside `convex/dynasty.ts` may read the hidden three. `listProspects`
+   * has no validator entry for them, and `__tests__/prospectsHideTruth.test.ts`
+   * fails if one is added — a leak here is not a cosmetic bug, it deletes the
+   * entire mechanic.
+   *
+   * ## Signing
+   *
+   * `playerId` is the record that a prospect became a player, and it is what
+   * makes signing idempotent: a set `playerId` means the work is done, so a
+   * retried request returns the existing player instead of creating a second
+   * one. `signedTeamId` is stored alongside rather than read back through the
+   * player because a signed player can later be released or traded, and the
+   * class should keep saying who actually recruited him.
+   */
+  recruitProspects: defineTable({
+    leagueId: v.id("leagues"),
+    /** The UPCOMING season this class signs into. */
+    seasonId: v.id("seasons"),
+    name: v.string(),
+    position: v.string(),
+    positionGroup: v.string(),
+    /** Shown at every scout level — the read a coach gets from film. */
+    archetype: v.string(),
+    hometown: v.union(v.string(), v.null()),
+
+    /** HIDDEN. Never in a `returns:` validator reachable from the Next layer. */
+    trueAttributesJson: v.string(),
+    /** HIDDEN. The number the projected band is built around. */
+    trueOverall: v.number(),
+    /** HIDDEN at every level, including 3 — this is where bust risk lives. */
+    potentialTier: v.string(),
+
+    /** 0–3. Higher is a narrower `projectedLow`..`projectedHigh` window. */
+    scoutLevel: v.number(),
+    scoutedAttributesJson: v.string(),
+    projectedLow: v.number(),
+    projectedHigh: v.number(),
+
+    signedTeamId: v.optional(v.id("teams")),
+    playerId: v.optional(v.id("players")),
+    signedAt: v.optional(v.string()),
+    createdAt: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  /*
    * Offseason snake draft (WSM-000233). One draft per target season; order is
    * reverse final standings. Writes are internalMutation only.
    */

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -106,3 +106,27 @@ export async function withScheduleFixture(
     },
   };
 }
+
+const seedProspectClassRef = makeFunctionReference<
+  "mutation",
+  any,
+  { created: number; alreadyExisted: boolean }
+>("e2eSeed:seedProspectClass");
+
+/**
+ * Put a recruiting class on a season (B3).
+ *
+ * The production path builds one in the `prospects_generated` rollover stage,
+ * which needs a completed season to roll over from. Simulating one to a
+ * champion just to render a board would make the recruiting spec the slowest
+ * in the suite and couple it to every earlier slice; the seed routes through
+ * the same Convex mutation the rollover calls, so what it produces is the real
+ * thing.
+ */
+export async function seedProspectClass(
+  seasonId: string,
+  count = 4,
+): Promise<{ created: number; alreadyExisted: boolean }> {
+  const client = getSeedClient();
+  return client.mutation(seedProspectClassRef, { seasonId, count });
+}

--- a/apps/web/e2e/tests/offseason-phases.spec.ts
+++ b/apps/web/e2e/tests/offseason-phases.spec.ts
@@ -98,9 +98,14 @@ test.describe("Offseason phase machine (B1)", () => {
     await offseasonLink.click();
     await expect(page).toHaveURL(/\/dashboard\/seasons\/[^/]+\/offseason$/);
 
-    // A freshly opened offseason sits at `draft` with the rollover recorded.
+    /*
+     * A freshly opened offseason sits at `recruiting` with the rollover
+     * recorded. B3 inserted that phase ahead of `draft`; the opening phase is
+     * whatever `INITIAL_OFFSEASON_PHASE` says, so this assertion moves with the
+     * machine rather than pinning a phase that later slices will displace.
+     */
     const stepper = page.getByTestId("offseason-phase-stepper");
-    await expect(stepper).toHaveAttribute("data-phase", "draft");
+    await expect(stepper).toHaveAttribute("data-phase", "recruiting");
     await expect(page.getByTestId("offseason-phase-rollover")).toHaveAttribute(
       "data-state",
       "complete",
@@ -108,7 +113,7 @@ test.describe("Offseason phase machine (B1)", () => {
 
     await page.getByTestId("offseason-advance").click();
     await expect(page.getByTestId("offseason-phase-message")).toContainText(
-      "Free agency",
+      "Draft",
       { timeout: 30_000 },
     );
 
@@ -116,12 +121,11 @@ test.describe("Offseason phase machine (B1)", () => {
     await page.reload();
     await expect(page.getByTestId("offseason-phase-stepper")).toHaveAttribute(
       "data-phase",
-      "free_agency",
+      "draft",
     );
-    await expect(page.getByTestId("offseason-phase-draft")).toHaveAttribute(
-      "data-state",
-      "complete",
-    );
+    await expect(
+      page.getByTestId("offseason-phase-recruiting"),
+    ).toHaveAttribute("data-state", "complete");
   });
 
   test("an active season has no Offseason link and no hub page", async ({

--- a/apps/web/e2e/tests/recruiting.spec.ts
+++ b/apps/web/e2e/tests/recruiting.spec.ts
@@ -183,19 +183,29 @@ test.describe("Recruiting class (B3)", () => {
     // The board records the signing rather than offering him again.
     await expect(row).toContainText("Signed", { timeout: 30_000 });
 
+    // And it PERSISTS — the signing is a write, not a local state change.
+    await page.reload();
+    const afterReload = page
+      .getByTestId("scouting-panel")
+      .getByTestId("prospect-row")
+      .filter({ hasText: name });
+    await expect(afterReload).toContainText("Signed", { timeout: 30_000 });
+
     /*
-     * And he is really on a roster. The signing is only meaningful if it
-     * produced a player — a board that marked prospects signed without creating
-     * anyone would pass every assertion above.
+     * And a real player exists. The signing is only meaningful if it produced
+     * one — a board that marked prospects signed without creating anybody
+     * would satisfy every assertion above.
      *
-     * The team is read off the row rather than assumed: the acting team is
-     * whichever team the viewer manages, and `getTeamsByLeague` gives no
-     * ordering guarantee to pin one.
+     * Checked on Players Home rather than the team's roster page. That page
+     * renders the ACTIVE season's `rosterAssignments`, and a recruit signs into
+     * the UPCOMING one — which is correct behaviour, not a gap: next year's
+     * class belongs on next year's roster. Players Home is league-scoped and
+     * season-independent, so it answers the question actually being asked.
+     *
+     * The fixture league is created with two teams and no players, so the
+     * signed prospect is the only name there.
      */
-    const signedTeam = (await row.innerText()).includes(fixture.homeTeamName)
-      ? fixture.homeTeamId
-      : fixture.awayTeamId;
-    await page.goto(`/dashboard/teams/${signedTeam}/roster`);
+    await page.goto("/dashboard/players");
     await expect(page.getByText(name, { exact: true }).first()).toBeVisible({
       timeout: 30_000,
     });

--- a/apps/web/e2e/tests/recruiting.spec.ts
+++ b/apps/web/e2e/tests/recruiting.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedProspectClass,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { acceptBrowserConfirms } from "../helpers/sim-league-setup";
+
+/*
+ * Incoming freshman class with scouting (Dynasty Mode B3, #621).
+ *
+ * Its own fixture league, for the reason `offseason-phases.spec.ts` records:
+ * the canonical shared league's season statuses churn between CI runs, and
+ * every assertion here depends on an UPCOMING season.
+ *
+ * The prospects are seeded rather than rolled over. Generating a real class
+ * needs a completed season to roll over from, and simulating one to a champion
+ * would make this the slowest spec in the suite while coupling it to A1–A6.
+ */
+test.describe("Recruiting class (B3)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "recruiting-class";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let seasonId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E RC Home",
+      awayTeamName: "E2E RC Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("shows prospects as ranges and never as an exact rating", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    // A new season is upcoming, which is what the offseason hub requires.
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Season name").fill(`E2E Recruiting ${Date.now()}`);
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    const href = await success
+      .getByTestId("create-season-generate-schedule")
+      .getAttribute("href");
+    seasonId = href?.split("/")[3] ?? null;
+    expect(seasonId).toBeTruthy();
+    await success.getByRole("button", { name: "Done" }).click();
+
+    await seedProspectClass(seasonId as string, 4);
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+
+    const panel = page.getByTestId("scouting-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    // Ranges, not numbers — the whole mechanic.
+    const ranges = panel.getByTestId("prospect-range");
+    await expect(ranges.first()).toBeVisible();
+    expect(await ranges.count()).toBe(4);
+
+    const firstRange = await ranges.first().innerText();
+    expect(firstRange).toMatch(/\d+–\d+/);
+
+    /*
+     * No exact-overall readout anywhere on the board. Asserted on the panel's
+     * text rather than on a locator, because the failure this guards against is
+     * a NEW element appearing, which no existing locator would catch.
+     */
+    const panelText = await panel.innerText();
+    expect(panelText).not.toMatch(/overall[:\s]*\d/i);
+
+    await expect(page.getByTestId("scouting-points-remaining")).toContainText(
+      "scouting points remaining",
+    );
+  });
+
+  test("scouting narrows the range and spends from the budget", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("scouting-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    /*
+     * Located by NAME, not by position. The board sorts by the top of each
+     * range, and scouting moves that — a locator pinned to the first row would
+     * be watching a different prospect by the time the range narrowed.
+     */
+    const name = await panel
+      .getByTestId("prospect-row")
+      .first()
+      .locator("p")
+      .first()
+      .innerText();
+    const row = panel.getByTestId("prospect-row").filter({ hasText: name });
+
+    const rangeBefore = await row.getByTestId("prospect-range").innerText();
+    const [lowBefore, highBefore] = rangeBefore
+      .match(/(\d+)–(\d+)/)!
+      .slice(1)
+      .map(Number);
+    const budgetBefore = await page
+      .getByTestId("scouting-points-remaining")
+      .innerText();
+
+    // `Scout (5)` — the cost is on the button, so this is a substring match.
+    await row.getByRole("button", { name: "Scout" }).click();
+
+    await expect
+      .poll(
+        async () => {
+          const text = await row.getByTestId("prospect-range").innerText();
+          const match = text.match(/(\d+)–(\d+)/);
+          return match ? Number(match[2]) - Number(match[1]) : null;
+        },
+        { timeout: 30_000 },
+      )
+      .toBeLessThan(highBefore - lowBefore);
+
+    await expect(page.getByTestId("scouting-points-remaining")).not.toHaveText(
+      budgetBefore,
+    );
+  });
+
+  test("signing a prospect turns him into a rostered player", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("scouting-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    const unsigned = panel
+      .getByTestId("prospect-row")
+      .filter({ has: page.getByRole("button", { name: "Sign" }) })
+      .first();
+    const name = await unsigned.locator("p").first().innerText();
+    const row = panel.getByTestId("prospect-row").filter({ hasText: name });
+    await row.getByRole("button", { name: "Sign" }).click();
+
+    // The board records the signing rather than offering him again.
+    await expect(row).toContainText("Signed", { timeout: 30_000 });
+
+    /*
+     * And he is really on a roster. The signing is only meaningful if it
+     * produced a player — a board that marked prospects signed without creating
+     * anyone would pass every assertion above.
+     *
+     * The team is read off the row rather than assumed: the acting team is
+     * whichever team the viewer manages, and `getTeamsByLeague` gives no
+     * ordering guarantee to pin one.
+     */
+    const signedTeam = (await row.innerText()).includes(fixture.homeTeamName)
+      ? fixture.homeTeamId
+      : fixture.awayTeamId;
+    await page.goto(`/dashboard/teams/${signedTeam}/roster`);
+    await expect(page.getByText(name, { exact: true }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -20,6 +20,8 @@ const {
   mockGetPlayersByTeam,
   mockCreateRolloverFreshmenForTeam,
   mockHealSeasonInjuries,
+  mockCreateProspectClass,
+  mockGetDynastyConfig,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockResolveOrgContext: vi.fn(),
@@ -40,6 +42,8 @@ const {
   mockGetPlayersByTeam: vi.fn(),
   mockCreateRolloverFreshmenForTeam: vi.fn(),
   mockHealSeasonInjuries: vi.fn(),
+  mockCreateProspectClass: vi.fn(),
+  mockGetDynastyConfig: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
@@ -64,6 +68,8 @@ vi.mock("@/lib/data-api", () => ({
   getPlayersByTeam: mockGetPlayersByTeam,
   createRolloverFreshmenForTeam: mockCreateRolloverFreshmenForTeam,
   healSeasonInjuries: mockHealSeasonInjuries,
+  createProspectClass: mockCreateProspectClass,
+  getDynastyConfig: mockGetDynastyConfig,
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
@@ -96,7 +102,7 @@ const completedSummary = {
     removedAssignments: 1,
     removedDepthEntries: 1,
   },
-  recruiting: { freshmen: 47, toPool: false },
+  recruiting: { freshmen: 47, toPool: false, prospects: 12 },
   healing: { injuries: 3 },
 };
 
@@ -154,7 +160,9 @@ beforeEach(() => {
                   ? "rosters_copied"
                   : stage === "injuries_healed"
                     ? "freshmen_created"
-                    : "injuries_healed",
+                    : stage === "prospects_generated"
+                      ? "injuries_healed"
+                      : "prospects_generated",
         status: "in_progress",
         graduatedPlayerIds: [],
         advancedPlayerIds: ["p1"],
@@ -164,6 +172,11 @@ beforeEach(() => {
   );
   mockReleaseSeasonRolloverStage.mockResolvedValue(null);
   mockHealSeasonInjuries.mockResolvedValue({ healed: 0 });
+  mockGetDynastyConfig.mockResolvedValue({ recruitingEnabled: true });
+  mockCreateProspectClass.mockResolvedValue({
+    created: 12,
+    alreadyExisted: false,
+  });
   mockRollover.mockResolvedValue({
     graduatedPlayerIds: [],
     advancedPlayerIds: ["p1"],
@@ -669,6 +682,85 @@ describe("startNextSeasonAction success path", () => {
       const res = await startNextSeasonAction({ leagueId: LEAGUE });
 
       expect(mockHealSeasonInjuries).not.toHaveBeenCalled();
+      expect(res).toMatchObject({ ok: true });
+    });
+  });
+
+  /*
+   * Recruiting class generation (B3, #621). The stage runs LAST, after the
+   * backfill has already filled every roster — the class is talent on top of a
+   * playable floor, not a replacement for one.
+   */
+  describe("prospects_generated stage", () => {
+    it("builds a class for the TARGET season and records the count", async () => {
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockCreateProspectClass).toHaveBeenCalledWith(
+        expect.objectContaining({
+          leagueId: LEAGUE,
+          // The season being BUILT. A class on the closing season would be
+          // recruits for a year that has already been played.
+          seasonId: "season_next",
+        }),
+      );
+      const call = mockCreateProspectClass.mock.calls[0]?.[0] as {
+        prospects: Array<{ trueAttributesJson: string; potentialTier: string }>;
+      };
+      expect(call.prospects.length).toBeGreaterThan(0);
+      // Truth is generated on this side and handed over once. If a prospect
+      // arrived without it there would be nothing for scouting to blur.
+      expect(call.prospects[0].trueAttributesJson).toContain("SPD");
+      expect(call.prospects[0].potentialTier.length).toBeGreaterThan(0);
+      expect(res).toMatchObject({ ok: true });
+    });
+
+    it("still fills rosters when recruiting is switched off", async () => {
+      /*
+       * The kill switch removes a MECHANIC, not the players. A league with
+       * recruiting off must still get a full roster out of the rollover, or
+       * the switch would be a way to break a season rather than to simplify
+       * one.
+       */
+      mockGetDynastyConfig.mockResolvedValue({ recruitingEnabled: false });
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockCreateProspectClass).not.toHaveBeenCalled();
+      expect(mockCreateRolloverFreshmenForTeam).toHaveBeenCalled();
+      expect(res).toMatchObject({ ok: true, seasonId: "season_next" });
+    });
+
+    it("still completes the rollover when class generation fails", async () => {
+      // Same posture as healing: the next season already exists, and a league
+      // with no board beats a rollover stuck short of `completed`.
+      mockCreateProspectClass.mockRejectedValue(new Error("convex_down"));
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(res).toMatchObject({ ok: true, seasonId: "season_next" });
+      expect(mockAdvanceSeasonRollover).toHaveBeenLastCalledWith(
+        expect.objectContaining({ stage: "completed" }),
+      );
+    });
+
+    it("does not rebuild the class on a rollover resumed past the stage", async () => {
+      mockBeginSeasonRollover.mockResolvedValue({
+        rolloverId: "rollover_1",
+        sourceSeasonId: ACTIVE.id,
+        sourceSeasonName: ACTIVE.name,
+        targetSeasonId: "season_next",
+        targetSeasonName: "2027",
+        resumed: true,
+        stage: "prospects_generated",
+        status: "in_progress",
+        graduatedPlayerIds: [],
+        advancedPlayerIds: ["p1"],
+        summaryJson: JSON.stringify(completedSummary),
+      });
+
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockCreateProspectClass).not.toHaveBeenCalled();
       expect(res).toMatchObject({ ok: true });
     });
   });

--- a/apps/web/src/app/dashboard/_actions/__tests__/recruiting.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/recruiting.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockResolveOrgRole,
+  mockGetLeagueOrgId,
+  mockGetTeamLeagueId,
+  mockCanManageTeam,
+  mockScoutProspect,
+  mockSignProspect,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockCanManageTeam: vi.fn(),
+  mockScoutProspect: vi.fn(),
+  mockSignProspect: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/org-context", () => ({ resolveOrgRole: mockResolveOrgRole }));
+vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+vi.mock("@/lib/data-api", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getTeamLeagueId: mockGetTeamLeagueId,
+  scoutProspect: mockScoutProspect,
+  signProspect: mockSignProspect,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  scoutProspectAction,
+  signProspectAction,
+} from "../recruiting";
+
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const SEASON = "season_1";
+const PROSPECT = "prospect_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockGetTeamLeagueId.mockResolvedValue("league_1");
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  // A coach, not an org admin — the case the per-team gate exists for.
+  mockResolveOrgRole.mockResolvedValue("member");
+  mockCanManageTeam.mockImplementation(async (teamId: string) => teamId === TEAM_A);
+  mockScoutProspect.mockResolvedValue({
+    prospect: { id: PROSPECT, scoutLevel: 1 },
+    scoutingPointsSpent: 5,
+    scoutingPointsTotal: 100,
+  });
+  mockSignProspect.mockResolvedValue({
+    prospect: { id: PROSPECT },
+    playerId: "player_1",
+    alreadySigned: false,
+  });
+});
+
+/*
+ * The roadmap's one non-negotiable multiplayer detail (B3).
+ *
+ * Both actions take a `teamId` and authorize on it. Getting this wrong is the
+ * single thing that would force a rewrite when a second coach joins a league —
+ * an action gated only on "is org admin" cannot later be scoped to one team
+ * without changing every call site.
+ */
+describe("recruiting actions authorize per team", () => {
+  it("lets a coach act for the team they manage", async () => {
+    const scouted = await scoutProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+    });
+    expect(scouted.ok).toBe(true);
+    expect(mockScoutProspect).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: TEAM_A, actorUserId: "coach_a" }),
+    );
+  });
+
+  it("refuses a coach of team A scouting for team B", async () => {
+    const result = await scoutProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    // Refused BEFORE the mutation, not by it. A gate that only rejected at the
+    // database would have already spent the budget.
+    expect(mockScoutProspect).not.toHaveBeenCalled();
+  });
+
+  it("refuses a coach of team A signing for team B", async () => {
+    const result = await signProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockSignProspect).not.toHaveBeenCalled();
+  });
+
+  it("lets an org admin act for any team in the league", async () => {
+    // Solo/commissioner mode: one admin passes each team's id in turn. The
+    // same mutation serves both shapes, which is the point.
+    mockResolveOrgRole.mockResolvedValue("admin");
+    const result = await signProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses an unauthenticated caller before touching anything", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const result = await scoutProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "unauthorized" });
+    expect(mockGetTeamLeagueId).not.toHaveBeenCalled();
+  });
+});
+
+describe("recruiting action failures", () => {
+  it("surfaces the bare reason a Convex error wraps", async () => {
+    /*
+     * Convex wraps a thrown Error in its own message. The UI switches on the
+     * bare reason, so an action that passed the wrapper through would show a
+     * stack-flavoured string where a sentence belongs.
+     */
+    mockScoutProspect.mockRejectedValue(
+      new Error("[Request ID: abc] Server Error: scouting_budget_exhausted"),
+    );
+    const result = await scoutProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "scouting_budget_exhausted" });
+  });
+
+  it("passes an unrecognised failure through rather than inventing one", async () => {
+    mockSignProspect.mockRejectedValue(new Error("network exploded"));
+    const result = await signProspectAction({
+      prospectId: PROSPECT,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "network exploded" });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
@@ -61,6 +61,21 @@ describe("rollover stage order", () => {
     );
   });
 
+  it("builds the recruiting class last, after the roster is settled (B3)", () => {
+    /*
+     * The class is generated once and never regenerated, so it has to be built
+     * against the roster the season actually starts with. Running it before
+     * the backfill would size a board against a roster that is about to change
+     * underneath it.
+     */
+    expect(clientStages.indexOf("prospects_generated")).toBeGreaterThan(
+      clientStages.indexOf("freshmen_created"),
+    );
+    expect(clientStages.indexOf("prospects_generated")).toBeLessThan(
+      clientStages.indexOf("completed"),
+    );
+  });
+
   it("keeps `completed` terminal", () => {
     expect(clientStages.at(-1)).toBe("completed");
     expect(serverStages.at(-1)).toBe("completed");

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -21,8 +21,14 @@ import {
   removePlayersFromSeasonRoster,
   createRolloverFreshmenForTeam,
   healSeasonInjuries,
+  createProspectClass,
+  getDynastyConfig,
 } from "@/lib/data-api";
 import { activeNonGraduatedNames } from "@/lib/dynasty";
+import {
+  generateProspectClass,
+  prospectClassSize,
+} from "@/lib/dynasty/prospects";
 import { computeProgressedAttributes } from "@/lib/dynasty-progression";
 import { resolveLifecycleSeason } from "@/lib/season-view";
 import {
@@ -45,6 +51,7 @@ const ROLLOVER_STAGES = [
   "rosters_copied",
   "freshmen_created",
   "injuries_healed",
+  "prospects_generated",
   "completed",
 ] as const;
 
@@ -74,7 +81,7 @@ function createRolloverSummary(input: {
       removedAssignments: 0,
       removedDepthEntries: 0,
     },
-    recruiting: { freshmen: 0, toPool: input.freshmenToPool },
+    recruiting: { freshmen: 0, toPool: input.freshmenToPool, prospects: 0 },
     healing: { injuries: 0 },
   };
 }
@@ -93,7 +100,14 @@ function parseRolloverSummary(
       advancement: parsed.advancement ?? fallback.advancement,
       progression: parsed.progression ?? fallback.progression,
       carryover: parsed.carryover ?? fallback.carryover,
-      recruiting: parsed.recruiting ?? fallback.recruiting,
+      /*
+       * MERGED, not substituted. A summary persisted before B3 has a
+       * `recruiting` object without `prospects`, and taking it wholesale would
+       * hand the renderer a field the type says is always a number — the exact
+       * shape of the crash B2 caused with `healing`. Spreading the fallback
+       * underneath fills the gap without overwriting what was really recorded.
+       */
+      recruiting: { ...fallback.recruiting, ...(parsed.recruiting ?? {}) },
       // Summaries persisted before B2 have no `healing` key. Falling back keeps
       // a rollover that started on the old code renderable on the new.
       healing: parsed.healing ?? fallback.healing,
@@ -492,6 +506,68 @@ export async function startNextSeasonAction(input: {
           summary = parseRolloverSummary(checkpoint.summaryJson, summary);
         } catch (err) {
           await releaseClaimedStage("injuries_healed", err);
+          throw err;
+        }
+      }
+    }
+
+    /*
+     * Generate the incoming freshman class (B3).
+     *
+     * After the backfill, not instead of it. `freshmen_created` still tops
+     * every roster up to the target size, so a league that never enters the
+     * recruiting phase keeps playable rosters — a phase nobody visits must not
+     * be able to produce a broken season. Prospects are the talent on top of
+     * that floor, and a team that recruits well displaces walk-ons with them.
+     *
+     * Same failure posture as healing: by this point the next season exists
+     * with full rosters, and a league with no recruiting board is strictly
+     * better than a rollover stuck short of `completed`. Both the generation
+     * and the persist fall back to zero rather than throwing.
+     */
+    if (!hasReachedRolloverStage(stage, "prospects_generated")) {
+      const acquired = await claimStage("prospects_generated");
+      if (acquired) {
+        try {
+          const config = await getDynastyConfig(input.leagueId).catch(
+            () => null,
+          );
+          if (config?.recruitingEnabled !== false) {
+            const teams = await getTeamsByLeague(
+              input.leagueId,
+              orgContext,
+            ).catch(() => []);
+            const prospects = generateProspectClass({
+              seasonId: nextSeasonId,
+              count: prospectClassSize(teams.length),
+              excludeNames: activeNonGraduatedNames(leaguePlayers),
+            });
+            const created = await createProspectClass({
+              leagueId: input.leagueId,
+              seasonId: nextSeasonId,
+              prospects: prospects.map((p) => ({
+                name: p.name,
+                position: p.position,
+                positionGroup: p.positionGroup,
+                archetype: p.archetype,
+                hometown: p.hometown,
+                trueAttributesJson: JSON.stringify(p.trueAttributes),
+                trueOverall: p.trueOverall,
+                potentialTier: p.potentialTier,
+              })),
+            }).catch(() => null);
+            if (created) summary.recruiting.prospects = created.created;
+          }
+          const checkpoint = await advanceSeasonRollover({
+            rolloverId: rollover.rolloverId,
+            stage: "prospects_generated",
+            summaryJson: serializeRolloverSummary(summary),
+            ownerId,
+          });
+          stage = checkpoint.stage;
+          summary = parseRolloverSummary(checkpoint.summaryJson, summary);
+        } catch (err) {
+          await releaseClaimedStage("prospects_generated", err);
           throw err;
         }
       }

--- a/apps/web/src/app/dashboard/_actions/recruiting.ts
+++ b/apps/web/src/app/dashboard/_actions/recruiting.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  getLeagueOrgId,
+  getTeamLeagueId,
+  scoutProspect,
+  signProspect,
+  type ProspectDto,
+} from "@/lib/data-api";
+
+/*
+ * Recruiting actions (Dynasty Mode B3).
+ *
+ * Both actions authorize on a **teamId**, never on "is org admin" alone. This
+ * is the roadmap's one non-negotiable multiplayer detail: in solo mode the
+ * commissioner passes each team's id in turn, and in Wave 5 the identical
+ * mutation serves a coach who owns exactly one. An action that only asked "are
+ * you an admin" would have to be rewritten — along with every call site — the
+ * day a second person joins a league.
+ *
+ * `canAdminOrManageTeam` mirrors the free-agency actions in `offseason.ts`
+ * rather than inventing a second predicate, so "who may act for this team" has
+ * one answer across the offseason.
+ */
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function canAdminOrManageTeam(
+  userId: string,
+  teamId: string,
+): Promise<boolean> {
+  const leagueId = await getTeamLeagueId(teamId);
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (canManageOrgSettings(role)) return true;
+  return canManageTeam(teamId, userId);
+}
+
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  /*
+   * Convex wraps a thrown Error in its own message, so the bare reason the UI
+   * switches on has to be recovered from the text. Same recovery as
+   * `offseason-phases.ts`; the list is the reasons this slice can produce.
+   */
+  const known = [
+    "prospect_not_found",
+    "prospect_already_signed",
+    "prospect_fully_scouted",
+    "scouting_budget_exhausted",
+    "recruiting_class_full",
+    "season_locked",
+    "season_not_upcoming",
+    "team_league_mismatch",
+    "team_not_found",
+  ];
+  return known.find((reason) => raw.includes(reason)) ?? raw;
+}
+
+export async function scoutProspectAction(input: {
+  prospectId: string;
+  teamId: string;
+  seasonId: string;
+}): Promise<
+  ActionResult<{
+    prospect: ProspectDto;
+    scoutingPointsSpent: number;
+    scoutingPointsTotal: number;
+  }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await scoutProspect({
+      prospectId: input.prospectId,
+      teamId: input.teamId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}
+
+export async function signProspectAction(input: {
+  prospectId: string;
+  teamId: string;
+  seasonId: string;
+}): Promise<
+  ActionResult<{
+    prospect: ProspectDto;
+    playerId: string;
+    alreadySigned: boolean;
+  }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await signProspect({
+      prospectId: input.prospectId,
+      teamId: input.teamId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
@@ -7,14 +7,18 @@ import {
   getOffseason,
   getSeason,
   getTeamsByLeague,
+  listProspects,
 } from "@/lib/data-api";
+import { canManageTeam } from "@/lib/authorization";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageOrgSettings } from "@/lib/permissions";
 import { Card, CardContent } from "@/components/ui/card";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
 import { seasonHomeHref } from "@/components/workspace/resource-navigation";
 import { OffseasonPhaseControls } from "@/components/offseason/OffseasonPhaseControls";
+import { ScoutingPanel } from "@/components/offseason/ScoutingPanel";
 import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
+import { DYNASTY_CONFIG_DEFAULTS } from "@/lib/dynasty-config";
 import { syncActiveLeagueForResource } from "@/lib/active-league-server";
 
 /*
@@ -51,14 +55,29 @@ export default async function SeasonOffseasonPage({
   if (!league) notFound();
   await syncActiveLeagueForResource(league.id);
 
-  const [offseason, draft, teams] = await Promise.all([
+  const [offseason, draft, teams, prospects] = await Promise.all([
     getOffseason(season.id).catch(() => null),
     getDraft(season.id).catch(() => null),
     getTeamsByLeague(league.id, orgContext).catch(() => []),
+    listProspects(season.id).catch(() => []),
   ]);
 
   const role = league.orgId ? await resolveOrgRole(league.orgId, userId) : null;
   const isAdmin = canManageOrgSettings(role);
+
+  /*
+   * Which team this viewer recruits FOR. An admin acts for the whole league and
+   * needs a team to attribute a signing to, so they act for the first one until
+   * multi-coach (Wave 5) gives every user their own; a coach acts for the team
+   * they manage and for no other. This is the page-level half of the per-team
+   * authorization the mutation enforces — it decides what to offer, and the
+   * action decides what is allowed.
+   */
+  const managed: { id: string; name: string }[] = [];
+  for (const team of teams) {
+    if (await canManageTeam(team.id, userId)) managed.push(team);
+  }
+  const actingTeam = managed[0] ?? (isAdmin ? (teams[0] ?? null) : null);
 
   const draftStatus = !draft
     ? ("none" as const)
@@ -85,6 +104,19 @@ export default async function SeasonOffseasonPage({
             draftStatus={draftStatus}
             isAdmin={isAdmin}
             teamCount={teams.length}
+          />
+
+          <ScoutingPanel
+            seasonId={season.id}
+            prospects={prospects}
+            teams={teams}
+            actingTeam={actingTeam}
+            canRecruit={actingTeam !== null}
+            scoutingPointsSpent={offseason?.scoutingPointsSpent ?? 0}
+            scoutingPointsTotal={
+              offseason?.scoutingPointsTotal ??
+              DYNASTY_CONFIG_DEFAULTS.scoutingPointsPerOffseason
+            }
           />
         </CardContent>
       </Card>

--- a/apps/web/src/components/dynasty/DynastySettingsCard.tsx
+++ b/apps/web/src/components/dynasty/DynastySettingsCard.tsx
@@ -64,6 +64,12 @@ const TOGGLES: Array<{
       "Each team's offense, defense and coaching dials shape how it plays.",
   },
   {
+    key: "recruitingEnabled",
+    label: "Recruiting",
+    description:
+      "Each offseason generates a freshman class programs scout and sign.",
+  },
+  {
     key: "transfersEnabled",
     label: "Transfers",
     description: "Players move between programs in the offseason.",

--- a/apps/web/src/components/dynasty/__tests__/DynastyPanel.test.ts
+++ b/apps/web/src/components/dynasty/__tests__/DynastyPanel.test.ts
@@ -102,7 +102,7 @@ const summary: RolloverOperationSummary = {
     removedAssignments: 8,
     removedDepthEntries: 4,
   },
-  recruiting: { freshmen: 47, toPool: false },
+  recruiting: { freshmen: 47, toPool: false, prospects: 72 },
   healing: { injuries: 2 },
 };
 

--- a/apps/web/src/components/offseason/ScoutingPanel.tsx
+++ b/apps/web/src/components/offseason/ScoutingPanel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  scoutProspectAction,
+  signProspectAction,
+} from "@/app/dashboard/_actions/recruiting";
+import type { ProspectDto } from "@/lib/data-api";
+import {
+  MAX_SCOUT_LEVEL,
+  OVERALL_MAX,
+  OVERALL_MIN,
+  nextScoutCost,
+} from "@/lib/dynasty/scouting";
+
+/*
+ * The recruiting board (Dynasty Mode B3).
+ *
+ * The one rule this component exists to enforce: a prospect is shown as a
+ * RANGE, never as a number. There is no exact-overall rendering path here even
+ * for a fully scouted prospect, because the moment one exists the mechanic
+ * becomes a spreadsheet — you would scout to level 3 and read the answer.
+ *
+ * The bar is the whole design. Its width is the uncertainty, so spending points
+ * is legible as the bar getting shorter rather than as a number changing, and
+ * two prospects with overlapping bars are visibly a judgment call.
+ */
+
+const REASON_COPY: Record<string, string> = {
+  scouting_budget_exhausted:
+    "The league is out of scouting points for this offseason.",
+  prospect_fully_scouted: "This prospect is already fully scouted.",
+  prospect_already_signed: "Another program signed this prospect first.",
+  recruiting_class_full: "This team's recruiting class is already full.",
+  season_locked: "The roster is locked for this season.",
+  not_authorized: "You cannot recruit for this team.",
+};
+
+function copyFor(reason: string): string {
+  return REASON_COPY[reason] ?? "Could not complete that recruiting action.";
+}
+
+export interface ScoutingPanelProps {
+  seasonId: string;
+  prospects: ProspectDto[];
+  teams: { id: string; name: string }[];
+  /** The team a coach acts for, or null when they manage none. */
+  actingTeam: { id: string; name: string } | null;
+  canRecruit: boolean;
+  scoutingPointsSpent: number;
+  scoutingPointsTotal: number;
+}
+
+export function ScoutingPanel({
+  seasonId,
+  prospects,
+  teams,
+  actingTeam,
+  canRecruit,
+  scoutingPointsSpent,
+  scoutingPointsTotal,
+}: ScoutingPanelProps) {
+  const [spent, setSpent] = useState(scoutingPointsSpent);
+  const [rows, setRows] = useState(prospects);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const teamNames = useMemo(
+    () => new Map(teams.map((team) => [team.id, team.name])),
+    [teams],
+  );
+
+  /*
+   * Sorted by the TOP of the range, so an unscouted prospect with a wide band
+   * can outrank a scouted one. That is deliberate: the board should reward
+   * looking again, not present a settled order that scouting merely confirms.
+   */
+  const board = useMemo(
+    () =>
+      [...rows].sort(
+        (a, b) => b.projectedHigh - a.projectedHigh || a.name.localeCompare(b.name),
+      ),
+    [rows],
+  );
+
+  const remaining = Math.max(0, scoutingPointsTotal - spent);
+
+  function replace(next: ProspectDto) {
+    setRows((current) =>
+      current.map((row) => (row.id === next.id ? next : row)),
+    );
+  }
+
+  function scout(prospect: ProspectDto) {
+    if (!actingTeam) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await scoutProspectAction({
+        prospectId: prospect.id,
+        teamId: actingTeam.id,
+        seasonId,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      replace(result.data.prospect);
+      setSpent(result.data.scoutingPointsSpent);
+    });
+  }
+
+  function sign(prospect: ProspectDto) {
+    if (!actingTeam) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await signProspectAction({
+        prospectId: prospect.id,
+        teamId: actingTeam.id,
+        seasonId,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      replace(result.data.prospect);
+      setMessage(`Signed ${prospect.name}.`);
+    });
+  }
+
+  if (board.length === 0) {
+    return (
+      <section data-testid="scouting-panel" className="space-y-2">
+        <h3 className="text-sm font-semibold">Recruiting class</h3>
+        <p className="text-sm text-muted-foreground">
+          No recruiting class was generated for this season.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="scouting-panel" className="space-y-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-semibold">Recruiting class</h3>
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="scouting-points-remaining"
+        >
+          {remaining} of {scoutingPointsTotal} scouting points remaining
+        </p>
+      </div>
+
+      {message && (
+        <p className="text-sm text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+
+      <ul className="divide-y rounded-md border">
+        {board.map((prospect) => {
+          const cost = nextScoutCost(prospect.scoutLevel);
+          const signedBy = prospect.signedTeamId
+            ? (teamNames.get(prospect.signedTeamId) ?? "another program")
+            : null;
+          return (
+            <li
+              key={prospect.id}
+              className="flex flex-wrap items-center gap-3 p-3"
+              data-testid="prospect-row"
+            >
+              <div className="min-w-[11rem] flex-1">
+                <p className="text-sm font-medium">{prospect.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {prospect.position} · {prospect.archetype}
+                  {prospect.hometown ? ` · ${prospect.hometown}` : ""}
+                </p>
+              </div>
+
+              <ProspectRange
+                low={prospect.projectedLow}
+                high={prospect.projectedHigh}
+                scoutLevel={prospect.scoutLevel}
+              />
+
+              {signedBy ? (
+                <span className="text-xs text-muted-foreground">
+                  Signed · {signedBy}
+                </span>
+              ) : (
+                canRecruit &&
+                actingTeam && (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={pending || cost === null || cost > remaining}
+                      onClick={() => scout(prospect)}
+                    >
+                      {cost === null ? "Fully scouted" : `Scout (${cost})`}
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => sign(prospect)}
+                    >
+                      Sign
+                    </Button>
+                  </div>
+                )
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * A prospect's projected overall, as a bar.
+ *
+ * Renders `low–high` and never a midpoint or a single figure: a midpoint would
+ * be read as the answer, and the whole point is that there is not one yet.
+ */
+function ProspectRange({
+  low,
+  high,
+  scoutLevel,
+}: {
+  low: number;
+  high: number;
+  scoutLevel: number;
+}) {
+  const span = OVERALL_MAX - OVERALL_MIN;
+  const left = ((low - OVERALL_MIN) / span) * 100;
+  const width = Math.max(1, ((high - low) / span) * 100);
+  return (
+    <div className="w-44" data-testid="prospect-range">
+      <div className="mb-1 flex items-baseline justify-between text-xs">
+        <span className="font-mono">
+          {low}–{high}
+        </span>
+        <span className="text-muted-foreground">
+          Scout {scoutLevel}/{MAX_SCOUT_LEVEL}
+        </span>
+      </div>
+      <div
+        className="h-2 w-full rounded-full bg-muted"
+        role="img"
+        aria-label={`Projected overall between ${low} and ${high}`}
+      >
+        <div
+          className="h-2 rounded-full bg-primary"
+          style={{ marginLeft: `${left}%`, width: `${width}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/offseason/__tests__/scouting-panel.test.ts
+++ b/apps/web/src/components/offseason/__tests__/scouting-panel.test.ts
@@ -1,0 +1,131 @@
+import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ProspectDto } from "@/lib/data-api";
+
+vi.mock("@/app/dashboard/_actions/recruiting", () => ({
+  scoutProspectAction: vi.fn(),
+  signProspectAction: vi.fn(),
+}));
+
+import { ScoutingPanel } from "@/components/offseason/ScoutingPanel";
+
+function prospect(overrides: Partial<ProspectDto> = {}): ProspectDto {
+  return {
+    id: "prospect_1",
+    leagueId: "league_1",
+    seasonId: "season_1",
+    name: "Cam Whitfield",
+    position: "WR",
+    positionGroup: "WR",
+    archetype: "Deep Threat",
+    hometown: "Acworth, GA",
+    scoutLevel: 0,
+    projectedLow: 58,
+    projectedHigh: 82,
+    scoutedAttributesJson: "{}",
+    signedTeamId: null,
+    playerId: null,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  seasonId: "season_1",
+  teams: [{ id: "team_1", name: "North HS" }],
+  actingTeam: { id: "team_1", name: "North HS" },
+  canRecruit: true,
+  scoutingPointsSpent: 15,
+  scoutingPointsTotal: 100,
+};
+
+describe("ScoutingPanel", () => {
+  it("shows a prospect as a range, never as a single rating", () => {
+    /*
+     * The one thing this component exists to guarantee. A rendered exact
+     * overall — even for a fully scouted prospect — turns recruiting into a
+     * lookup, so there is no code path that produces one and this asserts the
+     * absence rather than trusting it.
+     */
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, {
+        ...baseProps,
+        prospects: [prospect({ scoutLevel: 3, projectedLow: 68, projectedHigh: 74 })],
+      }),
+    );
+    expect(html).toContain('data-testid="prospect-range"');
+    expect(html).toContain("68–74");
+    expect(html).toContain(
+      'aria-label="Projected overall between 68 and 74"',
+    );
+    /*
+     * No "Overall 71" style readout anywhere in the markup. The pattern
+     * requires a digit directly after the word, so the range's own accessible
+     * label ("Projected overall between 68 and 74") is not a false positive —
+     * that one is the range, spelled out.
+     */
+    expect(html).not.toMatch(/overall[:\s]*\d/i);
+  });
+
+  it("shows how much of the budget is left", () => {
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, { ...baseProps, prospects: [prospect()] }),
+    );
+    expect(html).toContain('data-testid="scouting-points-remaining"');
+    expect(html).toContain("85 of 100 scouting points remaining");
+  });
+
+  it("prices the next scout so the cost is visible before it is spent", () => {
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, { ...baseProps, prospects: [prospect()] }),
+    );
+    expect(html).toContain("Scout (5)");
+  });
+
+  it("stops offering scouts once a prospect is fully scouted", () => {
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, {
+        ...baseProps,
+        prospects: [prospect({ scoutLevel: 3 })],
+      }),
+    );
+    expect(html).toContain("Fully scouted");
+  });
+
+  it("shows who signed a prospect instead of offering him again", () => {
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, {
+        ...baseProps,
+        prospects: [
+          prospect({ signedTeamId: "team_1", playerId: "player_1" }),
+        ],
+      }),
+    );
+    expect(html).toContain("Signed · North HS");
+    expect(html).not.toContain("Scout (");
+  });
+
+  it("renders read-only for someone who recruits for no team", () => {
+    // A league member browsing the board sees the class and no controls.
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, {
+        ...baseProps,
+        actingTeam: null,
+        canRecruit: false,
+        prospects: [prospect()],
+      }),
+    );
+    expect(html).toContain('data-testid="prospect-range"');
+    expect(html).not.toContain("Scout (");
+    expect(html).not.toContain(">Sign<");
+  });
+
+  it("says so plainly when a season has no class", () => {
+    // Honest absence — a league with recruiting switched off has an empty
+    // board, and an empty list with no explanation reads as a broken page.
+    const html = renderToStaticMarkup(
+      createElement(ScoutingPanel, { ...baseProps, prospects: [] }),
+    );
+    expect(html).toContain("No recruiting class was generated");
+  });
+});

--- a/apps/web/src/lib/__tests__/process-stages.test.ts
+++ b/apps/web/src/lib/__tests__/process-stages.test.ts
@@ -60,6 +60,7 @@ describe("process stage builders", () => {
       "carryover",
       "freshmen",
       "healing",
+      "prospects",
     ]);
     expect(pending[0]?.status).toBe("in_progress");
     // Stage list stays stable (identical ids/order) across outcomes.
@@ -79,7 +80,7 @@ describe("process stage builders", () => {
         removedAssignments: 12,
         removedDepthEntries: 6,
       },
-      recruiting: { freshmen: 48, toPool: true },
+      recruiting: { freshmen: 48, toPool: true, prospects: 72 },
       healing: { injuries: 3 },
     });
     expect(success.map((stage) => stage.id)).toEqual([
@@ -90,6 +91,7 @@ describe("process stage builders", () => {
       "carryover",
       "freshmen",
       "healing",
+      "prospects",
     ]);
     expect(success.find((stage) => stage.id === "rollover")?.detail).toBe(
       "2026 → 2027",

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -3042,3 +3042,99 @@ export async function advanceOffseasonPhase(input: {
     input,
   );
 }
+
+/*
+ * Incoming freshman class (B3).
+ *
+ * `ProspectDto` is deliberately the SHOWN prospect and nothing more. There is
+ * no DTO for the hidden fields because there is no caller on this side of the
+ * boundary entitled to them — the true ratings exist only inside
+ * `convex/dynasty.ts`, and the type here is the second lock on that.
+ */
+
+export interface ProspectDto {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  name: string;
+  position: string;
+  positionGroup: string;
+  archetype: string;
+  hometown: string | null;
+  scoutLevel: number;
+  projectedLow: number;
+  projectedHigh: number;
+  scoutedAttributesJson: string;
+  signedTeamId: string | null;
+  playerId: string | null;
+}
+
+export async function listProspects(seasonId: string): Promise<ProspectDto[]> {
+  const client = getConvexClient();
+  return client.query(dynastyRef.query<ProspectDto[]>("listProspects"), {
+    seasonId,
+  });
+}
+
+export async function createProspectClass(input: {
+  leagueId: string;
+  seasonId: string;
+  prospects: Array<{
+    name: string;
+    position: string;
+    positionGroup: string;
+    archetype: string;
+    hometown: string | null;
+    trueAttributesJson: string;
+    trueOverall: number;
+    potentialTier: string;
+  }>;
+}): Promise<{ created: number; alreadyExisted: boolean }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{ created: number; alreadyExisted: boolean }>(
+      "createProspectClass",
+    ),
+    input,
+  );
+}
+
+export async function scoutProspect(input: {
+  prospectId: string;
+  teamId: string;
+  actorUserId: string;
+}): Promise<{
+  prospect: ProspectDto;
+  scoutingPointsSpent: number;
+  scoutingPointsTotal: number;
+}> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      prospect: ProspectDto;
+      scoutingPointsSpent: number;
+      scoutingPointsTotal: number;
+    }>("scoutProspect"),
+    input,
+  );
+}
+
+export async function signProspect(input: {
+  prospectId: string;
+  teamId: string;
+  actorUserId: string;
+}): Promise<{
+  prospect: ProspectDto;
+  playerId: string;
+  alreadySigned: boolean;
+}> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      prospect: ProspectDto;
+      playerId: string;
+      alreadySigned: boolean;
+    }>("signProspect"),
+    input,
+  );
+}

--- a/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
@@ -46,9 +46,20 @@ describe("phase ordering", () => {
     expect(isOffseasonPhase("nonsense")).toBe(false);
   });
 
-  it("opens at draft, because the rollover has already happened", () => {
-    expect(INITIAL_OFFSEASON_PHASE).toBe("draft");
+  it("opens at recruiting, because the rollover has already happened", () => {
+    expect(INITIAL_OFFSEASON_PHASE).toBe("recruiting");
     expect(resolveOffseasonState(null).completedPhases).toContain("rollover");
+  });
+
+  it("puts recruiting between the rollover and the draft (B3)", () => {
+    /*
+     * Order is the contract, not the membership. Recruiting has to run before
+     * the draft because a prospect a team signs is a roster spot the draft can
+     * no longer fill — the other order would let a coach draft into a class he
+     * has not chosen yet.
+     */
+    expect(nextPhase("rollover")).toBe("recruiting");
+    expect(nextPhase("recruiting")).toBe("draft");
   });
 });
 
@@ -94,7 +105,7 @@ describe("phaseGate", () => {
   });
 
   it("rejects a phase name it does not know", () => {
-    expect(gate("draft", "recruiting")).toEqual({
+    expect(gate("draft", "bowl_season")).toEqual({
       ok: false,
       reason: "unknown_phase",
     });
@@ -118,7 +129,7 @@ describe("completePhase", () => {
   });
 
   it("drops names that are not phases instead of persisting them", () => {
-    expect(completePhase(["rollover", "recruiting"], "draft")).toEqual([
+    expect(completePhase(["rollover", "bowl_season"], "draft")).toEqual([
       "rollover",
       "draft",
     ]);
@@ -136,6 +147,21 @@ describe("buildPhaseSteps", () => {
     expect(byId.draft).toBe("optional");
     expect(byId.free_agency).toBe("complete");
     expect(byId.activate).toBe("active");
+  });
+
+  it("shows a skipped recruiting phase as optional, not as missing (B3)", () => {
+    /*
+     * A league that signed nobody must be able to leave the phase, and the
+     * stepper has to say so. Rendering it as `upcoming` behind the current
+     * phase would read as "you still have to do this" for something already
+     * passed.
+     */
+    const steps = buildPhaseSteps({
+      phase: "draft",
+      completedPhases: ["rollover"],
+    });
+    const byId = Object.fromEntries(steps.map((s) => [s.id, s.state]));
+    expect(byId.recruiting).toBe("optional");
   });
 
   it("labels every phase in the machine exactly once", () => {
@@ -163,7 +189,7 @@ describe("resolveOffseasonState", () => {
     // A row written by a future version must not put the stepper into a state
     // with no active phase.
     const state = resolveOffseasonState(
-      { phase: "recruiting", completedPhases: ["rollover"] },
+      { phase: "bowl_season", completedPhases: ["rollover"] },
       { draftStatus: "none" },
     );
     expect(state.phase).toBe(INITIAL_OFFSEASON_PHASE);
@@ -172,7 +198,7 @@ describe("resolveOffseasonState", () => {
   it("filters unknown names out of the completed set", () => {
     const state = resolveOffseasonState({
       phase: "free_agency",
-      completedPhases: ["rollover", "recruiting"],
+      completedPhases: ["rollover", "bowl_season"],
     });
     expect(state.completedPhases).toEqual(["rollover"]);
   });

--- a/apps/web/src/lib/dynasty/__tests__/prospects.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/prospects.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateProspectClass,
+  prospectClassSize,
+} from "@/lib/dynasty/prospects";
+import { OVERALL_MAX, OVERALL_MIN } from "@/lib/dynasty/scouting";
+
+describe("generateProspectClass", () => {
+  it("is deterministic per season, so a retried rollover rebuilds one class", () => {
+    /*
+     * The rollover stage can be retried after a lost response. If generation
+     * drifted, the persistence guard would see an existing class and keep the
+     * first one — but only by luck of ordering. Determinism is what makes the
+     * retry genuinely a no-op rather than a race that usually goes the right
+     * way.
+     */
+    const first = generateProspectClass({ seasonId: "season_x", count: 24 });
+    const second = generateProspectClass({ seasonId: "season_x", count: 24 });
+    expect(second).toEqual(first);
+  });
+
+  it("gives different seasons different classes", () => {
+    const a = generateProspectClass({ seasonId: "season_a", count: 12 });
+    const b = generateProspectClass({ seasonId: "season_b", count: 12 });
+    expect(b.map((p) => p.name)).not.toEqual(a.map((p) => p.name));
+  });
+
+  it("never reuses a name already in the league", () => {
+    // A prospect who shares a name with a rostered player makes every roster
+    // view ambiguous the moment he signs.
+    const existing = generateProspectClass({
+      seasonId: "season_names",
+      count: 20,
+    }).map((p) => p.name);
+    const next = generateProspectClass({
+      seasonId: "season_names_2",
+      count: 20,
+      excludeNames: existing,
+    });
+    for (const prospect of next) {
+      expect(existing).not.toContain(prospect.name);
+    }
+  });
+
+  it("keeps every rating on the scale", () => {
+    const board = generateProspectClass({ seasonId: "season_y", count: 60 });
+    for (const prospect of board) {
+      expect(prospect.trueOverall).toBeGreaterThanOrEqual(OVERALL_MIN);
+      expect(prospect.trueOverall).toBeLessThanOrEqual(OVERALL_MAX);
+      for (const value of Object.values(prospect.trueAttributes)) {
+        expect(value).toBeGreaterThanOrEqual(OVERALL_MIN);
+        expect(value).toBeLessThanOrEqual(OVERALL_MAX);
+        expect(Number.isInteger(value)).toBe(true);
+      }
+    }
+  });
+
+  it("produces a class with a real top and a real bottom", () => {
+    /*
+     * A board where everyone lands mid-pack gives scouting nothing to find.
+     * The spread is the reason a coach would spend points at all, so it is
+     * asserted rather than left to the generator's mood.
+     */
+    const board = generateProspectClass({ seasonId: "season_z", count: 72 });
+    const overalls = board.map((p) => p.trueOverall);
+    const spread = Math.max(...overalls) - Math.min(...overalls);
+    expect(spread).toBeGreaterThan(20);
+  });
+
+  it("draws potential independently of current rating", () => {
+    /*
+     * The risk model. If potential tracked current rating, scouting to level 3
+     * would tell you who develops, and there would be no such thing as a bust.
+     * Asserted as "the best names are not all stars and the worst are not all
+     * busts" rather than as a correlation coefficient, which is the claim that
+     * actually matters at the table.
+     */
+    const board = generateProspectClass({ seasonId: "season_tiers", count: 96 });
+    const sorted = [...board].sort((a, b) => b.trueOverall - a.trueOverall);
+    const topTiers = new Set(sorted.slice(0, 24).map((p) => p.potentialTier));
+    const bottomTiers = new Set(sorted.slice(-24).map((p) => p.potentialTier));
+    expect(topTiers.size).toBeGreaterThan(1);
+    expect(bottomTiers.size).toBeGreaterThan(1);
+    expect(topTiers).toContain("bust");
+  });
+
+  it("gives every prospect an archetype and a ninth-grade shape", () => {
+    const board = generateProspectClass({ seasonId: "season_w", count: 30 });
+    for (const prospect of board) {
+      expect(prospect.archetype.length).toBeGreaterThan(0);
+      expect(prospect.position.length).toBeGreaterThan(0);
+      expect(prospect.positionGroup.length).toBeGreaterThan(0);
+    }
+    // More than one position, or a class is a wall of quarterbacks.
+    expect(new Set(board.map((p) => p.position)).size).toBeGreaterThan(3);
+  });
+
+  it("returns nothing for an empty class rather than throwing", () => {
+    expect(generateProspectClass({ seasonId: "s", count: 0 })).toEqual([]);
+    expect(generateProspectClass({ seasonId: "s", count: -5 })).toEqual([]);
+  });
+
+  it("generates past the roster generator's per-call cap", () => {
+    // The name generator caps at 99 per call because it also hands out unique
+    // jerseys. A 16-team league's class is larger than that.
+    const board = generateProspectClass({ seasonId: "season_big", count: 150 });
+    expect(board).toHaveLength(150);
+    expect(new Set(board.map((p) => p.name)).size).toBe(150);
+  });
+});
+
+describe("prospectClassSize", () => {
+  it("scales with the league so recruiting stays contested", () => {
+    expect(prospectClassSize(12)).toBe(72);
+    expect(prospectClassSize(4)).toBe(24);
+  });
+
+  it("is zero for a league with no teams", () => {
+    expect(prospectClassSize(0)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/dynasty/__tests__/scouting.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/scouting.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_SCOUT_LEVEL,
+  OVERALL_MAX,
+  OVERALL_MIN,
+  SCOUT_BAND_WIDTH,
+  applyScoutingNoise,
+  clampScoutLevel,
+  nextScoutCost,
+  scoutingBand,
+  scoutingBands,
+} from "@/lib/dynasty/scouting";
+
+/*
+ * The invariants a recruiting board stands on (B3).
+ *
+ * These are property tests over a wide sweep of prospects and ratings rather
+ * than a handful of fixtures, because the failures they guard against live at
+ * the edges — a prospect at 99, a prospect at 40, a band that clamps against a
+ * rail — and a fixed example would sail straight past them.
+ */
+
+const IDS = Array.from({ length: 60 }, (_, i) => `prospect_${i}`);
+const OVERALLS = [40, 41, 47, 55, 63, 70, 78, 86, 94, 98, 99];
+
+describe("scoutingBands", () => {
+  it("nests every level inside the one below it", () => {
+    /*
+     * The invariant that makes scouting feel honest. If band 3 could sit
+     * outside band 2, spending a point would move the range AWAY from where it
+     * was, and a coach would reasonably conclude the game was lying.
+     *
+     * "Strictly inside" is expressed as containment plus strict narrowing
+     * rather than strict inequality on both edges: a band clamped against 40 or
+     * 99 shares that edge with the wider band around it, and demanding a gap
+     * there would make the rails unreachable.
+     */
+    for (const id of IDS) {
+      for (const overall of OVERALLS) {
+        const bands = scoutingBands(id, overall);
+        for (let level = 1; level <= MAX_SCOUT_LEVEL; level++) {
+          const tight = bands[level];
+          const wide = bands[level - 1];
+          expect(tight.projectedLow).toBeGreaterThanOrEqual(wide.projectedLow);
+          expect(tight.projectedHigh).toBeLessThanOrEqual(wide.projectedHigh);
+          expect(tight.projectedHigh - tight.projectedLow).toBeLessThan(
+            wide.projectedHigh - wide.projectedLow,
+          );
+        }
+      }
+    }
+  });
+
+  it("never collapses to a single number, even at the top level", () => {
+    // A zero-width band at level 3 would be an exact rating, and recruiting
+    // would stop being a judgment call the moment anyone spent the points.
+    for (const id of IDS) {
+      for (const overall of OVERALLS) {
+        const band = scoutingBands(id, overall)[MAX_SCOUT_LEVEL];
+        expect(band.projectedHigh - band.projectedLow).toBe(
+          SCOUT_BAND_WIDTH[MAX_SCOUT_LEVEL],
+        );
+        expect(band.projectedHigh - band.projectedLow).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("always contains the true overall", () => {
+    /*
+     * The band is imprecise, never wrong. Bust risk lives in `potentialTier`,
+     * which no scout level reveals — a range that could exclude the truth would
+     * make an unlucky read indistinguishable from a bug.
+     */
+    for (const id of IDS) {
+      for (const overall of OVERALLS) {
+        for (const band of scoutingBands(id, overall)) {
+          expect(overall).toBeGreaterThanOrEqual(band.projectedLow);
+          expect(overall).toBeLessThanOrEqual(band.projectedHigh);
+        }
+      }
+    }
+  });
+
+  it("stays on the ratings scale at both rails", () => {
+    for (const id of IDS) {
+      for (const overall of [OVERALL_MIN, OVERALL_MAX]) {
+        for (const band of scoutingBands(id, overall)) {
+          expect(band.projectedLow).toBeGreaterThanOrEqual(OVERALL_MIN);
+          expect(band.projectedHigh).toBeLessThanOrEqual(OVERALL_MAX);
+        }
+      }
+    }
+  });
+
+  it("gives different prospects different bands at the same rating", () => {
+    // A shared stream would make the whole board move together, so scouting
+    // one prospect would tell you about every other one at his rating.
+    const bands = IDS.map((id) => scoutingBands(id, 70)[0].projectedLow);
+    expect(new Set(bands).size).toBeGreaterThan(1);
+  });
+});
+
+describe("applyScoutingNoise", () => {
+  const trueAttributes = { SPD: 82, STR: 61, AWR: 74, ACC: 88, AGI: 55 };
+
+  it("is deterministic per (prospectId, scoutLevel)", () => {
+    // Re-reading a prospect must never reshuffle his range. A board that moved
+    // on refresh would make the numbers unusable for comparison.
+    for (let level = 0; level <= MAX_SCOUT_LEVEL; level++) {
+      const first = applyScoutingNoise({
+        prospectId: "prospect_7",
+        scoutLevel: level,
+        trueOverall: 72,
+        trueAttributes,
+      });
+      const second = applyScoutingNoise({
+        prospectId: "prospect_7",
+        scoutLevel: level,
+        trueOverall: 72,
+        trueAttributes,
+      });
+      expect(second).toEqual(first);
+    }
+  });
+
+  it("reports the band the same function would compute directly", () => {
+    for (let level = 0; level <= MAX_SCOUT_LEVEL; level++) {
+      const report = applyScoutingNoise({
+        prospectId: "prospect_11",
+        scoutLevel: level,
+        trueOverall: 64,
+        trueAttributes,
+      });
+      const band = scoutingBand("prospect_11", 64, level);
+      expect(report.projectedLow).toBe(band.projectedLow);
+      expect(report.projectedHigh).toBe(band.projectedHigh);
+    }
+  });
+
+  it("blurs every attribute and keeps them on the scale", () => {
+    const report = applyScoutingNoise({
+      prospectId: "prospect_3",
+      scoutLevel: 0,
+      trueOverall: 70,
+      trueAttributes,
+    });
+    expect(Object.keys(report.scoutedAttributes).sort()).toEqual(
+      Object.keys(trueAttributes).sort(),
+    );
+    for (const value of Object.values(report.scoutedAttributes)) {
+      expect(value).toBeGreaterThanOrEqual(OVERALL_MIN);
+      expect(value).toBeLessThanOrEqual(OVERALL_MAX);
+      expect(Number.isInteger(value)).toBe(true);
+    }
+  });
+
+  it("blurs attributes less at higher levels, on average", () => {
+    /*
+     * Asserted as an aggregate over the whole board rather than per prospect:
+     * a single prospect can draw a small offset at level 0 by luck, and a test
+     * that demanded otherwise would be flaky by construction.
+     */
+    const meanError = (level: number) => {
+      let total = 0;
+      let count = 0;
+      for (const id of IDS) {
+        const report = applyScoutingNoise({
+          prospectId: id,
+          scoutLevel: level,
+          trueOverall: 70,
+          trueAttributes,
+        });
+        for (const [key, value] of Object.entries(report.scoutedAttributes)) {
+          total += Math.abs(value - trueAttributes[key as keyof typeof trueAttributes]);
+          count += 1;
+        }
+      }
+      return total / count;
+    };
+    expect(meanError(3)).toBeLessThan(meanError(0));
+  });
+
+  it("clamps a level outside the scale rather than throwing", () => {
+    // Storage is a plain number, so a row from a future version with level 9
+    // has to render as something rather than take the board down.
+    expect(clampScoutLevel(9)).toBe(MAX_SCOUT_LEVEL);
+    expect(clampScoutLevel(-4)).toBe(0);
+    expect(clampScoutLevel(Number.NaN)).toBe(0);
+    expect(
+      applyScoutingNoise({
+        prospectId: "prospect_1",
+        scoutLevel: 99,
+        trueOverall: 70,
+        trueAttributes,
+      }).scoutLevel,
+    ).toBe(MAX_SCOUT_LEVEL);
+  });
+});
+
+describe("nextScoutCost", () => {
+  it("rises with each level, so a budget cannot buy certainty everywhere", () => {
+    const costs = [0, 1, 2].map((level) => nextScoutCost(level));
+    expect(costs.every((c) => c !== null)).toBe(true);
+    expect(costs[1]!).toBeGreaterThan(costs[0]!);
+    expect(costs[2]!).toBeGreaterThan(costs[1]!);
+  });
+
+  it("returns null once a prospect is fully scouted", () => {
+    expect(nextScoutCost(MAX_SCOUT_LEVEL)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/dynasty/prospects.ts
+++ b/apps/web/src/lib/dynasty/prospects.ts
@@ -1,0 +1,212 @@
+/*
+ * Incoming freshman class generation (Dynasty Mode B3).
+ *
+ * Builds the pool of prospects a league recruits from. Runs in the Next layer
+ * rather than inside Convex — same division of labour as the freshmen rollover
+ * stage, which generates in the action and persists through a mutation — because
+ * the name, jersey and attribute generators it reuses live under `src/`.
+ * Duplicating them into `convex/` to move 40 lines of generation across the
+ * boundary would be a worse trade than passing rows.
+ *
+ * ## What a prospect is, and what it is not
+ *
+ * A prospect is NOT a replacement for the rollover's roster backfill. That
+ * backfill still tops every team up to `targetRosterSize`, so a league that
+ * ignores recruiting entirely keeps playable rosters — a phase nobody enters
+ * must not be able to produce a broken season. Prospects are the talent ON TOP
+ * of that: a shared, contested pool where the backfill is walk-ons.
+ *
+ * ## Two independent rolls
+ *
+ * `trueOverall` is who a prospect is now. `potentialTier` is who he becomes, and
+ * it is drawn from a SEPARATE stream so it does not correlate with current
+ * rating. That independence is the whole risk model: the best player on the
+ * board can be a bust and the last name on it can be a star, so scouting buys
+ * precision about the present and never certainty about the future.
+ */
+import {
+  generateSyntheticAttributes,
+  type SyntheticAttributes,
+} from "@/lib/synthetic-attributes";
+import { generateSyntheticRoster } from "@/lib/synthetic-roster";
+import { rngFor, seedFor } from "@/lib/rng";
+import {
+  OVERALL_MAX,
+  OVERALL_MIN,
+  type PotentialTier,
+} from "@/lib/dynasty/scouting";
+
+/**
+ * Scouting-visible flavour text. Deliberately NOT hidden: an archetype is the
+ * kind of player a coach can see at a glance from film, and hiding it would
+ * make an unscouted board a wall of identical rows.
+ */
+const ARCHETYPES: Readonly<Record<string, readonly string[]>> = {
+  QB: ["Pocket Passer", "Dual Threat", "Field General"],
+  RB: ["Power Back", "Elusive Back", "Receiving Back"],
+  WR: ["Deep Threat", "Possession", "Slot Technician"],
+  TE: ["Blocking Y", "Vertical Seam", "Move Tight End"],
+  OL: ["Road Grader", "Pass Protector", "Athletic Zone"],
+  DL: ["Edge Rusher", "Run Stuffer", "Interior Penetrator"],
+  LB: ["Thumper", "Coverage Backer", "Blitzer"],
+  DB: ["Man Corner", "Zone Corner", "Ballhawk Safety"],
+  K: ["Big Leg", "Accurate"],
+  P: ["Big Leg", "Directional"],
+};
+
+const DEFAULT_ARCHETYPES: readonly string[] = ["Athlete"];
+
+/**
+ * Tier weights. Most of a class is what it looks like; the tails are why you
+ * care. A quarter bust and a tenth star is enough spread that a good class and
+ * a bad one are distinguishable four years later without making every signing
+ * a coin flip.
+ */
+const TIER_WEIGHTS: ReadonlyArray<{ tier: PotentialTier; weight: number }> = [
+  { tier: "bust", weight: 25 },
+  { tier: "steady", weight: 40 },
+  { tier: "riser", weight: 25 },
+  { tier: "star", weight: 10 },
+];
+
+function pickTier(roll: number): PotentialTier {
+  const total = TIER_WEIGHTS.reduce((sum, t) => sum + t.weight, 0);
+  let cursor = roll * total;
+  for (const entry of TIER_WEIGHTS) {
+    cursor -= entry.weight;
+    if (cursor < 0) return entry.tier;
+  }
+  return "steady";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export interface GeneratedProspect {
+  name: string;
+  position: string;
+  positionGroup: string;
+  archetype: string;
+  hometown: string | null;
+  /** Hidden. Never leaves the server unblurred — see `applyScoutingNoise`. */
+  trueAttributes: Record<string, number>;
+  /** Hidden. The number the projected band is built around. */
+  trueOverall: number;
+  /** Hidden at every scout level, including 3. */
+  potentialTier: PotentialTier;
+}
+
+export interface GenerateProspectClassInput {
+  /** Stable key for the class — the target season the prospects sign into. */
+  seasonId: string;
+  count: number;
+  /** Names already in the league, so a prospect never shares one. */
+  excludeNames?: string[];
+}
+
+/**
+ * A deterministic recruiting class for one season.
+ *
+ * Seeded from the season alone, so re-running a rollover that lost its response
+ * produces the SAME class rather than a second one — the persistence layer's
+ * idempotence guard and this seed have to agree or a retry doubles the board.
+ */
+export function generateProspectClass(
+  input: GenerateProspectClassInput,
+): GeneratedProspect[] {
+  const count = Math.max(0, Math.floor(input.count));
+  if (count === 0) return [];
+
+  /*
+   * Reused for names, positions and hometowns only. The roster generator caps
+   * at 99 per call because it also hands out unique jerseys; prospects have no
+   * jersey until they sign, so a class larger than that is generated in chunks
+   * with a per-chunk seed.
+   */
+  const CHUNK = 90;
+  const base: Array<{
+    name: string;
+    position: string;
+    hometown: string | null;
+  }> = [];
+  const used = new Set<string>(input.excludeNames ?? []);
+  for (let offset = 0; offset < count; offset += CHUNK) {
+    const chunk = generateSyntheticRoster({
+      count: Math.min(CHUNK, count - offset),
+      grade: 9,
+      excludeNames: Array.from(used),
+      seed: seedFor("prospects", input.seasonId, String(offset)),
+    });
+    for (const row of chunk) {
+      used.add(row.name);
+      base.push({
+        name: row.name,
+        position: row.position,
+        hometown: row.hometown ?? null,
+      });
+    }
+  }
+
+  return base.map((row, index) => {
+    const prospectKey = `${input.seasonId}:${index}`;
+    const attributes: SyntheticAttributes = generateSyntheticAttributes({
+      position: row.position,
+      seed: seedFor("prospects", prospectKey, "attributes"),
+    });
+
+    /*
+     * Widen the class past what the roster generator produces on its own
+     * (a 58–90 base). A recruiting board where every name lands mid-pack gives
+     * scouting nothing to find; the tilt pushes the tails out to roughly
+     * 45–95 so the top of the board is genuinely worth the points.
+     */
+    const shape = rngFor("prospects", prospectKey, "shape");
+    const tilt = Math.round((shape() - 0.55) * 18);
+    const trueAttributes: Record<string, number> = {};
+    for (const [key, value] of Object.entries(attributes.attributes)) {
+      trueAttributes[key] = Math.round(
+        clamp(value + tilt, OVERALL_MIN, OVERALL_MAX),
+      );
+    }
+    const values = Object.values(trueAttributes);
+    const trueOverall = values.length
+      ? Math.round(
+          clamp(
+            values.reduce((sum, n) => sum + n, 0) / values.length,
+            OVERALL_MIN,
+            OVERALL_MAX,
+          ),
+        )
+      : OVERALL_MIN;
+
+    // Separate stream from `shape` — see the two-independent-rolls note above.
+    const potentialTier = pickTier(rngFor("prospects", prospectKey, "tier")());
+
+    const pool = ARCHETYPES[attributes.positionGroup] ?? DEFAULT_ARCHETYPES;
+    const archetype =
+      pool[Math.floor(shape() * pool.length)] ?? pool[0] ?? "Athlete";
+
+    return {
+      name: row.name,
+      position: row.position,
+      positionGroup: attributes.positionGroup,
+      archetype,
+      hometown: row.hometown,
+      trueAttributes,
+      trueOverall,
+      potentialTier,
+    };
+  });
+}
+
+/**
+ * How many prospects a league's class holds.
+ *
+ * Scaled by team count so recruiting is contested at any league size: more
+ * names than any one program can sign, fewer than every program signing its
+ * fill. `perTeam` above the per-team cap would make the board a formality.
+ */
+export function prospectClassSize(teamCount: number, perTeam = 6): number {
+  return Math.max(0, Math.floor(teamCount) * Math.max(0, Math.floor(perTeam)));
+}

--- a/apps/web/src/lib/dynasty/scouting.ts
+++ b/apps/web/src/lib/dynasty/scouting.ts
@@ -1,0 +1,34 @@
+/*
+ * Recruit scouting (B3) — Next-layer entry point.
+ *
+ * The definition lives in `convex/lib/scouting.ts` because the Convex bundler
+ * can only reach files under `convex/`, while `src/` can reach both. Same
+ * arrangement as `src/lib/dynasty/offseason-phases.ts` and for a sharper reason:
+ * `applyScoutingNoise` runs in the mutation that persists a scout AND in the
+ * panel that renders one. Two implementations that drifted would show a coach a
+ * range the server does not believe.
+ *
+ * This is a re-export, NOT a copy.
+ */
+export {
+  MAX_SCOUT_LEVEL,
+  MIN_SCOUT_LEVEL,
+  OVERALL_MAX,
+  OVERALL_MIN,
+  POTENTIAL_TIERS,
+  SCOUT_BAND_WIDTH,
+  SCOUT_LEVEL_COST,
+  applyScoutingNoise,
+  clampScoutLevel,
+  isPotentialTier,
+  nextScoutCost,
+  scoutingBand,
+  scoutingBands,
+} from "../../../convex/lib/scouting";
+
+export type {
+  ApplyScoutingNoiseInput,
+  PotentialTier,
+  ScoutingBand,
+  ScoutingReport,
+} from "../../../convex/lib/scouting";

--- a/apps/web/src/lib/process-stages.ts
+++ b/apps/web/src/lib/process-stages.ts
@@ -202,6 +202,15 @@ export function dynastyRolloverProcessStages(
         ? "No lingering injuries"
         : `${players(healedInjuries)} cleared`;
 
+  /* Same optional read, same reason — see the note above (B3). */
+  const prospectCount = withSummary?.recruiting?.prospects;
+  const prospectDetail =
+    prospectCount === undefined
+      ? undefined
+      : prospectCount === 0
+        ? "No recruiting class"
+        : `${prospectCount} prospect${prospectCount === 1 ? "" : "s"}`;
+
   return [
     stage("rollover", "Start next season", outcome, rolloverDetail),
     terminalStage("graduate", "Graduate seniors", terminalOutcome, graduateDetail),
@@ -229,6 +238,12 @@ export function dynastyRolloverProcessStages(
       "Heal lingering injuries",
       terminalOutcome,
       healingDetail,
+    ),
+    terminalStage(
+      "prospects",
+      "Build recruiting class",
+      terminalOutcome,
+      prospectDetail,
     ),
   ];
 }

--- a/apps/web/src/lib/rng.ts
+++ b/apps/web/src/lib/rng.ts
@@ -1,91 +1,24 @@
 /*
- * Shared deterministic RNG for every seeded system in the app (Dynasty Mode F1).
+ * Shared deterministic RNG — Next-layer entry point (Dynasty Mode F1, moved B3).
  *
- * Before this module, `mulberry32` lived in `simulate-game.ts` (a legacy
- * score simulator) and `seedFromString` in `synthetic-roster.ts` (a test-data
- * generator) — so the play-by-play engine, dynasty progression and the fixture
- * simulator all reached into feature modules for their randomness. Both
- * functions now live here; the original modules re-export them, so no existing
- * import breaks.
+ * The implementation lives in `convex/lib/rng.ts` because the Convex bundler can
+ * only reach files under `convex/`, while `src/` can reach both. Scouting (B3)
+ * is the first system that needs the same stream on both sides of the boundary:
+ * `applyScoutingNoise` runs in the mutation that persists a scout AND in the
+ * component that renders one, and those two must agree exactly.
  *
- * ## Why this matters
+ * This is a re-export, NOT a copy. Same arrangement as `src/lib/dynasty-config.ts`
+ * and `src/lib/dynasty/offseason-phases.ts`, and for the same reason.
  *
- * "Same league, same actions => same dynasty" is only true if every seeded
- * system derives its seed the same way and never collides with another system.
- * Two subsystems that hash the same entity id produce the SAME stream — e.g.
- * seeding both a player's progression and his scouting noise from a bare
- * `playerId` would correlate them, so a player who develops well would always
- * also scout well. The namespace convention below prevents that.
- *
- * ## Seed namespace convention
- *
- * Build every seed with `seedFor(domain, ...parts)`:
- *
- *   seedFor("pbp", fixtureId)                    // play-by-play engine
- *   seedFor("progression", playerId, seasonId)   // offseason development
- *   seedFor("scouting", prospectId, String(lvl)) // recruit scouting noise
- *   seedFor("transfer", playerId, seasonId)      // transfer likelihood
- *   seedFor("weather", seasonId, String(week))   // game conditions
- *
- * Rules:
- * - The domain is always first and unique per subsystem.
- * - Include every id the result should vary by, and nothing else. Adding a part
- *   changes the stream, so adding one to an existing domain reshuffles history.
- * - Never seed from wall-clock time or `Math.random()` — that breaks replay,
- *   golden-log parity tests, and re-simulation.
+ * Import from here in Next code; import from `convex/lib/rng` inside Convex
+ * functions. The seed-namespace convention every caller must follow is
+ * documented on the implementation.
  */
+export {
+  mulberry32,
+  rngFor,
+  seedFor,
+  seedFromString,
+} from "../../convex/lib/rng";
 
-/** Domains registered with the seed-namespace convention. */
-export type SeedDomain =
-  | "pbp"
-  | "progression"
-  | "scouting"
-  | "prospects"
-  | "transfer"
-  | "training"
-  | "weather"
-  | "injury"
-  | "penalty"
-  | "goals"
-  | "roster";
-
-/**
- * FNV-1a over the string, returned as an unsigned 32-bit int. Stable across
- * runs and platforms — the same string always yields the same seed.
- */
-export function seedFromString(s: string): number {
-  let h = 2166136261;
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return h >>> 0;
-}
-
-/**
- * Namespaced seed. Prefer this over calling `seedFromString` directly so two
- * subsystems keyed on the same entity never share a stream.
- */
-export function seedFor(domain: SeedDomain, ...parts: string[]): number {
-  return seedFromString([domain, ...parts].join(":"));
-}
-
-/**
- * mulberry32 — small, fast, deterministic PRNG. Returns a generator producing
- * numbers in [0, 1). Identical seed => identical sequence.
- */
-export function mulberry32(seed: number): () => number {
-  let a = seed >>> 0;
-  return () => {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-/** Convenience: a generator seeded straight from a namespaced key. */
-export function rngFor(domain: SeedDomain, ...parts: string[]): () => number {
-  return mulberry32(seedFor(domain, ...parts));
-}
+export type { SeedDomain } from "../../convex/lib/rng";

--- a/apps/web/src/lib/rollover-summary.ts
+++ b/apps/web/src/lib/rollover-summary.ts
@@ -18,7 +18,18 @@ export interface RolloverOperationSummary {
     removedAssignments: number;
     removedDepthEntries: number;
   };
-  recruiting: { freshmen: number; toPool: boolean };
+  recruiting: {
+    /** Walk-ons the backfill added to top rosters up to the target size. */
+    freshmen: number;
+    toPool: boolean;
+    /**
+     * Prospects on the recruiting board (B3) — a separate count from
+     * `freshmen` because they are separate populations. The backfill guarantees
+     * a playable roster; the class is the talent a coach competes for on top of
+     * it. Adding them together would hide a league that recruited nothing.
+     */
+    prospects: number;
+  };
   /**
    * Injuries closed out by the `injuries_healed` stage (B2). Zero is a real
    * answer — a season nobody got hurt in — and is why this is not optional.


### PR DESCRIPTION
Closes #621.

Adds a recruiting class each offseason: a shared, contested board of ninth-graders whose ratings a coach can only see as a **range**, narrowing — but never closing — as scouting points are spent.

## The scope call worth reviewing

The issue's Context paragraph says this slice "replaces" the blind freshman generation. **It doesn't — the class is additive, and that is deliberate.** `freshmen_created` still tops every roster up to `targetRosterSize`, so a league that never opens the recruiting phase keeps playable seasons. A phase nobody visits must not be able to produce a broken league.

That reframing also makes the model coherent: the backfill is **walk-ons**, the class is **recruits**. A program that recruits well displaces walk-ons with better players; one that ignores recruiting fields a full roster of nobodies. Every acceptance criterion still lands.

## Two invariants carry the whole mechanic

**The band always contains the truth.** It is imprecise, never wrong. A range that could exclude the real rating would make an unlucky read indistinguishable from a bug. Bust risk lives instead in `potentialTier`, hidden at *every* level including 3 — so a coach can know almost exactly what a player is today and still be wrong about who he becomes.

**Bands nest by construction.** The obvious implementation draws an independent range per level, and then level 3 can sit *outside* level 2 — spending a point moves the range away from where it was, which reads as the game lying. `scoutingBands` builds the tightest band first and widens outward from one stream, so `band(3) ⊆ band(2) ⊆ band(1) ⊆ band(0)` holds structurally. Sliding (not squashing) at the 40/99 rails preserves both the width and the nesting; a prospect at 99 can't end up with a zero-width band handed out by an edge case.

Level 3 leaves a **six-point window**. Recruiting is a judgment call or it is a spreadsheet.

## Hiding the truth, twice

`trueAttributesJson` / `trueOverall` / `potentialTier` are absent from `prospectValidator` and from `ProspectDto`. Asserted from two directions: a runtime check that the query never returns them, and a source read that fails if any of the three names is ever *added* to the validator — the change that would silently make the runtime test pass while leaking everything.

## Also in this PR

- **`recruiting` phase** inserted ahead of `draft` (the migration-free insert B1's header describes), and **`prospects_generated`** appended to the rollover stage machine on both sides of the Convex boundary. The cross-boundary drift guard covers it.
- **Per-`teamId` authorization** on scouting and signing, never a bare org-admin check. This is the roadmap's one non-negotiable multiplayer detail; a coach of team A gets `not_authorized` for team B, before the mutation runs.
- **`convex/lib/rng.ts` is now canonical**, with `src/lib/rng.ts` re-exporting it. Scouting is the first system needing the same stream on both sides, and two copies of a PRNG is exactly the drift that arrangement exists to prevent. Streams are byte-identical; no import site changed.
- `resetCanonicalFixture` clears `recruitProspects` (risk 5).
- **Prospect** added to `CONTEXT.md` (risk 7).
- `parseRolloverSummary` now **merges** `recruiting` instead of substituting it — taking a pre-B3 object wholesale would hand the renderer a missing `prospects` field, the exact crash B2 caused with `healing`.

## Verification

- `vitest run` — **207 files, 1638 tests passed** (59 net-new)
- `pnpm turbo type-check` — 5/5 (the real CI gate; vitest does not run in CI)
- `pnpm --filter @sports-management/web lint` — clean
- New Playwright spec `recruiting.spec.ts`; `offseason-phases.spec.ts` updated for the inserted phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4K9xVJisz7DNZDiGbGCB2