### PR TITLE
feat: JV to Varsity promotions, position changes and roster cuts (#623)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,10 @@ _Avoid_: Offseason page, preseason, transfer window
 The Offseason Hub list of players who have asked to leave a Team and the offers other Teams have made for them, for one upcoming Season. A Transfer moves a player between Teams in the same League; nobody arrives from outside it.
 _Avoid_: Portal, trade, free agency, waiver
 
+**Squad**:
+Which of a Team's two rosters a player is on for a Season — Varsity or JV. Ninth-graders are always JV and eleventh- and twelfth-graders are always Varsity, so only a tenth-grader's Squad is a coaching decision.
+_Avoid_: Team level, sub-team, second string, reserves
+
 **Prospect**:
 An incoming ninth-grader on the Recruiting class for one upcoming Season, shown as a projected range rather than a rating until a Team signs him. Scouting narrows the range and never removes it.
 _Avoid_: Recruit rating, star rating, draft prospect, blue-chip
@@ -122,6 +126,8 @@ _Avoid_: Playbook, formation, strategy, system
 - A **Prospect** is scouted and signed from the **Offseason Hub**, because the class is shared by the whole League rather than owned by one Team
 - A **Transfer Window** entry needs two decisions: the Team losing the player releases or keeps him, and a Team offering a spot signs or passes
 - A **Transfer** never changes the number of players in a League, only which Team each belongs to
+- A player's **Squad** and position are changed from the **Offseason Hub**, and both are one Team's decision about its own roster
+- Cutting a player from the **Offseason Hub** releases him to free agency rather than removing him from the League
 - **Account Settings** contains cross-league **Import** and **Account Billing**
 - A successful **Import** may set the imported League as the **Active League** and offer navigation to its **League Home**
 - The **League Directory** provides access to **Discover**

--- a/apps/web/convex/__tests__/rosterMoves.test.ts
+++ b/apps/web/convex/__tests__/rosterMoves.test.ts
@@ -1,0 +1,438 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_admin";
+
+/*
+ * Roster shaping (B5). One team, a handful of players across grades and
+ * squads, so each rule has a case it can actually be broken by.
+ */
+async function seedTeam(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Roster League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2027",
+      status: "upcoming",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+    const teamIds: string[] = [];
+    for (const name of ["North", "South"]) {
+      teamIds.push(
+        (await ctx.db.insert("teams", {
+          leagueId,
+          name: `${name} HS`,
+          city: name,
+          stadium: `${name} Field`,
+          location: `${name}, GA`,
+          foundedYear: null,
+          divisionId: null,
+          rosterLimit: null,
+          logoUrl: null,
+        })) as string,
+      );
+    }
+
+    async function addPlayer(spec: {
+      name: string;
+      position: string;
+      grade: number | null;
+      squad: string;
+      overall: number;
+      teamIndex?: number;
+      depthRank?: number;
+      withDepthEntry?: boolean;
+    }) {
+      const teamId = teamIds[spec.teamIndex ?? 0] as never;
+      const playerId = await ctx.db.insert("players", {
+        name: spec.name,
+        leagueId,
+        teamId,
+        position: spec.position,
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        experienceYears: null,
+        grade: spec.grade,
+        squad: spec.squad,
+        hometown: null,
+        synthetic: true,
+      });
+      await ctx.db.insert("rosterAssignments", {
+        seasonId,
+        teamId,
+        playerId,
+        leagueId,
+        depthRank: spec.depthRank ?? 1,
+        positionSlot: spec.position,
+        status: "active",
+        assignedAt: new Date(0).toISOString(),
+        assignedBy: ACTOR,
+      });
+      if (spec.withDepthEntry !== false) {
+        await ctx.db.insert("depthChartEntries", {
+          teamId,
+          seasonId,
+          playerId,
+          positionSlot: spec.position,
+          sortOrder: (spec.depthRank ?? 1) - 1,
+          updatedAt: new Date(0).toISOString(),
+        });
+      }
+      await ctx.db.insert("playerAttributes", {
+        playerId,
+        seasonId,
+        positionGroup: "WR",
+        attributesJson: JSON.stringify({ SPD: spec.overall, STR: 60 }),
+        pffSourceJson: null,
+        maddenSourceJson: null,
+        pffWeight: 0,
+        maddenWeight: 0,
+        weightedOverall: spec.overall,
+        ingestedAt: new Date(0).toISOString(),
+      });
+      return playerId;
+    }
+
+    const sophomore = await addPlayer({
+      name: "Cam Whitfield",
+      position: "WR",
+      grade: 10,
+      squad: "JV",
+      overall: 84,
+      depthRank: 2,
+    });
+    const senior = await addPlayer({
+      name: "Ty Barrow",
+      position: "WR",
+      grade: 12,
+      squad: "Varsity",
+      overall: 70,
+    });
+    const freshman = await addPlayer({
+      name: "Nate Ellis",
+      position: "CB",
+      grade: 9,
+      squad: "JV",
+      overall: 88,
+    });
+    const gradeless = await addPlayer({
+      name: "Unknown Grade",
+      position: "TE",
+      grade: null,
+      squad: "JV",
+      overall: 75,
+    });
+    const rival = await addPlayer({
+      name: "Other Program",
+      position: "QB",
+      grade: 11,
+      squad: "Varsity",
+      overall: 80,
+      teamIndex: 1,
+    });
+
+    return {
+      leagueId,
+      seasonId,
+      teamIds,
+      sophomore,
+      senior,
+      freshman,
+      gradeless,
+      rival,
+    };
+  });
+}
+
+describe("listRosterBoard", () => {
+  it("returns this team's roster with everything a decision needs", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const rows = await t.query(api.dynasty.listRosterBoard, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+
+    expect(rows).toHaveLength(4);
+    const cam = rows.find((row) => row.name === "Cam Whitfield");
+    expect(cam).toMatchObject({ grade: 10, squad: "JV", overall: 84 });
+    // Attributes travel with the row so the panel can price a position change
+    // without a round trip per candidate.
+    expect(JSON.parse(cam?.attributesJson ?? "{}")).toMatchObject({ SPD: 84 });
+  });
+
+  it("does not leak another program's roster", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const rows = await t.query(api.dynasty.listRosterBoard, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(rows.some((row) => row.name === "Other Program")).toBe(false);
+  });
+});
+
+describe("setPlayerSquad", () => {
+  it("promotes a sophomore and records it", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const result = await t.mutation(internal.dynasty.setPlayerSquad, {
+      playerId: seed.sophomore,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      squad: "Varsity",
+      actorUserId: ACTOR,
+    });
+    expect(result).toEqual({ squad: "Varsity", changed: true });
+
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(seed.sophomore))?.squad).toBe("Varsity");
+      const audit = await ctx.db.query("rosterAuditLog").collect();
+      expect(audit.map((row) => row.action)).toContain("promote");
+    });
+  });
+
+  it("refuses a freshman", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.setPlayerSquad, {
+        playerId: seed.freshman,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        squad: "Varsity",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("grade_too_low_for_varsity");
+  });
+
+  it("refuses to send a senior down to JV", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.setPlayerSquad, {
+        playerId: seed.senior,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        squad: "JV",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("grade_requires_varsity");
+  });
+
+  it("refuses a player with no grade rather than assuming one", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.setPlayerSquad, {
+        playerId: seed.gradeless,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        squad: "Varsity",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("grade_unknown");
+  });
+
+  it("refuses a coach acting for a team the player is not on", async () => {
+    /*
+     * The DB half of the per-team gate. The Next layer authorizes a `teamId`;
+     * if this mutation derived the team from the player instead, an action
+     * that authorized team A could patch a player who had since moved to B.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.setPlayerSquad, {
+        playerId: seed.sophomore,
+        teamId: seed.teamIds[1] as never,
+        seasonId: seed.seasonId,
+        squad: "Varsity",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("player_not_on_team");
+  });
+
+  it("treats a repeat of the same move as a no-op", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const args = {
+      playerId: seed.sophomore,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      squad: "Varsity",
+      actorUserId: ACTOR,
+    };
+    await t.mutation(internal.dynasty.setPlayerSquad, args);
+    const second = await t.mutation(internal.dynasty.setPlayerSquad, args);
+    expect(second).toEqual({ squad: "Varsity", changed: false });
+
+    // And it does not write a second audit row for a decision made once.
+    await t.run(async (ctx) => {
+      const audit = await ctx.db.query("rosterAuditLog").collect();
+      expect(audit.filter((row) => row.action === "promote")).toHaveLength(1);
+    });
+  });
+});
+
+describe("changePlayerPosition", () => {
+  it("rewrites the player, the assignment and the depth chart together", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const result = await t.mutation(internal.dynasty.changePlayerPosition, {
+      playerId: seed.sophomore,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      position: "CB",
+      actorUserId: ACTOR,
+    });
+    expect(result).toMatchObject({
+      position: "CB",
+      positionGroup: "DB",
+      changed: true,
+    });
+
+    await t.run(async (ctx) => {
+      const player = await ctx.db.get(seed.sophomore);
+      expect(player?.position).toBe("CB");
+      expect(player?.positionGroup).toBe("DB");
+
+      // No stale slot anywhere: this is the bug the AC names.
+      const assignments = (
+        await ctx.db.query("rosterAssignments").collect()
+      ).filter((row) => row.playerId === seed.sophomore);
+      expect(assignments.map((row) => row.positionSlot)).toEqual(["CB"]);
+
+      const depth = (await ctx.db.query("depthChartEntries").collect()).filter(
+        (row) => row.playerId === seed.sophomore,
+      );
+      expect(depth.map((row) => row.positionSlot)).toEqual(["CB"]);
+    });
+  });
+
+  it("puts him at the BACK of his new position's depth", async () => {
+    /*
+     * He was WR2. Converting him must not hand him the CB job over the player
+     * who already holds it — he has never played there.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await t.mutation(internal.dynasty.changePlayerPosition, {
+      playerId: seed.sophomore,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      position: "CB",
+      actorUserId: ACTOR,
+    });
+
+    await t.run(async (ctx) => {
+      const cbs = (await ctx.db.query("rosterAssignments").collect()).filter(
+        (row) => row.positionSlot === "CB",
+      );
+      const moved = cbs.find((row) => row.playerId === seed.sophomore);
+      const incumbent = cbs.find((row) => row.playerId === seed.freshman);
+      expect(moved?.depthRank).toBeGreaterThan(incumbent?.depthRank ?? 0);
+    });
+  });
+
+  it("rejects a position the league does not recognise", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.changePlayerPosition, {
+        playerId: seed.sophomore,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        position: "GOALIE",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("invalid_position");
+  });
+
+  it("refuses to reshape a locked roster", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(seed.seasonId, { rosterLocked: true });
+    });
+    await expect(
+      t.mutation(internal.dynasty.changePlayerPosition, {
+        playerId: seed.sophomore,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        position: "CB",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("season_locked");
+  });
+
+  it("is a no-op when he already plays there", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    const result = await t.mutation(internal.dynasty.changePlayerPosition, {
+      playerId: seed.sophomore,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      position: "WR",
+      actorUserId: ACTOR,
+    });
+    expect(result.changed).toBe(false);
+  });
+
+  it("refuses a coach acting for another program's player", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await expect(
+      t.mutation(internal.dynasty.changePlayerPosition, {
+        playerId: seed.rival,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        position: "WR",
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow("player_not_on_team");
+  });
+});
+
+describe("cuts route through the existing release", () => {
+  it("clears the roster rows and drops him to free agency", async () => {
+    /*
+     * B5 adds no release path of its own. This asserts the existing one still
+     * does what a cut needs, so the panel wiring is the only new part.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedTeam(t);
+    await t.mutation(internal.sports.releasePlayerToFreeAgency, {
+      playerId: seed.sophomore,
+    });
+
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(seed.sophomore))?.status).toBe("free_agent");
+      const assignments = (
+        await ctx.db.query("rosterAssignments").collect()
+      ).filter((row) => row.playerId === seed.sophomore);
+      expect(assignments).toEqual([]);
+    });
+
+    const rows = await t.query(api.dynasty.listRosterBoard, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(rows.some((row) => row.name === "Cam Whitfield")).toBe(false);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -242,7 +242,14 @@ type AllowedPublicDynastyReads =
    * program can see who is looking. What is NOT public is acting on it:
    * `resolveTransfer` is an internalMutation behind a per-`teamId` gate.
    */
-  | "listTransfers";
+  | "listTransfers"
+  /*
+   * B5. A roster is already readable through the team and roster pages; this
+   * query returns the same players with their grade, squad and ratings so the
+   * panel can compute position fit without a round trip per candidate. The
+   * MOVES are internalMutations behind the same per-`teamId` gate.
+   */
+  | "listRosterBoard";
 type AllowedPublicSimReads =
   | "moduleStatus"
   | "listRivalries"

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -25,6 +25,11 @@ import {
   matchTransfersIn,
   type TransferCandidate,
 } from "./lib/transfers";
+import { VARSITY, squadChange } from "./lib/promotions";
+import {
+  attributeGroupForPosition,
+  derivePositionGroup,
+} from "./lib/positions";
 import { MAX_TARGET_ROSTER_SIZE } from "./lib/offseason";
 import { emitDynastyEvent } from "./lib/events";
 import { transferResolvedDedupeKey } from "./lib/narrative";
@@ -1328,5 +1333,286 @@ export const resolveTransfer = internalMutation({
     });
 
     return { status: "accepted", moved: true, withdrawn };
+  },
+});
+
+/*
+ * ── Roster shaping: promotions, position changes, cuts (B5) ────────────────
+ *
+ * Three operations on one board, and zero new tables. A promotion is a patch
+ * to `players.squad`; a position change is a patch to `players.position` plus
+ * the season rows that mirror it; a cut is the free-agency release that has
+ * shipped since WSM-000231. Inventing a `rosterMoves` table would have given
+ * the offseason a second, quieter record of roster state that the roster pages
+ * do not read — the audit log already answers "what happened", and the roster
+ * itself answers "what is true".
+ */
+
+const rosterBoardPlayerValidator = v.object({
+  playerId: v.string(),
+  name: v.string(),
+  position: v.string(),
+  positionGroup: v.union(v.string(), v.null()),
+  grade: v.union(v.number(), v.null()),
+  squad: v.union(v.string(), v.null()),
+  overall: v.union(v.number(), v.null()),
+  depthRank: v.union(v.number(), v.null()),
+  /** Ratings map, JSON-encoded. Null when the player has no rated season. */
+  attributesJson: v.union(v.string(), v.null()),
+});
+
+/**
+ * One team's roster for a season, with everything roster shaping needs.
+ *
+ * Attributes come along because `positionChangeFit` is computed in the panel,
+ * per candidate position, as the coach scrubs the control — a round trip per
+ * hover would be a worse version of the same answer.
+ *
+ * The per-player attribute read is one indexed `.first()` each, bounded by
+ * roster size (~40). That is deliberately NOT the `by_seasonId_positionGroup`
+ * prefix B4 switched to: that index would return every rated player in the
+ * league for the season (~600) to serve one team.
+ */
+export const listRosterBoard = query({
+  args: { seasonId: v.id("seasons"), teamId: v.id("teams") },
+  returns: v.array(rosterBoardPlayerValidator),
+  handler: async (ctx, args) => {
+    const assignments = (
+      await ctx.db
+        .query("rosterAssignments")
+        .withIndex("by_seasonId_teamId", (q) =>
+          q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+        )
+        .collect()
+    ).filter((row) => row.status === "active");
+
+    const rows: Infer<typeof rosterBoardPlayerValidator>[] = [];
+    for (const assignment of assignments) {
+      const player = await ctx.db.get(assignment.playerId);
+      if (!player) continue;
+
+      /*
+       * Ratings resolve through `sourcePlayerId` when the player is a
+       * workspace fork, matching `resolvePlayerOverall` in `sports.ts`. A fork
+       * that read its own empty attribute row would show every player as
+       * unrated.
+       */
+      const ratingPlayerId = player.sourcePlayerId ?? assignment.playerId;
+      const attributes = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", ratingPlayerId).eq("seasonId", args.seasonId),
+        )
+        .first();
+
+      rows.push({
+        playerId: assignment.playerId as string,
+        name: player.name,
+        position: player.position,
+        positionGroup: player.positionGroup ?? null,
+        grade: player.grade ?? null,
+        squad: player.squad ?? null,
+        overall: attributes?.weightedOverall ?? null,
+        depthRank: assignment.depthRank,
+        attributesJson: attributes?.attributesJson ?? null,
+      });
+    }
+
+    return rows.sort((a, b) =>
+      a.position === b.position
+        ? (a.depthRank ?? 0) - (b.depthRank ?? 0)
+        : a.position < b.position
+          ? -1
+          : 1,
+    );
+  },
+});
+
+/**
+ * Move a player between Varsity and JV.
+ *
+ * `teamId` is an argument rather than something derived from the player so the
+ * Next layer's per-team gate and this check are about the SAME team: an action
+ * that authorized team A and then patched a player who had already moved to
+ * team B would be a real hole, and deriving the team here would hide it.
+ */
+export const setPlayerSquad = internalMutation({
+  args: {
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    squad: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({ squad: v.string(), changed: v.boolean() }),
+  handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+    if (player.teamId !== args.teamId) throw new Error("player_not_on_team");
+
+    const decision = squadChange({
+      grade: player.grade ?? null,
+      from: player.squad ?? null,
+      to: args.squad,
+    });
+    if (!decision.ok) throw new Error(decision.reason);
+    if (decision.kind === "noop") {
+      return { squad: args.squad, changed: false };
+    }
+
+    await ctx.db.patch(args.playerId, { squad: args.squad });
+    await ctx.db.insert("rosterAuditLog", {
+      leagueId: player.leagueId,
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      actorUserId: args.actorUserId,
+      action: args.squad === VARSITY ? "promote" : "demote",
+      beforeJson: JSON.stringify({ squad: player.squad ?? null }),
+      afterJson: JSON.stringify({
+        squad: args.squad,
+        playerId: args.playerId as string,
+      }),
+      createdAt: new Date().toISOString(),
+    });
+
+    return { squad: args.squad, changed: true };
+  },
+});
+
+/**
+ * Move a player to a different position.
+ *
+ * Rewrites three things, because a position lives in three places: the player
+ * row (what he is), the season's roster assignment (where he is slotted this
+ * year) and the depth chart (where he is in the pecking order). Leaving any of
+ * them behind is the stale-slot bug this is tested against — a player listed
+ * at QB whose depth-chart card still sits under DB.
+ *
+ * ONLY the season passed in is rewritten. `players.position` is global and a
+ * completed season's assignment is a record of where he actually played; a
+ * coach who converts a safety to receiver in the offseason has not retroped
+ * last year's snaps to receiver, and rewriting them would be falsifying a
+ * result. The disagreement between the two is the honest reading.
+ */
+export const changePlayerPosition = internalMutation({
+  args: {
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    position: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    position: v.string(),
+    positionGroup: v.string(),
+    changed: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const position = args.position.trim().toUpperCase();
+    if (derivePositionGroup(position) === null) {
+      throw new Error("invalid_position");
+    }
+    const positionGroup = attributeGroupForPosition(position);
+
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+    if (player.teamId !== args.teamId) throw new Error("player_not_on_team");
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.rosterLocked === true) throw new Error("season_locked");
+
+    if (player.position === position) {
+      return { position, positionGroup, changed: false };
+    }
+
+    const previous = { position: player.position, group: player.positionGroup };
+    await ctx.db.patch(args.playerId, { position, positionGroup });
+
+    const teamAssignments = await ctx.db
+      .query("rosterAssignments")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+
+    /*
+     * He joins the BACK of the new position's depth, not the rank he held at
+     * the old one. A converted player has not earned a starting job at a
+     * position he has never played, and inheriting rank 1 would silently
+     * demote whoever actually held it.
+     */
+    const nextDepthRank =
+      teamAssignments
+        .filter(
+          (row) =>
+            row.status === "active" &&
+            row.positionSlot === position &&
+            row.playerId !== args.playerId,
+        )
+        .reduce((max, row) => Math.max(max, row.depthRank), 0) + 1;
+
+    for (const row of teamAssignments) {
+      if (row.playerId !== args.playerId) continue;
+      await ctx.db.patch(row._id, {
+        positionSlot: position,
+        depthRank: nextDepthRank,
+      });
+    }
+
+    const depthEntries = await ctx.db
+      .query("depthChartEntries")
+      .withIndex("by_team_season", (q) =>
+        q.eq("teamId", args.teamId).eq("seasonId", args.seasonId),
+      )
+      .collect();
+    const mine = depthEntries.filter((row) => row.playerId === args.playerId);
+    const nextSortOrder =
+      depthEntries
+        .filter(
+          (row) =>
+            row.positionSlot === position && row.playerId !== args.playerId,
+        )
+        .reduce((max, row) => Math.max(max, row.sortOrder), -1) + 1;
+
+    const now = new Date().toISOString();
+    if (mine.length === 0) {
+      /*
+       * No depth entry to move. Nothing is created here: a player absent from
+       * the depth chart was absent before the change too, and adding him now
+       * would make a position change quietly do roster work nobody asked for.
+       */
+    } else {
+      // Keep the first, drop any duplicates rather than leaving him listed at
+      // two positions at once.
+      await ctx.db.patch(mine[0]._id, {
+        positionSlot: position,
+        sortOrder: nextSortOrder,
+        updatedAt: now,
+      });
+      for (const extra of mine.slice(1)) {
+        await ctx.db.delete(extra._id);
+      }
+    }
+
+    await ctx.db.insert("rosterAuditLog", {
+      leagueId: player.leagueId,
+      teamId: args.teamId,
+      seasonId: args.seasonId,
+      actorUserId: args.actorUserId,
+      action: "position_change",
+      beforeJson: JSON.stringify({
+        position: previous.position,
+        positionGroup: previous.group,
+      }),
+      afterJson: JSON.stringify({
+        position,
+        positionGroup,
+        playerId: args.playerId as string,
+      }),
+      createdAt: now,
+    });
+
+    return { position, positionGroup, changed: true };
   },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -788,3 +788,115 @@ export const seedTransferCandidates = internalMutation({
     return { created };
   },
 });
+
+/**
+ * Seed a roster the B5 panel has an obvious decision about.
+ *
+ * One weak senior holding the starting job and `count` strong sophomores on JV
+ * behind him, so `recommendPromotions` has a comparative case to make. Grades
+ * are explicit because every rule in B5 turns on them — a roster of
+ * grade-less players would make the panel correctly show nothing.
+ */
+export const seedRosterMoveCandidates = internalMutation({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    count: v.optional(v.number()),
+  },
+  returns: v.object({ created: v.number() }),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("team_not_found");
+
+    const count = Math.max(1, Math.min(args.count ?? 3, 20));
+    const now = new Date().toISOString();
+    let created = 0;
+
+    async function addPlayer(spec: {
+      name: string;
+      grade: number;
+      squad: string;
+      overall: number;
+      depthRank: number;
+    }) {
+      const playerId = await ctx.db.insert("players", {
+        name: spec.name,
+        leagueId: season!.leagueId,
+        teamId: args.teamId,
+        position: "WR",
+        positionGroup: "WR",
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        experienceYears: null,
+        grade: spec.grade,
+        squad: spec.squad,
+        hometown: null,
+        synthetic: true,
+      });
+      await ctx.db.insert("rosterAssignments", {
+        seasonId: args.seasonId,
+        teamId: args.teamId,
+        playerId,
+        leagueId: season!.leagueId,
+        depthRank: spec.depthRank,
+        positionSlot: "WR",
+        status: "active",
+        assignedAt: now,
+        assignedBy: SEED_ACTOR,
+      });
+      await ctx.db.insert("depthChartEntries", {
+        teamId: args.teamId,
+        seasonId: args.seasonId,
+        playerId,
+        positionSlot: "WR",
+        sortOrder: spec.depthRank - 1,
+        updatedAt: now,
+      });
+      await ctx.db.insert("playerAttributes", {
+        playerId,
+        seasonId: args.seasonId,
+        positionGroup: "WR",
+        attributesJson: JSON.stringify({
+          SPD: spec.overall,
+          AGI: spec.overall,
+          ACC: spec.overall,
+          STR: 55,
+          AWR: 60,
+          STA: 70,
+        }),
+        pffSourceJson: null,
+        maddenSourceJson: null,
+        pffWeight: 0,
+        maddenWeight: 0,
+        weightedOverall: spec.overall,
+        ingestedAt: now,
+      });
+      created += 1;
+    }
+
+    // The incumbent: a senior who cannot be sent down, holding the job.
+    await addPlayer({
+      name: "E2E Starter Senior",
+      grade: 12,
+      squad: "Varsity",
+      overall: 62,
+      depthRank: 1,
+    });
+    for (let i = 0; i < count; i++) {
+      await addPlayer({
+        name: `E2E JV Sophomore ${i + 1}`,
+        grade: 10,
+        squad: "JV",
+        overall: 88 - i,
+        depthRank: i + 2,
+      });
+    }
+
+    return { created };
+  },
+});

--- a/apps/web/convex/lib/positions.ts
+++ b/apps/web/convex/lib/positions.ts
@@ -1,0 +1,173 @@
+/*
+ * The position vocabulary, shared by both runtimes (Dynasty Mode B5).
+ *
+ * Everything here was already in the codebase — the roster-group map lived in
+ * `src/lib/position-group.ts`, the attribute-group split in
+ * `src/lib/synthetic-attributes.ts`, and the development weights in
+ * `src/lib/dynasty-progression.ts`. B5 moved them here and left re-exports
+ * behind, for the same reason B3 moved the RNG: a position change is validated
+ * in a Convex mutation and previewed in a React panel, and the two must agree
+ * about what a position IS. A second copy under `convex/` would be a fork of
+ * the app's football vocabulary that nothing would notice had drifted until a
+ * coach moved a player to a position one side had never heard of.
+ *
+ * No Convex imports — this is a pure data module.
+ */
+
+/** Roster-facing groups. Kickers and punters share one, as the roster UI shows them. */
+export type PositionGroup =
+  | "QB"
+  | "RB"
+  | "WR"
+  | "TE"
+  | "OL"
+  | "DL"
+  | "LB"
+  | "DB"
+  | "K/P";
+
+/**
+ * Every position the app recognises.
+ *
+ * This is the authority for "is that a real position", which is what
+ * `changePlayerPosition` validates against. Deliberately the full vocabulary
+ * rather than a shorter list built for the dropdown: a position that arrived
+ * from an import or a seed is still a position, and rejecting it because it is
+ * not offered in a select would be the UI dictating the data model.
+ */
+export const POSITION_TO_GROUP: Readonly<Record<string, PositionGroup>> = {
+  QB: "QB",
+  HB: "RB",
+  RB: "RB",
+  FB: "RB",
+  WR: "WR",
+  TE: "TE",
+  LT: "OL",
+  LG: "OL",
+  C: "OL",
+  RG: "OL",
+  RT: "OL",
+  G: "OL",
+  OG: "OL",
+  OT: "OL",
+  OL: "OL",
+  DE: "DL",
+  DT: "DL",
+  NT: "DL",
+  EDGE: "DL",
+  DL: "DL",
+  OLB: "LB",
+  MLB: "LB",
+  ILB: "LB",
+  LB: "LB",
+  CB: "DB",
+  S: "DB",
+  FS: "DB",
+  SS: "DB",
+  NB: "DB",
+  DB: "DB",
+  K: "K/P",
+  PK: "K/P",
+  P: "K/P",
+  LS: "K/P",
+};
+
+/** The roster group for a position, or null when it is not one we know. */
+export function derivePositionGroup(position: string): PositionGroup | null {
+  const normalized = position.trim().toUpperCase();
+  return POSITION_TO_GROUP[normalized] ?? null;
+}
+
+/**
+ * Attribute-domain groups. Kickers and punters split here, unlike the roster
+ * group above, because they are rated on different things.
+ */
+export const ATTRIBUTE_GROUPS = [
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "OL",
+  "DL",
+  "LB",
+  "DB",
+  "K",
+  "P",
+] as const;
+
+export type AttributeGroup = (typeof ATTRIBUTE_GROUPS)[number];
+
+/**
+ * Map a concrete position to its attribute group.
+ *
+ * Unmappable positions fall back to "WR" — a generic athletic profile — so
+ * every player has ratings. That fallback predates B5 and is preserved
+ * verbatim; changing it would silently re-rate existing players.
+ */
+export function attributeGroupForPosition(position: string): AttributeGroup {
+  const group = derivePositionGroup(position);
+  if (group === "K/P") {
+    return position.trim().toUpperCase() === "P" ? "P" : "K";
+  }
+  if (group === null) return "WR";
+  return group;
+}
+
+/**
+ * Position-tilted attribute weights (higher weight → the position leans on
+ * that attribute more).
+ *
+ * Two mechanics read this and they read it for opposite reasons. Offseason
+ * progression uses it to decide where a player's development GOES; B5's
+ * position fit uses it to decide whether the athlete he already is SUITS a
+ * position. Same emphasis, both directions — which is why they must not be two
+ * tables that agree by coincidence.
+ */
+export const POSITION_ATTR_WEIGHTS: Readonly<
+  Record<string, Partial<Record<string, number>>>
+> = {
+  QB: { THP: 1.4, SAC: 1.2, AWR: 1.3, SPD: 0.8 },
+  RB: { SPD: 1.5, AGI: 1.3, ACC: 1.2, CAR: 1.1 },
+  WR: { SPD: 1.4, CTH: 1.2, SRR: 1.2, AGI: 1.1 },
+  TE: { CTH: 1.3, STR: 1.2, SPD: 1.0 },
+  OL: { STR: 1.4, RBK: 1.2, PBK: 1.2 },
+  DL: { STR: 1.3, PMV: 1.2, FMV: 1.2, BSH: 1.1 },
+  LB: { SPD: 1.2, TAK: 1.3, PRC: 1.2, AWR: 1.1 },
+  DB: { SPD: 1.4, AGI: 1.3, MCV: 1.2, ZCV: 1.2 },
+  K: { KPW: 1.2, KAC: 1.2 },
+  P: { KPW: 1.2, KAC: 1.2 },
+};
+
+/** The weight an attribute carries for a group; 1 when the group is indifferent. */
+export function attrWeight(positionGroup: string, key: string): number {
+  return POSITION_ATTR_WEIGHTS[positionGroup]?.[key] ?? 1;
+}
+
+/**
+ * The positions the position-change control offers.
+ *
+ * A curated subset of `POSITION_TO_GROUP` — one representative per role rather
+ * than all thirty-four, because a select with every offensive-line variant in
+ * it is a worse control, not a more honest one. The mutation validates against
+ * the full map, so this list narrows what is SUGGESTED and never what is
+ * legal.
+ */
+export const POSITION_CHANGE_OPTIONS: readonly string[] = [
+  "QB",
+  "HB",
+  "FB",
+  "WR",
+  "TE",
+  "OT",
+  "OG",
+  "C",
+  "DE",
+  "DT",
+  "OLB",
+  "MLB",
+  "CB",
+  "FS",
+  "SS",
+  "K",
+  "P",
+];

--- a/apps/web/convex/lib/promotions.ts
+++ b/apps/web/convex/lib/promotions.ts
@@ -1,0 +1,221 @@
+/*
+ * Roster shaping: squads, position changes and who deserves a promotion
+ * (Dynasty Mode B5).
+ *
+ * Pure and Convex-free. The rules live here because both ends need them and
+ * need the same answer: the mutation ENFORCES them, and the panel uses them to
+ * decide which buttons to offer. A panel that offered a move the mutation
+ * rejects would be worse than one that offered nothing.
+ *
+ * ## Why `squad` is a rule and not a free-text field
+ *
+ * `players.squad` has existed since the HS model landed and nothing has ever
+ * written to it deliberately — it is seeded by `squadForGrade`, which puts
+ * every junior and senior on Varsity and coin-flips the rest. B5 is the first
+ * mechanic that lets a coach disagree with that, so it is also the first place
+ * the rule has to be stated rather than assumed:
+ *
+ *   - Grade 11 and 12 are ALWAYS Varsity. This is `squadForGrade`'s invariant,
+ *     and B5 preserves rather than re-implements it: an upperclassman cannot be
+ *     sent down. In a high-school program that is not a coaching decision,
+ *     it is what JV means.
+ *   - Grade 9 is ALWAYS JV. A freshman is not promotable, however good he is.
+ *   - Grade 10 is the only genuine decision, which is exactly where a
+ *     promotion mechanic should live.
+ *
+ * A player with no grade is not in the dynasty model at all, and B5 refuses to
+ * guess one for him — see `squadChangeError`.
+ */
+
+import {
+  attrWeight,
+  attributeGroupForPosition,
+  derivePositionGroup,
+} from "./positions";
+
+export const VARSITY = "Varsity";
+export const JV = "JV";
+
+/** The lowest grade that may be promoted to Varsity by a coach. */
+export const MIN_PROMOTION_GRADE = 10;
+
+/** The grade at and above which Varsity is mandatory, mirroring `squadForGrade`. */
+export const MANDATORY_VARSITY_GRADE = 11;
+
+export type Squad = typeof VARSITY | typeof JV;
+
+export function isSquad(value: string): value is Squad {
+  return value === VARSITY || value === JV;
+}
+
+export type SquadChangeRejection =
+  | "invalid_squad"
+  | "grade_unknown"
+  | "grade_too_low_for_varsity"
+  | "grade_requires_varsity";
+
+export interface SquadChangeInput {
+  grade: number | null;
+  from: string | null;
+  to: string;
+}
+
+export type SquadChangeDecision =
+  | { ok: true; kind: "change" }
+  /** Already on that squad — a retry of a request that landed. */
+  | { ok: true; kind: "noop" }
+  | { ok: false; reason: SquadChangeRejection };
+
+/**
+ * Whether a player may move to `to`.
+ *
+ * Returns a `noop` rather than an error when he is already there, mirroring
+ * `phaseGate` in `offseasonPhases.ts`: a double-submitted move is not a
+ * failure, it is a request that was already satisfied. Two concurrency idioms
+ * for the same shape in one feature is how off-by-one bugs get written.
+ */
+export function squadChange(input: SquadChangeInput): SquadChangeDecision {
+  if (!isSquad(input.to)) return { ok: false, reason: "invalid_squad" };
+  if (input.from === input.to) return { ok: true, kind: "noop" };
+
+  /*
+   * Honest absence: a null grade means this player is not modelled as a
+   * high-school student, not that he is a freshman. Defaulting him to a grade
+   * would invent the fact the whole rule turns on.
+   */
+  if (input.grade === null) return { ok: false, reason: "grade_unknown" };
+
+  if (input.to === VARSITY && input.grade < MIN_PROMOTION_GRADE) {
+    return { ok: false, reason: "grade_too_low_for_varsity" };
+  }
+  if (input.to === JV && input.grade >= MANDATORY_VARSITY_GRADE) {
+    return { ok: false, reason: "grade_requires_varsity" };
+  }
+  return { ok: true, kind: "change" };
+}
+
+/* ── Position fit ──────────────────────────────────────────────────────── */
+
+/** Attribute ceiling — the scale `positionChangeFit` normalises against. */
+const ATTRIBUTE_MAX = 99;
+
+export interface PositionFitInput {
+  toPosition: string;
+  /** The player's ratings. Keys absent from his profile are absent, not zero. */
+  attributes: Readonly<Record<string, number>>;
+}
+
+/**
+ * How well a player suits a position, from 0 to 1.
+ *
+ * Scored over the attributes he HAS, weighted by what the target position
+ * leans on. A quarterback moving to cornerback has no coverage ratings at all,
+ * and the honest reading of that is not "he covers at zero" — it is that he
+ * has to be judged on the athleticism he demonstrably has: speed, agility,
+ * awareness. Which is how a real coach judges the same move.
+ *
+ * Treating a missing attribute as 0 would make every cross-group move score
+ * near-zero and the control would be decoration. Treating it as average would
+ * invent a rating. Leaving it out of both sides of the ratio is the only
+ * reading that adds no information that is not there.
+ *
+ * An unrecognised position scores 0: nothing is known about a position that
+ * does not exist, and offering a fit for it would be a fabrication.
+ */
+export function positionChangeFit(input: PositionFitInput): number {
+  if (derivePositionGroup(input.toPosition) === null) return 0;
+  const group = attributeGroupForPosition(input.toPosition);
+
+  let weighted = 0;
+  let weightSum = 0;
+  for (const [key, value] of Object.entries(input.attributes)) {
+    if (!Number.isFinite(value)) continue;
+    const weight = attrWeight(group, key);
+    weighted += value * weight;
+    weightSum += weight;
+  }
+  if (weightSum === 0) return 0;
+
+  const fit = weighted / (weightSum * ATTRIBUTE_MAX);
+  return Math.min(1, Math.max(0, fit));
+}
+
+/* ── Promotion recommendations ─────────────────────────────────────────── */
+
+export interface RosterPlayer {
+  playerId: string;
+  name: string;
+  position: string;
+  grade: number | null;
+  squad: string | null;
+  overall: number | null;
+}
+
+export interface PromotionRecommendation {
+  playerId: string;
+  name: string;
+  position: string;
+  overall: number;
+  /** The Varsity player he would leapfrog, or null when nobody plays there. */
+  replacesPlayerId: string | null;
+  replacesName: string | null;
+  /** Rating points he adds at the position. */
+  margin: number;
+}
+
+/**
+ * Who on JV has outgrown it.
+ *
+ * The argument a recommendation makes is comparative, never "he is good": a
+ * player is worth promoting when he is better than the WEAKEST Varsity player
+ * at his position, because that is the man he would actually replace. A list
+ * ranked by raw rating would recommend the same handful of athletes every year
+ * regardless of whether the roster needed them.
+ *
+ * An unmanned position is the strongest case of all and sorts first — there is
+ * nobody there at all, so the comparison has no incumbent to beat.
+ *
+ * Pure and total: no RNG, no clock, stable ties. Same roster in, same list out.
+ */
+export function recommendPromotions(
+  roster: readonly RosterPlayer[],
+): PromotionRecommendation[] {
+  const weakestVarsity = new Map<string, RosterPlayer>();
+  for (const player of roster) {
+    if (player.squad !== VARSITY || player.overall === null) continue;
+    const held = weakestVarsity.get(player.position);
+    if (!held || (held.overall ?? 0) > player.overall) {
+      weakestVarsity.set(player.position, player);
+    }
+  }
+
+  const out: PromotionRecommendation[] = [];
+  for (const player of roster) {
+    if (player.squad !== JV || player.overall === null) continue;
+    if (squadChange({ grade: player.grade, from: player.squad, to: VARSITY }).ok !== true) {
+      continue;
+    }
+
+    const incumbent = weakestVarsity.get(player.position) ?? null;
+    const margin = player.overall - (incumbent?.overall ?? 0);
+    if (incumbent && margin <= 0) continue;
+
+    out.push({
+      playerId: player.playerId,
+      name: player.name,
+      position: player.position,
+      overall: player.overall,
+      replacesPlayerId: incumbent?.playerId ?? null,
+      replacesName: incumbent?.name ?? null,
+      margin,
+    });
+  }
+
+  return out.sort((a, b) => {
+    const openA = a.replacesPlayerId === null ? 0 : 1;
+    const openB = b.replacesPlayerId === null ? 0 : 1;
+    if (openA !== openB) return openA - openB;
+    if (a.margin !== b.margin) return b.margin - a.margin;
+    return a.playerId < b.playerId ? -1 : a.playerId > b.playerId ? 1 : 0;
+  });
+}

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -156,3 +156,30 @@ export async function seedTransferCandidates(
     count,
   });
 }
+
+const seedRosterMoveCandidatesRef = makeFunctionReference<
+  "mutation",
+  any,
+  { created: number }
+>("e2eSeed:seedRosterMoveCandidates");
+
+/**
+ * Seed a roster with an obvious promotion in it (B5).
+ *
+ * A weak senior starting ahead of strong sophomores. The MOVES are still made
+ * through the real buttons and the real mutations; this only guarantees the
+ * panel has a decision to show, rather than depending on whatever the rollover
+ * happened to generate.
+ */
+export async function seedRosterMoveCandidates(
+  seasonId: string,
+  teamId: string,
+  count = 3,
+): Promise<{ created: number }> {
+  const client = getSeedClient();
+  return client.mutation(seedRosterMoveCandidatesRef, {
+    seasonId,
+    teamId,
+    count,
+  });
+}

--- a/apps/web/e2e/tests/roster-moves.spec.ts
+++ b/apps/web/e2e/tests/roster-moves.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedRosterMoveCandidates,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { acceptBrowserConfirms } from "../helpers/sim-league-setup";
+
+/*
+ * Roster shaping (Dynasty Mode B5, #623).
+ *
+ * Its own fixture league, for the reason `offseason-phases.spec.ts` records:
+ * the canonical shared league's season statuses churn between CI runs, and
+ * everything here needs an UPCOMING season.
+ *
+ * The roster is seeded — a weak senior starting ahead of strong sophomores —
+ * but every MOVE goes through the real button, the real action and the real
+ * mutation. Seeding the moves would test nothing.
+ */
+test.describe("Roster moves (B5)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "roster-moves";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let seasonId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E RM Home",
+      awayTeamName: "E2E RM Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("the panel recommends the sophomore starting behind a weaker senior", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Season name").fill(`E2E Roster ${Date.now()}`);
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    const href = await success
+      .getByTestId("create-season-generate-schedule")
+      .getAttribute("href");
+    seasonId = href?.split("/")[3] ?? null;
+    expect(seasonId).toBeTruthy();
+    await success.getByRole("button", { name: "Done" }).click();
+
+    /*
+     * BOTH teams, not just the home one. The hub acts for the first team the
+     * viewer manages in `getTeamsByLeague` order, which is not the fixture's
+     * home-first order — B4's first CI run proved that the hard way. Seeding
+     * both means the spec never depends on which one the query returned first.
+     */
+    await seedRosterMoveCandidates(seasonId as string, fixture.homeTeamId, 3);
+    await seedRosterMoveCandidates(seasonId as string, fixture.awayTeamId, 3);
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("promotions-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    // The recommendation has to make its COMPARATIVE argument on screen — a
+    // bare name would give the coach nothing to weigh.
+    const recommendations = page.getByTestId("promotion-recommendations");
+    await expect(
+      recommendations.getByTestId("promotion-recommendation").first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(recommendations).toContainText("E2E JV Sophomore");
+    await expect(recommendations).toContainText("E2E Starter Senior");
+  });
+
+  test("promoting a sophomore moves him to Varsity and it sticks", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const board = page.getByTestId("roster-board");
+    const row = board
+      .getByTestId("roster-move-row")
+      .filter({ hasText: "E2E JV Sophomore 1" });
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    await expect(row.getByTestId("roster-move-squad")).toContainText("JV");
+
+    await row.getByRole("button", { name: "Move up" }).click();
+    await expect(row.getByTestId("roster-move-squad")).toContainText("Varsity", {
+      timeout: 30_000,
+    });
+
+    // And it PERSISTS — the decision is a write, not local state.
+    await page.reload();
+    await expect(
+      page
+        .getByTestId("roster-board")
+        .getByTestId("roster-move-row")
+        .filter({ hasText: "E2E JV Sophomore 1" })
+        .getByTestId("roster-move-squad"),
+    ).toContainText("Varsity", { timeout: 30_000 });
+  });
+
+  test("a position change follows him onto the roster page", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const row = page
+      .getByTestId("roster-board")
+      .getByTestId("roster-move-row")
+      .filter({ hasText: "E2E JV Sophomore 2" });
+    await expect(row).toBeVisible({ timeout: 30_000 });
+
+    await row.getByRole("button", { name: "Change position" }).click();
+    const options = row.getByTestId("position-change-options");
+    await expect(options).toBeVisible();
+    // Fit is shown per option — the whole question is "can he play there".
+    await expect(options).toContainText("% fit");
+    await options.getByRole("button", { name: "CB", exact: false }).click();
+
+    await expect(row).toContainText("CB", { timeout: 30_000 });
+
+    /*
+     * Asserted on the OFFSEASON board after a reload rather than on the team
+     * roster page: that page renders the ACTIVE season's assignments and this
+     * change belongs to the upcoming one — the same trap B3 hit.
+     */
+    await page.reload();
+    await expect(
+      page
+        .getByTestId("roster-board")
+        .getByTestId("roster-move-row")
+        .filter({ hasText: "E2E JV Sophomore 2" }),
+    ).toContainText("CB", { timeout: 30_000 });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/offseason.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/offseason.test.ts
@@ -23,7 +23,19 @@ const {
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
-vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+/*
+ * `canAdminOrManageTeam` moved to `@/lib/authorization` in B5. The mock
+ * composes it from the same two inputs the real one reads, so every case below
+ * still drives it by setting an org role and a per-team coach seat.
+ */
+vi.mock("@/lib/authorization", () => ({
+  canManageTeam: mockCanManageTeam,
+  canAdminOrManageTeam: async (teamId: string) => {
+    const role = await mockResolveOrgRole();
+    if (role === "admin" || role === "owner") return true;
+    return mockCanManageTeam(teamId);
+  },
+}));
 vi.mock("@/lib/org-context", () => ({
   resolveOrgContext: mockResolveOrgContext,
   resolveOrgRole: mockResolveOrgRole,

--- a/apps/web/src/app/dashboard/_actions/__tests__/recruiting.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/recruiting.test.ts
@@ -20,7 +20,19 @@ const {
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
 vi.mock("@/lib/org-context", () => ({ resolveOrgRole: mockResolveOrgRole }));
-vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+/*
+ * `canAdminOrManageTeam` moved to `@/lib/authorization` in B5. The mock
+ * composes it from the same two inputs the real one reads, so every case below
+ * still drives it by setting an org role and a per-team coach seat.
+ */
+vi.mock("@/lib/authorization", () => ({
+  canManageTeam: mockCanManageTeam,
+  canAdminOrManageTeam: async (teamId: string) => {
+    const role = await mockResolveOrgRole();
+    if (role === "admin" || role === "owner") return true;
+    return mockCanManageTeam(teamId);
+  },
+}));
 vi.mock("@/lib/data-api", () => ({
   getLeagueOrgId: mockGetLeagueOrgId,
   getTeamLeagueId: mockGetTeamLeagueId,

--- a/apps/web/src/app/dashboard/_actions/__tests__/roster-moves.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/roster-moves.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockCanAdminOrManageTeam,
+  mockGetTeamLeagueId,
+  mockSetPlayerSquad,
+  mockChangePlayerPosition,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCanAdminOrManageTeam: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockSetPlayerSquad: vi.fn(),
+  mockChangePlayerPosition: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({
+  canAdminOrManageTeam: mockCanAdminOrManageTeam,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getTeamLeagueId: mockGetTeamLeagueId,
+  setPlayerSquad: mockSetPlayerSquad,
+  changePlayerPosition: mockChangePlayerPosition,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import {
+  changePlayerPositionAction,
+  setPlayerSquadAction,
+} from "../roster-moves";
+
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const SEASON = "season_1";
+const PLAYER = "player_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockGetTeamLeagueId.mockResolvedValue("league_1");
+  mockCanAdminOrManageTeam.mockImplementation(
+    async (teamId: string) => teamId === TEAM_A,
+  );
+  mockSetPlayerSquad.mockResolvedValue({ squad: "Varsity", changed: true });
+  mockChangePlayerPosition.mockResolvedValue({
+    position: "CB",
+    positionGroup: "DB",
+    changed: true,
+  });
+});
+
+/*
+ * Both actions gate on `teamId` (B5), the shape recruiting and transfers
+ * already use. In Wave 5 the identical action serves a coach who owns exactly
+ * one team; one written against "is org admin" could not be narrowed without
+ * rewriting every call site.
+ */
+describe("setPlayerSquadAction", () => {
+  it("lets a coach promote on the team they manage", async () => {
+    const result = await setPlayerSquadAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      squad: "Varsity",
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: { squad: "Varsity", changed: true },
+    });
+    expect(mockSetPlayerSquad).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: TEAM_A, actorUserId: "coach_a" }),
+    );
+  });
+
+  it("refuses a coach of team A acting on team B", async () => {
+    const result = await setPlayerSquadAction({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+      squad: "Varsity",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    // Refused BEFORE the mutation — a gate that only rejected at the database
+    // would already have read and locked the row.
+    expect(mockSetPlayerSquad).not.toHaveBeenCalled();
+  });
+
+  it("refuses an unauthenticated caller before touching anything", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const result = await setPlayerSquadAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      squad: "Varsity",
+    });
+    expect(result).toEqual({ ok: false, error: "unauthorized" });
+    expect(mockCanAdminOrManageTeam).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the bare reason a Convex error wraps", async () => {
+    mockSetPlayerSquad.mockRejectedValue(
+      new Error("[Request ID: abc] Server Error: grade_too_low_for_varsity"),
+    );
+    const result = await setPlayerSquadAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      squad: "Varsity",
+    });
+    expect(result).toEqual({ ok: false, error: "grade_too_low_for_varsity" });
+  });
+});
+
+describe("changePlayerPositionAction", () => {
+  it("lets a coach convert a player on their own team", async () => {
+    const result = await changePlayerPositionAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      position: "CB",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses a coach acting for another program", async () => {
+    const result = await changePlayerPositionAction({
+      playerId: PLAYER,
+      teamId: TEAM_B,
+      seasonId: SEASON,
+      position: "CB",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockChangePlayerPosition).not.toHaveBeenCalled();
+  });
+
+  it("revalidates the depth chart, not only the team page", async () => {
+    /*
+     * A position change rewrites the depth chart. Leaving that page cached
+     * would have it assert the old position until something unrelated evicted
+     * it — the same staleness B4 fixed for the losing program's league page.
+     */
+    await changePlayerPositionAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      position: "CB",
+    });
+    const paths = mockRevalidatePath.mock.calls.map((call) => call[0]);
+    expect(paths).toContain(`/dashboard/teams/${TEAM_A}/depth-chart`);
+    expect(paths).toContain(`/dashboard/seasons/${SEASON}/offseason`);
+    expect(paths).toContain(`/dashboard/players/${PLAYER}`);
+  });
+
+  it("passes an unrecognised failure through rather than inventing one", async () => {
+    mockChangePlayerPosition.mockRejectedValue(new Error("network exploded"));
+    const result = await changePlayerPositionAction({
+      playerId: PLAYER,
+      teamId: TEAM_A,
+      seasonId: SEASON,
+      position: "CB",
+    });
+    expect(result).toEqual({ ok: false, error: "network exploded" });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/transfers.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/transfers.test.ts
@@ -22,7 +22,19 @@ const {
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
 vi.mock("@/lib/org-context", () => ({ resolveOrgRole: mockResolveOrgRole }));
-vi.mock("@/lib/authorization", () => ({ canManageTeam: mockCanManageTeam }));
+/*
+ * `canAdminOrManageTeam` moved to `@/lib/authorization` in B5. The mock
+ * composes it from the same two inputs the real one reads, so every case below
+ * still drives it by setting an org role and a per-team coach seat.
+ */
+vi.mock("@/lib/authorization", () => ({
+  canManageTeam: mockCanManageTeam,
+  canAdminOrManageTeam: async (teamId: string) => {
+    const role = await mockResolveOrgRole();
+    if (role === "admin" || role === "owner") return true;
+    return mockCanManageTeam(teamId);
+  },
+}));
 vi.mock("@/lib/data-api", () => ({
   getLeagueOrgId: mockGetLeagueOrgId,
   getTeamLeagueId: mockGetTeamLeagueId,

--- a/apps/web/src/app/dashboard/_actions/offseason.ts
+++ b/apps/web/src/app/dashboard/_actions/offseason.ts
@@ -2,11 +2,9 @@
 
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
-import { canManageTeam } from "@/lib/authorization";
+import { canAdminOrManageTeam } from "@/lib/authorization";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
-import { canManageOrgSettings } from "@/lib/permissions";
 import {
-  getLeagueOrgId,
   getPlayer,
   getTeamLeagueId,
   releasePlayerToFreeAgency,
@@ -15,16 +13,6 @@ import {
 
 type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
-async function canAdminOrManageTeam(
-  userId: string,
-  teamId: string,
-): Promise<boolean> {
-  const leagueId = await getTeamLeagueId(teamId);
-  const orgId = await getLeagueOrgId(leagueId);
-  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
-  if (canManageOrgSettings(role)) return true;
-  return canManageTeam(teamId, userId);
-}
 
 export async function releaseToFreeAgencyAction(input: {
   playerId: string;
@@ -39,7 +27,7 @@ export async function releaseToFreeAgencyAction(input: {
   } catch {
     return { ok: false, error: "player_not_found" };
   }
-  if (!(await canAdminOrManageTeam(userId, player.teamId))) {
+  if (!(await canAdminOrManageTeam(player.teamId, userId))) {
     return { ok: false, error: "not_authorized" };
   }
 
@@ -67,7 +55,7 @@ export async function signFreeAgentAction(input: {
 > {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
-  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
     return { ok: false, error: "not_authorized" };
   }
 

--- a/apps/web/src/app/dashboard/_actions/recruiting.ts
+++ b/apps/web/src/app/dashboard/_actions/recruiting.ts
@@ -2,12 +2,8 @@
 
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
-import { canManageTeam } from "@/lib/authorization";
-import { resolveOrgRole } from "@/lib/org-context";
-import { canManageOrgSettings } from "@/lib/permissions";
+import { canAdminOrManageTeam } from "@/lib/authorization";
 import {
-  getLeagueOrgId,
-  getTeamLeagueId,
   scoutProspect,
   signProspect,
   type ProspectDto,
@@ -23,23 +19,13 @@ import {
  * you an admin" would have to be rewritten — along with every call site — the
  * day a second person joins a league.
  *
- * `canAdminOrManageTeam` mirrors the free-agency actions in `offseason.ts`
- * rather than inventing a second predicate, so "who may act for this team" has
- * one answer across the offseason.
+ * `canAdminOrManageTeam` comes from `@/lib/authorization` rather than being
+ * redefined here, so "who may act for this team" has exactly one answer across
+ * the offseason (B5 consolidated the four copies).
  */
 
 type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
-async function canAdminOrManageTeam(
-  userId: string,
-  teamId: string,
-): Promise<boolean> {
-  const leagueId = await getTeamLeagueId(teamId);
-  const orgId = await getLeagueOrgId(leagueId);
-  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
-  if (canManageOrgSettings(role)) return true;
-  return canManageTeam(teamId, userId);
-}
 
 function messageOf(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
@@ -75,7 +61,7 @@ export async function scoutProspectAction(input: {
 > {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
-  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
     return { ok: false, error: "not_authorized" };
   }
 
@@ -105,7 +91,7 @@ export async function signProspectAction(input: {
 > {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
-  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
     return { ok: false, error: "not_authorized" };
   }
 

--- a/apps/web/src/app/dashboard/_actions/roster-moves.ts
+++ b/apps/web/src/app/dashboard/_actions/roster-moves.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canAdminOrManageTeam } from "@/lib/authorization";
+import {
+  changePlayerPosition,
+  getTeamLeagueId,
+  setPlayerSquad,
+} from "@/lib/data-api";
+
+/*
+ * Roster shaping actions (Dynasty Mode B5).
+ *
+ * Both gate on `teamId`, like recruiting and transfers before them: promoting
+ * a player and moving him to a new position are one program's decisions about
+ * its own roster, and an action written against "is org admin" could not be
+ * narrowed for Wave 5 without rewriting every call site.
+ *
+ * Cuts are NOT here. They go through `releaseToFreeAgencyAction` in
+ * `offseason.ts`, which already resolves the player's own team and gates on it
+ * — a stricter check than passing a `teamId` in, and one release path instead
+ * of two sets of rules about what leaving a roster means.
+ */
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  /*
+   * Convex wraps a thrown Error in its own message, so the bare reason the UI
+   * switches on has to be recovered from the text — same recovery as
+   * `transfers.ts` and `recruiting.ts`.
+   */
+  const known = [
+    "player_not_found",
+    "player_not_on_team",
+    "invalid_squad",
+    "invalid_position",
+    "grade_unknown",
+    "grade_too_low_for_varsity",
+    "grade_requires_varsity",
+    "season_locked",
+    "season_not_found",
+  ];
+  return known.find((reason) => raw.includes(reason)) ?? raw;
+}
+
+/**
+ * Revalidate everything a roster move is visible on.
+ *
+ * A promotion or position change shows up on the offseason hub, the team's
+ * pages and the player's own — the depth chart in particular, since a position
+ * change rewrites it. Missing one leaves a page asserting the old position
+ * until something unrelated evicts the cache.
+ */
+async function revalidateRosterSurfaces(input: {
+  teamId: string;
+  seasonId: string;
+  playerId: string;
+}): Promise<void> {
+  revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+  revalidatePath(`/dashboard/teams/${input.teamId}`);
+  revalidatePath(`/dashboard/teams/${input.teamId}/roster`);
+  revalidatePath(`/dashboard/teams/${input.teamId}/depth-chart`);
+  revalidatePath(`/dashboard/players/${input.playerId}`);
+  const leagueId = await getTeamLeagueId(input.teamId).catch(() => null);
+  if (leagueId) revalidatePath(`/dashboard/leagues/${leagueId}`);
+}
+
+export async function setPlayerSquadAction(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  squad: string;
+}): Promise<ActionResult<{ squad: string; changed: boolean }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await setPlayerSquad({
+      playerId: input.playerId,
+      teamId: input.teamId,
+      seasonId: input.seasonId,
+      squad: input.squad,
+      actorUserId: userId,
+    });
+    await revalidateRosterSurfaces(input);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}
+
+export async function changePlayerPositionAction(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  position: string;
+}): Promise<
+  ActionResult<{ position: string; positionGroup: string; changed: boolean }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await changePlayerPosition({
+      playerId: input.playerId,
+      teamId: input.teamId,
+      seasonId: input.seasonId,
+      position: input.position,
+      actorUserId: userId,
+    });
+    await revalidateRosterSurfaces(input);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}

--- a/apps/web/src/app/dashboard/_actions/transfers.ts
+++ b/apps/web/src/app/dashboard/_actions/transfers.ts
@@ -2,14 +2,13 @@
 
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
-import { canManageTeam } from "@/lib/authorization";
+import { canAdminOrManageTeam } from "@/lib/authorization";
 import { resolveOrgRole } from "@/lib/org-context";
 import { canManageOrgSettings } from "@/lib/permissions";
 import {
   generateTransferWindow,
   getLeagueOrgId,
   getSeason,
-  getTeamLeagueId,
   resolveTransfer,
 } from "@/lib/data-api";
 
@@ -31,16 +30,6 @@ import {
 
 type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
-async function canAdminOrManageTeam(
-  userId: string,
-  teamId: string,
-): Promise<boolean> {
-  const leagueId = await getTeamLeagueId(teamId);
-  const orgId = await getLeagueOrgId(leagueId);
-  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
-  if (canManageOrgSettings(role)) return true;
-  return canManageTeam(teamId, userId);
-}
 
 function messageOf(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
@@ -98,7 +87,7 @@ export async function resolveTransferAction(input: {
 > {
   const { userId } = await auth();
   if (!userId) return { ok: false, error: "unauthorized" };
-  if (!(await canAdminOrManageTeam(userId, input.teamId))) {
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
     return { ok: false, error: "not_authorized" };
   }
 

--- a/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
@@ -8,6 +8,7 @@ import {
   getSeason,
   getTeamsByLeague,
   listProspects,
+  listRosterBoard,
   listTransfers,
 } from "@/lib/data-api";
 import { canManageTeam } from "@/lib/authorization";
@@ -19,6 +20,7 @@ import { seasonHomeHref } from "@/components/workspace/resource-navigation";
 import { OffseasonPhaseControls } from "@/components/offseason/OffseasonPhaseControls";
 import { ScoutingPanel } from "@/components/offseason/ScoutingPanel";
 import { TransferPanel } from "@/components/offseason/TransferPanel";
+import { PromotionsPanel } from "@/components/offseason/PromotionsPanel";
 import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
 import { DYNASTY_CONFIG_DEFAULTS } from "@/lib/dynasty-config";
 import { syncActiveLeagueForResource } from "@/lib/active-league-server";
@@ -82,6 +84,15 @@ export default async function SeasonOffseasonPage({
   }
   const actingTeam = managed[0] ?? (isAdmin ? (teams[0] ?? null) : null);
 
+  /*
+   * The roster board is fetched AFTER the acting team is known, because it is
+   * one team's roster rather than the league's. Loading it alongside the
+   * others would mean fetching twelve rosters to render one.
+   */
+  const rosterBoard = actingTeam
+    ? await listRosterBoard(season.id, actingTeam.id).catch(() => [])
+    : [];
+
   const draftStatus = !draft
     ? ("none" as const)
     : draft.status === "complete"
@@ -128,6 +139,12 @@ export default async function SeasonOffseasonPage({
             transfers={transfers}
             actingTeam={actingTeam}
             isAdmin={isAdmin}
+          />
+
+          <PromotionsPanel
+            seasonId={season.id}
+            players={rosterBoard}
+            actingTeam={actingTeam}
           />
         </CardContent>
       </Card>

--- a/apps/web/src/components/offseason/PromotionsPanel.tsx
+++ b/apps/web/src/components/offseason/PromotionsPanel.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { ReleasePlayerButton } from "@/components/offseason/ReleasePlayerButton";
+import {
+  changePlayerPositionAction,
+  setPlayerSquadAction,
+} from "@/app/dashboard/_actions/roster-moves";
+import type { RosterBoardPlayerDto } from "@/lib/data-api";
+import {
+  JV,
+  POSITION_CHANGE_OPTIONS,
+  VARSITY,
+  positionChangeFit,
+  recommendPromotions,
+  squadChange,
+} from "@/lib/dynasty/promotions";
+
+/*
+ * Roster shaping (Dynasty Mode B5).
+ *
+ * Three decisions, in the order a coach actually makes them: who comes up,
+ * who moves, who goes. The recommendations sit at the top because they are the
+ * only part of this panel that has an OPINION — the rest is a list of players
+ * and controls, and a coach who opened it cold would otherwise have to compare
+ * forty ratings by eye to find the one decision worth making.
+ *
+ * The eligibility rules are asked of the same pure function the mutation
+ * enforces (`squadChange`), so a button that is offered is a button that works.
+ * Rendering a control and letting the server reject it is how a panel starts
+ * lying about the rules.
+ */
+
+const REASON_COPY: Record<string, string> = {
+  grade_too_low_for_varsity:
+    "Freshmen play JV. He is eligible once he reaches tenth grade.",
+  grade_requires_varsity:
+    "Juniors and seniors are Varsity — he cannot be sent down.",
+  grade_unknown: "He has no grade on file, so eligibility cannot be checked.",
+  invalid_position: "That is not a position this league recognises.",
+  invalid_squad: "That is not a squad.",
+  season_locked: "The roster is locked for this season.",
+  player_not_on_team: "He is no longer on this roster.",
+  not_authorized: "You cannot make roster moves for this team.",
+};
+
+function copyFor(reason: string): string {
+  return REASON_COPY[reason] ?? "Could not complete that roster move.";
+}
+
+function parseAttributes(json: string | null): Record<string, number> {
+  if (!json) return {};
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "number") out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export interface PromotionsPanelProps {
+  seasonId: string;
+  players: RosterBoardPlayerDto[];
+  /** The team this viewer shapes, or null when they manage none. */
+  actingTeam: { id: string; name: string } | null;
+}
+
+export function PromotionsPanel({
+  seasonId,
+  players,
+  actingTeam,
+}: PromotionsPanelProps) {
+  const [rows, setRows] = useState(players);
+  const [message, setMessage] = useState<string | null>(null);
+  const [openFor, setOpenFor] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const recommendations = useMemo(
+    () =>
+      recommendPromotions(
+        rows.map((row) => ({
+          playerId: row.playerId,
+          name: row.name,
+          position: row.position,
+          grade: row.grade,
+          squad: row.squad,
+          overall: row.overall,
+        })),
+      ),
+    [rows],
+  );
+
+  function move(player: RosterBoardPlayerDto, squad: string) {
+    if (!actingTeam) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await setPlayerSquadAction({
+        playerId: player.playerId,
+        teamId: actingTeam.id,
+        seasonId,
+        squad,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      setRows((current) =>
+        current.map((row) =>
+          row.playerId === player.playerId
+            ? { ...row, squad: result.data.squad }
+            : row,
+        ),
+      );
+      setMessage(
+        squad === VARSITY
+          ? `${player.name} moves up to Varsity.`
+          : `${player.name} drops to JV.`,
+      );
+    });
+  }
+
+  function changePosition(player: RosterBoardPlayerDto, position: string) {
+    if (!actingTeam) return;
+    setMessage(null);
+    setOpenFor(null);
+    startTransition(async () => {
+      const result = await changePlayerPositionAction({
+        playerId: player.playerId,
+        teamId: actingTeam.id,
+        seasonId,
+        position,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      setRows((current) =>
+        current.map((row) =>
+          row.playerId === player.playerId
+            ? {
+                ...row,
+                position: result.data.position,
+                positionGroup: result.data.positionGroup,
+              }
+            : row,
+        ),
+      );
+      setMessage(`${player.name} moves to ${result.data.position}.`);
+    });
+  }
+
+  if (!actingTeam) {
+    return (
+      <section data-testid="promotions-panel" className="space-y-3">
+        <h3 className="text-sm font-semibold">Roster moves</h3>
+        <p className="text-sm text-muted-foreground">
+          You do not manage a team in this league, so there is nothing here to
+          decide.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="promotions-panel" className="space-y-4">
+      <h3 className="text-sm font-semibold">Roster moves</h3>
+
+      {message && (
+        <p className="text-sm text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+
+      <div className="space-y-2" data-testid="promotion-recommendations">
+        <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+          Ready to move up
+        </h4>
+        {recommendations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Nobody on JV is outplaying your Varsity roster.
+          </p>
+        ) : (
+          <ul className="divide-y rounded-md border">
+            {recommendations.map((rec) => {
+              const player = rows.find((row) => row.playerId === rec.playerId);
+              return (
+                <li
+                  key={rec.playerId}
+                  className="flex flex-wrap items-center gap-3 p-3"
+                  data-testid="promotion-recommendation"
+                >
+                  <div className="min-w-[12rem] flex-1">
+                    <p className="text-sm font-medium">{rec.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {rec.position} · {rec.overall} OVR ·{" "}
+                      {rec.replacesName
+                        ? `${rec.margin} better than ${rec.replacesName}`
+                        : "nobody plays there"}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    disabled={pending || !player}
+                    onClick={() => player && move(player, VARSITY)}
+                  >
+                    Move up
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="space-y-2" data-testid="roster-board">
+        <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+          Roster
+        </h4>
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            This roster is empty for the upcoming season.
+          </p>
+        ) : (
+          <ul className="divide-y rounded-md border">
+            {rows.map((row) => {
+              const target = row.squad === VARSITY ? JV : VARSITY;
+              const decision = squadChange({
+                grade: row.grade,
+                from: row.squad,
+                to: target,
+              });
+              const attributes = parseAttributes(row.attributesJson);
+              return (
+                <li
+                  key={row.playerId}
+                  className="space-y-2 p-3"
+                  data-testid="roster-move-row"
+                >
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="min-w-[12rem] flex-1">
+                      <p className="text-sm font-medium">{row.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {row.position}
+                        {row.grade === null ? "" : ` · Grade ${row.grade}`}
+                        {row.overall === null ? "" : ` · ${row.overall} OVR`}
+                        <span data-testid="roster-move-squad">
+                          {" "}
+                          · {row.squad ?? "Unassigned"}
+                        </span>
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        // Offered only when the rule allows it. A disabled
+                        // control with a tooltip would still imply the move is
+                        // a coaching call; for an upperclassman it is not.
+                        disabled={pending || decision.ok !== true}
+                        onClick={() => move(row, target)}
+                      >
+                        {target === VARSITY ? "Move up" : "Send to JV"}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={pending}
+                        onClick={() =>
+                          setOpenFor(
+                            openFor === row.playerId ? null : row.playerId,
+                          )
+                        }
+                      >
+                        Change position
+                      </Button>
+                      <ReleasePlayerButton
+                        playerId={row.playerId}
+                        playerName={row.name}
+                      />
+                    </div>
+                  </div>
+
+                  {openFor === row.playerId && (
+                    <div
+                      className="flex flex-wrap gap-2 rounded-md bg-muted/40 p-2"
+                      data-testid="position-change-options"
+                    >
+                      {POSITION_CHANGE_OPTIONS.filter(
+                        (position) => position !== row.position,
+                      ).map((position) => {
+                        /*
+                         * Fit is shown next to every option because the whole
+                         * question a coach is asking is "can he play there".
+                         * A bare list of positions would make the control a
+                         * guess.
+                         */
+                        const fit = Math.round(
+                          positionChangeFit({
+                            toPosition: position,
+                            attributes,
+                          }) * 100,
+                        );
+                        return (
+                          <Button
+                            key={position}
+                            size="sm"
+                            variant="ghost"
+                            disabled={pending}
+                            onClick={() => changePosition(row, position)}
+                          >
+                            {position}
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              {fit}% fit
+                            </span>
+                          </Button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/offseason/__tests__/promotions-panel.test.ts
+++ b/apps/web/src/components/offseason/__tests__/promotions-panel.test.ts
@@ -1,0 +1,134 @@
+import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { RosterBoardPlayerDto } from "@/lib/data-api";
+
+vi.mock("@/app/dashboard/_actions/roster-moves", () => ({
+  setPlayerSquadAction: vi.fn(),
+  changePlayerPositionAction: vi.fn(),
+}));
+vi.mock("@/app/dashboard/_actions/offseason", () => ({
+  releaseToFreeAgencyAction: vi.fn(),
+}));
+// `ReleasePlayerButton` refreshes the router after a cut; static rendering has
+// no app-router context to give it.
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+import { PromotionsPanel } from "@/components/offseason/PromotionsPanel";
+
+const MINE = { id: "team_1", name: "North HS" };
+
+function player(overrides: Partial<RosterBoardPlayerDto> = {}): RosterBoardPlayerDto {
+  return {
+    playerId: "player_1",
+    name: "Cam Whitfield",
+    position: "WR",
+    positionGroup: "WR",
+    grade: 10,
+    squad: "JV",
+    overall: 84,
+    depthRank: 2,
+    attributesJson: JSON.stringify({ SPD: 90, STR: 60, AGI: 88 }),
+    ...overrides,
+  };
+}
+
+const baseProps = { seasonId: "season_1", actingTeam: MINE };
+
+describe("PromotionsPanel", () => {
+  it("leads with the decision worth making", () => {
+    // A coach opening this cold should not have to compare forty ratings by
+    // eye to find the one move his roster is asking for.
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, {
+        ...baseProps,
+        players: [
+          player(),
+          player({
+            playerId: "player_2",
+            name: "Ty Barrow",
+            grade: 12,
+            squad: "Varsity",
+            overall: 70,
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain('data-testid="promotion-recommendations"');
+    expect(html).toContain("Cam Whitfield");
+    expect(html).toContain("better than Ty Barrow");
+  });
+
+  it("says so plainly when nobody has outgrown JV", () => {
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, {
+        ...baseProps,
+        players: [
+          player({ overall: 60 }),
+          player({
+            playerId: "player_2",
+            name: "Ty Barrow",
+            grade: 12,
+            squad: "Varsity",
+            overall: 88,
+          }),
+        ],
+      }),
+    );
+    expect(html).toContain("Nobody on JV is outplaying your Varsity roster.");
+  });
+
+  it("does not offer a move the mutation would reject", () => {
+    /*
+     * A senior cannot be sent to JV. Rendering the control and letting the
+     * server refuse it would make the panel lie about the rules — so the same
+     * pure `squadChange` the mutation enforces decides what is offered.
+     */
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, {
+        ...baseProps,
+        players: [
+          player({ name: "Ty Barrow", grade: 12, squad: "Varsity", overall: 70 }),
+        ],
+      }),
+    );
+    expect(html).toMatch(/Send to JV[\s\S]{0,200}/);
+    expect(html).toContain("disabled");
+  });
+
+  it("shows each player's grade and squad — the facts the rules turn on", () => {
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, { ...baseProps, players: [player()] }),
+    );
+    expect(html).toContain("Grade 10");
+    expect(html).toContain('data-testid="roster-move-squad"');
+    expect(html).toContain("JV");
+  });
+
+  it("offers a cut through the existing release control", () => {
+    // Not a second release path — the same button the free-agency panel uses.
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, { ...baseProps, players: [player()] }),
+    );
+    expect(html).toContain("Release Cam Whitfield");
+  });
+
+  it("says plainly when a viewer manages no team", () => {
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, {
+        ...baseProps,
+        actingTeam: null,
+        players: [player()],
+      }),
+    );
+    expect(html).toContain("nothing here to decide");
+    expect(html).not.toContain("Cam Whitfield");
+  });
+
+  it("renders an empty roster without pretending it has one", () => {
+    const html = renderToStaticMarkup(
+      createElement(PromotionsPanel, { ...baseProps, players: [] }),
+    );
+    expect(html).toContain("This roster is empty for the upcoming season.");
+  });
+});

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -6,7 +6,11 @@ import {
   getTeamOwnerOrgId,
   forkTeamToWorkspace,
 } from "./data-api";
-import { requireOrgAdmin, resolveBestOrgRole } from "./org-context";
+import {
+  requireOrgAdmin,
+  resolveBestOrgRole,
+  resolveOrgRole,
+} from "./org-context";
 import {
   canManageRoster,
   canManageOrgSettings,
@@ -102,6 +106,30 @@ export async function canManageTeam(
 ): Promise<boolean> {
   const result = await authorizeTeamMutation(teamId, userId);
   return result.isAuthorized;
+}
+
+/**
+ * Whether the user may act FOR a team: a league admin acting on any of them,
+ * or the coach of that one.
+ *
+ * The offseason's per-team gate. It lived as a private copy in four server
+ * action modules (free agency, recruiting, transfers, and B5's roster moves)
+ * before B5 pulled it here — four copies of an authorization predicate is how
+ * one of them quietly stops matching the others.
+ *
+ * The two halves answer different questions and both are needed. In solo play
+ * the commissioner acts for all twelve programs and holds no coach seat on any
+ * of them; in Wave 5 a coach acts for exactly one and holds no admin role.
+ */
+export async function canAdminOrManageTeam(
+  teamId: string,
+  userId: string,
+): Promise<boolean> {
+  const leagueId = await getTeamLeagueId(teamId);
+  const orgId = await getLeagueOrgId(leagueId);
+  const role = orgId ? await resolveOrgRole(orgId, userId) : null;
+  if (canManageOrgSettings(role)) return true;
+  return canManageTeam(teamId, userId);
 }
 
 /**

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -3203,3 +3203,67 @@ export async function resolveTransfer(input: {
     input,
   );
 }
+
+/*
+ * Roster shaping (B5): promotions, position changes and cuts.
+ *
+ * A cut has no entry here on purpose — it routes through the free-agency
+ * `releasePlayerToFreeAgency` that has shipped since WSM-000231. A second
+ * release path would be a second set of rules about what leaving a roster
+ * means.
+ */
+
+export interface RosterBoardPlayerDto {
+  playerId: string;
+  name: string;
+  position: string;
+  positionGroup: string | null;
+  grade: number | null;
+  squad: string | null;
+  overall: number | null;
+  depthRank: number | null;
+  attributesJson: string | null;
+}
+
+export async function listRosterBoard(
+  seasonId: string,
+  teamId: string,
+): Promise<RosterBoardPlayerDto[]> {
+  const client = getConvexClient();
+  return client.query(dynastyRef.query<RosterBoardPlayerDto[]>("listRosterBoard"), {
+    seasonId,
+    teamId,
+  });
+}
+
+export async function setPlayerSquad(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  squad: string;
+  actorUserId: string;
+}): Promise<{ squad: string; changed: boolean }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{ squad: string; changed: boolean }>("setPlayerSquad"),
+    input,
+  );
+}
+
+export async function changePlayerPosition(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  position: string;
+  actorUserId: string;
+}): Promise<{ position: string; positionGroup: string; changed: boolean }> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      position: string;
+      positionGroup: string;
+      changed: boolean;
+    }>("changePlayerPosition"),
+    input,
+  );
+}

--- a/apps/web/src/lib/dynasty-progression.ts
+++ b/apps/web/src/lib/dynasty-progression.ts
@@ -4,6 +4,14 @@
  */
 import { mulberry32, seedFromString } from "@/lib/simulate-game";
 import { attributeGroupForPosition } from "@/lib/synthetic-attributes";
+/*
+ * The development weights moved to `convex/lib/positions.ts` in B5, where
+ * B5's `positionChangeFit` also reads them. Progression asks where a player's
+ * growth GOES; fit asks whether the athlete he already is SUITS a position.
+ * Same emphasis, opposite directions — two tables that agreed by coincidence
+ * would drift the first time either was tuned.
+ */
+import { attrWeight } from "../../convex/lib/positions";
 
 const ATTRIBUTE_GROUPS = [
   "QB",
@@ -18,22 +26,6 @@ const ATTRIBUTE_GROUPS = [
   "P",
 ] as const;
 
-/** Position-tilted attribute keys (higher weight → larger typical gain). */
-const POSITION_ATTR_WEIGHTS: Readonly<
-  Record<string, Partial<Record<string, number>>>
-> = {
-  QB: { THP: 1.4, SAC: 1.2, AWR: 1.3, SPD: 0.8 },
-  RB: { SPD: 1.5, AGI: 1.3, ACC: 1.2, CAR: 1.1 },
-  WR: { SPD: 1.4, CTH: 1.2, SRR: 1.2, AGI: 1.1 },
-  TE: { CTH: 1.3, STR: 1.2, SPD: 1.0 },
-  OL: { STR: 1.4, RBK: 1.2, PBK: 1.2 },
-  DL: { STR: 1.3, PMV: 1.2, FMV: 1.2, BSH: 1.1 },
-  LB: { SPD: 1.2, TAK: 1.3, PRC: 1.2, AWR: 1.1 },
-  DB: { SPD: 1.4, AGI: 1.3, MCV: 1.2, ZCV: 1.2 },
-  K: { KPW: 1.2, KAC: 1.2 },
-  P: { KPW: 1.2, KAC: 1.2 },
-};
-
 function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n));
 }
@@ -43,10 +35,6 @@ function weightedOverall(attributes: Record<string, number>): number {
   if (values.length === 0) return 0;
   const sum = values.reduce((a, b) => a + b, 0);
   return clamp(Math.round(sum / values.length), 0, 99);
-}
-
-function attrWeight(positionGroup: string, key: string): number {
-  return POSITION_ATTR_WEIGHTS[positionGroup]?.[key] ?? 1;
 }
 
 export interface ProgressionInput {

--- a/apps/web/src/lib/dynasty/__tests__/promotions.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/promotions.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import {
+  JV,
+  VARSITY,
+  positionChangeFit,
+  recommendPromotions,
+  squadChange,
+  type RosterPlayer,
+} from "../promotions";
+import {
+  POSITION_CHANGE_OPTIONS,
+  POSITION_TO_GROUP,
+} from "../../../../convex/lib/positions";
+
+function player(over: Partial<RosterPlayer> = {}): RosterPlayer {
+  return {
+    playerId: "p1",
+    name: "Cam Whitfield",
+    position: "WR",
+    grade: 10,
+    squad: JV,
+    overall: 78,
+    ...over,
+  };
+}
+
+describe("squadChange", () => {
+  it("lets a sophomore be promoted — the only real decision", () => {
+    expect(squadChange({ grade: 10, from: JV, to: VARSITY })).toEqual({
+      ok: true,
+      kind: "change",
+    });
+  });
+
+  it("refuses to promote a freshman however good he is", () => {
+    // Grade 9 is JV in a high-school program. It is not a coaching call.
+    expect(squadChange({ grade: 9, from: JV, to: VARSITY })).toEqual({
+      ok: false,
+      reason: "grade_too_low_for_varsity",
+    });
+  });
+
+  it("refuses to send an upperclassman down", () => {
+    /*
+     * `squadForGrade` puts every grade 11+ player on Varsity. B5 must preserve
+     * that rather than let a coach create a state the seeder would never
+     * produce and nothing else in the app expects.
+     */
+    for (const grade of [11, 12]) {
+      expect(squadChange({ grade, from: VARSITY, to: JV })).toEqual({
+        ok: false,
+        reason: "grade_requires_varsity",
+      });
+    }
+  });
+
+  it("refuses a player with no grade rather than assuming one", () => {
+    // Honest absence: null means "not modelled as a student", not "freshman".
+    expect(squadChange({ grade: null, from: JV, to: VARSITY })).toEqual({
+      ok: false,
+      reason: "grade_unknown",
+    });
+  });
+
+  it("treats a move to the squad he is already on as a no-op, not an error", () => {
+    // A double-submitted promotion is a request that was already satisfied.
+    expect(squadChange({ grade: 10, from: VARSITY, to: VARSITY })).toEqual({
+      ok: true,
+      kind: "noop",
+    });
+  });
+
+  it("rejects a squad that is not a squad", () => {
+    expect(squadChange({ grade: 10, from: JV, to: "Practice" })).toEqual({
+      ok: false,
+      reason: "invalid_squad",
+    });
+  });
+});
+
+describe("positionChangeFit", () => {
+  const attributes = {
+    SPD: 90,
+    STR: 60,
+    AGI: 88,
+    ACC: 89,
+    AWR: 70,
+    STA: 80,
+    CTH: 84,
+  };
+
+  it("stays inside 0..1 for every position pair the app knows", () => {
+    for (const from of Object.keys(POSITION_TO_GROUP)) {
+      for (const to of Object.keys(POSITION_TO_GROUP)) {
+        const fit = positionChangeFit({ toPosition: to, attributes });
+        expect(fit, `${from} → ${to}`).toBeGreaterThanOrEqual(0);
+        expect(fit, `${from} → ${to}`).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("rates a burner higher at a speed position than at a strength one", () => {
+    // The weights are the whole mechanic: a 90-speed / 60-strength athlete
+    // belongs at corner, not on the offensive line.
+    const cb = positionChangeFit({ toPosition: "CB", attributes });
+    const ot = positionChangeFit({ toPosition: "OT", attributes });
+    expect(cb).toBeGreaterThan(ot);
+  });
+
+  it("judges a cross-group move on the athleticism he actually has", () => {
+    /*
+     * A quarterback has no coverage ratings at all. Scoring the missing keys as
+     * zero would make every cross-group move ~0 and the control decoration;
+     * leaving them out of both sides of the ratio adds no information that is
+     * not there.
+     */
+    const fit = positionChangeFit({
+      toPosition: "CB",
+      attributes: { SPD: 95, AGI: 92, ACC: 93, AWR: 80, STR: 70, STA: 85 },
+    });
+    expect(fit).toBeGreaterThan(0.7);
+  });
+
+  it("scores an unknown position at zero rather than guessing", () => {
+    expect(positionChangeFit({ toPosition: "GOALIE", attributes })).toBe(0);
+  });
+
+  it("scores a player with no ratings at zero", () => {
+    expect(positionChangeFit({ toPosition: "WR", attributes: {} })).toBe(0);
+  });
+
+  it("offers only positions the app recognises", () => {
+    // The dropdown narrows what is suggested; it must never suggest something
+    // the mutation would reject.
+    for (const position of POSITION_CHANGE_OPTIONS) {
+      expect(POSITION_TO_GROUP[position]).toBeDefined();
+    }
+  });
+});
+
+describe("recommendPromotions", () => {
+  it("recommends a JV player who outrates the weakest Varsity man at his spot", () => {
+    const out = recommendPromotions([
+      player({ playerId: "jv", overall: 80 }),
+      player({ playerId: "v1", squad: VARSITY, grade: 11, overall: 72 }),
+      player({ playerId: "v2", squad: VARSITY, grade: 12, overall: 88 }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      playerId: "jv",
+      replacesPlayerId: "v1",
+      margin: 8,
+    });
+  });
+
+  it("stays quiet when the JV man is not better than anyone he would replace", () => {
+    // The argument is comparative. "He is good" is not a reason to promote.
+    const out = recommendPromotions([
+      player({ playerId: "jv", overall: 70 }),
+      player({ playerId: "v1", squad: VARSITY, grade: 11, overall: 72 }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("puts an unmanned position first — there is nobody to beat", () => {
+    const out = recommendPromotions([
+      player({ playerId: "jv-wr", position: "WR", overall: 95 }),
+      player({
+        playerId: "v-wr",
+        position: "WR",
+        squad: VARSITY,
+        grade: 11,
+        overall: 60,
+      }),
+      player({ playerId: "jv-k", position: "K", overall: 55 }),
+    ]);
+    expect(out.map((r) => r.playerId)).toEqual(["jv-k", "jv-wr"]);
+    expect(out[0].replacesName).toBeNull();
+  });
+
+  it("never recommends a freshman", () => {
+    const out = recommendPromotions([
+      player({ playerId: "fr", grade: 9, overall: 99 }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("ignores players with no rating rather than ranking them as zero", () => {
+    const out = recommendPromotions([
+      player({ playerId: "unrated", overall: null }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("is stable: the same roster always yields the same order", () => {
+    const roster = [
+      player({ playerId: "b", position: "WR", overall: 80 }),
+      player({ playerId: "a", position: "TE", overall: 80 }),
+      player({
+        playerId: "v-wr",
+        position: "WR",
+        squad: VARSITY,
+        grade: 11,
+        overall: 70,
+      }),
+      player({
+        playerId: "v-te",
+        position: "TE",
+        squad: VARSITY,
+        grade: 11,
+        overall: 70,
+      }),
+    ];
+    const first = recommendPromotions(roster).map((r) => r.playerId);
+    const again = recommendPromotions([...roster].reverse()).map(
+      (r) => r.playerId,
+    );
+    expect(first).toEqual(again);
+    expect(first).toEqual(["a", "b"]);
+  });
+});

--- a/apps/web/src/lib/dynasty/promotions.ts
+++ b/apps/web/src/lib/dynasty/promotions.ts
@@ -1,0 +1,31 @@
+/*
+ * Roster shaping rules (Dynasty Mode B5) — see `convex/lib/promotions.ts`.
+ *
+ * Canonical under `convex/` because the mutation enforces these rules and the
+ * panel previews them; re-exported here so the Next layer imports it the same
+ * way it imports every other dynasty lib. Same arrangement as `scouting.ts`
+ * (B3) and `transfers.ts` (B4).
+ */
+
+export {
+  JV,
+  MANDATORY_VARSITY_GRADE,
+  MIN_PROMOTION_GRADE,
+  VARSITY,
+  isSquad,
+  positionChangeFit,
+  recommendPromotions,
+  squadChange,
+} from "../../../convex/lib/promotions";
+
+export type {
+  PositionFitInput,
+  PromotionRecommendation,
+  RosterPlayer,
+  Squad,
+  SquadChangeDecision,
+  SquadChangeInput,
+  SquadChangeRejection,
+} from "../../../convex/lib/promotions";
+
+export { POSITION_CHANGE_OPTIONS } from "../../../convex/lib/positions";

--- a/apps/web/src/lib/position-group.ts
+++ b/apps/web/src/lib/position-group.ts
@@ -1,54 +1,20 @@
-export type PositionGroup =
-  | "QB"
-  | "RB"
-  | "WR"
-  | "TE"
-  | "OL"
-  | "DL"
-  | "LB"
-  | "DB"
-  | "K/P";
+/*
+ * The group map and `derivePositionGroup` moved to `convex/lib/positions.ts`
+ * in B5 so a Convex mutation can validate a position change against the same
+ * vocabulary this file renders. They are re-exported here unchanged — every
+ * existing import keeps working, and there is still exactly one map.
+ */
+export {
+  derivePositionGroup,
+  POSITION_TO_GROUP,
+  type PositionGroup,
+} from "../../convex/lib/positions";
+
+import { derivePositionGroup, type PositionGroup } from "../../convex/lib/positions";
 
 /** Bucket for positions `derivePositionGroup` can't map — shown last, never dropped. */
 export const OTHER_GROUP = "Other" as const;
 export type RosterGroup = PositionGroup | typeof OTHER_GROUP;
-
-const POSITION_TO_GROUP: Readonly<Record<string, PositionGroup>> = {
-  QB: "QB",
-  HB: "RB",
-  RB: "RB",
-  FB: "RB",
-  WR: "WR",
-  TE: "TE",
-  LT: "OL",
-  LG: "OL",
-  C: "OL",
-  RG: "OL",
-  RT: "OL",
-  G: "OL",
-  OG: "OL",
-  OT: "OL",
-  OL: "OL",
-  DE: "DL",
-  DT: "DL",
-  NT: "DL",
-  EDGE: "DL",
-  DL: "DL",
-  OLB: "LB",
-  MLB: "LB",
-  ILB: "LB",
-  LB: "LB",
-  CB: "DB",
-  S: "DB",
-  FS: "DB",
-  SS: "DB",
-  NB: "DB",
-  DB: "DB",
-  K: "K/P",
-  PK: "K/P",
-  P: "K/P",
-  LS: "K/P",
-};
 
 /** Canonical football ordering — offense, defense, special teams. */
 export const POSITION_GROUP_ORDER: readonly PositionGroup[] = [
@@ -76,11 +42,6 @@ const POSITION_ORDER_IN_GROUP: Readonly<Partial<Record<PositionGroup, readonly s
   DB: ["CB", "NB", "FS", "SS", "S", "DB"],
   "K/P": ["K", "PK", "P", "LS"],
 };
-
-export function derivePositionGroup(position: string): PositionGroup | null {
-  const normalized = position.trim().toUpperCase();
-  return POSITION_TO_GROUP[normalized] ?? null;
-}
 
 /**
  * Madden-style name abbreviation: "Adam Thielen" → "A. Thielen".

--- a/apps/web/src/lib/synthetic-attributes.ts
+++ b/apps/web/src/lib/synthetic-attributes.ts
@@ -11,22 +11,24 @@
  * output shape matches what `ingestPlayerAttributesBatch` expects: a
  * position-group code, a 0–99 attribute map, and a weighted overall.
  */
-import { derivePositionGroup } from "@/lib/position-group";
 import { seedFromString } from "@/lib/synthetic-roster";
 
-/** Attribute-domain position groups (kicker/punter split, unlike the roster
- *  K/P group). Mirrors `lib/attributes/position-groups.ts`. */
-export type AttributeGroup =
-  | "QB"
-  | "RB"
-  | "WR"
-  | "TE"
-  | "OL"
-  | "DL"
-  | "LB"
-  | "DB"
-  | "K"
-  | "P";
+/*
+ * `AttributeGroup` and `attributeGroupForPosition` moved to
+ * `convex/lib/positions.ts` in B5 — a position change has to resolve a
+ * player's new attribute group inside a Convex mutation, and a second copy of
+ * that mapping would be a fork of the app's football vocabulary. Re-exported
+ * here so every existing import is untouched.
+ */
+export {
+  attributeGroupForPosition,
+  type AttributeGroup,
+} from "../../convex/lib/positions";
+
+import {
+  attributeGroupForPosition,
+  type AttributeGroup,
+} from "../../convex/lib/positions";
 
 /** Universal athletic attributes every group carries. */
 export const COMMON_KEYS: readonly string[] = ["SPD", "STR", "AGI", "ACC", "AWR", "STA"];
@@ -44,21 +46,6 @@ export const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
   K: ["KPW", "KAC"],
   P: ["KPW", "KAC"],
 };
-
-/**
- * Map a concrete roster position to an attribute-domain group. The roster
- * util collapses kickers + punters into "K/P"; here we split them by the
- * concrete position. Unmappable positions (e.g. "ATH") fall back to "WR" — a
- * generic athletic skill profile — so every synthetic player gets ratings.
- */
-export function attributeGroupForPosition(position: string): AttributeGroup {
-  const group = derivePositionGroup(position);
-  if (group === "K/P") {
-    return position.trim().toUpperCase() === "P" ? "P" : "K";
-  }
-  if (group === null) return "WR";
-  return group;
-}
 
 /** mulberry32 — tiny deterministic PRNG (same family as synthetic-roster). */
 function rng(seed: number): () => number {


### PR DESCRIPTION
Closes #623.

Roster shaping on the Offseason Hub: promote a sophomore from JV to Varsity, move a player to a position that fits him better, and cut the ones you don't want.

## No new tables, and no new phase

B3 and B4 each added an offseason phase. **This one deliberately doesn't.** A phase earns its place when there is a league-wide event to open — a recruiting class to generate, a transfer window to throw. Promotions have no such event; they are available for as long as the offseason is, and the Hub already renders only for an `upcoming` season, which is the real gate. A phase whose content is "the panel was usable anyway" is ceremony, and it would have cost a third round of phase-test churn.

Same reasoning on storage. A promotion patches `players.squad`; a position change patches the player plus the season rows that mirror him; **a cut routes through `releasePlayerToFreeAgency`, which has shipped since WSM-000231.** A `rosterMoves` table would have given the offseason a quieter second record of roster state that no roster page reads — `rosterAuditLog` already answers "what happened" and the roster itself answers "what is true".

## Two rules that had to be stated rather than assumed

`players.squad` has existed since the HS model landed and nothing has ever written to it deliberately — `squadForGrade` seeds it and that is all. B5 is the first mechanic that lets a coach disagree, so it is the first place the rule exists:

- **Grade 9 is always JV.** A freshman is not promotable, however good he is.
- **Grade 11+ is always Varsity.** That is `squadForGrade`'s invariant, preserved rather than re-implemented — an upperclassman cannot be sent down.
- **Grade 10 is the only genuine decision**, which is exactly where a promotion mechanic belongs.

A player with **no** grade is refused outright rather than defaulted. Null means "not modelled as a high-school student", not "freshman"; defaulting him would invent the fact the whole rule turns on.

The panel asks the same pure `squadChange` the mutation enforces, so a control that is offered is a control that works. Rendering it and letting the server refuse is how a panel starts lying about the rules.

## Position fit judges him on what he actually has

A quarterback moving to corner has **no coverage ratings at all**. Scoring the missing keys as zero makes every cross-group move ≈0 and the control becomes decoration; scoring them as average invents a rating. Leaving them out of both sides of the ratio judges him on the athleticism he demonstrably has — speed, agility, awareness — which is how a real coach judges the same move.

A converted player joins the **back** of his new position's depth. Inheriting his old rank would silently demote whoever actually held the job.

Only the season passed in is rewritten. `players.position` is global, but a completed season's assignment records where he actually played; converting a safety to receiver in the offseason has not retroped last year's snaps, and rewriting them would falsify a result.

## Recommendations make a comparative argument

A player is worth promoting when he is better than the **weakest Varsity man at his position** — the one he would actually replace. Ranking by raw rating would recommend the same handful of athletes every year regardless of whether the roster needed them. An unmanned position sorts first: there is nobody to beat.

## The position vocabulary moved under `convex/`

`positionChangeFit` is previewed in the panel and its target position is validated in the mutation, so both need the same answer about what a position *is*. `POSITION_TO_GROUP`, `attributeGroupForPosition` and `POSITION_ATTR_WEIGHTS` moved to `convex/lib/positions.ts` with re-exports left behind — every existing import is untouched and there is still exactly one map. Same arrangement B3 used for the RNG.

Progression and fit share the weights on purpose: one asks where a player's development *goes*, the other whether the athlete he already is *suits* a position. Two tables that agreed by coincidence would drift the first time either was tuned.

## Outside the issue's scope, flagged

`canAdminOrManageTeam` was about to become its **fourth** copy-pasted definition (free agency, recruiting, transfers, and this). It moved to `src/lib/authorization.ts` and the three existing modules now import it. Four copies of the per-team authorization gate is how one of them quietly stops matching the others — and this is the gate Wave 5 depends on.

## CI note

B4's Playwright failure was a spec bug of the same shape this PR's spec would have had: **the Hub acts for the first team the viewer manages in `getTeamsByLeague` order, which is not the fixture's home-first order.** Both specs now seed both teams rather than asserting on a query's ordering.

## Verification

- `vitest run` → **215 files, 1739 tests passed** (48 net-new: 18 rules, 15 Convex, 8 action, 7 panel)
- `pnpm turbo type-check` → 5/5
- `pnpm --filter @sports-management/web lint` → clean
- New Playwright spec `roster-moves.spec.ts`: recommendation shown, promotion persists, position change persists
- No new tables, so `resetCanonicalFixture` is unchanged
- **Squad** added to `CONTEXT.md` with its `_Avoid_` line
