### PR TITLE
feat: transfers in and out during the offseason (#622)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,8 +81,12 @@ The single Season currently in progress for a League and the primary seasonal de
 _Avoid_: Viewed season, selected year
 
 **Offseason Hub**:
-The phase-machine surface for one upcoming Season at `/dashboard/seasons/[seasonId]/offseason`, where an administrator moves the league through Rollover, Recruiting, Draft, Free agency and Activate.
+The phase-machine surface for one upcoming Season at `/dashboard/seasons/[seasonId]/offseason`, where an administrator moves the league through Rollover, Recruiting, Transfers, Draft, Free agency and Activate.
 _Avoid_: Offseason page, preseason, transfer window
+
+**Transfer Window**:
+The Offseason Hub list of players who have asked to leave a Team and the offers other Teams have made for them, for one upcoming Season. A Transfer moves a player between Teams in the same League; nobody arrives from outside it.
+_Avoid_: Portal, trade, free agency, waiver
 
 **Prospect**:
 An incoming ninth-grader on the Recruiting class for one upcoming Season, shown as a projected range rather than a rating until a Team signs him. Scouting narrows the range and never removes it.
@@ -116,6 +120,8 @@ _Avoid_: Playbook, formation, strategy, system
 - A Team has at most one **Scheme** per Season, set from **Team Home** because a Scheme changes only that Team's own games
 - An upcoming **Season** has at most one recruiting class, and every **Prospect** in it belongs to exactly one Team once signed
 - A **Prospect** is scouted and signed from the **Offseason Hub**, because the class is shared by the whole League rather than owned by one Team
+- A **Transfer Window** entry needs two decisions: the Team losing the player releases or keeps him, and a Team offering a spot signs or passes
+- A **Transfer** never changes the number of players in a League, only which Team each belongs to
 - **Account Settings** contains cross-league **Import** and **Account Billing**
 - A successful **Import** may set the imported League as the **Active League** and offer navigation to its **League Home**
 - The **League Directory** provides access to **Discover**

--- a/apps/web/convex/__tests__/offseasonPhases.test.ts
+++ b/apps/web/convex/__tests__/offseasonPhases.test.ts
@@ -3,7 +3,12 @@ import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
-import { OFFSEASON_PHASES, phaseGate } from "../lib/offseasonPhases";
+import {
+  INITIAL_OFFSEASON_PHASE,
+  OFFSEASON_PHASES,
+  nextPhase,
+  phaseGate,
+} from "../lib/offseasonPhases";
 import {
   OFFSEASON_PHASES as NEXT_PHASES,
   phaseGate as nextPhaseGate,
@@ -146,19 +151,36 @@ describe("advanceOffseasonPhase", () => {
   ) =>
     t.mutation(internal.dynasty.advanceOffseasonPhase, {
       seasonId,
-      // Defaults are the FIRST advance a fresh offseason can make. B3 inserted
-      // `recruiting` ahead of `draft`, so that is now recruiting → draft.
-      expectedPhase: args.expectedPhase ?? "recruiting",
-      to: args.to ?? "draft",
+      /*
+       * Defaults are the FIRST advance a fresh offseason can make, DERIVED
+       * from the machine rather than named. Slices keep inserting phases here
+       * (B3 added recruiting, B4 added transfers), and a hard-coded pair has
+       * to be edited every time — which is churn on a test that is not about
+       * which phases exist.
+       */
+      expectedPhase: args.expectedPhase ?? INITIAL_OFFSEASON_PHASE,
+      to: args.to ?? (nextPhase(INITIAL_OFFSEASON_PHASE) as string),
       ownerId: args.ownerId ?? "owner_a",
       actorUserId: ACTOR,
       draftStatus: args.draftStatus ?? "none",
     });
 
-  /** An offseason moved forward to the draft phase, for the draft-only gates. */
+  /**
+   * An offseason walked forward to the draft phase, for the draft-only gates.
+   *
+   * Walks the machine rather than hard-coding the hops, so inserting a phase
+   * ahead of `draft` (B3 added recruiting, B4 added transfers) does not need
+   * this helper edited again.
+   */
   async function atDraft() {
     const { t, seasonId } = await opened();
-    await advance(t, seasonId as never);
+    const target = OFFSEASON_PHASES.indexOf("draft");
+    for (let i = OFFSEASON_PHASES.indexOf(INITIAL_OFFSEASON_PHASE); i < target; i++) {
+      await advance(t, seasonId as never, {
+        expectedPhase: OFFSEASON_PHASES[i],
+        to: OFFSEASON_PHASES[i + 1],
+      });
+    }
     return { t, seasonId };
   }
 
@@ -166,7 +188,7 @@ describe("advanceOffseasonPhase", () => {
     const { t, seasonId } = await opened();
     const result = await advance(t, seasonId as never);
     expect(result.changed).toBe(true);
-    expect(result.offseason.phase).toBe("draft");
+    expect(result.offseason.phase).toBe("transfers");
     expect(result.offseason.completedPhases).toEqual([
       "rollover",
       "recruiting",
@@ -182,7 +204,7 @@ describe("advanceOffseasonPhase", () => {
     expect(second.offseason.completedPhases).toEqual(
       first.offseason.completedPhases,
     );
-    expect(second.offseason.phase).toBe("draft");
+    expect(second.offseason.phase).toBe("transfers");
   });
 
   it("rejects a backward request as phase_regression", async () => {
@@ -216,7 +238,7 @@ describe("advanceOffseasonPhase", () => {
     );
 
     const final = await t.query(api.dynasty.getOffseason, { seasonId });
-    expect(final?.phase).toBe("draft");
+    expect(final?.phase).toBe("transfers");
     expect(final?.completedPhases).toEqual(["rollover", "recruiting"]);
   });
 
@@ -240,7 +262,7 @@ describe("advanceOffseasonPhase", () => {
     const { t, seasonId } = await opened();
     const result = await advance(t, seasonId as never);
     expect(result.changed).toBe(true);
-    expect(result.offseason.phase).toBe("draft");
+    expect(result.offseason.phase).toBe("transfers");
   });
 
   it("reports an invalid request as invalid rather than as a conflict", async () => {
@@ -269,6 +291,7 @@ describe("advanceOffseasonPhase", () => {
     expect(final?.completedPhases).toEqual([
       "rollover",
       "recruiting",
+      "transfers",
       "draft",
       "free_agency",
     ]);

--- a/apps/web/convex/__tests__/transferEvents.test.ts
+++ b/apps/web/convex/__tests__/transferEvents.test.ts
@@ -1,0 +1,532 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { MAX_TARGET_ROSTER_SIZE } from "../lib/offseason";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_admin";
+
+/*
+ * A league built to guarantee a slate: four teams, and one team stacked deep
+ * with high-rated juniors so the seeded roll finds somebody. Relying on a
+ * realistic roster would make these tests depend on the RNG landing well.
+ */
+async function seedLeague(
+  t: ReturnType<typeof convexTest>,
+  opts: { depth?: number; overall?: number } = {},
+) {
+  const depth = opts.depth ?? 6;
+  const overall = opts.overall ?? 95;
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Transfer League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2027",
+      status: "upcoming",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+    const teamIds = [];
+    for (const name of ["North", "South", "East", "West"]) {
+      teamIds.push(
+        await ctx.db.insert("teams", {
+          leagueId,
+          name: `${name} HS`,
+          city: name,
+          stadium: `${name} Field`,
+          location: `${name}, GA`,
+          foundedYear: null,
+          divisionId: null,
+          rosterLimit: null,
+          logoUrl: null,
+        }),
+      );
+    }
+
+    // Stack the first team: one starter and `depth - 1` buried juniors.
+    const playerIds = [];
+    for (let i = 0; i < depth; i++) {
+      const playerId = await ctx.db.insert("players", {
+        name: `Buried ${i}`,
+        leagueId,
+        teamId: teamIds[0],
+        position: "WR",
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        experienceYears: null,
+        grade: 11,
+        squad: "Varsity",
+        hometown: null,
+        synthetic: true,
+      });
+      await ctx.db.insert("rosterAssignments", {
+        seasonId,
+        teamId: teamIds[0],
+        playerId,
+        leagueId,
+        depthRank: i + 1,
+        positionSlot: "WR",
+        status: "active",
+        assignedAt: new Date(0).toISOString(),
+        assignedBy: ACTOR,
+      });
+      await ctx.db.insert("playerAttributes", {
+        playerId,
+        seasonId,
+        positionGroup: "WR",
+        attributesJson: JSON.stringify({ SPD: overall }),
+        pffSourceJson: null,
+        maddenSourceJson: null,
+        pffWeight: 0,
+        maddenWeight: 0,
+        weightedOverall: overall,
+        ingestedAt: new Date(0).toISOString(),
+      });
+      playerIds.push(playerId);
+    }
+    return { leagueId, seasonId, teamIds, playerIds };
+  });
+}
+
+async function openWindow(
+  t: ReturnType<typeof convexTest>,
+  seasonId: never,
+) {
+  return t.mutation(internal.dynasty.generateTransferWindow, {
+    seasonId,
+    actorUserId: ACTOR,
+  });
+}
+
+describe("generateTransferWindow", () => {
+  it("puts buried players in the window with offers from other programs", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    const result = await openWindow(t, ids.seasonId as never);
+    expect(result.outbound).toBeGreaterThan(0);
+    expect(result.offers).toBeGreaterThan(0);
+
+    const rows = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    const out = rows.filter((r) => r.direction === "out");
+    const inn = rows.filter((r) => r.direction === "in");
+    expect(out.length).toBe(result.outbound);
+    expect(inn.length).toBe(result.offers);
+    // Conserved: every offer traces back to a real outbound player.
+    const outPlayers = new Set(out.map((r) => r.playerId));
+    expect(inn.every((r) => outPlayers.has(r.playerId))).toBe(true);
+    expect(inn.every((r) => r.toTeamId !== r.fromTeamId)).toBe(true);
+  });
+
+  it("does not open a second window on a retry", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    const first = await openWindow(t, ids.seasonId as never);
+    const retry = await openWindow(t, ids.seasonId as never);
+    expect(retry.alreadyExisted).toBe(true);
+    expect(retry.outbound).toBe(first.outbound);
+    const rows = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    expect(rows.filter((r) => r.direction === "out")).toHaveLength(
+      first.outbound,
+    );
+  });
+
+  it("generates nothing when transfers are switched off", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await t.mutation(internal.dynasty.setDynastyConfig, {
+      leagueId: ids.leagueId,
+      actorUserId: ACTOR,
+      patch: { transfersEnabled: false },
+    });
+    const result = await openWindow(t, ids.seasonId as never);
+    expect(result).toEqual({
+      outbound: 0,
+      offers: 0,
+      alreadyExisted: false,
+    });
+    expect(
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId }),
+    ).toEqual([]);
+  });
+
+  it("leaves graduated players out of the window", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await t.run(async (ctx) => {
+      for (const playerId of ids.playerIds) {
+        await ctx.db.patch(playerId, { status: "graduated" });
+      }
+    });
+    const result = await openWindow(t, ids.seasonId as never);
+    expect(result.outbound).toBe(0);
+  });
+});
+
+describe("resolveTransfer — the losing coach", () => {
+  async function windowed() {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const rows = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    return { t, ids, rows };
+  }
+
+  it("retains a player and withdraws every offer for him", async () => {
+    const { t, ids, rows } = await windowed();
+    const out = rows.find((r) => r.direction === "out")!;
+    const result = await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "reject",
+      actorUserId: ACTOR,
+    });
+    expect(result.status).toBe("rejected");
+    expect(result.withdrawn).toBeGreaterThan(0);
+
+    const after = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    const hisOffers = after.filter(
+      (r) => r.direction === "in" && r.playerId === out.playerId,
+    );
+    expect(hisOffers.every((r) => r.status === "withdrawn")).toBe(true);
+  });
+
+  it("releasing him changes nothing on any roster yet", async () => {
+    /*
+     * A release puts him on the market; it does not move him. Emitting an
+     * event or touching a roster here would announce a transfer that may never
+     * happen.
+     */
+    const { t, ids, rows } = await windowed();
+    const out = rows.find((r) => r.direction === "out")!;
+    const result = await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+    expect(result).toEqual({
+      status: "accepted",
+      moved: false,
+      withdrawn: 0,
+    });
+    await t.run(async (ctx) => {
+      const player = await ctx.db.get(out.playerId as never);
+      expect((player as { teamId: unknown }).teamId).toBe(ids.teamIds[0]);
+      const events = await ctx.db.query("dynastyEvents").collect();
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  it("refuses a decision from a team that does not own it", async () => {
+    // The per-team argument is the Wave 5 hook; this is what makes it real.
+    const { t, ids, rows } = await windowed();
+    const out = rows.find((r) => r.direction === "out")!;
+    await expect(
+      t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: out.id as never,
+        teamId: ids.teamIds[1],
+        decision: "reject",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/transfer_team_mismatch/);
+  });
+
+  it("refuses to resolve the same row twice", async () => {
+    const { t, ids, rows } = await windowed();
+    const out = rows.find((r) => r.direction === "out")!;
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "reject",
+      actorUserId: ACTOR,
+    });
+    await expect(
+      t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: out.id as never,
+        teamId: ids.teamIds[0],
+        decision: "accept",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/transfer_not_pending/);
+  });
+});
+
+describe("resolveTransfer — a destination coach", () => {
+  async function released() {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const rows = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    const out = rows.find((r) => r.direction === "out")!;
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+    const offers = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).filter((r) => r.direction === "in" && r.playerId === out.playerId);
+    return { t, ids, out, offers };
+  }
+
+  it("cannot sign a player his own coach has not released", async () => {
+    /*
+     * Two people, two decisions, and they can race. The check lives in the
+     * mutation rather than the UI because a destination coach's page may have
+     * rendered before the losing coach decided anything.
+     */
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const offer = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).find((r) => r.direction === "in")!;
+    await expect(
+      t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: offer.id as never,
+        teamId: offer.toTeamId as never,
+        decision: "accept",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/transfer_not_released/);
+  });
+
+  it("moves the player, his roster spot and his depth chart", async () => {
+    const { t, ids, out, offers } = await released();
+    const offer = offers[0];
+    const result = await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: offer.id as never,
+      teamId: offer.toTeamId as never,
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+    expect(result.moved).toBe(true);
+
+    await t.run(async (ctx) => {
+      const player = await ctx.db.get(out.playerId as never);
+      expect((player as { teamId: unknown }).teamId).toBe(offer.toTeamId);
+
+      const assignments = (
+        await ctx.db
+          .query("rosterAssignments")
+          .withIndex("by_playerId", (q) =>
+            q.eq("playerId", out.playerId as never),
+          )
+          .collect()
+      ).filter((row) => row.seasonId === ids.seasonId);
+      // Exactly one — the old spot is deleted, not left behind. A stale row
+      // would make him show up on two rosters at once.
+      expect(assignments).toHaveLength(1);
+      expect(assignments[0].teamId).toBe(offer.toTeamId);
+    });
+  });
+
+  it("withdraws the rival offers when one destination signs him", async () => {
+    const { t, ids, out, offers } = await released();
+    expect(offers.length).toBeGreaterThan(1);
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: offers[0].id as never,
+      teamId: offers[0].toTeamId as never,
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+    const after = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).filter((r) => r.direction === "in" && r.playerId === out.playerId);
+    expect(after.filter((r) => r.status === "accepted")).toHaveLength(1);
+    expect(after.filter((r) => r.status === "withdrawn")).toHaveLength(
+      offers.length - 1,
+    );
+  });
+
+  it("refuses to overfill a roster", async () => {
+    /*
+     * Re-checked at acceptance, not only when the offer was made. Recruiting,
+     * the draft or another transfer may have filled the destination since.
+     */
+    const { t, ids, offers } = await released();
+    const offer = offers[0];
+    await t.run(async (ctx) => {
+      for (let i = 0; i < MAX_TARGET_ROSTER_SIZE; i++) {
+        const playerId = await ctx.db.insert("players", {
+          name: `Filler ${i}`,
+          leagueId: ids.leagueId,
+          teamId: offer.toTeamId as never,
+          position: "OL",
+          positionGroup: null,
+          jerseyNumber: null,
+          dateOfBirth: null,
+          status: "active",
+          headshotUrl: null,
+          experienceYears: null,
+          grade: 10,
+          squad: "Varsity",
+          hometown: null,
+          synthetic: true,
+        });
+        await ctx.db.insert("rosterAssignments", {
+          seasonId: ids.seasonId,
+          teamId: offer.toTeamId as never,
+          playerId,
+          leagueId: ids.leagueId,
+          depthRank: i + 1,
+          positionSlot: "OL",
+          status: "active",
+          assignedAt: new Date(0).toISOString(),
+          assignedBy: ACTOR,
+        });
+      }
+    });
+    await expect(
+      t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: offer.id as never,
+        teamId: offer.toTeamId as never,
+        decision: "accept",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/roster_full/);
+  });
+
+  it("refuses to move a player into a locked season", async () => {
+    const { t, ids, offers } = await released();
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.seasonId, { rosterLocked: true } as never);
+    });
+    await expect(
+      t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: offers[0].id as never,
+        teamId: offers[0].toTeamId as never,
+        decision: "accept",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/season_locked/);
+  });
+
+  it("passing on an offer leaves the others alone", async () => {
+    const { t, ids, out, offers } = await released();
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: offers[0].id as never,
+      teamId: offers[0].toTeamId as never,
+      decision: "reject",
+      actorUserId: ACTOR,
+    });
+    const after = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).filter((r) => r.direction === "in" && r.playerId === out.playerId);
+    expect(after.find((r) => r.id === offers[0].id)?.status).toBe("rejected");
+    expect(after.filter((r) => r.status === "pending")).toHaveLength(
+      offers.length - 1,
+    );
+  });
+});
+
+describe("transfer events", () => {
+  it("writes exactly one event per resolved transfer", async () => {
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const rows = await t.query(api.dynasty.listTransfers, {
+      seasonId: ids.seasonId,
+    });
+    const out = rows.find((r) => r.direction === "out")!;
+
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+    const offer = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).find((r) => r.direction === "in" && r.playerId === out.playerId)!;
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: offer.id as never,
+      teamId: offer.toTeamId as never,
+      decision: "accept",
+      actorUserId: ACTOR,
+    });
+
+    await t.run(async (ctx) => {
+      const events = await ctx.db.query("dynastyEvents").collect();
+      // ONE. The release is not news; the move is.
+      expect(events).toHaveLength(1);
+      expect(events[0].eventType).toBe("transfer_completed");
+      expect(events[0].category).toBe("offseason");
+      expect(events[0].headline).toContain("transfers from");
+    });
+  });
+
+  it("writes one event for a retention too", async () => {
+    // A program talking a player out of leaving is exactly what a dynasty
+    // should remember.
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const out = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).find((r) => r.direction === "out")!;
+    await t.mutation(internal.dynasty.resolveTransfer, {
+      transferId: out.id as never,
+      teamId: ids.teamIds[0],
+      decision: "reject",
+      actorUserId: ACTOR,
+    });
+    await t.run(async (ctx) => {
+      const events = await ctx.db.query("dynastyEvents").collect();
+      expect(events).toHaveLength(1);
+      expect(events[0].eventType).toBe("transfer_retained");
+      expect(events[0].dedupeKey).toBe(`transfer_resolved:${out.id}`);
+    });
+  });
+
+  it("keys the event on the transfer row, so two players do not collide", async () => {
+    /*
+     * Keying on player and season would make a second decision about the same
+     * player overwrite the first — and the release-then-sign sequence is
+     * exactly two decisions about one player.
+     */
+    const t = convexTest(schema, modules);
+    const ids = await seedLeague(t);
+    await openWindow(t, ids.seasonId as never);
+    const outs = (
+      await t.query(api.dynasty.listTransfers, { seasonId: ids.seasonId })
+    ).filter((r) => r.direction === "out");
+    expect(outs.length).toBeGreaterThan(1);
+    for (const out of outs) {
+      await t.mutation(internal.dynasty.resolveTransfer, {
+        transferId: out.id as never,
+        teamId: ids.teamIds[0],
+        decision: "reject",
+        actorUserId: ACTOR,
+      });
+    }
+    await t.run(async (ctx) => {
+      const events = await ctx.db.query("dynastyEvents").collect();
+      expect(events).toHaveLength(outs.length);
+      expect(new Set(events.map((e) => e.dedupeKey)).size).toBe(outs.length);
+    });
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -236,7 +236,13 @@ type AllowedPublicDynastyReads =
    * `returns:` validator — see `prospectsHideTruth.test.ts`, which is the test
    * that makes this line reviewable rather than trusting.
    */
-  | "listProspects";
+  | "listProspects"
+  /*
+   * B4. Public because the transfer window is public information — every
+   * program can see who is looking. What is NOT public is acting on it:
+   * `resolveTransfer` is an internalMutation behind a per-`teamId` gate.
+   */
+  | "listTransfers";
 type AllowedPublicSimReads =
   | "moduleStatus"
   | "listRivalries"

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -20,6 +20,14 @@ import {
   isPotentialTier,
   nextScoutCost,
 } from "./lib/scouting";
+import {
+  generateTransferSlate,
+  matchTransfersIn,
+  type TransferCandidate,
+} from "./lib/transfers";
+import { MAX_TARGET_ROSTER_SIZE } from "./lib/offseason";
+import { emitDynastyEvent } from "./lib/events";
+import { transferResolvedDedupeKey } from "./lib/narrative";
 
 /*
  * Dynasty Mode — offseason pipeline (Epic B).
@@ -803,5 +811,522 @@ export const signProspect = internalMutation({
       playerId: playerId as string,
       alreadySigned: false,
     };
+  },
+});
+
+/*
+ * ── Offseason transfers (B4) ────────────────────────────────────────────────
+ */
+
+const transferValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  playerId: v.string(),
+  playerName: v.string(),
+  position: v.string(),
+  grade: v.union(v.number(), v.null()),
+  direction: v.string(),
+  fromTeamId: v.string(),
+  fromTeamName: v.string(),
+  toTeamId: v.union(v.string(), v.null()),
+  toTeamName: v.union(v.string(), v.null()),
+  reason: v.string(),
+  likelihood: v.number(),
+  status: v.string(),
+  /**
+   * Whether the losing coach has released him yet. Derived, not stored: it is a
+   * property of the `out` row, and duplicating it onto every offer would need
+   * a second write on every retention — the exact denormalisation that goes
+   * stale first.
+   */
+  released: v.boolean(),
+});
+
+type TransferDoc = Doc<"transferEvents">;
+
+function toTransferDto(
+  row: TransferDoc,
+  names: {
+    playerName: string;
+    position: string;
+    grade: number | null;
+    fromTeamName: string;
+    toTeamName: string | null;
+  },
+  released: boolean,
+): Infer<typeof transferValidator> {
+  return {
+    id: row._id as string,
+    leagueId: row.leagueId as string,
+    seasonId: row.seasonId as string,
+    playerId: row.playerId as string,
+    playerName: names.playerName,
+    position: names.position,
+    grade: names.grade,
+    direction: row.direction,
+    fromTeamId: row.fromTeamId as string,
+    fromTeamName: names.fromTeamName,
+    toTeamId: (row.toTeamId as string | null) ?? null,
+    toTeamName: names.toTeamName,
+    reason: row.reason,
+    likelihood: row.likelihood,
+    status: row.status,
+    released,
+  };
+}
+
+/**
+ * A season's transfer window, both directions.
+ *
+ * Player and team NAMES are resolved here rather than in the panel. The slate
+ * is bounded by roster size and every row needs three lookups; doing them in
+ * the Next layer would be an N+1 across the Convex boundary, which is the exact
+ * shape F2/F3 existed to remove.
+ */
+export const listTransfers = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(transferValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("transferEvents")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    if (rows.length === 0) return [];
+
+    const players = new Map<string, Doc<"players"> | null>();
+    const teams = new Map<string, Doc<"teams"> | null>();
+    for (const row of rows) {
+      if (!players.has(row.playerId as string)) {
+        players.set(row.playerId as string, await ctx.db.get(row.playerId));
+      }
+      for (const teamId of [row.fromTeamId, row.toTeamId]) {
+        if (teamId && !teams.has(teamId as string)) {
+          teams.set(teamId as string, await ctx.db.get(teamId));
+        }
+      }
+    }
+
+    // One pass to learn who has been released, so `released` costs no extra
+    // reads per offer.
+    const releasedPlayers = new Set(
+      rows
+        .filter((row) => row.direction === "out" && row.status === "accepted")
+        .map((row) => row.playerId as string),
+    );
+
+    return rows.map((row) => {
+      const player = players.get(row.playerId as string) ?? null;
+      const from = teams.get(row.fromTeamId as string) ?? null;
+      const to = row.toTeamId
+        ? (teams.get(row.toTeamId as string) ?? null)
+        : null;
+      return toTransferDto(
+        row,
+        {
+          playerName: player?.name ?? "Unknown player",
+          position: player?.position ?? "ATH",
+          grade: player?.grade ?? null,
+          fromTeamName: from?.name ?? "Unknown team",
+          toTeamName: to ? to.name : null,
+        },
+        releasedPlayers.has(row.playerId as string),
+      );
+    });
+  },
+});
+
+/**
+ * Open the transfer window for a season.
+ *
+ * Idempotent on the season: an existing window is returned untouched. The slate
+ * is seeded per `(playerId, seasonId)`, so a retry would regenerate the same
+ * names anyway — but "same names" written twice is still two rows per decision,
+ * and a coach would be asked about the same player repeatedly.
+ *
+ * Not gated on the offseason phase. A commissioner who opens the window early
+ * has made a scheduling choice; the phase machine already governs when the
+ * panel is reachable, and enforcing it twice would mean a phase advance could
+ * strand a half-generated window.
+ */
+export const generateTransferWindow = internalMutation({
+  args: { seasonId: v.id("seasons"), actorUserId: v.string() },
+  returns: v.object({
+    outbound: v.number(),
+    offers: v.number(),
+    alreadyExisted: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("transferEvents")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    if (existing.length > 0) {
+      return {
+        outbound: existing.filter((r) => r.direction === "out").length,
+        offers: existing.filter((r) => r.direction === "in").length,
+        alreadyExisted: true,
+      };
+    }
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+
+    const configRow = await ctx.db
+      .query("dynastyConfig")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .first();
+    const config = resolveDynastyConfig(configRow);
+
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+      .collect();
+
+    /*
+     * Ratings come from the season's own `playerAttributes` snapshot, which the
+     * rollover's `attributes_copied` stage writes. Reading the live player row
+     * instead would rate everyone on last year's form, so a junior who
+     * developed would still look like the freshman he was.
+     */
+    const overallByPlayer = new Map<string, number>();
+    for (const row of await ctx.db
+      .query("playerAttributes")
+      // Prefix of `by_seasonId_positionGroup` — one indexed range for the
+      // season rather than a scan of every snapshot ever ingested.
+      .withIndex("by_seasonId_positionGroup", (q) =>
+        q.eq("seasonId", args.seasonId),
+      )
+      .collect()) {
+      if (row.weightedOverall !== null) {
+        overallByPlayer.set(row.playerId as string, row.weightedOverall);
+      }
+    }
+
+    const candidates: TransferCandidate[] = [];
+    const rosterCount = new Map<string, number>();
+    const positionCount = new Map<string, number>();
+    for (const team of teams) {
+      const assignments = await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", args.seasonId).eq("teamId", team._id),
+        )
+        .collect();
+      const active = assignments.filter((row) => row.status === "active");
+      rosterCount.set(team._id as string, active.length);
+
+      for (const assignment of active) {
+        const player = await ctx.db.get(assignment.playerId);
+        if (!player) continue;
+        const key = `${team._id as string}:${assignment.positionSlot}`;
+        positionCount.set(key, (positionCount.get(key) ?? 0) + 1);
+        candidates.push({
+          playerId: assignment.playerId as string,
+          teamId: team._id as string,
+          position: assignment.positionSlot,
+          depthRank: assignment.depthRank,
+          overall: overallByPlayer.get(assignment.playerId as string) ?? 60,
+          grade: player.grade ?? null,
+          status: player.status,
+        });
+      }
+    }
+
+    const outbound = generateTransferSlate({
+      seasonId: args.seasonId as string,
+      candidates,
+      volume: config.transferVolume,
+      enabled: config.transfersEnabled,
+    });
+
+    const offers = matchTransfersIn({
+      seasonId: args.seasonId as string,
+      outbound,
+      destinationsFor: (transfer) =>
+        teams.map((team) => ({
+          teamId: team._id as string,
+          rosterCount: rosterCount.get(team._id as string) ?? 0,
+          countAtPosition:
+            positionCount.get(`${team._id as string}:${transfer.position}`) ?? 0,
+        })),
+    });
+
+    const now = new Date().toISOString();
+    const byPlayer = new Map(outbound.map((t) => [t.playerId, t]));
+    for (const transfer of outbound) {
+      await ctx.db.insert("transferEvents", {
+        leagueId: season.leagueId,
+        seasonId: args.seasonId,
+        playerId: transfer.playerId as Id<"players">,
+        direction: "out",
+        fromTeamId: transfer.fromTeamId as Id<"teams">,
+        toTeamId: null,
+        reason: transfer.reason,
+        likelihood: transfer.likelihood,
+        status: "pending",
+        createdAt: now,
+      });
+    }
+    for (const offer of offers) {
+      const source = byPlayer.get(offer.playerId);
+      await ctx.db.insert("transferEvents", {
+        leagueId: season.leagueId,
+        seasonId: args.seasonId,
+        playerId: offer.playerId as Id<"players">,
+        direction: "in",
+        fromTeamId: offer.fromTeamId as Id<"teams">,
+        toTeamId: offer.toTeamId as Id<"teams">,
+        reason: source?.reason ?? "opportunity",
+        likelihood: source?.likelihood ?? 0,
+        status: "pending",
+        createdAt: now,
+      });
+    }
+
+    return {
+      outbound: outbound.length,
+      offers: offers.length,
+      alreadyExisted: false,
+    };
+  },
+});
+
+/**
+ * Accept or reject one transfer decision.
+ *
+ * `teamId` is the team acting, and it must be the side that owns the row — the
+ * losing coach for an `out`, the destination for an `in`. Passing it explicitly
+ * rather than deriving it from the row is the multiplayer hook the roadmap
+ * requires: the Next action authorizes the caller against this id, and in Wave
+ * 5 the same mutation serves a coach scoped to one team.
+ *
+ * Resolution cascades. Retaining a player withdraws every offer for him;
+ * signing him withdraws every rival offer. Both happen here rather than in the
+ * action so a coach cannot be shown an offer that a concurrent decision has
+ * already invalidated.
+ */
+export const resolveTransfer = internalMutation({
+  args: {
+    transferId: v.id("transferEvents"),
+    teamId: v.id("teams"),
+    decision: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    status: v.string(),
+    moved: v.boolean(),
+    withdrawn: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    if (args.decision !== "accept" && args.decision !== "reject") {
+      throw new Error("invalid_decision");
+    }
+    const transfer = await ctx.db.get(args.transferId);
+    if (!transfer) throw new Error("transfer_not_found");
+    if (transfer.status !== "pending") throw new Error("transfer_not_pending");
+
+    const owningTeamId =
+      transfer.direction === "out" ? transfer.fromTeamId : transfer.toTeamId;
+    if (!owningTeamId || owningTeamId !== args.teamId) {
+      throw new Error("transfer_team_mismatch");
+    }
+
+    const now = new Date().toISOString();
+    const siblings = (
+      await ctx.db
+        .query("transferEvents")
+        .withIndex("by_playerId", (q) => q.eq("playerId", transfer.playerId))
+        .collect()
+    ).filter(
+      (row) => row.seasonId === transfer.seasonId && row._id !== transfer._id,
+    );
+
+    async function withdraw(rows: TransferDoc[]): Promise<number> {
+      let count = 0;
+      for (const row of rows) {
+        if (row.status !== "pending") continue;
+        await ctx.db.patch(row._id, {
+          status: "withdrawn",
+          resolvedAt: now,
+          resolvedBy: args.actorUserId,
+        });
+        count += 1;
+      }
+      return count;
+    }
+
+    const player = await ctx.db.get(transfer.playerId);
+    const fromTeam = await ctx.db.get(transfer.fromTeamId);
+
+    /* ── The losing coach's decision ───────────────────────────────────── */
+    if (transfer.direction === "out") {
+      const status = args.decision === "accept" ? "accepted" : "rejected";
+      await ctx.db.patch(transfer._id, {
+        status,
+        resolvedAt: now,
+        resolvedBy: args.actorUserId,
+      });
+
+      if (status === "rejected") {
+        // Retained. Every offer for him dies with the decision.
+        const withdrawn = await withdraw(
+          siblings.filter((row) => row.direction === "in"),
+        );
+        await emitDynastyEvent(ctx, {
+          leagueId: transfer.leagueId,
+          seasonId: transfer.seasonId,
+          teamId: transfer.fromTeamId,
+          playerId: transfer.playerId,
+          dedupeKey: transferResolvedDedupeKey(transfer._id as string),
+          narrative: {
+            type: "transfer_retained",
+            playerName: player?.name ?? "A player",
+            teamName: fromTeam?.name ?? "The program",
+            position: player?.position ?? "ATH",
+          },
+        });
+        return { status, moved: false, withdrawn };
+      }
+
+      /*
+       * Released. No event yet — nothing has happened to any roster, and a
+       * feed entry here would announce a move that may never occur.
+       */
+      return { status, moved: false, withdrawn: 0 };
+    }
+
+    /* ── A destination coach's decision ────────────────────────────────── */
+    const outRow = siblings.find((row) => row.direction === "out");
+    if (args.decision === "reject") {
+      await ctx.db.patch(transfer._id, {
+        status: "rejected",
+        resolvedAt: now,
+        resolvedBy: args.actorUserId,
+      });
+      return { status: "rejected", moved: false, withdrawn: 0 };
+    }
+
+    /*
+     * A destination cannot sign a player his own coach has not released. The
+     * check is here rather than only in the UI because the two decisions are
+     * made by different people and can race.
+     */
+    if (!outRow || outRow.status !== "accepted") {
+      throw new Error("transfer_not_released");
+    }
+    if (!player) throw new Error("player_not_found");
+
+    const toTeam = await ctx.db.get(args.teamId);
+    if (!toTeam) throw new Error("team_not_found");
+    if (toTeam.leagueId !== transfer.leagueId) {
+      throw new Error("team_league_mismatch");
+    }
+    const season = await ctx.db.get(transfer.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.rosterLocked === true) throw new Error("season_locked");
+
+    /*
+     * Re-checked at acceptance, not only at generation. The offer was made
+     * against a roster count that recruiting, the draft or another transfer
+     * may have moved since.
+     */
+    const destinationRoster = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", transfer.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+    const activeCount = destinationRoster.filter(
+      (row) => row.status === "active",
+    ).length;
+    if (activeCount >= MAX_TARGET_ROSTER_SIZE) {
+      throw new Error("roster_full");
+    }
+
+    // Move him: player row, roster assignment, depth chart.
+    const assignments = (
+      await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_playerId", (q) => q.eq("playerId", transfer.playerId))
+        .collect()
+    ).filter((row) => row.seasonId === transfer.seasonId);
+    for (const row of assignments) {
+      await ctx.db.delete(row._id);
+    }
+
+    const oldDepth = (
+      await ctx.db
+        .query("depthChartEntries")
+        .withIndex("by_team_season", (q) =>
+          q
+            .eq("teamId", transfer.fromTeamId)
+            .eq("seasonId", transfer.seasonId),
+        )
+        .collect()
+    ).filter((row) => row.playerId === transfer.playerId);
+    for (const row of oldDepth) {
+      await ctx.db.delete(row._id);
+    }
+
+    await ctx.db.patch(transfer.playerId, { teamId: args.teamId });
+
+    const slot = player.position;
+    const depthRank =
+      destinationRoster
+        .filter((row) => row.status === "active" && row.positionSlot === slot)
+        .reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+    await ctx.db.insert("rosterAssignments", {
+      seasonId: transfer.seasonId,
+      teamId: args.teamId,
+      playerId: transfer.playerId,
+      leagueId: transfer.leagueId,
+      depthRank,
+      positionSlot: slot,
+      status: "active",
+      assignedAt: now,
+      assignedBy: args.actorUserId,
+    });
+
+    await ctx.db.patch(transfer._id, {
+      status: "accepted",
+      resolvedAt: now,
+      resolvedBy: args.actorUserId,
+    });
+    const withdrawn = await withdraw(
+      siblings.filter((row) => row.direction === "in"),
+    );
+
+    await ctx.db.insert("rosterAuditLog", {
+      leagueId: transfer.leagueId,
+      teamId: args.teamId,
+      seasonId: transfer.seasonId,
+      actorUserId: args.actorUserId,
+      action: "transfer_in",
+      beforeJson: JSON.stringify({ teamId: transfer.fromTeamId as string }),
+      afterJson: JSON.stringify({
+        teamId: args.teamId as string,
+        playerId: transfer.playerId as string,
+        transferId: transfer._id as string,
+      }),
+      createdAt: now,
+    });
+
+    await emitDynastyEvent(ctx, {
+      leagueId: transfer.leagueId,
+      seasonId: transfer.seasonId,
+      teamId: args.teamId,
+      playerId: transfer.playerId,
+      dedupeKey: transferResolvedDedupeKey(transfer._id as string),
+      narrative: {
+        type: "transfer_completed",
+        playerName: player.name,
+        fromTeamName: fromTeam?.name ?? "another program",
+        toTeamName: toTeam.name,
+        position: player.position,
+      },
+    });
+
+    return { status: "accepted", moved: true, withdrawn };
   },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -176,6 +176,18 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
+  // Transfer windows (B4). A leaked row is worse than stale: the window is
+  // generated once per season and never regenerated, so an old row would make
+  // a later run's panel offer a player who belongs to a team that no longer
+  // exists — and `resolveTransfer` would then move a ghost.
+  const transferRows = (await ctx.db
+    .query("transferEvents")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"transferEvents"> }>;
+  for (const row of transferRows) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
   // Dynasty feed (F4) — league-scoped, so cleared once rather than per season.
   const events = (await ctx.db
     .query("dynastyEvents")
@@ -701,5 +713,78 @@ export const seedProspectClass = internalMutation({
       seasonId: args.seasonId,
       prospects,
     });
+  },
+});
+
+/*
+ * Stack a team with buried players so a transfer window has somebody in it (B4).
+ *
+ * The slate is a seeded roll against `transferOutLikelihood`, which is driven
+ * by depth rank and rating. A realistic fixture roster would make the spec
+ * depend on the RNG landing well; six high-rated juniors behind one starter
+ * makes it a certainty without touching the production path — the window is
+ * still opened by the real mutation, through the real button.
+ */
+export const seedTransferCandidates = internalMutation({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    count: v.optional(v.number()),
+  },
+  returns: v.object({ created: v.number() }),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("team_not_found");
+
+    const count = Math.max(1, Math.min(args.count ?? 6, 20));
+    const now = new Date().toISOString();
+    let created = 0;
+    for (let i = 0; i < count; i++) {
+      const playerId = await ctx.db.insert("players", {
+        name: `E2E Transfer ${i + 1}`,
+        leagueId: season.leagueId,
+        teamId: args.teamId,
+        position: "WR",
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        experienceYears: null,
+        grade: 11,
+        squad: "Varsity",
+        hometown: null,
+        synthetic: true,
+      });
+      await ctx.db.insert("rosterAssignments", {
+        seasonId: args.seasonId,
+        teamId: args.teamId,
+        playerId,
+        leagueId: season.leagueId,
+        // Rank 1 is the starter; everyone behind him is a transfer candidate.
+        depthRank: i + 1,
+        positionSlot: "WR",
+        status: "active",
+        assignedAt: now,
+        assignedBy: SEED_ACTOR,
+      });
+      await ctx.db.insert("playerAttributes", {
+        playerId,
+        seasonId: args.seasonId,
+        positionGroup: "WR",
+        attributesJson: JSON.stringify({ SPD: 95 }),
+        pffSourceJson: null,
+        maddenSourceJson: null,
+        pffWeight: 0,
+        maddenWeight: 0,
+        weightedOverall: 95,
+        ingestedAt: now,
+      });
+      created += 1;
+    }
+    return { created };
   },
 });

--- a/apps/web/convex/lib/narrative.ts
+++ b/apps/web/convex/lib/narrative.ts
@@ -52,6 +52,19 @@ export type NarrativeInput =
       label: string;
       gamesOut: number;
       week: number | null;
+    }
+  | {
+      type: "transfer_completed";
+      playerName: string;
+      fromTeamName: string;
+      toTeamName: string;
+      position: string;
+    }
+  | {
+      type: "transfer_retained";
+      playerName: string;
+      teamName: string;
+      position: string;
     };
 
 export type NarrativeEventType = NarrativeInput["type"];
@@ -89,6 +102,14 @@ export function renderHeadline(input: NarrativeInput): string {
           : `and is out ${input.gamesOut} game${input.gamesOut === 1 ? "" : "s"}`;
       return `${weekPrefix(input.week)}${input.teamName}'s ${input.playerName} was hurt ${duration}`;
     }
+    case "transfer_completed": {
+      return `${input.playerName} (${input.position}) transfers from ${input.fromTeamName} to ${input.toTeamName}`;
+    }
+    case "transfer_retained": {
+      // The non-move is news too — a program talking a player out of leaving
+      // is exactly the kind of thing a dynasty should remember.
+      return `${input.teamName} keeps ${input.playerName} (${input.position})`;
+    }
     default: {
       // Exhaustiveness guard: adding a NarrativeInput variant without a case
       // here fails `tsc`, so a new event type cannot ship copy-less.
@@ -109,6 +130,11 @@ export function defaultSeverity(type: NarrativeEventType): EventSeverity {
     case "player_injured":
       // A knock is background; anything costing games is worth surfacing.
       return "info";
+    case "transfer_completed":
+      // A roster changing hands between programs is the offseason's headline.
+      return "notable";
+    case "transfer_retained":
+      return "info";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;
@@ -126,6 +152,9 @@ export function categoryFor(type: NarrativeEventType): EventCategory {
       return "program";
     case "player_injured":
       return "game";
+    case "transfer_completed":
+    case "transfer_retained":
+      return "offseason";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;
@@ -147,4 +176,16 @@ export function gameFinalDedupeKey(fixtureId: string): string {
 
 export function seasonCompletedDedupeKey(seasonId: string): string {
   return `season_completed:${seasonId}`;
+}
+
+/*
+ * Keyed on the TRANSFER ROW, not on the player and season.
+ *
+ * A player can be offered to several programs and can be looked at again in a
+ * later window; the happening being recorded is "this decision resolved this
+ * way". Keying on the player would make a retained-then-released player
+ * overwrite his own history, which is precisely the story worth keeping.
+ */
+export function transferResolvedDedupeKey(transferId: string): string {
+  return `transfer_resolved:${transferId}`;
 }

--- a/apps/web/convex/lib/offseasonPhases.ts
+++ b/apps/web/convex/lib/offseasonPhases.ts
@@ -27,6 +27,7 @@
 export const OFFSEASON_PHASES = [
   "rollover",
   "recruiting",
+  "transfers",
   "draft",
   "free_agency",
   "activate",
@@ -37,6 +38,7 @@ export type OffseasonPhase = (typeof OFFSEASON_PHASES)[number];
 export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
   rollover: "Rollover",
   recruiting: "Recruiting",
+  transfers: "Transfers",
   draft: "Draft",
   free_agency: "Free agency",
   activate: "Activate",
@@ -52,9 +54,15 @@ export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
  * Recruiting joined it in B3 for a stronger reason than convenience: a class
  * left entirely unsigned must not be able to trap an offseason. The cost of
  * skipping it is a roster of walk-ons, which is a consequence, not a block.
+ *
+ * Transfers joined it in B4 for the same reason, plus one of its own: an
+ * unresolved transfer is a decision NOT to decide, and a coach who never opens
+ * the window has implicitly kept everybody. Blocking on it would let one
+ * absent coach freeze the league.
  */
 const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set([
   "recruiting",
+  "transfers",
   "draft",
 ]);
 

--- a/apps/web/convex/lib/transfers.ts
+++ b/apps/web/convex/lib/transfers.ts
@@ -1,0 +1,282 @@
+/*
+ * Offseason transfers (Dynasty Mode B4) — pure, Convex-free.
+ *
+ * A talented junior buried on the depth chart goes looking for snaps. That one
+ * sentence is the whole model, and everything here follows from it.
+ *
+ * ## Transfers are CONSERVED, not generated
+ *
+ * Every inbound offer originates from a specific outbound player on a specific
+ * roster. Nobody arrives from outside the league. That is a deliberate choice
+ * over the easier alternative of synthesising newcomers:
+ *
+ * - League talent stays constant, so transfers redistribute rather than inflate.
+ *   A commissioner who runs ten offseasons does not end up with a league of
+ *   ninety-overall rosters.
+ * - Every move has two sides. One program's gain is visibly another's loss,
+ *   which is what makes the panel worth reading.
+ * - The roster cap becomes trivially satisfiable: a conserved move cannot grow
+ *   total headcount, so only the DESTINATION needs a ceiling check.
+ *
+ * ## The two-sided resolution
+ *
+ * The outbound row is the player's intent and the losing coach's decision; the
+ * inbound rows are offers to everyone else. A coach who retains his player
+ * withdraws every offer for him. A coach who lets him go puts him on the
+ * market, and the first destination to accept gets him — withdrawing the rest.
+ *
+ * Modelling it as one decision would have been simpler and worse: "your best
+ * backup wants out and you cannot argue" is an event, not a mechanic.
+ */
+import { rngFor } from "./rng";
+import { MAX_TARGET_ROSTER_SIZE } from "./offseason";
+import type { TransferVolume } from "./dynastyConfig";
+
+export type TransferDirection = "out" | "in";
+
+/**
+ * `pending` → the decision is open.
+ * `accepted` / `rejected` → the row's own coach decided.
+ * `withdrawn` → the decision was taken away by another row resolving (the
+ *   player was retained, or a rival destination signed him first). Distinct
+ *   from `rejected` on purpose: "we passed" and "we never got the chance" are
+ *   different stories, and collapsing them would make the panel lie about who
+ *   decided what.
+ */
+export type TransferStatus = "pending" | "accepted" | "rejected" | "withdrawn";
+
+export const TRANSFER_STATUSES: readonly TransferStatus[] = [
+  "pending",
+  "accepted",
+  "rejected",
+  "withdrawn",
+];
+
+export function isTransferStatus(value: string): value is TransferStatus {
+  return (TRANSFER_STATUSES as readonly string[]).includes(value);
+}
+
+/** Why a player is looking. Shown to the coach — it is the argument he answers. */
+export type TransferReason = "buried" | "role" | "opportunity";
+
+export const TRANSFER_REASON_LABELS: Record<TransferReason, string> = {
+  buried: "Buried on the depth chart",
+  role: "Wants a bigger role",
+  opportunity: "Looking for a better fit",
+};
+
+/**
+ * How hard the volume knob pushes. Multiplies the per-player likelihood, so
+ * `low` is a quiet year rather than a different mechanic.
+ */
+export const TRANSFER_VOLUME_RATE: Record<TransferVolume, number> = {
+  low: 0.4,
+  normal: 1,
+  high: 1.9,
+};
+
+/** Destinations offered per outbound player. */
+export const OFFERS_PER_TRANSFER = 2;
+
+/** Ceiling on any single player's chance of leaving. Nobody is certain. */
+const MAX_LIKELIHOOD = 0.85;
+
+/**
+ * Grades that can transfer, and how strongly.
+ *
+ * 12 is absent, not zero: a senior is graduating, so "he might transfer" is not
+ * a quieter version of the same story — it is a different one that cannot
+ * happen. Freshmen are damped because a player who arrived four months ago
+ * leaving immediately reads as churn rather than as drama.
+ */
+const GRADE_WEIGHT: Record<number, number> = { 9: 0.45, 10: 1, 11: 1.15 };
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export interface LikelihoodInput {
+  /** 1 is the starter at his slot. Higher is further down. */
+  depthRank: number;
+  /** 40–99 rating. */
+  overall: number;
+  grade: number | null;
+  volume: TransferVolume;
+}
+
+/**
+ * How likely this player is to look elsewhere, in [0, 1].
+ *
+ * Talent and burial MULTIPLY rather than add. A buried scrub is not a story and
+ * a starting star is not either; the transfer that hurts is the good player who
+ * cannot get on the field, and only a product produces that shape. Adding them
+ * would make a benchwarming 50-overall as likely to leave as a starting
+ * 90-overall, which is how you get a portal full of players nobody wants.
+ *
+ * The small talent-only floor is the other half of realism: a star at a
+ * struggling program has a reason to leave even from the top of the chart. It
+ * is deliberately an order of magnitude below the burial term, so a starter is
+ * always strictly less likely to leave than an identical player behind him.
+ */
+export function transferOutLikelihood(input: LikelihoodInput): number {
+  const gradeWeight = input.grade === null ? 1 : (GRADE_WEIGHT[input.grade] ?? 0);
+  if (gradeWeight === 0) return 0;
+
+  // Rank 1 → 0, rank 5 and beyond → 1. Being third string is not much worse
+  // than being fifth; the cliff is between playing and not.
+  const burial = clamp((input.depthRank - 1) / 4, 0, 1);
+  const talent = clamp((input.overall - 55) / 35, 0, 1);
+
+  const floor = 0.012 * talent;
+  const raw = floor + burial * (0.1 + 0.5 * talent);
+  return clamp(raw * TRANSFER_VOLUME_RATE[input.volume] * gradeWeight, 0, MAX_LIKELIHOOD);
+}
+
+export interface TransferCandidate {
+  playerId: string;
+  teamId: string;
+  position: string;
+  depthRank: number;
+  overall: number;
+  grade: number | null;
+  /** Player row status — "graduated" and anything inactive is excluded. */
+  status: string;
+}
+
+export interface OutboundTransfer {
+  playerId: string;
+  fromTeamId: string;
+  position: string;
+  likelihood: number;
+  reason: TransferReason;
+}
+
+export interface SlateInput {
+  seasonId: string;
+  candidates: readonly TransferCandidate[];
+  volume: TransferVolume;
+  /** `dynastyConfig.transfersEnabled`. False yields an empty slate. */
+  enabled: boolean;
+}
+
+function reasonFor(candidate: TransferCandidate): TransferReason {
+  if (candidate.depthRank >= 3) return "buried";
+  if (candidate.depthRank === 2) return "role";
+  return "opportunity";
+}
+
+/**
+ * Who wants out this offseason.
+ *
+ * Seeded per `(playerId, seasonId)`, so re-running the window produces the same
+ * slate rather than rerolling until the commissioner likes it. That is also
+ * what makes the generating mutation safe to retry.
+ *
+ * Sorted by likelihood so the panel's top row is the player most likely to go —
+ * the one whose decision actually matters — with the id as a stable tiebreak so
+ * two equally likely players never swap places between reads.
+ */
+export function generateTransferSlate(input: SlateInput): OutboundTransfer[] {
+  if (!input.enabled) return [];
+
+  const out: OutboundTransfer[] = [];
+  for (const candidate of input.candidates) {
+    /*
+     * A graduated player is gone, not buried. Skipping on status rather than
+     * on grade alone matters because the two can disagree: the rollover marks
+     * seniors graduated and leaves their grade at 12, and a league that edits
+     * grades by hand can produce either without the other.
+     */
+    if (candidate.status === "graduated") continue;
+    if (candidate.status !== "active" && candidate.status !== "Active") continue;
+
+    const likelihood = transferOutLikelihood({
+      depthRank: candidate.depthRank,
+      overall: candidate.overall,
+      grade: candidate.grade,
+      volume: input.volume,
+    });
+    if (likelihood <= 0) continue;
+
+    const roll = rngFor("transfer", candidate.playerId, input.seasonId)();
+    if (roll >= likelihood) continue;
+
+    out.push({
+      playerId: candidate.playerId,
+      fromTeamId: candidate.teamId,
+      position: candidate.position,
+      likelihood,
+      reason: reasonFor(candidate),
+    });
+  }
+
+  return out.sort(
+    (a, b) => b.likelihood - a.likelihood || a.playerId.localeCompare(b.playerId),
+  );
+}
+
+export interface DestinationTeam {
+  teamId: string;
+  /** Active players already on the roster. */
+  rosterCount: number;
+  /** How many the team already has at the outbound player's position. */
+  countAtPosition: number;
+}
+
+export interface TransferOffer {
+  playerId: string;
+  fromTeamId: string;
+  toTeamId: string;
+}
+
+export interface MatchInput {
+  seasonId: string;
+  outbound: readonly OutboundTransfer[];
+  /** Called per outbound player — position need is specific to him. */
+  destinationsFor: (transfer: OutboundTransfer) => readonly DestinationTeam[];
+}
+
+/**
+ * Which programs come calling for each outbound player.
+ *
+ * Offers go to the teams THINNEST at his position, because a transfer that
+ * lands where nobody plays his spot is a roster move, not a story. A seeded
+ * jitter breaks ties so a league whose teams all carry three receivers does not
+ * send every one of them to whichever team sorts first.
+ *
+ * Teams at the roster ceiling are excluded here as well as at acceptance. Both
+ * are needed: this keeps the panel from showing an offer that can never be
+ * taken, and the acceptance check catches a roster that filled up in between.
+ */
+export function matchTransfersIn(input: MatchInput): TransferOffer[] {
+  const offers: TransferOffer[] = [];
+  for (const transfer of input.outbound) {
+    const ranked = input
+      .destinationsFor(transfer)
+      .filter(
+        (team) =>
+          team.teamId !== transfer.fromTeamId &&
+          team.rosterCount < MAX_TARGET_ROSTER_SIZE,
+      )
+      .map((team) => {
+        const jitter = rngFor(
+          "transfer",
+          transfer.playerId,
+          input.seasonId,
+          team.teamId,
+        )();
+        return { team, score: team.countAtPosition + jitter };
+      })
+      .sort((a, b) => a.score - b.score)
+      .slice(0, OFFERS_PER_TRANSFER);
+
+    for (const { team } of ranked) {
+      offers.push({
+        playerId: transfer.playerId,
+        fromTeamId: transfer.fromTeamId,
+        toTeamId: team.teamId,
+      });
+    }
+  }
+  return offers;
+}

--- a/apps/web/convex/tables/offseason.ts
+++ b/apps/web/convex/tables/offseason.ts
@@ -120,6 +120,54 @@ export const offseasonTables = {
     .index("by_leagueId", ["leagueId"]),
 
   /*
+   * Offseason transfers (Dynasty Mode B4). One row per DECISION, not per move.
+   *
+   * A player who wants out produces one `out` row (his current coach's decision:
+   * retain him or let him go) and up to `OFFERS_PER_TRANSFER` `in` rows (each
+   * destination coach's decision). They share a `playerId`, which is what lets
+   * one resolution withdraw the others — retaining a player kills every offer
+   * for him, and the first destination to accept kills its rivals.
+   *
+   * ## Why the direction is stored rather than derived
+   *
+   * `fromTeamId` and `toTeamId` would nearly determine it: an `out` row has no
+   * destination yet. But "nearly" is the problem — the two rows for the same
+   * move would then be distinguished by a null, and every query that wanted one
+   * side would encode that trick. Storing the direction makes
+   * `by_seasonId_status` usable for both panels without a second index.
+   *
+   * `likelihood` is kept after generation even though it is only read once, so
+   * a coach can see how close a call it was and so a slate can be audited
+   * against `transferOutLikelihood` without re-deriving depth charts that have
+   * since changed.
+   */
+  transferEvents: defineTable({
+    leagueId: v.id("leagues"),
+    /** The UPCOMING season this window belongs to. */
+    seasonId: v.id("seasons"),
+    playerId: v.id("players"),
+    /** "out" | "in" — see the note above. */
+    direction: v.string(),
+    /** The program losing him. Always set: transfers are conserved. */
+    fromTeamId: v.id("teams"),
+    /** The program offering a spot. Null on the `out` row. */
+    toTeamId: v.union(v.id("teams"), v.null()),
+    /** "buried" | "role" | "opportunity" — the argument the coach answers. */
+    reason: v.string(),
+    /** 0–1 chance that produced this row, kept for audit. */
+    likelihood: v.number(),
+    /** "pending" | "accepted" | "rejected" | "withdrawn". */
+    status: v.string(),
+    resolvedAt: v.optional(v.string()),
+    resolvedBy: v.optional(v.string()),
+    createdAt: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_seasonId_status", ["seasonId", "status"])
+    .index("by_playerId", ["playerId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  /*
    * Offseason snake draft (WSM-000233). One draft per target season; order is
    * reverse final standings. Writes are internalMutation only.
    */

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -130,3 +130,29 @@ export async function seedProspectClass(
   const client = getSeedClient();
   return client.mutation(seedProspectClassRef, { seasonId, count });
 }
+
+const seedTransferCandidatesRef = makeFunctionReference<
+  "mutation",
+  any,
+  { created: number }
+>("e2eSeed:seedTransferCandidates");
+
+/**
+ * Stack a team with buried players so the transfer window has somebody in it (B4).
+ *
+ * The window itself is still opened through the real button and the real
+ * mutation — this only guarantees the seeded likelihood roll has candidates to
+ * find, so the spec is not testing whether the RNG felt generous today.
+ */
+export async function seedTransferCandidates(
+  seasonId: string,
+  teamId: string,
+  count = 6,
+): Promise<{ created: number }> {
+  const client = getSeedClient();
+  return client.mutation(seedTransferCandidatesRef, {
+    seasonId,
+    teamId,
+    count,
+  });
+}

--- a/apps/web/e2e/tests/offseason-phases.spec.ts
+++ b/apps/web/e2e/tests/offseason-phases.spec.ts
@@ -113,7 +113,7 @@ test.describe("Offseason phase machine (B1)", () => {
 
     await page.getByTestId("offseason-advance").click();
     await expect(page.getByTestId("offseason-phase-message")).toContainText(
-      "Draft",
+      "Transfers",
       { timeout: 30_000 },
     );
 
@@ -121,7 +121,7 @@ test.describe("Offseason phase machine (B1)", () => {
     await page.reload();
     await expect(page.getByTestId("offseason-phase-stepper")).toHaveAttribute(
       "data-phase",
-      "draft",
+      "transfers",
     );
     await expect(
       page.getByTestId("offseason-phase-recruiting"),

--- a/apps/web/e2e/tests/transfers.spec.ts
+++ b/apps/web/e2e/tests/transfers.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedTransferCandidates,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { acceptBrowserConfirms } from "../helpers/sim-league-setup";
+
+/*
+ * Offseason transfers (Dynasty Mode B4, #622).
+ *
+ * Its own fixture league, for the reason `offseason-phases.spec.ts` records:
+ * the canonical shared league's season statuses churn between CI runs, and
+ * everything here needs an UPCOMING season.
+ *
+ * The candidates are seeded — six high-rated juniors stacked behind one
+ * starter — but the WINDOW is opened through the real button and the real
+ * mutation. Seeding the window itself would test nothing; seeding the roster
+ * only guarantees the likelihood roll has somebody to find.
+ */
+test.describe("Transfer window (B4)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "transfer-window";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let seasonId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E TW Home",
+      awayTeamName: "E2E TW Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("an admin opens the window and buried players appear in it", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    // A new season is upcoming, which is what the offseason hub requires.
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Season name").fill(`E2E Transfers ${Date.now()}`);
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    const href = await success
+      .getByTestId("create-season-generate-schedule")
+      .getAttribute("href");
+    seasonId = href?.split("/")[3] ?? null;
+    expect(seasonId).toBeTruthy();
+    await success.getByRole("button", { name: "Done" }).click();
+
+    await seedTransferCandidates(seasonId as string, fixture.homeTeamId, 6);
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("transfer-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    // Nothing exists until the commissioner opens it.
+    await expect(panel).toContainText("has not been opened");
+    await panel.getByTestId("open-transfer-window").click();
+    await expect(panel).toContainText("entered the window", {
+      timeout: 30_000,
+    });
+
+    await page.reload();
+    const outbound = page.getByTestId("transfer-outbound");
+    await expect(outbound.getByTestId("transfer-row").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    // The reason is the argument the coach answers, so it has to be on screen.
+    await expect(outbound).toContainText("Buried on the depth chart");
+  });
+
+  test("keeping a player takes him off the board", async ({ page }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const outbound = page.getByTestId("transfer-outbound");
+    await expect(outbound.getByTestId("transfer-row").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    /*
+     * Located by NAME rather than by position: resolving a row can withdraw
+     * others, so the list can reorder underneath a positional locator.
+     */
+    const row = outbound.getByTestId("transfer-row").first();
+    const name = await row.locator("p").first().innerText();
+    await row.getByRole("button", { name: "Keep him" }).click();
+
+    const byName = outbound
+      .getByTestId("transfer-row")
+      .filter({ hasText: name });
+    await expect(byName.getByTestId("transfer-status")).toContainText(
+      "Declined",
+      { timeout: 30_000 },
+    );
+
+    // And it PERSISTS — the decision is a write, not local state.
+    await page.reload();
+    await expect(
+      page
+        .getByTestId("transfer-outbound")
+        .getByTestId("transfer-row")
+        .filter({ hasText: name })
+        .getByTestId("transfer-status"),
+    ).toContainText("Declined", { timeout: 30_000 });
+  });
+
+  test("a released player can be signed by the program that wanted him", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const outbound = page.getByTestId("transfer-outbound");
+    await expect(outbound.getByTestId("transfer-row").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const pending = outbound
+      .getByTestId("transfer-row")
+      .filter({ has: page.getByRole("button", { name: "Let him go" }) })
+      .first();
+    const name = await pending.locator("p").first().innerText();
+    await pending.getByRole("button", { name: "Let him go" }).click();
+
+    await expect(
+      outbound
+        .getByTestId("transfer-row")
+        .filter({ hasText: name })
+        .getByTestId("transfer-status"),
+    ).toContainText("Accepted", { timeout: 30_000 });
+
+    /*
+     * The inbound half is only visible to the DESTINATION team. This viewer is
+     * the commissioner, who acts for whichever team the page resolved — so
+     * rather than assume the offer landed in this panel, assert on what the
+     * outbound decision guarantees: he is released, and the losing program's
+     * board says so after a reload.
+     */
+    await page.reload();
+    await expect(
+      page
+        .getByTestId("transfer-outbound")
+        .getByTestId("transfer-row")
+        .filter({ hasText: name })
+        .getByTestId("transfer-status"),
+    ).toContainText("Accepted", { timeout: 30_000 });
+  });
+});

--- a/apps/web/e2e/tests/transfers.spec.ts
+++ b/apps/web/e2e/tests/transfers.spec.ts
@@ -80,7 +80,18 @@ test.describe("Transfer window (B4)", () => {
     expect(seasonId).toBeTruthy();
     await success.getByRole("button", { name: "Done" }).click();
 
+    /*
+     * BOTH teams get a stacked depth chart, not just the home one.
+     *
+     * The hub picks the team this viewer acts for as the first one they manage
+     * in `getTeamsByLeague` order, which is not the fixture's home-first order
+     * — the first CI run proved it by resolving the AWAY team and rendering a
+     * correct, empty "Leaving" list. A spec that assumes which team the page
+     * chose is testing the ordering of a query, so seed both and let whichever
+     * one it picked have candidates.
+     */
     await seedTransferCandidates(seasonId as string, fixture.homeTeamId, 6);
+    await seedTransferCandidates(seasonId as string, fixture.awayTeamId, 6);
 
     await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
     const panel = page.getByTestId("transfer-panel");

--- a/apps/web/src/app/dashboard/_actions/__tests__/transfers.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/transfers.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockResolveOrgRole,
+  mockGetLeagueOrgId,
+  mockGetTeamLeagueId,
+  mockGetSeason,
+  mockCanManageTeam,
+  mockGenerateTransferWindow,
+  mockResolveTransfer,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockGetSeason: vi.fn(),
+  mockCanManageTeam: vi.fn(),
+  mockGenerateTransferWindow: vi.fn(),
+  mockResolveTransfer: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/org-context", () => ({ resolveOrgRole: mockResolveOrgRole }));
+vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+vi.mock("@/lib/data-api", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getTeamLeagueId: mockGetTeamLeagueId,
+  getSeason: mockGetSeason,
+  generateTransferWindow: mockGenerateTransferWindow,
+  resolveTransfer: mockResolveTransfer,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  openTransferWindowAction,
+  resolveTransferAction,
+} from "../transfers";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const TRANSFER = "transfer_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockGetTeamLeagueId.mockResolvedValue(LEAGUE);
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  // A coach, not an org admin — the case the per-team gate exists for.
+  mockResolveOrgRole.mockResolvedValue("member");
+  mockCanManageTeam.mockImplementation(
+    async (teamId: string) => teamId === TEAM_A,
+  );
+  mockGetSeason.mockResolvedValue({ id: SEASON, leagueId: LEAGUE });
+  mockGenerateTransferWindow.mockResolvedValue({
+    outbound: 3,
+    offers: 6,
+    alreadyExisted: false,
+  });
+  mockResolveTransfer.mockResolvedValue({
+    status: "accepted",
+    moved: true,
+    withdrawn: 1,
+  });
+});
+
+/*
+ * Two gates, two shapes (B4).
+ *
+ * Opening the window generates every team's slate in one write, so it is a
+ * commissioner action. Resolving one transfer is one program's call about one
+ * player, so it is gated per `teamId` — the shape Wave 5 needs and the one
+ * that cannot be retrofitted.
+ */
+describe("openTransferWindowAction", () => {
+  it("lets an org admin open the window", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+    const result = await openTransferWindowAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { outbound: 3, offers: 6, alreadyExisted: false },
+    });
+  });
+
+  it("refuses a coach who is not an admin", async () => {
+    // Opening the window moves every team at once; a single coach should not
+    // be able to start the league's offseason churn.
+    const result = await openTransferWindowAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockGenerateTransferWindow).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTransferAction authorizes per team", () => {
+  it("lets a coach decide for the team they manage", async () => {
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(result.ok).toBe(true);
+    expect(mockResolveTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: TEAM_A,
+        decision: "accept",
+        actorUserId: "coach_a",
+      }),
+    );
+  });
+
+  it("refuses a coach of team A deciding for team B", async () => {
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    // Refused BEFORE the mutation. A gate that only rejected at the database
+    // would have already read and locked the row.
+    expect(mockResolveTransfer).not.toHaveBeenCalled();
+  });
+
+  it("lets an org admin decide for any team, for solo play", async () => {
+    mockResolveOrgRole.mockResolvedValue("admin");
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+      decision: "reject",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses an unauthenticated caller before touching anything", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(result).toEqual({ ok: false, error: "unauthorized" });
+    expect(mockGetTeamLeagueId).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTransferAction cache invalidation", () => {
+  it("revalidates the losing program too when a player actually moves", async () => {
+    /*
+     * A completed transfer changes TWO rosters. Revalidating only the
+     * destination would leave the losing program's pages showing a player it
+     * no longer has until something unrelated evicted the cache.
+     */
+    await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(mockGetSeason).toHaveBeenCalled();
+  });
+
+  it("does not do the extra read when nothing moved", async () => {
+    mockResolveTransfer.mockResolvedValue({
+      status: "rejected",
+      moved: false,
+      withdrawn: 2,
+    });
+    await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "reject",
+    });
+    expect(mockGetSeason).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTransferAction failures", () => {
+  it("surfaces the bare reason a Convex error wraps", async () => {
+    mockResolveTransfer.mockRejectedValue(
+      new Error("[Request ID: abc] Server Error: transfer_not_released"),
+    );
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(result).toEqual({ ok: false, error: "transfer_not_released" });
+  });
+
+  it("passes an unrecognised failure through rather than inventing one", async () => {
+    mockResolveTransfer.mockRejectedValue(new Error("network exploded"));
+    const result = await resolveTransferAction({
+      transferId: TRANSFER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      decision: "accept",
+    });
+    expect(result).toEqual({ ok: false, error: "network exploded" });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/transfers.ts
+++ b/apps/web/src/app/dashboard/_actions/transfers.ts
@@ -1,0 +1,133 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canManageTeam } from "@/lib/authorization";
+import { resolveOrgRole } from "@/lib/org-context";
+import { canManageOrgSettings } from "@/lib/permissions";
+import {
+  generateTransferWindow,
+  getLeagueOrgId,
+  getSeason,
+  getTeamLeagueId,
+  resolveTransfer,
+} from "@/lib/data-api";
+
+/*
+ * Transfer actions (Dynasty Mode B4).
+ *
+ * Two different gates on purpose, because the two operations are different
+ * kinds of decision:
+ *
+ * - Opening the window moves the whole league at once — it generates every
+ *   team's slate in one write. That is a commissioner action, gated the same
+ *   way advancing a phase is.
+ * - Resolving a transfer is one program's call about one player, gated per
+ *   `teamId`. This is the roadmap's multiplayer-critical shape: in Wave 5 the
+ *   identical mutation serves a coach who owns exactly one team, and an action
+ *   written against "is org admin" could not be narrowed without rewriting
+ *   every call site.
+ */
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function canAdminOrManageTeam(
+  userId: string,
+  teamId: string,
+): Promise<boolean> {
+  const leagueId = await getTeamLeagueId(teamId);
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (canManageOrgSettings(role)) return true;
+  return canManageTeam(teamId, userId);
+}
+
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  /*
+   * Convex wraps a thrown Error in its own message, so the bare reason the UI
+   * switches on has to be recovered from the text — same recovery as
+   * `offseason-phases.ts` and `recruiting.ts`.
+   */
+  const known = [
+    "transfer_not_found",
+    "transfer_not_pending",
+    "transfer_not_released",
+    "transfer_team_mismatch",
+    "roster_full",
+    "season_locked",
+    "season_not_found",
+    "team_league_mismatch",
+    "invalid_decision",
+  ];
+  return known.find((reason) => raw.includes(reason)) ?? raw;
+}
+
+export async function openTransferWindowAction(input: {
+  leagueId: string;
+  seasonId: string;
+}): Promise<ActionResult<{ outbound: number; offers: number }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const orgId = await getLeagueOrgId(input.leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (!canManageOrgSettings(role)) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await generateTransferWindow({
+      seasonId: input.seasonId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}
+
+export async function resolveTransferAction(input: {
+  transferId: string;
+  teamId: string;
+  seasonId: string;
+  decision: "accept" | "reject";
+}): Promise<
+  ActionResult<{ status: string; moved: boolean; withdrawn: number }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await resolveTransfer({
+      transferId: input.transferId,
+      teamId: input.teamId,
+      decision: input.decision,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    revalidatePath(`/dashboard/teams/${input.teamId}`);
+    /*
+     * A completed transfer changes TWO rosters. Revalidating only the
+     * destination would leave the losing program's page showing a player it no
+     * longer has until something else happened to evict the cache.
+     */
+    if (data.moved) {
+      const season = await getSeason(input.seasonId, {
+        userId,
+        orgIds: [],
+        visibleLeagueIds: [],
+        subscribedLeagueIds: [],
+        subscriptionTeamScopes: {},
+      }).catch(() => null);
+      if (season) revalidatePath(`/dashboard/leagues/${season.leagueId}`);
+    }
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
@@ -8,6 +8,7 @@ import {
   getSeason,
   getTeamsByLeague,
   listProspects,
+  listTransfers,
 } from "@/lib/data-api";
 import { canManageTeam } from "@/lib/authorization";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
@@ -17,6 +18,7 @@ import { ResourceHeader } from "@/components/workspace/ResourceHeader";
 import { seasonHomeHref } from "@/components/workspace/resource-navigation";
 import { OffseasonPhaseControls } from "@/components/offseason/OffseasonPhaseControls";
 import { ScoutingPanel } from "@/components/offseason/ScoutingPanel";
+import { TransferPanel } from "@/components/offseason/TransferPanel";
 import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
 import { DYNASTY_CONFIG_DEFAULTS } from "@/lib/dynasty-config";
 import { syncActiveLeagueForResource } from "@/lib/active-league-server";
@@ -55,11 +57,12 @@ export default async function SeasonOffseasonPage({
   if (!league) notFound();
   await syncActiveLeagueForResource(league.id);
 
-  const [offseason, draft, teams, prospects] = await Promise.all([
+  const [offseason, draft, teams, prospects, transfers] = await Promise.all([
     getOffseason(season.id).catch(() => null),
     getDraft(season.id).catch(() => null),
     getTeamsByLeague(league.id, orgContext).catch(() => []),
     listProspects(season.id).catch(() => []),
+    listTransfers(season.id).catch(() => []),
   ]);
 
   const role = league.orgId ? await resolveOrgRole(league.orgId, userId) : null;
@@ -117,6 +120,14 @@ export default async function SeasonOffseasonPage({
               offseason?.scoutingPointsTotal ??
               DYNASTY_CONFIG_DEFAULTS.scoutingPointsPerOffseason
             }
+          />
+
+          <TransferPanel
+            leagueId={league.id}
+            seasonId={season.id}
+            transfers={transfers}
+            actingTeam={actingTeam}
+            isAdmin={isAdmin}
           />
         </CardContent>
       </Card>

--- a/apps/web/src/components/offseason/TransferPanel.tsx
+++ b/apps/web/src/components/offseason/TransferPanel.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  openTransferWindowAction,
+  resolveTransferAction,
+} from "@/app/dashboard/_actions/transfers";
+import type { TransferDto } from "@/lib/data-api";
+import {
+  TRANSFER_REASON_LABELS,
+  type TransferReason,
+} from "@/lib/dynasty/transfers";
+
+/*
+ * The transfer window (Dynasty Mode B4).
+ *
+ * Two lists, because there are two decisions. Outbound is "one of yours wants
+ * to leave — argue or let him go". Inbound is "someone else's player is
+ * available — take him or pass".
+ *
+ * An inbound offer stays visible but UNACTIONABLE until the losing coach
+ * releases him. Hiding it instead would be less honest: a coach should be able
+ * to see who he might get and that he is waiting on somebody else, which is
+ * the tension the two-sided model exists to create.
+ */
+
+const REASON_COPY: Record<string, string> = {
+  transfer_not_released:
+    "His program has not released him yet.",
+  transfer_not_pending: "That decision has already been made.",
+  transfer_team_mismatch: "That is not your decision to make.",
+  roster_full: "This roster is already at the maximum size.",
+  season_locked: "The roster is locked for this season.",
+  not_authorized: "You cannot make transfer decisions for this team.",
+};
+
+function copyFor(reason: string): string {
+  return REASON_COPY[reason] ?? "Could not complete that transfer decision.";
+}
+
+function reasonLabel(reason: string): string {
+  return (
+    TRANSFER_REASON_LABELS[reason as TransferReason] ?? "Considering a move"
+  );
+}
+
+export interface TransferPanelProps {
+  leagueId: string;
+  seasonId: string;
+  transfers: TransferDto[];
+  /** The team this viewer decides for, or null when they manage none. */
+  actingTeam: { id: string; name: string } | null;
+  isAdmin: boolean;
+}
+
+export function TransferPanel({
+  leagueId,
+  seasonId,
+  transfers,
+  actingTeam,
+  isAdmin,
+}: TransferPanelProps) {
+  const [rows, setRows] = useState(transfers);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const { outbound, inbound } = useMemo(() => {
+    const mine = actingTeam?.id ?? null;
+    return {
+      outbound: rows.filter(
+        (row) => row.direction === "out" && row.fromTeamId === mine,
+      ),
+      inbound: rows.filter(
+        (row) => row.direction === "in" && row.toTeamId === mine,
+      ),
+    };
+  }, [rows, actingTeam]);
+
+  function decide(transfer: TransferDto, decision: "accept" | "reject") {
+    if (!actingTeam) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await resolveTransferAction({
+        transferId: transfer.id,
+        teamId: actingTeam.id,
+        seasonId,
+        decision,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      /*
+       * Resolving one row can withdraw others, so the local update touches
+       * every row for that player rather than only the one clicked. Patching
+       * just the clicked row would leave a withdrawn offer looking live until
+       * the next navigation.
+       */
+      setRows((current) =>
+        current.map((row) => {
+          if (row.id === transfer.id) {
+            return { ...row, status: result.data.status };
+          }
+          if (row.playerId !== transfer.playerId) return row;
+          if (row.status !== "pending") return row;
+          if (transfer.direction === "out" && decision === "accept") {
+            return { ...row, released: true };
+          }
+          return row.direction === "in" ? { ...row, status: "withdrawn" } : row;
+        }),
+      );
+      setMessage(
+        result.data.moved
+          ? `${transfer.playerName} joins ${actingTeam.name}.`
+          : null,
+      );
+    });
+  }
+
+  function openWindow() {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await openTransferWindowAction({ leagueId, seasonId });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      setMessage(
+        result.data.outbound === 0
+          ? "Nobody is looking to transfer this offseason."
+          : `${result.data.outbound} player${result.data.outbound === 1 ? "" : "s"} entered the window. Reload to see them.`,
+      );
+    });
+  }
+
+  if (rows.length === 0) {
+    return (
+      <section data-testid="transfer-panel" className="space-y-3">
+        <h3 className="text-sm font-semibold">Transfer window</h3>
+        <p className="text-sm text-muted-foreground">
+          The transfer window has not been opened for this season.
+        </p>
+        {isAdmin && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={openWindow}
+            data-testid="open-transfer-window"
+          >
+            Open transfer window
+          </Button>
+        )}
+        {message && (
+          <p className="text-sm text-muted-foreground" role="status">
+            {message}
+          </p>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="transfer-panel" className="space-y-4">
+      <h3 className="text-sm font-semibold">Transfer window</h3>
+
+      {message && (
+        <p className="text-sm text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+
+      {!actingTeam && (
+        <p className="text-sm text-muted-foreground">
+          You do not manage a team in this league, so there is nothing here to
+          decide.
+        </p>
+      )}
+
+      <TransferList
+        testId="transfer-outbound"
+        title="Leaving"
+        empty="Nobody on your roster is looking to move."
+        rows={outbound}
+        pending={pending}
+        renderContext={(row) => `${row.position} · ${reasonLabel(row.reason)}`}
+        acceptLabel="Let him go"
+        rejectLabel="Keep him"
+        canAct={() => true}
+        onDecide={decide}
+      />
+
+      <TransferList
+        testId="transfer-inbound"
+        title="Available"
+        empty="No programs have offered you a transfer."
+        rows={inbound}
+        pending={pending}
+        renderContext={(row) =>
+          `${row.position} · from ${row.fromTeamName}${
+            row.released ? "" : " · awaiting release"
+          }`
+        }
+        acceptLabel="Sign him"
+        rejectLabel="Pass"
+        // An offer is only actionable once his own coach has released him.
+        canAct={(row) => row.released}
+        onDecide={decide}
+      />
+    </section>
+  );
+}
+
+function TransferList({
+  testId,
+  title,
+  empty,
+  rows,
+  pending,
+  renderContext,
+  acceptLabel,
+  rejectLabel,
+  canAct,
+  onDecide,
+}: {
+  testId: string;
+  title: string;
+  empty: string;
+  rows: TransferDto[];
+  pending: boolean;
+  renderContext: (row: TransferDto) => string;
+  acceptLabel: string;
+  rejectLabel: string;
+  canAct: (row: TransferDto) => boolean;
+  onDecide: (row: TransferDto, decision: "accept" | "reject") => void;
+}) {
+  return (
+    <div className="space-y-2" data-testid={testId}>
+      <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+        {title}
+      </h4>
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{empty}</p>
+      ) : (
+        <ul className="divide-y rounded-md border">
+          {rows.map((row) => (
+            <li
+              key={row.id}
+              className="flex flex-wrap items-center gap-3 p-3"
+              data-testid="transfer-row"
+            >
+              <div className="min-w-[12rem] flex-1">
+                <p className="text-sm font-medium">{row.playerName}</p>
+                <p className="text-xs text-muted-foreground">
+                  {renderContext(row)}
+                </p>
+              </div>
+              {row.status === "pending" ? (
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={pending}
+                    onClick={() => onDecide(row, "reject")}
+                  >
+                    {rejectLabel}
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={pending || !canAct(row)}
+                    onClick={() => onDecide(row, "accept")}
+                  >
+                    {acceptLabel}
+                  </Button>
+                </div>
+              ) : (
+                <span
+                  className="text-xs text-muted-foreground"
+                  data-testid="transfer-status"
+                >
+                  {statusCopy(row.status)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * `withdrawn` reads differently from `rejected` on purpose: one is a decision
+ * this coach made, the other is a decision taken away from him by somebody
+ * else. Collapsing them would make the panel misreport who chose what.
+ */
+function statusCopy(status: string): string {
+  switch (status) {
+    case "accepted":
+      return "Accepted";
+    case "rejected":
+      return "Declined";
+    case "withdrawn":
+      return "No longer available";
+    default:
+      return status;
+  }
+}

--- a/apps/web/src/components/offseason/__tests__/transfer-panel.test.ts
+++ b/apps/web/src/components/offseason/__tests__/transfer-panel.test.ts
@@ -1,0 +1,188 @@
+import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { TransferDto } from "@/lib/data-api";
+
+vi.mock("@/app/dashboard/_actions/transfers", () => ({
+  openTransferWindowAction: vi.fn(),
+  resolveTransferAction: vi.fn(),
+}));
+
+import { TransferPanel } from "@/components/offseason/TransferPanel";
+
+const MINE = { id: "team_1", name: "North HS" };
+
+function transfer(overrides: Partial<TransferDto> = {}): TransferDto {
+  return {
+    id: "transfer_1",
+    leagueId: "league_1",
+    seasonId: "season_1",
+    playerId: "player_1",
+    playerName: "Cam Whitfield",
+    position: "WR",
+    grade: 11,
+    direction: "out",
+    fromTeamId: MINE.id,
+    fromTeamName: MINE.name,
+    toTeamId: null,
+    toTeamName: null,
+    reason: "buried",
+    likelihood: 0.4,
+    status: "pending",
+    released: false,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  leagueId: "league_1",
+  seasonId: "season_1",
+  actingTeam: MINE,
+  isAdmin: true,
+};
+
+describe("TransferPanel", () => {
+  it("separates the two decisions a coach has to make", () => {
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [
+          transfer(),
+          transfer({
+            id: "transfer_2",
+            direction: "in",
+            playerId: "player_2",
+            playerName: "Dre Alston",
+            fromTeamId: "team_2",
+            fromTeamName: "South HS",
+            toTeamId: MINE.id,
+            toTeamName: MINE.name,
+            released: true,
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('data-testid="transfer-outbound"');
+    expect(html).toContain('data-testid="transfer-inbound"');
+    expect(html).toContain("Cam Whitfield");
+    expect(html).toContain("Dre Alston");
+    expect(html).toContain("Keep him");
+    expect(html).toContain("Sign him");
+  });
+
+  it("explains WHY a player is looking", () => {
+    // The reason is the argument the coach answers. A row that just said
+    // "wants to transfer" would give him nothing to weigh.
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [transfer({ reason: "buried" })],
+      }),
+    );
+    expect(html).toContain("Buried on the depth chart");
+  });
+
+  it("shows an unreleased offer but does not let it be signed", () => {
+    /*
+     * Visible and disabled, not hidden. A coach should be able to see who he
+     * might get and that he is waiting on somebody else — that tension is the
+     * whole point of the two-sided model.
+     */
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [
+          transfer({
+            direction: "in",
+            fromTeamId: "team_2",
+            fromTeamName: "South HS",
+            toTeamId: MINE.id,
+            toTeamName: MINE.name,
+            released: false,
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain("awaiting release");
+    expect(html).toMatch(/Sign him[\s\S]{0,40}$|disabled/);
+  });
+
+  it("distinguishes a decision this coach made from one taken away", () => {
+    // "We passed" and "we never got the chance" are different stories.
+    const rejected = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [
+          transfer({
+            direction: "in",
+            toTeamId: MINE.id,
+            status: "rejected",
+          }),
+        ],
+      }),
+    );
+    const withdrawn = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [
+          transfer({
+            direction: "in",
+            toTeamId: MINE.id,
+            status: "withdrawn",
+          }),
+        ],
+      }),
+    );
+    expect(rejected).toContain("Declined");
+    expect(withdrawn).toContain("No longer available");
+  });
+
+  it("shows only this team's decisions", () => {
+    // Another program's outbound player is not this coach's call, and showing
+    // it with buttons would imply otherwise.
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        transfers: [
+          transfer({
+            playerName: "Someone Else",
+            fromTeamId: "team_9",
+            fromTeamName: "West HS",
+          }),
+        ],
+      }),
+    );
+    expect(html).not.toContain("Someone Else");
+    expect(html).toContain("Nobody on your roster is looking to move.");
+  });
+
+  it("offers an admin the window when none has been opened", () => {
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, { ...baseProps, transfers: [] }),
+    );
+    expect(html).toContain('data-testid="open-transfer-window"');
+    expect(html).toContain("has not been opened");
+  });
+
+  it("does not offer a non-admin the window", () => {
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        isAdmin: false,
+        transfers: [],
+      }),
+    );
+    expect(html).not.toContain('data-testid="open-transfer-window"');
+  });
+
+  it("says plainly when a viewer manages no team", () => {
+    const html = renderToStaticMarkup(
+      createElement(TransferPanel, {
+        ...baseProps,
+        actingTeam: null,
+        transfers: [transfer()],
+      }),
+    );
+    expect(html).toContain("nothing here to decide");
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -3138,3 +3138,68 @@ export async function signProspect(input: {
     input,
   );
 }
+
+/*
+ * Offseason transfers (B4).
+ *
+ * Player and team names arrive already resolved on the DTO — see the note on
+ * `listTransfers`. The Next layer never joins them back up.
+ */
+
+export interface TransferDto {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  playerId: string;
+  playerName: string;
+  position: string;
+  grade: number | null;
+  direction: string;
+  fromTeamId: string;
+  fromTeamName: string;
+  toTeamId: string | null;
+  toTeamName: string | null;
+  reason: string;
+  likelihood: number;
+  status: string;
+  released: boolean;
+}
+
+export async function listTransfers(seasonId: string): Promise<TransferDto[]> {
+  const client = getConvexClient();
+  return client.query(dynastyRef.query<TransferDto[]>("listTransfers"), {
+    seasonId,
+  });
+}
+
+export async function generateTransferWindow(input: {
+  seasonId: string;
+  actorUserId: string;
+}): Promise<{ outbound: number; offers: number; alreadyExisted: boolean }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      outbound: number;
+      offers: number;
+      alreadyExisted: boolean;
+    }>("generateTransferWindow"),
+    input,
+  );
+}
+
+export async function resolveTransfer(input: {
+  transferId: string;
+  teamId: string;
+  decision: string;
+  actorUserId: string;
+}): Promise<{ status: string; moved: boolean; withdrawn: number }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      status: string;
+      moved: boolean;
+      withdrawn: number;
+    }>("resolveTransfer"),
+    input,
+  );
+}

--- a/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
@@ -7,6 +7,7 @@ import {
   hasReachedPhase,
   isOffseasonPhase,
   nextPhase,
+  phaseIndex,
   phaseGate,
   resolveOffseasonState,
   type OffseasonPhase,
@@ -51,15 +52,21 @@ describe("phase ordering", () => {
     expect(resolveOffseasonState(null).completedPhases).toContain("rollover");
   });
 
-  it("puts recruiting between the rollover and the draft (B3)", () => {
+  it("puts recruiting and transfers between the rollover and the draft", () => {
     /*
-     * Order is the contract, not the membership. Recruiting has to run before
-     * the draft because a prospect a team signs is a roster spot the draft can
-     * no longer fill — the other order would let a coach draft into a class he
-     * has not chosen yet.
+     * Order is the contract, not adjacency. Recruiting has to run before the
+     * draft because a prospect a team signs is a roster spot the draft can no
+     * longer fill; transfers sit between them (B4) because the roster should
+     * shake out after the class is signed and before the draft backfills what
+     * is left.
+     *
+     * Asserted by index rather than by `nextPhase`, so inserting a further
+     * phase between two of these does not fail a test that was never about
+     * adjacency in the first place.
      */
-    expect(nextPhase("rollover")).toBe("recruiting");
-    expect(nextPhase("recruiting")).toBe("draft");
+    expect(phaseIndex("rollover")).toBeLessThan(phaseIndex("recruiting"));
+    expect(phaseIndex("recruiting")).toBeLessThan(phaseIndex("transfers"));
+    expect(phaseIndex("transfers")).toBeLessThan(phaseIndex("draft"));
   });
 });
 

--- a/apps/web/src/lib/dynasty/__tests__/transfers.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/transfers.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from "vitest";
+import {
+  OFFERS_PER_TRANSFER,
+  generateTransferSlate,
+  matchTransfersIn,
+  transferOutLikelihood,
+  type DestinationTeam,
+  type TransferCandidate,
+} from "@/lib/dynasty/transfers";
+import { MAX_TARGET_ROSTER_SIZE } from "../../../../convex/lib/offseason";
+
+function candidate(over: Partial<TransferCandidate> = {}): TransferCandidate {
+  return {
+    playerId: "player_1",
+    teamId: "team_1",
+    position: "WR",
+    depthRank: 1,
+    overall: 75,
+    grade: 11,
+    status: "active",
+    ...over,
+  };
+}
+
+describe("transferOutLikelihood", () => {
+  it("makes a buried player likelier to leave than an identical starter", () => {
+    /*
+     * The user story in one assertion. Everything else in this module exists to
+     * produce this shape.
+     */
+    const starter = transferOutLikelihood({
+      depthRank: 1,
+      overall: 85,
+      grade: 11,
+      volume: "normal",
+    });
+    const buried = transferOutLikelihood({
+      depthRank: 4,
+      overall: 85,
+      grade: 11,
+      volume: "normal",
+    });
+    expect(buried).toBeGreaterThan(starter);
+  });
+
+  it("makes a buried GOOD player likelier than a buried bad one", () => {
+    /*
+     * Talent and burial multiply. If they merely added, a benchwarming
+     * 50-overall would be as likely to move as a benchwarming 90-overall, and
+     * the window would fill with players nobody wants.
+     */
+    const good = transferOutLikelihood({
+      depthRank: 4,
+      overall: 90,
+      grade: 11,
+      volume: "normal",
+    });
+    const bad = transferOutLikelihood({
+      depthRank: 4,
+      overall: 50,
+      grade: 11,
+      volume: "normal",
+    });
+    expect(good).toBeGreaterThan(bad * 2);
+  });
+
+  it("never lets a senior enter the window", () => {
+    // He is graduating. "Might transfer" is not a quieter version of that
+    // story — it is one that cannot happen.
+    expect(
+      transferOutLikelihood({
+        depthRank: 5,
+        overall: 95,
+        grade: 12,
+        volume: "high",
+      }),
+    ).toBe(0);
+  });
+
+  it("scales with the volume knob without changing the ordering", () => {
+    const at = (volume: "low" | "normal" | "high") =>
+      transferOutLikelihood({
+        depthRank: 4,
+        overall: 80,
+        grade: 11,
+        volume,
+      });
+    expect(at("low")).toBeLessThan(at("normal"));
+    expect(at("normal")).toBeLessThan(at("high"));
+  });
+
+  it("stays inside [0, 1] at every extreme", () => {
+    for (const depthRank of [1, 2, 5, 40]) {
+      for (const overall of [40, 70, 99]) {
+        for (const grade of [9, 10, 11, 12, null]) {
+          const value = transferOutLikelihood({
+            depthRank,
+            overall,
+            grade,
+            volume: "high",
+          });
+          expect(value).toBeGreaterThanOrEqual(0);
+          expect(value).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
+});
+
+describe("generateTransferSlate", () => {
+  const roster = Array.from({ length: 40 }, (_, i) =>
+    candidate({
+      playerId: `player_${i}`,
+      depthRank: (i % 5) + 1,
+      overall: 55 + (i % 40),
+      grade: [9, 10, 11][i % 3],
+    }),
+  );
+
+  it("is deterministic for a fixed season", () => {
+    // Re-running the window must not reroll until the commissioner likes it,
+    // and it is what makes the generating mutation safe to retry.
+    const first = generateTransferSlate({
+      seasonId: "season_1",
+      candidates: roster,
+      volume: "normal",
+      enabled: true,
+    });
+    const second = generateTransferSlate({
+      seasonId: "season_1",
+      candidates: roster,
+      volume: "normal",
+      enabled: true,
+    });
+    expect(second).toEqual(first);
+  });
+
+  it("produces a different slate in a different season", () => {
+    const a = generateTransferSlate({
+      seasonId: "season_a",
+      candidates: roster,
+      volume: "high",
+      enabled: true,
+    });
+    const b = generateTransferSlate({
+      seasonId: "season_b",
+      candidates: roster,
+      volume: "high",
+      enabled: true,
+    });
+    expect(b.map((t) => t.playerId)).not.toEqual(a.map((t) => t.playerId));
+  });
+
+  it("never touches a graduated player", () => {
+    /*
+     * Checked on status, not on grade. The two can disagree — the rollover
+     * marks seniors graduated and leaves their grade at 12, and a hand-edited
+     * league can produce either without the other.
+     */
+    const graduated = Array.from({ length: 60 }, (_, i) =>
+      candidate({
+        playerId: `grad_${i}`,
+        depthRank: 5,
+        overall: 95,
+        grade: 11,
+        status: "graduated",
+      }),
+    );
+    const slate = generateTransferSlate({
+      seasonId: "season_1",
+      candidates: graduated,
+      volume: "high",
+      enabled: true,
+    });
+    expect(slate).toEqual([]);
+  });
+
+  it("ignores anyone who is not active", () => {
+    const inactive = Array.from({ length: 40 }, (_, i) =>
+      candidate({
+        playerId: `inactive_${i}`,
+        depthRank: 5,
+        overall: 90,
+        status: "free_agent",
+      }),
+    );
+    expect(
+      generateTransferSlate({
+        seasonId: "season_1",
+        candidates: inactive,
+        volume: "high",
+        enabled: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("produces nothing at all when transfers are switched off", () => {
+    // The kill switch has to be total. A slate of one is still a panel a
+    // commissioner has to work through.
+    expect(
+      generateTransferSlate({
+        seasonId: "season_1",
+        candidates: roster,
+        volume: "high",
+        enabled: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("moves fewer players on low volume than on high", () => {
+    const count = (volume: "low" | "high") =>
+      generateTransferSlate({
+        seasonId: "season_vol",
+        candidates: roster,
+        volume,
+        enabled: true,
+      }).length;
+    expect(count("low")).toBeLessThan(count("high"));
+  });
+
+  it("puts the likeliest mover first", () => {
+    const slate = generateTransferSlate({
+      seasonId: "season_1",
+      candidates: roster,
+      volume: "high",
+      enabled: true,
+    });
+    const likelihoods = slate.map((t) => t.likelihood);
+    expect([...likelihoods].sort((a, b) => b - a)).toEqual(likelihoods);
+  });
+});
+
+describe("matchTransfersIn", () => {
+  const outbound = [
+    {
+      playerId: "player_1",
+      fromTeamId: "team_1",
+      position: "WR",
+      likelihood: 0.4,
+      reason: "buried" as const,
+    },
+  ];
+
+  function destinations(over: Partial<DestinationTeam>[] = []): DestinationTeam[] {
+    const base: DestinationTeam[] = [
+      { teamId: "team_1", rosterCount: 40, countAtPosition: 5 },
+      { teamId: "team_2", rosterCount: 40, countAtPosition: 1 },
+      { teamId: "team_3", rosterCount: 40, countAtPosition: 6 },
+      { teamId: "team_4", rosterCount: 40, countAtPosition: 2 },
+    ];
+    return base.map((team, i) => ({ ...team, ...(over[i] ?? {}) }));
+  }
+
+  it("never offers a player back to the team he is leaving", () => {
+    const offers = matchTransfersIn({
+      seasonId: "season_1",
+      outbound,
+      destinationsFor: () => destinations(),
+    });
+    expect(offers.every((o) => o.toTeamId !== "team_1")).toBe(true);
+  });
+
+  it("prefers the programs thinnest at his position", () => {
+    // A transfer that lands where nobody plays his spot is a roster move, not
+    // a story.
+    const offers = matchTransfersIn({
+      seasonId: "season_1",
+      outbound,
+      destinationsFor: () => destinations(),
+    });
+    expect(offers).toHaveLength(OFFERS_PER_TRANSFER);
+    expect(offers.map((o) => o.toTeamId).sort()).toEqual(["team_2", "team_4"]);
+  });
+
+  it("never offers a spot on a full roster", () => {
+    /*
+     * The roster cap, enforced at the point the offer is MADE. Without it the
+     * panel would show a coach an offer that acceptance can only refuse.
+     */
+    const offers = matchTransfersIn({
+      seasonId: "season_1",
+      outbound,
+      destinationsFor: () =>
+        destinations().map((team) => ({
+          ...team,
+          rosterCount: MAX_TARGET_ROSTER_SIZE,
+        })),
+    });
+    expect(offers).toEqual([]);
+  });
+
+  it("keeps every destination under the cap across a whole slate", () => {
+    /*
+     * Property check over a randomised league: transfers are CONSERVED, so
+     * accepting every offer can only move headcount between teams, and no
+     * team that started under the cap can be pushed over it by an offer this
+     * function made.
+     */
+    const teams = Array.from({ length: 12 }, (_, i) => ({
+      teamId: `team_${i}`,
+      rosterCount: 40 + (i % 21),
+      countAtPosition: i % 7,
+    }));
+    const slate = Array.from({ length: 30 }, (_, i) => ({
+      playerId: `player_${i}`,
+      fromTeamId: `team_${i % 12}`,
+      position: "WR",
+      likelihood: 0.3,
+      reason: "buried" as const,
+    }));
+    const offers = matchTransfersIn({
+      seasonId: "season_prop",
+      outbound: slate,
+      destinationsFor: () => teams,
+    });
+    const byTeam = new Map(teams.map((t) => [t.teamId, t.rosterCount]));
+    for (const offer of offers) {
+      expect(byTeam.get(offer.toTeamId)!).toBeLessThan(MAX_TARGET_ROSTER_SIZE);
+      expect(offer.toTeamId).not.toBe(offer.fromTeamId);
+    }
+  });
+
+  it("is deterministic per season", () => {
+    const run = () =>
+      matchTransfersIn({
+        seasonId: "season_1",
+        outbound,
+        destinationsFor: () => destinations(),
+      });
+    expect(run()).toEqual(run());
+  });
+
+  it("breaks position ties differently for different players", () => {
+    // Without the seeded jitter, a league whose teams all carry three
+    // receivers would send every outbound receiver to whichever team sorts
+    // first.
+    const flat = () => [
+      { teamId: "team_2", rosterCount: 40, countAtPosition: 3 },
+      { teamId: "team_3", rosterCount: 40, countAtPosition: 3 },
+      { teamId: "team_4", rosterCount: 40, countAtPosition: 3 },
+    ];
+    const picks = new Set<string>();
+    for (let i = 0; i < 12; i++) {
+      const offers = matchTransfersIn({
+        seasonId: "season_1",
+        outbound: [{ ...outbound[0], playerId: `p_${i}` }],
+        destinationsFor: flat,
+      });
+      picks.add(offers.map((o) => o.toTeamId).join(","));
+    }
+    expect(picks.size).toBeGreaterThan(1);
+  });
+});

--- a/apps/web/src/lib/dynasty/transfers.ts
+++ b/apps/web/src/lib/dynasty/transfers.ts
@@ -1,0 +1,35 @@
+/*
+ * Offseason transfers (B4) — Next-layer entry point.
+ *
+ * The definition lives in `convex/lib/transfers.ts` because the Convex bundler
+ * can only reach files under `convex/`, while `src/` can reach both. The slate
+ * is generated inside a mutation (the rosters, depth ranks and ratings it reads
+ * all live in Convex, and pulling them into Next would be dozens of round
+ * trips), while the panel renders reasons and likelihoods from the same module.
+ *
+ * This is a re-export, NOT a copy. Same arrangement as
+ * `src/lib/dynasty/scouting.ts` and for the same reason.
+ */
+export {
+  OFFERS_PER_TRANSFER,
+  TRANSFER_REASON_LABELS,
+  TRANSFER_STATUSES,
+  TRANSFER_VOLUME_RATE,
+  generateTransferSlate,
+  isTransferStatus,
+  matchTransfersIn,
+  transferOutLikelihood,
+} from "../../../convex/lib/transfers";
+
+export type {
+  DestinationTeam,
+  LikelihoodInput,
+  MatchInput,
+  OutboundTransfer,
+  SlateInput,
+  TransferCandidate,
+  TransferDirection,
+  TransferOffer,
+  TransferReason,
+  TransferStatus,
+} from "../../../convex/lib/transfers";


### PR DESCRIPTION
Closes #622.

A talented junior buried on the depth chart goes looking for snaps. That one sentence is the model, and everything here follows from it.

## The design decision worth reviewing: transfers are conserved

Every inbound offer originates from a specific outbound player on a specific roster. **Nobody arrives from outside the league.** The easier alternative — synthesising newcomers — was rejected for three reasons:

- **League talent stays constant.** Run ten offseasons and you do not end up with twelve rosters of 90-overalls.
- **Every move has two sides.** One program's gain is visibly another's loss, which is what makes the panel worth reading.
- **The roster cap becomes trivially satisfiable.** A conserved move cannot grow total headcount, so only the destination needs a ceiling check.

## Talent and burial multiply, they do not add

If they added, a benchwarming 50-overall would be about as likely to move as a benchwarming 90-overall, and the window would fill with players nobody wants. Only a product produces the shape the user story asks for: the transfer that hurts is the *good* player who cannot get on the field.

There is a small talent-only floor so a star at a struggling program has a reason to leave even from the top of the chart — deliberately an order of magnitude below the burial term, so a starter is always strictly less likely to leave than an identical player behind him. That is the AC, asserted directly.

## Two-sided resolution

The `out` row is the losing coach's decision — retain him or let him go. The `in` rows are offers to everyone else. Retaining withdraws every offer for him; the first destination to sign withdraws its rivals. A destination **cannot sign a player his own coach has not released**, checked in the mutation rather than the UI because the two decisions are made by different people and can race.

Modelling it as one decision would have been simpler and worse: "your best backup wants out and you cannot argue" is an event, not a mechanic.

`withdrawn` is a distinct status from `rejected` on purpose — "we passed" and "we never got the chance" are different stories, and collapsing them would make the panel misreport who decided what.

## Also in this PR

- **`transfers` phase** between `recruiting` and `draft`: sign your class, then let the roster shake out, then backfill with the draft. Optional, because an unresolved transfer is a decision *not* to decide and one absent coach must not freeze the league.
- **Two different gates, deliberately.** Resolving a transfer is per-`teamId` (the Wave 5 shape). Opening the window is a commissioner action, because it generates every team's slate in one write.
- **One `dynastyEvents` row per resolved transfer**, keyed on the transfer row rather than the player — the release-then-sign sequence is two decisions about one player, and a player key would make them overwrite each other. A release emits nothing: nothing has happened to any roster yet, and a feed entry would announce a move that may never occur.
- **Roster cap checked twice** — when the offer is made, and again at acceptance, because recruiting or another transfer may have filled the destination in between.
- `resetCanonicalFixture` clears `transferEvents` (risk 5); **Transfer Window** added to `CONTEXT.md` (risk 7).
- The `advance` helper in the phase tests now derives its defaults from the machine, so the next slice that inserts a phase does not have to edit it again.

## Verification

- `vitest run` — **211 files, 1691 tests passed** (53 net-new)
- `pnpm turbo type-check` — 5/5 (the real CI gate; the guard test caught `listTransfers` needing an explicit allowlist entry)
- `pnpm --filter @sports-management/web lint` — clean
- New Playwright spec `transfers.spec.ts`; `offseason-phases.spec.ts` updated for the inserted phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4K9xVJisz7DNZDiGbGCB2