### PR TITLE
feat: offseason training allocation feeding player progression (#624)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,6 +96,10 @@ _Avoid_: Team level, sub-team, second string, reserves
 An incoming ninth-grader on the Recruiting class for one upcoming Season, shown as a projected range rather than a rating until a Team signs him. Scouting narrows the range and never removes it.
 _Avoid_: Recruit rating, star rating, draft prospect, blue-chip
 
+**Training**:
+Points a Team commits from its own offseason budget to develop named players in a named direction — athleticism, strength, technique or football IQ. Committing is a plan; the ratings move when the Offseason Hub leaves the Training phase.
+_Avoid_: XP, skill points, upgrades, boosts, practice reps
+
 **Resource Header**:
 The orientation and sibling-navigation surface shared by a Home and its child pages without using breadcrumb trails.
 _Avoid_: Breadcrumb, back-link row
@@ -128,6 +132,8 @@ _Avoid_: Playbook, formation, strategy, system
 - A **Transfer** never changes the number of players in a League, only which Team each belongs to
 - A player's **Squad** and position are changed from the **Offseason Hub**, and both are one Team's decision about its own roster
 - Cutting a player from the **Offseason Hub** releases him to free agency rather than removing him from the League
+- **Training** is budgeted per Team rather than per League, so one coach cannot spend another program's offseason
+- **Training** a Team commits is applied to that Season's ratings once, when the Offseason Hub advances past the Training phase
 - **Account Settings** contains cross-league **Import** and **Account Billing**
 - A successful **Import** may set the imported League as the **Active League** and offer navigation to its **League Home**
 - The **League Directory** provides access to **Discover**

--- a/apps/web/convex/__tests__/offseasonPhases.test.ts
+++ b/apps/web/convex/__tests__/offseasonPhases.test.ts
@@ -294,6 +294,11 @@ describe("advanceOffseasonPhase", () => {
       "transfers",
       "draft",
       "free_agency",
+      // B6 inserted `training` in front of `activate`. The list is spelled out
+      // rather than derived from `OFFSEASON_PHASES` on purpose: a phase that
+      // silently vanished from the machine should fail this test, and a loop
+      // over the machine would agree with itself either way.
+      "training",
     ]);
   });
 });

--- a/apps/web/convex/__tests__/offseasonPhases.test.ts
+++ b/apps/web/convex/__tests__/offseasonPhases.test.ts
@@ -301,4 +301,55 @@ describe("advanceOffseasonPhase", () => {
       "training",
     ]);
   });
+
+  /*
+   * Regression: one admin walking their own offseason (B6).
+   *
+   * Every test above advances as one fixed `ownerId`, so the lease never comes
+   * into play. The real action used to mint `${userId}:${from}:${to}` — a
+   * DIFFERENT owner for every transition — and B6's e2e is the first thing to
+   * walk several phases back to back. It found the consequence the hard way:
+   * the second advance inside the 30-second lease was refused as `phase_busy`
+   * by the admin's own previous move.
+   *
+   * This is the MUTATION half of the contract: one claimant may hold the lease
+   * across consecutive moves. The other half — that the action sends a stable
+   * claimant rather than a fresh one per transition — is asserted in
+   * `_actions/__tests__/offseason-phases.test.ts`, because that is where the
+   * bug actually lived.
+   */
+  it("lets one claimant walk several phases without fighting its own lease", async () => {
+    const { t, seasonId } = await opened();
+
+    const first = await advance(t, seasonId as never, {
+      expectedPhase: "recruiting",
+      to: "transfers",
+      ownerId: ACTOR,
+    });
+    expect(first.offseason.phase).toBe("transfers");
+
+    const second = await advance(t, seasonId as never, {
+      expectedPhase: "transfers",
+      to: "draft",
+      ownerId: ACTOR,
+    });
+    expect(second.offseason.phase).toBe("draft");
+  });
+
+  it("still refuses a second admin who arrives inside the lease", async () => {
+    // The protection the lease exists for has to survive the fix above.
+    const { t, seasonId } = await opened();
+    await advance(t, seasonId as never, {
+      expectedPhase: "recruiting",
+      to: "transfers",
+      ownerId: "user_a",
+    });
+    await expect(
+      advance(t, seasonId as never, {
+        expectedPhase: "transfers",
+        to: "draft",
+        ownerId: "user_b",
+      }),
+    ).rejects.toThrow(/phase_busy/);
+  });
 });

--- a/apps/web/convex/__tests__/training.test.ts
+++ b/apps/web/convex/__tests__/training.test.ts
@@ -1,0 +1,529 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const ACTOR = "user_admin";
+
+/*
+ * Offseason training (B6). Two teams so the per-team budget has something to be
+ * wrong about, and one player with no ratings so the apply step has a case
+ * where there is genuinely nothing to train.
+ */
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Training League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      leagueId,
+      name: "2028",
+      status: "upcoming",
+      startDate: null,
+      endDate: null,
+      rosterLocked: false,
+    });
+
+    const teamIds: string[] = [];
+    for (const name of ["North", "South"]) {
+      teamIds.push(
+        (await ctx.db.insert("teams", {
+          leagueId,
+          name: `${name} HS`,
+          city: name,
+          stadium: `${name} Field`,
+          location: `${name}, GA`,
+          foundedYear: null,
+          divisionId: null,
+          rosterLimit: null,
+          logoUrl: null,
+        })) as string,
+      );
+    }
+
+    async function addPlayer(spec: {
+      name: string;
+      position: string;
+      teamIndex?: number;
+      attributes?: Record<string, number> | null;
+    }) {
+      const teamId = teamIds[spec.teamIndex ?? 0] as never;
+      const playerId = await ctx.db.insert("players", {
+        name: spec.name,
+        leagueId,
+        teamId,
+        position: spec.position,
+        positionGroup: null,
+        jerseyNumber: null,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        experienceYears: null,
+        grade: 10,
+        squad: "JV",
+        hometown: null,
+        synthetic: true,
+      });
+      if (spec.attributes) {
+        const values = Object.values(spec.attributes);
+        await ctx.db.insert("playerAttributes", {
+          playerId,
+          seasonId,
+          positionGroup: "WR",
+          attributesJson: JSON.stringify(spec.attributes),
+          pffSourceJson: null,
+          maddenSourceJson: null,
+          pffWeight: 0,
+          maddenWeight: 0,
+          weightedOverall: Math.round(
+            values.reduce((a, b) => a + b, 0) / values.length,
+          ),
+          ingestedAt: new Date(0).toISOString(),
+        });
+      }
+      return playerId;
+    }
+
+    const receiver = await addPlayer({
+      name: "Cam Whitfield",
+      position: "WR",
+      attributes: { SPD: 70, ACC: 68, AGI: 72, STR: 60, AWR: 66, CTH: 74 },
+    });
+    const unrated = await addPlayer({
+      name: "Walk On",
+      position: "WR",
+      attributes: null,
+    });
+    const rival = await addPlayer({
+      name: "Other Program",
+      position: "WR",
+      teamIndex: 1,
+      attributes: { SPD: 70, ACC: 68, AGI: 72, STR: 60, AWR: 66, CTH: 74 },
+    });
+
+    return { leagueId, seasonId, teamIds, receiver, unrated, rival };
+  });
+}
+
+describe("allocateTraining", () => {
+  it("records an allocation and reports the spend back", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    const result = await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.receiver,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      focus: "athleticism",
+      points: 5,
+      actorUserId: ACTOR,
+    });
+
+    expect(result.pointsSpent).toBe(5);
+    expect(result.allocation.appliedAt).toBeNull();
+
+    const ledger = await t.query(api.dynasty.listTrainingAllocations, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]?.focus).toBe("athleticism");
+  });
+
+  it("does not change the player's ratings yet — an allocation is a plan", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.receiver,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      focus: "athleticism",
+      points: 5,
+      actorUserId: ACTOR,
+    });
+
+    const before = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    expect(JSON.parse(before!.attributesJson).SPD).toBe(70);
+  });
+
+  it("refuses to spend past the team's allowance", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("offseasons")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seed.seasonId))
+        .first();
+      if (row) await ctx.db.patch(row._id, { trainingPointsTotal: 6 });
+      else {
+        await ctx.db.insert("offseasons", {
+          leagueId: seed.leagueId,
+          seasonId: seed.seasonId,
+          phase: "training",
+          completedPhases: ["rollover"],
+          scoutingPointsTotal: 100,
+          scoutingPointsSpent: 0,
+          trainingPointsTotal: 6,
+          trainingPointsSpent: 0,
+          configJson: "{}",
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          updatedBy: ACTOR,
+        });
+      }
+    });
+
+    const spend = (points: number) =>
+      t.mutation(internal.dynasty.allocateTraining, {
+        playerId: seed.receiver,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        focus: "athleticism",
+        points,
+        actorUserId: ACTOR,
+      });
+
+    await spend(5);
+    await expect(spend(5)).rejects.toThrow(/training_budget_exhausted/);
+    // The one that exactly fills the budget is still allowed.
+    await expect(spend(1)).resolves.toBeTruthy();
+  });
+
+  it("keeps each team's budget its own", async () => {
+    /*
+     * The divergence from B3's shared scouting pool. A shared training budget
+     * means the first coach to open the hub spends the league's spring on his
+     * own quarterback.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.receiver,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      focus: "athleticism",
+      points: 10,
+      actorUserId: ACTOR,
+    });
+    const rival = await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.rival,
+      teamId: seed.teamIds[1] as never,
+      seasonId: seed.seasonId,
+      focus: "athleticism",
+      points: 10,
+      actorUserId: ACTOR,
+    });
+
+    expect(rival.pointsSpent).toBe(10);
+  });
+
+  it("refuses to train a player who is not on the team", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await expect(
+      t.mutation(internal.dynasty.allocateTraining, {
+        playerId: seed.rival,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        focus: "athleticism",
+        points: 5,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/player_not_on_team/);
+  });
+
+  it("refuses a focus that is not one", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await expect(
+      t.mutation(internal.dynasty.allocateTraining, {
+        playerId: seed.receiver,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        focus: "vibes",
+        points: 5,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/invalid_focus/);
+  });
+
+  it("refuses to train against a locked roster", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await t.run(async (ctx) =>
+      ctx.db.patch(seed.seasonId, { rosterLocked: true }),
+    );
+
+    await expect(
+      t.mutation(internal.dynasty.allocateTraining, {
+        playerId: seed.receiver,
+        teamId: seed.teamIds[0] as never,
+        seasonId: seed.seasonId,
+        focus: "athleticism",
+        points: 5,
+        actorUserId: ACTOR,
+      }),
+    ).rejects.toThrow(/season_locked/);
+  });
+
+  it("shows a team only its own ledger", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+
+    await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.rival,
+      teamId: seed.teamIds[1] as never,
+      seasonId: seed.seasonId,
+      focus: "technique",
+      points: 5,
+      actorUserId: ACTOR,
+    });
+
+    const mine = await t.query(api.dynasty.listTrainingAllocations, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(mine).toEqual([]);
+  });
+});
+
+describe("applyTrainingAllocations", () => {
+  async function allocate(
+    t: ReturnType<typeof convexTest>,
+    seed: Awaited<ReturnType<typeof seedLeague>>,
+    playerId: (typeof seed)["receiver"],
+    points = 5,
+  ) {
+    return t.mutation(internal.dynasty.allocateTraining, {
+      playerId,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      focus: "athleticism",
+      points,
+      actorUserId: ACTOR,
+    });
+  }
+
+  it("lands the gain on the player's ratings", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await allocate(t, seed, seed.receiver);
+
+    const result = await t.mutation(
+      internal.dynasty.applyTrainingAllocations,
+      { seasonId: seed.seasonId, actorUserId: ACTOR },
+    );
+    expect(result.playersTrained).toBe(1);
+    expect(result.pointsPlaced).toBeGreaterThan(0);
+
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    const attributes = JSON.parse(after!.attributesJson);
+    expect(attributes.SPD + attributes.ACC + attributes.AGI).toBeGreaterThan(
+      70 + 68 + 72,
+    );
+    // Untouched by an athleticism focus.
+    expect(attributes.CTH).toBe(74);
+  });
+
+  it("applies twice with one effect — the appliedAt guard", async () => {
+    /*
+     * The single most damaging way this could go wrong. Application is additive
+     * (a freshman signed in this offseason has no prior season to re-derive
+     * from), so without the stamp a retried advance trains the whole roster
+     * again.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await allocate(t, seed, seed.receiver);
+
+    const first = await t.mutation(
+      internal.dynasty.applyTrainingAllocations,
+      { seasonId: seed.seasonId, actorUserId: ACTOR },
+    );
+    const snapshot = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+
+    const second = await t.mutation(
+      internal.dynasty.applyTrainingAllocations,
+      { seasonId: seed.seasonId, actorUserId: ACTOR },
+    );
+    expect(second).toEqual({ applied: 0, playersTrained: 0, pointsPlaced: 0 });
+
+    const again = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    expect(again!.attributesJson).toBe(snapshot!.attributesJson);
+    expect(first.applied).toBe(1);
+  });
+
+  it("records what the points bought", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await allocate(t, seed, seed.receiver);
+    await t.mutation(internal.dynasty.applyTrainingAllocations, {
+      seasonId: seed.seasonId,
+      actorUserId: ACTOR,
+    });
+
+    const ledger = await t.query(api.dynasty.listTrainingAllocations, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(ledger[0]?.appliedAt).not.toBeNull();
+    const gains = JSON.parse(ledger[0]!.appliedGainJson!);
+    expect(Object.keys(gains).length).toBeGreaterThan(0);
+  });
+
+  it("shifts the overall by what training added rather than redefining it", async () => {
+    /*
+     * `weightedOverall` is a PFF/Madden blend for a player with real ratings,
+     * not a mean. Replacing it with a fresh average would move the number for a
+     * reason unrelated to the points a coach spent.
+     */
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first();
+      // Deliberately nothing like the mean of the map.
+      if (row) await ctx.db.patch(row._id, { weightedOverall: 91 });
+    });
+
+    await allocate(t, seed, seed.receiver, 10);
+    await t.mutation(internal.dynasty.applyTrainingAllocations, {
+      seasonId: seed.seasonId,
+      actorUserId: ACTOR,
+    });
+
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    // Six attributes, six points placed → the mean rises by one.
+    expect(after!.weightedOverall).toBe(92);
+  });
+
+  it("recomputes the overall so the roster and the ratings agree", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    const before = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    await allocate(t, seed, seed.receiver, 10);
+    await t.mutation(internal.dynasty.applyTrainingAllocations, {
+      seasonId: seed.seasonId,
+      actorUserId: ACTOR,
+    });
+    const after = await t.run(async (ctx) =>
+      ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", seed.receiver).eq("seasonId", seed.seasonId),
+        )
+        .first(),
+    );
+    expect(after!.weightedOverall!).toBeGreaterThan(before!.weightedOverall!);
+  });
+
+  it("stamps an unrated player's allocation instead of leaving it pending", async () => {
+    // Nothing to train, and a row that never applies would try again on every
+    // future advance forever.
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await allocate(t, seed, seed.unrated);
+
+    const result = await t.mutation(
+      internal.dynasty.applyTrainingAllocations,
+      { seasonId: seed.seasonId, actorUserId: ACTOR },
+    );
+    expect(result.applied).toBe(1);
+    expect(result.playersTrained).toBe(0);
+
+    const ledger = await t.query(api.dynasty.listTrainingAllocations, {
+      seasonId: seed.seasonId,
+      teamId: seed.teamIds[0] as never,
+    });
+    expect(ledger[0]?.appliedAt).not.toBeNull();
+  });
+
+  it("is a no-op for a season nobody trained in", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    expect(
+      await t.mutation(internal.dynasty.applyTrainingAllocations, {
+        seasonId: seed.seasonId,
+        actorUserId: ACTOR,
+      }),
+    ).toEqual({ applied: 0, playersTrained: 0, pointsPlaced: 0 });
+  });
+
+  it("gives a player with two allocations one consistent snapshot", async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedLeague(t);
+    await allocate(t, seed, seed.receiver, 5);
+    await t.mutation(internal.dynasty.allocateTraining, {
+      playerId: seed.receiver,
+      teamId: seed.teamIds[0] as never,
+      seasonId: seed.seasonId,
+      focus: "technique",
+      points: 5,
+      actorUserId: ACTOR,
+    });
+
+    const result = await t.mutation(
+      internal.dynasty.applyTrainingAllocations,
+      { seasonId: seed.seasonId, actorUserId: ACTOR },
+    );
+    expect(result.applied).toBe(2);
+    expect(result.playersTrained).toBe(1);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -249,7 +249,15 @@ type AllowedPublicDynastyReads =
    * panel can compute position fit without a round trip per candidate. The
    * MOVES are internalMutations behind the same per-`teamId` gate.
    */
-  | "listRosterBoard";
+  | "listRosterBoard"
+  /*
+   * B6. One team's own training ledger, keyed by the `teamId` the caller
+   * already had to resolve to reach the page. Nothing hidden passes through it
+   * — an allocation is a coach's stated plan, not a rating anyone can't see —
+   * and both writes (`allocateTraining`, `applyTrainingAllocations`) are
+   * internalMutations.
+   */
+  | "listTrainingAllocations";
 type AllowedPublicSimReads =
   | "moduleStatus"
   | "listRivalries"

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -27,6 +27,11 @@ import {
 } from "./lib/transfers";
 import { VARSITY, squadChange } from "./lib/promotions";
 import {
+  applyTraining,
+  totalAllocatedPoints,
+  trainingGate,
+} from "./lib/training";
+import {
   attributeGroupForPosition,
   derivePositionGroup,
 } from "./lib/positions";
@@ -1614,5 +1619,302 @@ export const changePlayerPosition = internalMutation({
     });
 
     return { position, positionGroup, changed: true };
+  },
+});
+
+/*
+ * ── Offseason training (B6) ────────────────────────────────────────────────
+ *
+ * A finite budget, spent on named players in a named direction, applied to the
+ * ratings the rollover already wrote for the upcoming season.
+ *
+ * ## Why allocation and application are two steps
+ *
+ * Scouting (B3) applies the instant you spend, and that is right for scouting:
+ * you are buying information and you should see it. Training is a PLAN. A coach
+ * assembling a spring wants to move points between players while he decides,
+ * and a mechanic that rewrote his roster on every click would make undo the
+ * first thing he asked for. So allocations accumulate against the budget and
+ * land together when the offseason leaves the training phase.
+ *
+ * The rules themselves live in `lib/training.ts`, Convex-free and tested there.
+ * This end owns storage, the budget check and the idempotency stamp.
+ */
+
+const trainingAllocationValidator = v.object({
+  id: v.string(),
+  seasonId: v.string(),
+  teamId: v.string(),
+  playerId: v.string(),
+  focus: v.string(),
+  points: v.number(),
+  appliedAt: v.union(v.string(), v.null()),
+  /** Per-attribute gain once applied, JSON-encoded. Null until then. */
+  appliedGainJson: v.union(v.string(), v.null()),
+  createdAt: v.string(),
+});
+
+type TrainingAllocationDoc = Doc<"playerTrainingAllocations">;
+
+function toTrainingAllocationDto(
+  row: TrainingAllocationDoc,
+): Infer<typeof trainingAllocationValidator> {
+  return {
+    id: row._id as string,
+    seasonId: row.seasonId as string,
+    teamId: row.teamId as string,
+    playerId: row.playerId as string,
+    focus: row.focus,
+    points: row.points,
+    appliedAt: row.appliedAt ?? null,
+    appliedGainJson: row.appliedGainJson ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * One team's training ledger for a season.
+ *
+ * Scoped to a team rather than the season on purpose. The budget is per team
+ * (see `convex/tables/offseason.ts`), so the number the panel needs is this
+ * team's spend — returning the league's rows to compute it would leak every
+ * other program's spring plan to anyone who opened the hub.
+ */
+export const listTrainingAllocations = query({
+  args: { seasonId: v.id("seasons"), teamId: v.id("teams") },
+  returns: v.array(trainingAllocationValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("playerTrainingAllocations")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+    return rows
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+      .map(toTrainingAllocationDto);
+  },
+});
+
+/**
+ * Commit points to one player.
+ *
+ * `teamId` is an argument and is checked against the player, for the same
+ * reason as `setPlayerSquad` (B5): the Next layer's per-team gate and this
+ * check must be about the SAME team, and deriving it here would hide a coach
+ * spending on a player who has already left.
+ *
+ * The budget is read from this team's own rows, so two coaches allocating at
+ * the same moment cannot oversell a shared pool — Convex serializes the
+ * mutations, and the second one sees the first one's row.
+ */
+export const allocateTraining = internalMutation({
+  args: {
+    playerId: v.id("players"),
+    teamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    focus: v.string(),
+    points: v.number(),
+    actorUserId: v.string(),
+  },
+  returns: v.object({
+    allocation: trainingAllocationValidator,
+    pointsSpent: v.number(),
+    pointsTotal: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) throw new Error("player_not_found");
+    if (player.teamId !== args.teamId) throw new Error("player_not_on_team");
+
+    const season = await ctx.db.get(args.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (season.rosterLocked) throw new Error("season_locked");
+
+    const offseason = await ensureOffseason(
+      ctx,
+      args.seasonId,
+      args.actorUserId,
+    );
+
+    const existing = await ctx.db
+      .query("playerTrainingAllocations")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .collect();
+    const spent = totalAllocatedPoints(existing);
+
+    const decision = trainingGate({
+      focus: args.focus,
+      points: args.points,
+      spent,
+      total: offseason.trainingPointsTotal,
+    });
+    if (!decision.ok) throw new Error(decision.reason);
+
+    const now = new Date().toISOString();
+    const id = await ctx.db.insert("playerTrainingAllocations", {
+      leagueId: season.leagueId,
+      seasonId: args.seasonId,
+      teamId: args.teamId,
+      playerId: args.playerId,
+      focus: args.focus,
+      points: args.points,
+      createdAt: now,
+      createdBy: args.actorUserId,
+    });
+
+    /*
+     * The league counter on the offseason row is the audit total across every
+     * team, kept in step here so an admin can see how much of the league's
+     * spring has been planned. The gate above deliberately does NOT read it —
+     * it is a sum of per-team budgets, not a budget itself.
+     */
+    await ctx.db.patch(offseason._id, {
+      trainingPointsSpent: offseason.trainingPointsSpent + args.points,
+      updatedAt: now,
+      updatedBy: args.actorUserId,
+    });
+
+    const row = await ctx.db.get(id);
+    if (!row) throw new Error("allocation_not_found");
+    return {
+      allocation: toTrainingAllocationDto(row),
+      pointsSpent: spent + args.points,
+      pointsTotal: offseason.trainingPointsTotal,
+    };
+  },
+});
+
+/**
+ * Land every unapplied allocation for a season on the players' ratings.
+ *
+ * Called when the offseason leaves the training phase. Additive rather than a
+ * re-derivation of progression: a freshman signed in this same offseason has no
+ * prior season to re-derive from, and a mechanic that worked for veterans and
+ * silently skipped the class you just recruited would be worse than no
+ * mechanic. `appliedAt` is therefore load-bearing, not decorative — it is the
+ * only thing standing between a retry and a roster trained twice.
+ *
+ * Grouped per player so a player with three allocations gets one patch and one
+ * consistent `weightedOverall`, rather than three that each recompute from a
+ * map the previous one had already moved.
+ */
+export const applyTrainingAllocations = internalMutation({
+  args: { seasonId: v.id("seasons"), actorUserId: v.string() },
+  returns: v.object({
+    applied: v.number(),
+    playersTrained: v.number(),
+    pointsPlaced: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const pending = (
+      await ctx.db
+        .query("playerTrainingAllocations")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+        .collect()
+    ).filter((row) => row.appliedAt === undefined);
+    if (pending.length === 0) {
+      return { applied: 0, playersTrained: 0, pointsPlaced: 0 };
+    }
+
+    const byPlayer = new Map<Id<"players">, TrainingAllocationDoc[]>();
+    for (const row of pending) {
+      const bucket = byPlayer.get(row.playerId);
+      if (bucket) bucket.push(row);
+      else byPlayer.set(row.playerId, [row]);
+    }
+
+    const now = new Date().toISOString();
+    let applied = 0;
+    let playersTrained = 0;
+    let pointsPlaced = 0;
+
+    for (const [playerId, rows] of byPlayer) {
+      const player = await ctx.db.get(playerId);
+      /*
+       * A player who left between allocation and application. His points are
+       * stamped rather than left pending: they were spent, the spring happened
+       * somewhere else, and leaving them unapplied would make them land on
+       * whoever holds that id next.
+       */
+      if (!player) {
+        for (const row of rows) {
+          await ctx.db.patch(row._id, { appliedAt: now });
+          applied++;
+        }
+        continue;
+      }
+
+      const ratingPlayerId = player.sourcePlayerId ?? playerId;
+      const snapshot = await ctx.db
+        .query("playerAttributes")
+        .withIndex("by_playerId_seasonId", (q) =>
+          q.eq("playerId", ratingPlayerId).eq("seasonId", args.seasonId),
+        )
+        .first();
+      if (!snapshot) {
+        // Nothing to train. An unrated player would need ratings invented for
+        // him, which is a different decision than the one a coach made here.
+        for (const row of rows) {
+          await ctx.db.patch(row._id, { appliedAt: now });
+          applied++;
+        }
+        continue;
+      }
+
+      const attributes = parseAttributes(snapshot.attributesJson);
+      const positionGroup =
+        snapshot.positionGroup || attributeGroupForPosition(player.position);
+      const result = applyTraining({
+        attributes,
+        positionGroup,
+        allocations: rows.map((row) => ({
+          focus: row.focus,
+          points: row.points,
+        })),
+      });
+
+      if (result.pointsPlaced > 0) {
+        /*
+         * The overall moves by the DELTA, not by a fresh mean of the map.
+         *
+         * `weightedOverall` is not always the mean: for a player with real
+         * ratings it is a PFF/Madden blend written by `ingestPlayerAttributesBatch`.
+         * Recomputing it here would silently replace that blend with an average
+         * the first time anyone trained him, and the rating would jump for a
+         * reason no coach could connect to the points he spent. Spreading
+         * `pointsPlaced` over the map raises its mean by exactly
+         * `pointsPlaced / keys`, so applying that same shift moves the stored
+         * number without redefining what it means.
+         */
+        const keys = Object.keys(result.attributes).length;
+        const shift = keys > 0 ? result.pointsPlaced / keys : 0;
+        const values = Object.values(result.attributes);
+        const overall =
+          snapshot.weightedOverall === null
+            ? values.length > 0
+              ? Math.round(values.reduce((a, b) => a + b, 0) / values.length)
+              : null
+            : Math.min(99, Math.round(snapshot.weightedOverall + shift));
+        await ctx.db.patch(snapshot._id, {
+          attributesJson: JSON.stringify(result.attributes),
+          weightedOverall: overall,
+        });
+        playersTrained++;
+        pointsPlaced += result.pointsPlaced;
+      }
+
+      for (const row of rows) {
+        await ctx.db.patch(row._id, {
+          appliedAt: now,
+          appliedGainJson: JSON.stringify(result.gains),
+        });
+        applied++;
+      }
+    }
+
+    return { applied, playersTrained, pointsPlaced };
   },
 });

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -153,6 +153,20 @@ async function cascadeDeleteLeague(
       await ctx.db.delete(row._id);
       deleted += 1;
     }
+    /*
+     * Training ledgers (B6). Season-scoped rather than league-scoped, so they
+     * are cleared here. A leaked row is doubly bad: it spends a later run's
+     * budget before the coach arrives, and if it is still unapplied it lands
+     * on whichever player inherits the id.
+     */
+    const training = (await ctx.db
+      .query("playerTrainingAllocations")
+      .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
+      .collect()) as Array<{ _id: Id<"playerTrainingAllocations"> }>;
+    for (const row of training) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
   }
   // Persisted offseason phase machine (B1). Left behind, a row would carry one
   // run's phase into the next and make the stepper assertions order-dependent.

--- a/apps/web/convex/lib/offseasonPhases.ts
+++ b/apps/web/convex/lib/offseasonPhases.ts
@@ -30,6 +30,7 @@ export const OFFSEASON_PHASES = [
   "transfers",
   "draft",
   "free_agency",
+  "training",
   "activate",
 ] as const;
 
@@ -41,6 +42,7 @@ export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
   transfers: "Transfers",
   draft: "Draft",
   free_agency: "Free agency",
+  training: "Training",
   activate: "Activate",
 };
 
@@ -59,11 +61,16 @@ export const OFFSEASON_PHASE_LABELS: Record<OffseasonPhase, string> = {
  * unresolved transfer is a decision NOT to decide, and a coach who never opens
  * the window has implicitly kept everybody. Blocking on it would let one
  * absent coach freeze the league.
+ *
+ * Training joined it in B6. An unspent budget is a coach declining to run a
+ * spring, and the cost is already paid in the ratings he did not buy. Blocking
+ * would make the phase a chore rather than an opportunity.
  */
 const OPTIONAL_PHASES: ReadonlySet<OffseasonPhase> = new Set([
   "recruiting",
   "transfers",
   "draft",
+  "training",
 ]);
 
 /*

--- a/apps/web/convex/lib/positions.ts
+++ b/apps/web/convex/lib/positions.ts
@@ -114,6 +114,37 @@ export function attributeGroupForPosition(position: string): AttributeGroup {
 }
 
 /**
+ * Universal athletic attributes every player carries, whatever he plays.
+ *
+ * Moved here from `src/lib/synthetic-attributes.ts` in B6 alongside
+ * `GROUP_KEYS` — training resolves a focus to attribute keys inside a Convex
+ * mutation, and a second copy of "which ratings does a linebacker have" is the
+ * kind of fork that shows up as a focus quietly training nothing.
+ */
+export const COMMON_KEYS: readonly string[] = [
+  "SPD",
+  "STR",
+  "AGI",
+  "ACC",
+  "AWR",
+  "STA",
+];
+
+/** Madden-style position-specific attribute codes per attribute group. */
+export const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
+  QB: ["THP", "SAC", "MAC", "DAC", "TUP", "PAC"],
+  RB: ["CAR", "BCV", "TRK", "ELU", "JKM", "BTK"],
+  WR: ["CTH", "SRR", "MRR", "DRR", "CIT", "RLS"],
+  TE: ["CTH", "RBK", "CIT", "SRR", "PBK"],
+  OL: ["RBK", "PBK", "RBP", "PBP", "IBL"],
+  DL: ["PMV", "FMV", "BSH", "TAK", "PUR"],
+  LB: ["TAK", "PUR", "PRC", "ZCV", "MCV", "POW"],
+  DB: ["MCV", "ZCV", "PRS", "CTH", "PUR"],
+  K: ["KPW", "KAC"],
+  P: ["KPW", "KAC"],
+};
+
+/**
  * Position-tilted attribute weights (higher weight → the position leans on
  * that attribute more).
  *

--- a/apps/web/convex/lib/training.ts
+++ b/apps/web/convex/lib/training.ts
@@ -1,0 +1,325 @@
+/*
+ * Offseason training (Dynasty Mode B6) — pure, Convex-free.
+ *
+ * Development is entirely automatic today: `computeProgressedAttributes` moves
+ * every player by a seeded amount and a coach watches. This is the half that
+ * makes it a decision — a finite budget, spent on named players in a named
+ * direction.
+ *
+ * ## The three properties the whole slice rests on
+ *
+ * 1. **Spreading beats dumping.** The yield is `sqrt(points)`, so ten points on
+ *    one player earn far less than one point on ten. A linear yield would make
+ *    the budget a single choice ("who is the best player?") rather than a
+ *    portfolio; a hard cap would do the same thing with a cliff, and would stop
+ *    being monotonic exactly where a coach is deciding.
+ *
+ * 2. **Focus changes SHAPE, never total.** Every focus turns the same points
+ *    into the same number of attribute points; they land on different
+ *    attributes. So a coach picking a focus is choosing what kind of player he
+ *    wants, not trying to guess which focus is secretly worth more. Overall is
+ *    the mean of the map, so the overall gain is identical either way and the
+ *    difference is entirely legible in the ratings that moved.
+ *
+ * 3. **Points are never silently wasted.** Attributes cap at 99, so a naive
+ *    "add n to each key" would quietly discard the training of a player already
+ *    at the ceiling. Distribution walks the keys with headroom, lowest first —
+ *    coaching lifts the floor within a focus before it sharpens the peak.
+ *
+ * Deliberately NOT seeded. Every other dynasty mechanic is random and
+ * reproducible; training is the one a coach paid for, and a spent point that
+ * rolled badly would be indistinguishable from a bug.
+ */
+import { GROUP_KEYS, type AttributeGroup } from "./positions";
+
+/** Ratings live on the same 40–99 scale as `generateSyntheticAttributes`. */
+export const ATTRIBUTE_MIN = 40;
+export const ATTRIBUTE_MAX = 99;
+
+export type TrainingFocus =
+  | "athleticism"
+  | "strength"
+  | "technique"
+  | "football_iq";
+
+export interface TrainingFocusMeta {
+  id: TrainingFocus;
+  label: string;
+  /** What a coach is buying, in one line, for the panel. */
+  blurb: string;
+}
+
+/**
+ * The four directions a program can develop a player.
+ *
+ * Four rather than one-per-attribute because a focus has to be a coaching
+ * decision a person can hold in their head. "Work on his release" is a drill;
+ * "he is our technique project this spring" is a plan.
+ */
+export const TRAINING_FOCUSES: readonly TrainingFocusMeta[] = [
+  {
+    id: "athleticism",
+    label: "Athleticism",
+    blurb: "Speed, acceleration and agility.",
+  },
+  { id: "strength", label: "Strength", blurb: "Raw power and stamina." },
+  {
+    id: "technique",
+    label: "Technique",
+    blurb: "The skills specific to his position.",
+  },
+  {
+    id: "football_iq",
+    label: "Football IQ",
+    blurb: "Awareness and reading the game.",
+  },
+];
+
+export function isTrainingFocus(value: string): value is TrainingFocus {
+  return TRAINING_FOCUSES.some((focus) => focus.id === value);
+}
+
+/**
+ * Attribute keys each focus develops, for the athletic attributes every player
+ * carries. `technique` is absent because it resolves through the player's
+ * position group instead — see `focusAttributeKeys`.
+ */
+const COMMON_FOCUS_KEYS: Readonly<
+  Partial<Record<TrainingFocus, readonly string[]>>
+> = {
+  athleticism: ["SPD", "ACC", "AGI"],
+  strength: ["STR", "STA"],
+  football_iq: ["AWR"],
+};
+
+/**
+ * Which attributes a focus develops for a player in `positionGroup`.
+ *
+ * `technique` is the only focus whose keys depend on position, and that is the
+ * point of it: a quarterback's technique is throw power and accuracy, a
+ * lineman's is run and pass blocking. Routing it through the same `GROUP_KEYS`
+ * the attribute generator uses means a group can never gain a technique
+ * attribute that training cannot reach.
+ */
+export function focusAttributeKeys(
+  focus: TrainingFocus,
+  positionGroup: string,
+): readonly string[] {
+  if (focus !== "technique") return COMMON_FOCUS_KEYS[focus] ?? [];
+  const keys = GROUP_KEYS[positionGroup as AttributeGroup];
+  return keys ?? [];
+}
+
+/** Points a coach may commit to one player at once. */
+export const TRAINING_POINT_OPTIONS: readonly number[] = [2, 5, 10];
+
+/**
+ * Attribute points earned per `sqrt(point)`.
+ *
+ * Two is calibrated against the seeded base progression, which moves a player
+ * by an overall-equivalent 2–5 a year. Five training points earn ~4.5 attribute
+ * points, so a well-spent offseason is worth roughly one extra year of natural
+ * growth for the handful of players it is spent on — noticeable, and nowhere
+ * near enough to make development a solved problem.
+ */
+export const TRAINING_YIELD = 2;
+
+/**
+ * Coach development rating and facilities are 0–100 with 50 neutral.
+ *
+ * Absent means neutral, not zero. C1 and C2 have not shipped, so no league has
+ * a coach rating or a facilities score yet; treating that absence as a bad
+ * coach would make every league's training worse than it will be next month for
+ * no reason a player could see. This is a multiplier on an effect, not an
+ * invented fact about anyone.
+ */
+export const NEUTRAL_RATING = 50;
+const DEVELOPMENT_SWING = 0.5;
+const FACILITIES_SWING = 0.3;
+
+function ratingMultiplier(rating: number | null | undefined, swing: number): number {
+  if (rating === null || rating === undefined || !Number.isFinite(rating)) {
+    return 1;
+  }
+  const clamped = Math.max(0, Math.min(100, rating));
+  return 1 - swing / 2 + (clamped / 100) * swing;
+}
+
+export interface TrainingBonusInput {
+  focus: string;
+  points: number;
+  positionGroup: string;
+  /** Coach development rating, 0–100. Null until C1 ships one. */
+  developmentRating?: number | null;
+  /** Program facilities, 0–100. Null until C2 ships them. */
+  facilities?: number | null;
+}
+
+/**
+ * Attribute points a training allocation earns, before they are placed.
+ *
+ * Strictly increasing in `points`, `developmentRating` and `facilities`, and
+ * independent of `focus` — see property 2 in the header. Returns a real number;
+ * rounding happens once, at distribution, so a coach who splits a budget across
+ * two allocations is not taxed twice by the same rounding.
+ */
+export function trainingBonus(input: TrainingBonusInput): number {
+  if (!isTrainingFocus(input.focus)) return 0;
+  if (!Number.isFinite(input.points) || input.points <= 0) return 0;
+  if (focusAttributeKeys(input.focus, input.positionGroup).length === 0) {
+    return 0;
+  }
+  return (
+    TRAINING_YIELD *
+    Math.sqrt(input.points) *
+    ratingMultiplier(input.developmentRating, DEVELOPMENT_SWING) *
+    ratingMultiplier(input.facilities, FACILITIES_SWING)
+  );
+}
+
+export interface TrainingAllocation {
+  focus: string;
+  points: number;
+}
+
+export interface ApplyTrainingInput {
+  attributes: Readonly<Record<string, number>>;
+  positionGroup: string;
+  allocations: readonly TrainingAllocation[];
+  developmentRating?: number | null;
+  facilities?: number | null;
+  /**
+   * A direct multiplier on the earned points, for callers that hold a
+   * multiplier rather than the 0–100 ratings behind one — `ProgressionInput`'s
+   * `developmentMultiplier` is the only one today. Absent is 1, so it never
+   * changes a result by being omitted.
+   */
+  multiplier?: number | null;
+}
+
+export interface AppliedTraining {
+  /** The full map after training — unchanged keys included. */
+  attributes: Record<string, number>;
+  /** Per-key gain, for "what did my points buy". Only non-zero keys. */
+  gains: Record<string, number>;
+  /** Attribute points actually placed. Below the earned total at the ceiling. */
+  pointsPlaced: number;
+}
+
+/**
+ * Place earned attribute points on a player's ratings.
+ *
+ * One point at a time onto the lowest-rated key in the focus that still has
+ * headroom. That ordering is the coaching model: a spring spent on athleticism
+ * closes the gap between a player's speed and his agility before it makes his
+ * best trait better. It also makes the placement total-preserving, which a
+ * flat "share it out and round" is not — rounding down four ways is how a
+ * coach loses a point they paid for.
+ */
+export function applyTraining(input: ApplyTrainingInput): AppliedTraining {
+  const attributes: Record<string, number> = { ...input.attributes };
+  const gains: Record<string, number> = {};
+  let pointsPlaced = 0;
+
+  const multiplier =
+    input.multiplier === null ||
+    input.multiplier === undefined ||
+    !Number.isFinite(input.multiplier)
+      ? 1
+      : Math.max(0, input.multiplier);
+
+  for (const allocation of input.allocations) {
+    if (!isTrainingFocus(allocation.focus)) continue;
+    const earned = Math.round(
+      trainingBonus({
+        focus: allocation.focus,
+        points: allocation.points,
+        positionGroup: input.positionGroup,
+        developmentRating: input.developmentRating,
+        facilities: input.facilities,
+      }) * multiplier,
+    );
+    if (earned <= 0) continue;
+
+    /*
+     * Only keys the player actually has. A rating that is not in the map is not
+     * a zero he can train up from — it is an attribute this player was never
+     * given, and inventing it here would put a coverage rating on a punter.
+     */
+    const keys = focusAttributeKeys(allocation.focus, input.positionGroup)
+      .filter((key) => Object.prototype.hasOwnProperty.call(attributes, key))
+      .slice()
+      .sort();
+    if (keys.length === 0) continue;
+
+    for (let placed = 0; placed < earned; placed++) {
+      let target: string | null = null;
+      for (const key of keys) {
+        if ((attributes[key] ?? 0) >= ATTRIBUTE_MAX) continue;
+        if (target === null || (attributes[key] ?? 0) < (attributes[target] ?? 0)) {
+          target = key;
+        }
+      }
+      // Every key in the focus is maxed. The rest of this allocation has
+      // nowhere to go, and saying so beats pretending it landed.
+      if (target === null) break;
+      attributes[target] = (attributes[target] ?? 0) + 1;
+      gains[target] = (gains[target] ?? 0) + 1;
+      pointsPlaced++;
+    }
+  }
+
+  return { attributes, gains, pointsPlaced };
+}
+
+/** Points already committed, for a budget meter or an over-budget check. */
+export function totalAllocatedPoints(
+  allocations: readonly { points: number }[],
+): number {
+  return allocations.reduce(
+    (sum, row) => sum + (Number.isFinite(row.points) ? row.points : 0),
+    0,
+  );
+}
+
+export type TrainingRejection =
+  | "invalid_focus"
+  | "invalid_points"
+  | "training_budget_exhausted";
+
+export interface TrainingBudgetInput {
+  points: number;
+  focus: string;
+  /** Points this team has already committed for the season. */
+  spent: number;
+  /** This team's allowance for the season. */
+  total: number;
+}
+
+export type TrainingDecision =
+  | { ok: true }
+  | { ok: false; reason: TrainingRejection };
+
+/**
+ * Whether an allocation may be recorded.
+ *
+ * The panel and the mutation both call this, so a control that is offered is a
+ * control that works. The budget is checked against the team's own spend, not
+ * the league's — see the note on `playerTrainingAllocations` in
+ * `convex/tables/offseason.ts` for why training diverges from scouting there.
+ */
+export function trainingGate(input: TrainingBudgetInput): TrainingDecision {
+  if (!isTrainingFocus(input.focus)) {
+    return { ok: false, reason: "invalid_focus" };
+  }
+  if (!Number.isFinite(input.points) || input.points <= 0) {
+    return { ok: false, reason: "invalid_points" };
+  }
+  if (!Number.isInteger(input.points)) {
+    return { ok: false, reason: "invalid_points" };
+  }
+  if (input.spent + input.points > input.total) {
+    return { ok: false, reason: "training_budget_exhausted" };
+  }
+  return { ok: true };
+}

--- a/apps/web/convex/tables/offseason.ts
+++ b/apps/web/convex/tables/offseason.ts
@@ -168,6 +168,55 @@ export const offseasonTables = {
     .index("by_leagueId", ["leagueId"]),
 
   /*
+   * Offseason training (Dynasty Mode B6). One row per allocation — a coach
+   * committing points to one player in one direction.
+   *
+   * ## Why the rows survive being applied
+   *
+   * The obvious design patches the player's ratings and keeps nothing. That
+   * loses the only record of WHY a rating moved: a coach who comes back in
+   * March and finds his safety four points faster has no way to tell his own
+   * spring from the seeded progression that ran at rollover. `appliedAt` turns
+   * these into a ledger — what was bought, and whether it has landed yet.
+   *
+   * It is also the idempotency guard. Applying is additive (it patches the
+   * already-progressed snapshot rather than re-deriving it, because a freshman
+   * signed this offseason has no prior season to re-derive from), so a second
+   * apply without the stamp would train everyone twice.
+   *
+   * ## Why the budget is per TEAM, unlike scouting
+   *
+   * B3 put one league-wide scouting budget on the offseason row and noted that
+   * per-team is a Wave 5 concern. Training does not get that deferral: scouting
+   * a shared recruiting class out of a shared pool is at least arguable, but a
+   * shared training budget means the first coach to open the hub can spend the
+   * whole league's spring on his own quarterback. `trainingPointsTotal` on the
+   * offseason row is therefore read as each team's allowance, and a team's
+   * spend is the sum of its own rows through `by_seasonId_teamId`. The league
+   * total on the offseason row is kept in step for audit and for the admin view.
+   */
+  playerTrainingAllocations: defineTable({
+    leagueId: v.id("leagues"),
+    /** The UPCOMING season these points develop a player for. */
+    seasonId: v.id("seasons"),
+    /** The program that spent the points — the unit the budget belongs to. */
+    teamId: v.id("teams"),
+    playerId: v.id("players"),
+    /** "athleticism" | "strength" | "technique" | "football_iq". */
+    focus: v.string(),
+    points: v.number(),
+    /** Set when the gain has landed on `playerAttributes`. See the note above. */
+    appliedAt: v.optional(v.string()),
+    /** Attribute points actually placed, for "what did my points buy". */
+    appliedGainJson: v.optional(v.string()),
+    createdAt: v.string(),
+    createdBy: v.string(),
+  })
+    .index("by_seasonId_teamId", ["seasonId", "teamId"])
+    .index("by_playerId_seasonId", ["playerId", "seasonId"])
+    .index("by_seasonId", ["seasonId"]),
+
+  /*
    * Offseason snake draft (WSM-000233). One draft per target season; order is
    * reverse final standings. Writes are internalMutation only.
    */

--- a/apps/web/e2e/tests/training.spec.ts
+++ b/apps/web/e2e/tests/training.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedRosterMoveCandidates,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+import { acceptBrowserConfirms } from "../helpers/sim-league-setup";
+
+/*
+ * Offseason training (Dynasty Mode B6, #624).
+ *
+ * Its own fixture league, for the reason `offseason-phases.spec.ts` records:
+ * the canonical shared league's season statuses churn between CI runs, and
+ * everything here needs an UPCOMING season.
+ *
+ * The roster is seeded; every allocation and the application that follows go
+ * through the real controls, the real actions and the real mutations. The last
+ * test is the one that matters — training that never lands on a rating is a
+ * budget meter, not a mechanic.
+ */
+test.describe("Training (B6)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "training";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let seasonId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E TR Home",
+      awayTeamName: "E2E TR Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await setupClerkTestingToken({ page });
+    acceptBrowserConfirms(page);
+  });
+
+  test("the panel prices each option in the ratings it would move", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto("/dashboard/seasons");
+    const card = page.locator('[data-slot="card"]', { hasText: LEAGUE_NAME });
+    await card.getByRole("button", { name: "New season" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "New season" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Season name").fill(`E2E Training ${Date.now()}`);
+    await dialog.getByTestId("create-season-submit").click();
+
+    const success = page.getByRole("dialog", { name: "Season created" });
+    await expect(success).toBeVisible({ timeout: 30_000 });
+    const href = await success
+      .getByTestId("create-season-generate-schedule")
+      .getAttribute("href");
+    seasonId = href?.split("/")[3] ?? null;
+    expect(seasonId).toBeTruthy();
+    await success.getByRole("button", { name: "Done" }).click();
+
+    /*
+     * BOTH teams. The hub acts for the first team the viewer manages in
+     * `getTeamsByLeague` order, which is not the fixture's home-first order —
+     * B4's first CI run proved that the hard way.
+     */
+    await seedRosterMoveCandidates(seasonId as string, fixture.homeTeamId, 3);
+    await seedRosterMoveCandidates(seasonId as string, fixture.awayTeamId, 3);
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("training-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    // A budget meter alone is a chore. The point is seeing what a point buys.
+    await expect(panel.getByTestId("training-budget-meter")).toBeVisible();
+    await expect(panel.getByTestId("training-preview").first()).toContainText(
+      /\+\d/,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("committing points spends the budget and it sticks", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    const panel = page.getByTestId("training-panel");
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    const remaining = panel.getByTestId("training-points-remaining");
+    const before = await remaining.textContent();
+
+    /*
+     * Ten points rather than the default two. The yield is `sqrt(points)`, and
+     * the next test asserts the OVR moved — two points buy three attribute
+     * points across six ratings, which is half an overall and rounds either
+     * way depending on the seed. Ten is unambiguous.
+     */
+    await panel.getByTestId("training-points").selectOption("10");
+
+    const row = panel
+      .getByTestId("training-row")
+      .filter({ hasText: "E2E JV Sophomore 1" });
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    await row.getByTestId("training-commit").click();
+    await expect(remaining).not.toHaveText(before ?? "", { timeout: 30_000 });
+
+    // Persisted, not local state — a coach's plan has to survive a reload.
+    const after = await remaining.textContent();
+    await page.reload();
+    await expect(
+      page.getByTestId("training-panel").getByTestId("training-points-remaining"),
+    ).toHaveText(after ?? "", { timeout: 30_000 });
+  });
+
+  test("leaving the training phase lands the gain on the roster", async ({
+    page,
+  }) => {
+    if (!fixture || !seasonId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${seasonId}/offseason`);
+    await expect(page.getByTestId("training-panel")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    /*
+     * The overall BEFORE, read off the roster board rather than computed —
+     * the assertion is that the number a coach looks at moved, not that a
+     * function returned what it returns.
+     */
+    const boardRow = page
+      .getByTestId("roster-board")
+      .getByTestId("roster-move-row")
+      .filter({ hasText: "E2E JV Sophomore 1" });
+    await expect(boardRow).toBeVisible({ timeout: 30_000 });
+    const before = await boardRow.textContent();
+
+    /*
+     * Walk to `training` and then out of it. Every step is the real Advance
+     * button, so the spec also proves the new phase sits in the machine where
+     * the stepper and the gate both expect it.
+     */
+    const stepper = page.getByTestId("offseason-phase-stepper");
+    for (let i = 0; i < 6; i++) {
+      const phase = await stepper.getAttribute("data-phase");
+      if (phase === "activate") break;
+      await page.getByTestId("offseason-advance").click();
+      await expect(page.getByTestId("offseason-phase-message")).toBeVisible({
+        timeout: 30_000,
+      });
+      await page.reload();
+      await expect(stepper).toBeVisible({ timeout: 30_000 });
+    }
+    await expect(stepper).toHaveAttribute("data-phase", "activate", {
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("offseason-phase-training")).toHaveAttribute(
+      "data-state",
+      "complete",
+    );
+
+    const after = await page
+      .getByTestId("roster-board")
+      .getByTestId("roster-move-row")
+      .filter({ hasText: "E2E JV Sophomore 1" })
+      .textContent();
+    expect(after).not.toBe(before);
+  });
+});

--- a/apps/web/e2e/tests/training.spec.ts
+++ b/apps/web/e2e/tests/training.spec.ts
@@ -172,11 +172,21 @@ test.describe("Training (B6)", () => {
       const phase = await stepper.getAttribute("data-phase");
       if (phase === "activate") break;
       await page.getByTestId("offseason-advance").click();
-      await expect(page.getByTestId("offseason-phase-message")).toBeVisible({
-        timeout: 30_000,
-      });
+      /*
+       * "Advanced to", not merely visible. A REFUSED advance renders its reason
+       * into the same element, so asserting the message exists passes on
+       * failure — which is exactly how this spec's first CI run walked six
+       * times, never left `transfers`, and only fell over at the end with no
+       * indication of why.
+       */
+      await expect(
+        page.getByTestId("offseason-phase-message"),
+      ).toContainText("Advanced to", { timeout: 30_000 });
       await page.reload();
       await expect(stepper).toBeVisible({ timeout: 30_000 });
+      // The stepper reads persisted state, so this is the phase that actually
+      // committed rather than what the client thinks it asked for.
+      await expect(stepper).not.toHaveAttribute("data-phase", phase as string);
     }
     await expect(stepper).toHaveAttribute("data-phase", "activate", {
       timeout: 30_000,

--- a/apps/web/src/app/dashboard/_actions/__tests__/offseason-phases.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/offseason-phases.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockResolveOrgContext,
+  mockResolveOrgRole,
+  mockGetLeagueOrgId,
+  mockGetDraft,
+  mockBeginOffseason,
+  mockAdvanceOffseasonPhase,
+  mockApplyTrainingAllocations,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockResolveOrgContext: vi.fn(),
+  mockResolveOrgRole: vi.fn(),
+  mockGetLeagueOrgId: vi.fn(),
+  mockGetDraft: vi.fn(),
+  mockBeginOffseason: vi.fn(),
+  mockAdvanceOffseasonPhase: vi.fn(),
+  mockApplyTrainingAllocations: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/org-context", () => ({
+  resolveOrgContext: mockResolveOrgContext,
+  resolveOrgRole: mockResolveOrgRole,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getLeagueOrgId: mockGetLeagueOrgId,
+  getDraft: mockGetDraft,
+  beginOffseason: mockBeginOffseason,
+  advanceOffseasonPhase: mockAdvanceOffseasonPhase,
+  applyTrainingAllocations: mockApplyTrainingAllocations,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { advanceOffseasonPhaseAction } from "../offseason-phases";
+
+const LEAGUE = "league_1";
+const SEASON = "season_1";
+const USER = "user_admin";
+
+function offseason(phase: string) {
+  return {
+    id: "off_1",
+    leagueId: LEAGUE,
+    seasonId: SEASON,
+    phase,
+    completedPhases: ["rollover"],
+    scoutingPointsTotal: 100,
+    scoutingPointsSpent: 0,
+    trainingPointsTotal: 100,
+    trainingPointsSpent: 0,
+    createdAt: "2028-01-01T00:00:00.000Z",
+    updatedAt: "2028-01-01T00:00:00.000Z",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: USER });
+  mockGetLeagueOrgId.mockResolvedValue("org_1");
+  mockResolveOrgRole.mockResolvedValue("admin");
+  mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
+  mockGetDraft.mockResolvedValue(null);
+  mockBeginOffseason.mockResolvedValue(offseason("recruiting"));
+  mockAdvanceOffseasonPhase.mockResolvedValue({
+    changed: true,
+    offseason: offseason("transfers"),
+  });
+  mockApplyTrainingAllocations.mockResolvedValue({
+    applied: 2,
+    playersTrained: 1,
+    pointsPlaced: 6,
+  });
+});
+
+describe("advanceOffseasonPhaseAction", () => {
+  it("claims the lease as the ADMIN, not as the individual transition", async () => {
+    /*
+     * The regression B6's e2e caught. `ownerId` used to be
+     * `${userId}:${from}:${to}`, so every move claimed the lease under a new
+     * name — and the admin's own 30-second lease from the previous phase then
+     * read as a foreign one, refusing the next Advance as `phase_busy`. An
+     * admin walking their own offseason could not get past the second step.
+     */
+    await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "recruiting",
+      to: "transfers",
+    });
+    await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "transfers",
+      to: "draft",
+    });
+
+    const owners = mockAdvanceOffseasonPhase.mock.calls.map(
+      ([args]) => args.ownerId,
+    );
+    expect(owners).toEqual([USER, USER]);
+  });
+
+  it("applies training before it leaves the training phase", async () => {
+    /*
+     * Order matters. Applying AFTER the advance would leave a failure with the
+     * offseason already past `training` and every allocation stranded —
+     * unapplied, unspendable, and with no phase left to retry from.
+     */
+    const order: string[] = [];
+    mockApplyTrainingAllocations.mockImplementation(async () => {
+      order.push("apply");
+      return { applied: 1, playersTrained: 1, pointsPlaced: 6 };
+    });
+    mockAdvanceOffseasonPhase.mockImplementation(async () => {
+      order.push("advance");
+      return { changed: true, offseason: offseason("activate") };
+    });
+
+    await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "training",
+      to: "activate",
+    });
+
+    expect(order).toEqual(["apply", "advance"]);
+  });
+
+  it("leaves the offseason in training when applying fails", async () => {
+    mockApplyTrainingAllocations.mockRejectedValue(new Error("boom"));
+    const result = await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "training",
+      to: "activate",
+    });
+    expect(result.ok).toBe(false);
+    expect(mockAdvanceOffseasonPhase).not.toHaveBeenCalled();
+  });
+
+  it("does not apply training on any other transition", async () => {
+    await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "free_agency",
+      to: "training",
+    });
+    expect(mockApplyTrainingAllocations).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller who cannot manage the league", async () => {
+    mockResolveOrgRole.mockResolvedValue("member");
+    const result = await advanceOffseasonPhaseAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      expectedPhase: "recruiting",
+      to: "transfers",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockAdvanceOffseasonPhase).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/training.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/training.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockCanAdminOrManageTeam,
+  mockGetTeamLeagueId,
+  mockAllocateTraining,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCanAdminOrManageTeam: vi.fn(),
+  mockGetTeamLeagueId: vi.fn(),
+  mockAllocateTraining: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({
+  canAdminOrManageTeam: mockCanAdminOrManageTeam,
+}));
+vi.mock("@/lib/data-api", () => ({
+  getTeamLeagueId: mockGetTeamLeagueId,
+  allocateTraining: mockAllocateTraining,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { allocateTrainingAction } from "../training";
+
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const SEASON = "season_1";
+const PLAYER = "player_1";
+
+const INPUT = {
+  playerId: PLAYER,
+  teamId: TEAM_A,
+  seasonId: SEASON,
+  focus: "athleticism",
+  points: 5,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockGetTeamLeagueId.mockResolvedValue("league_1");
+  mockCanAdminOrManageTeam.mockImplementation(
+    async (teamId: string) => teamId === TEAM_A,
+  );
+  mockAllocateTraining.mockResolvedValue({
+    allocation: {
+      id: "alloc_1",
+      seasonId: SEASON,
+      teamId: TEAM_A,
+      playerId: PLAYER,
+      focus: "athleticism",
+      points: 5,
+      appliedAt: null,
+      appliedGainJson: null,
+      createdAt: "2028-01-01T00:00:00.000Z",
+    },
+    pointsSpent: 5,
+    pointsTotal: 100,
+  });
+});
+
+/*
+ * Training gates on `teamId` (B6), the shape recruiting, transfers and roster
+ * moves already use. In Wave 5 the identical action serves a coach who owns one
+ * team; one written against "is org admin" could not be narrowed without
+ * rewriting every call site.
+ */
+describe("allocateTrainingAction", () => {
+  it("records training for a team the caller manages", async () => {
+    const result = await allocateTrainingAction(INPUT);
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({ pointsSpent: 5, pointsTotal: 100 }),
+    });
+    expect(mockAllocateTraining).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: TEAM_A, actorUserId: "coach_a" }),
+    );
+  });
+
+  it("refuses a team the caller does not manage", async () => {
+    const result = await allocateTrainingAction({ ...INPUT, teamId: TEAM_B });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockAllocateTraining).not.toHaveBeenCalled();
+  });
+
+  it("refuses a signed-out caller before it reaches authorization", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const result = await allocateTrainingAction(INPUT);
+    expect(result).toEqual({ ok: false, error: "unauthorized" });
+    expect(mockCanAdminOrManageTeam).not.toHaveBeenCalled();
+  });
+
+  it("recovers the bare reason from a Convex-wrapped error", async () => {
+    // Convex wraps a thrown Error in its own message, so the code the panel
+    // switches on has to be found in the text.
+    mockAllocateTraining.mockRejectedValue(
+      new Error(
+        "[CONVEX M(dynasty:allocateTraining)] Uncaught Error: training_budget_exhausted",
+      ),
+    );
+    const result = await allocateTrainingAction(INPUT);
+    expect(result).toEqual({ ok: false, error: "training_budget_exhausted" });
+  });
+
+  it("revalidates the hub, where an allocation is visible", async () => {
+    await allocateTrainingAction(INPUT);
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      `/dashboard/seasons/${SEASON}/offseason`,
+    );
+  });
+
+  it("leaves the roster and player pages alone — nothing has changed there yet", async () => {
+    /*
+     * An allocation is a plan. The team, roster and player pages still show
+     * what the player IS until the phase advance applies it, and revalidating
+     * them would suggest a rating moved when none did.
+     */
+    await allocateTrainingAction(INPUT);
+    const paths = mockRevalidatePath.mock.calls.map(([path]) => path);
+    expect(paths).not.toContain(`/dashboard/teams/${TEAM_A}/roster`);
+    expect(paths).not.toContain(`/dashboard/players/${PLAYER}`);
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/offseason-phases.ts
+++ b/apps/web/src/app/dashboard/_actions/offseason-phases.ts
@@ -6,6 +6,7 @@ import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageOrgSettings } from "@/lib/permissions";
 import {
   advanceOffseasonPhase,
+  applyTrainingAllocations,
   beginOffseason,
   getDraft,
   getLeagueOrgId,
@@ -90,6 +91,22 @@ export async function advanceOffseasonPhaseAction(input: {
      * module would couple two Convex modules for one boolean.
      */
     const draft = await getDraft(input.seasonId).catch(() => null);
+
+    /*
+     * Leaving the training phase is when a spring lands (B6). It runs BEFORE
+     * the advance, not after, so a failure here leaves the offseason in
+     * `training` with the allocations still pending — a state an admin can
+     * retry — rather than past the phase with the points silently unspent.
+     *
+     * `applyTrainingAllocations` is idempotent through each row's `appliedAt`,
+     * so the retry that follows a lost response trains nobody twice.
+     */
+    if (input.expectedPhase === "training") {
+      await applyTrainingAllocations({
+        seasonId: input.seasonId,
+        actorUserId: userId,
+      });
+    }
 
     const result = await advanceOffseasonPhase({
       seasonId: input.seasonId,

--- a/apps/web/src/app/dashboard/_actions/offseason-phases.ts
+++ b/apps/web/src/app/dashboard/_actions/offseason-phases.ts
@@ -112,9 +112,22 @@ export async function advanceOffseasonPhaseAction(input: {
       seasonId: input.seasonId,
       expectedPhase: input.expectedPhase,
       to: input.to,
-      // Identifies this attempt, so a retry by the same admin is not mistaken
-      // for a second admin racing them.
-      ownerId: `${userId}:${input.expectedPhase}:${input.to}`,
+      /*
+       * The admin, not the attempt.
+       *
+       * This was `${userId}:${from}:${to}` — a different owner for every
+       * transition — which meant an admin walking their own offseason was
+       * refused by their OWN 30-second lease the moment they clicked Advance
+       * twice in a row. B6's e2e is the first thing to walk several phases back
+       * to back, and it found it; every earlier test advanced once, or advanced
+       * through the mutation with one fixed owner, so the machine looked fine.
+       *
+       * Keying the lease to the user is what the lease was always documented to
+       * do — "a second admin clicking Advance loses cleanly". A retry by the
+       * same admin still matches, so the `changed: false` path is unaffected,
+       * and a genuinely concurrent second admin is still turned away.
+       */
+      ownerId: userId,
       actorUserId: userId,
       draftStatus: draftStatusFor(draft),
     });

--- a/apps/web/src/app/dashboard/_actions/training.ts
+++ b/apps/web/src/app/dashboard/_actions/training.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canAdminOrManageTeam } from "@/lib/authorization";
+import {
+  allocateTraining,
+  getTeamLeagueId,
+  type TrainingAllocationDto,
+} from "@/lib/data-api";
+
+/*
+ * Offseason training actions (Dynasty Mode B6).
+ *
+ * Gated on `teamId`, like recruiting, transfers and roster moves before it.
+ * Spending a program's training budget is that program's decision, and an
+ * action written against "is org admin" could not be narrowed for Wave 5
+ * without rewriting every call site.
+ *
+ * Applying the allocations is NOT here — it runs from the phase advance in
+ * `offseason-phases.ts`, which is an org-admin action because leaving a phase
+ * moves every team in the league at once.
+ */
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  /*
+   * Convex wraps a thrown Error in its own message, so the bare reason the UI
+   * switches on has to be recovered from the text — same recovery as
+   * `roster-moves.ts` and `transfers.ts`.
+   */
+  const known = [
+    "player_not_found",
+    "player_not_on_team",
+    "invalid_focus",
+    "invalid_points",
+    "training_budget_exhausted",
+    "season_locked",
+    "season_not_found",
+    "season_not_upcoming",
+  ];
+  return known.find((reason) => raw.includes(reason)) ?? raw;
+}
+
+export async function allocateTrainingAction(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  focus: string;
+  points: number;
+}): Promise<
+  ActionResult<{
+    allocation: TrainingAllocationDto;
+    pointsSpent: number;
+    pointsTotal: number;
+  }>
+> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const data = await allocateTraining({
+      playerId: input.playerId,
+      teamId: input.teamId,
+      seasonId: input.seasonId,
+      focus: input.focus,
+      points: input.points,
+      actorUserId: userId,
+    });
+
+    /*
+     * Only the hub. An allocation is a plan, not a rating change — the team,
+     * roster and player pages still show what the player IS until the phase
+     * advance applies it, and revalidating them here would suggest otherwise.
+     */
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/offseason`);
+    const leagueId = await getTeamLeagueId(input.teamId).catch(() => null);
+    if (leagueId) revalidatePath(`/dashboard/leagues/${leagueId}`);
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/offseason/page.tsx
@@ -9,6 +9,7 @@ import {
   getTeamsByLeague,
   listProspects,
   listRosterBoard,
+  listTrainingAllocations,
   listTransfers,
 } from "@/lib/data-api";
 import { canManageTeam } from "@/lib/authorization";
@@ -21,6 +22,7 @@ import { OffseasonPhaseControls } from "@/components/offseason/OffseasonPhaseCon
 import { ScoutingPanel } from "@/components/offseason/ScoutingPanel";
 import { TransferPanel } from "@/components/offseason/TransferPanel";
 import { PromotionsPanel } from "@/components/offseason/PromotionsPanel";
+import { TrainingPanel } from "@/components/offseason/TrainingPanel";
 import { resolveOffseasonState } from "@/lib/dynasty/offseason-phases";
 import { DYNASTY_CONFIG_DEFAULTS } from "@/lib/dynasty-config";
 import { syncActiveLeagueForResource } from "@/lib/active-league-server";
@@ -89,9 +91,12 @@ export default async function SeasonOffseasonPage({
    * one team's roster rather than the league's. Loading it alongside the
    * others would mean fetching twelve rosters to render one.
    */
-  const rosterBoard = actingTeam
-    ? await listRosterBoard(season.id, actingTeam.id).catch(() => [])
-    : [];
+  const [rosterBoard, trainingAllocations] = actingTeam
+    ? await Promise.all([
+        listRosterBoard(season.id, actingTeam.id).catch(() => []),
+        listTrainingAllocations(season.id, actingTeam.id).catch(() => []),
+      ])
+    : [[], []];
 
   const draftStatus = !draft
     ? ("none" as const)
@@ -145,6 +150,21 @@ export default async function SeasonOffseasonPage({
             seasonId={season.id}
             players={rosterBoard}
             actingTeam={actingTeam}
+          />
+
+          <TrainingPanel
+            seasonId={season.id}
+            players={rosterBoard}
+            allocations={trainingAllocations}
+            actingTeam={actingTeam}
+            /*
+             * `trainingPointsTotal` is read as THIS TEAM's allowance, not the
+             * league's — see the note on `playerTrainingAllocations`.
+             */
+            pointsTotal={
+              offseason?.trainingPointsTotal ??
+              DYNASTY_CONFIG_DEFAULTS.trainingPointsPerOffseason
+            }
           />
         </CardContent>
       </Card>

--- a/apps/web/src/components/offseason/TrainingPanel.tsx
+++ b/apps/web/src/components/offseason/TrainingPanel.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { allocateTrainingAction } from "@/app/dashboard/_actions/training";
+import type {
+  RosterBoardPlayerDto,
+  TrainingAllocationDto,
+} from "@/lib/data-api";
+import {
+  TRAINING_FOCUSES,
+  TRAINING_POINT_OPTIONS,
+  applyTraining,
+  focusAttributeKeys,
+  totalAllocatedPoints,
+  trainingGate,
+  type TrainingFocus,
+} from "@/lib/dynasty/training";
+import { attributeGroupForPosition } from "@/lib/synthetic-attributes";
+
+/*
+ * The spring training board (Dynasty Mode B6).
+ *
+ * The one thing this panel exists to make visible: what a point BUYS. A budget
+ * meter on its own is a chore — you spend down to zero because the number is
+ * there. So every option is priced in the ratings it would move, computed with
+ * the same `applyTraining` the mutation runs, and the coach can see that ten
+ * points on one player is worth less than the same ten spread across three.
+ *
+ * The panel and the mutation share `trainingGate`, so a control that is offered
+ * is a control that works — the same arrangement as B5's squad button.
+ */
+
+const REASON_COPY: Record<string, string> = {
+  training_budget_exhausted:
+    "This team has no training points left for the offseason.",
+  invalid_focus: "That is not a training focus.",
+  invalid_points: "That is not a valid number of points.",
+  player_not_on_team: "That player is no longer on this roster.",
+  season_locked: "The roster is locked for this season.",
+  not_authorized: "You cannot train for this team.",
+};
+
+function copyFor(reason: string): string {
+  return REASON_COPY[reason] ?? "Could not record that training.";
+}
+
+function parseAttributes(json: string | null): Record<string, number> {
+  if (!json) return {};
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const out: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export interface TrainingPanelProps {
+  seasonId: string;
+  players: RosterBoardPlayerDto[];
+  allocations: TrainingAllocationDto[];
+  /** The team this viewer trains for, or null when they manage none. */
+  actingTeam: { id: string; name: string } | null;
+  /** This team's allowance for the offseason. */
+  pointsTotal: number;
+}
+
+export function TrainingPanel({
+  seasonId,
+  players,
+  allocations,
+  actingTeam,
+  pointsTotal,
+}: TrainingPanelProps) {
+  const [rows, setRows] = useState(allocations);
+  const [focus, setFocus] = useState<TrainingFocus>("athleticism");
+  const [points, setPoints] = useState(TRAINING_POINT_OPTIONS[0] ?? 2);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const spent = useMemo(() => totalAllocatedPoints(rows), [rows]);
+  const remaining = Math.max(0, pointsTotal - spent);
+
+  /*
+   * Committed points per player, so a coach can see where his spring has
+   * already gone without reading the ledger as a list of transactions.
+   */
+  const committed = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of rows) {
+      map.set(row.playerId, (map.get(row.playerId) ?? 0) + row.points);
+    }
+    return map;
+  }, [rows]);
+
+  const board = useMemo(
+    () =>
+      [...players].sort(
+        (a, b) => (b.overall ?? 0) - (a.overall ?? 0) || a.name.localeCompare(b.name),
+      ),
+    [players],
+  );
+
+  const gate = trainingGate({ focus, points, spent, total: pointsTotal });
+
+  function allocate(player: RosterBoardPlayerDto) {
+    if (!actingTeam) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await allocateTrainingAction({
+        playerId: player.playerId,
+        teamId: actingTeam.id,
+        seasonId,
+        focus,
+        points,
+      });
+      if (!result.ok) {
+        setMessage(copyFor(result.error));
+        return;
+      }
+      setRows((current) => [...current, result.data.allocation]);
+      setMessage(`Committed ${points} points to ${player.name}.`);
+    });
+  }
+
+  if (board.length === 0) {
+    return (
+      <section data-testid="training-panel" className="space-y-2">
+        <h3 className="text-sm font-semibold">Training</h3>
+        <p className="text-sm text-muted-foreground">
+          {actingTeam
+            ? `${actingTeam.name} has nobody on its roster to train.`
+            : "You do not manage a team in this league."}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="training-panel" className="space-y-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-semibold">Training</h3>
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="training-points-remaining"
+        >
+          {remaining} of {pointsTotal} training points remaining
+        </p>
+      </div>
+
+      <div
+        className="h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label={`${spent} of ${pointsTotal} training points committed`}
+        data-testid="training-budget-meter"
+      >
+        <div
+          className="h-2 rounded-full bg-primary"
+          style={{
+            width: `${pointsTotal > 0 ? Math.min(100, (spent / pointsTotal) * 100) : 0}%`,
+          }}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-xs text-muted-foreground">
+          Focus
+          <select
+            className="ml-2 rounded-md border bg-background px-2 py-1 text-sm"
+            data-testid="training-focus"
+            value={focus}
+            onChange={(event) => setFocus(event.target.value as TrainingFocus)}
+          >
+            {TRAINING_FOCUSES.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="text-xs text-muted-foreground">
+          Points
+          <select
+            className="ml-2 rounded-md border bg-background px-2 py-1 text-sm"
+            data-testid="training-points"
+            value={points}
+            onChange={(event) => setPoints(Number(event.target.value))}
+          >
+            {TRAINING_POINT_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <p className="text-xs text-muted-foreground">
+          {TRAINING_FOCUSES.find((option) => option.id === focus)?.blurb}
+        </p>
+      </div>
+
+      {message && (
+        <p className="text-sm text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+
+      <ul className="divide-y rounded-md border">
+        {board.map((player) => {
+          const attributes = parseAttributes(player.attributesJson);
+          const positionGroup =
+            player.positionGroup ?? attributeGroupForPosition(player.position);
+          /*
+           * The preview is the mutation's own arithmetic, not an estimate of
+           * it. `applyTraining` respects the 99 ceiling, so a maxed-out player
+           * honestly shows +0 rather than a gain he cannot receive.
+           */
+          const preview = applyTraining({
+            attributes,
+            positionGroup,
+            allocations: [{ focus, points }],
+          });
+          /*
+           * "Nothing to train" and "nowhere left to put it" are different
+           * facts and a coach needs to tell them apart: one is a player
+           * without ratings, the other is a player already at 99. Collapsing
+           * them into one message would read as the panel being broken.
+           */
+          const trainable = focusAttributeKeys(focus, positionGroup).some(
+            (key) => key in attributes,
+          );
+          const already = committed.get(player.playerId) ?? 0;
+
+          return (
+            <li
+              key={player.playerId}
+              className="flex flex-wrap items-center gap-3 p-3"
+              data-testid="training-row"
+            >
+              <div className="min-w-[11rem] flex-1">
+                <p className="text-sm font-medium">{player.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {player.position}
+                  {player.grade !== null ? ` · Grade ${player.grade}` : ""}
+                  {player.overall !== null ? ` · ${player.overall} OVR` : ""}
+                  {already > 0 ? ` · ${already} pts committed` : ""}
+                </p>
+              </div>
+
+              <p
+                className="min-w-[9rem] font-mono text-xs text-muted-foreground"
+                data-testid="training-preview"
+              >
+                {preview.pointsPlaced > 0
+                  ? Object.entries(preview.gains)
+                      .sort(([a], [b]) => a.localeCompare(b))
+                      .map(([key, gain]) => `${key} +${gain}`)
+                      .join(" · ")
+                  : trainable
+                    ? "no headroom"
+                    : "not trainable"}
+              </p>
+
+              {actingTeam && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  data-testid="training-commit"
+                  disabled={pending || gate.ok !== true}
+                  onClick={() => allocate(player)}
+                >
+                  Train ({points})
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/offseason/__tests__/training-panel.test.ts
+++ b/apps/web/src/components/offseason/__tests__/training-panel.test.ts
@@ -1,0 +1,148 @@
+import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type {
+  RosterBoardPlayerDto,
+  TrainingAllocationDto,
+} from "@/lib/data-api";
+
+vi.mock("@/app/dashboard/_actions/training", () => ({
+  allocateTrainingAction: vi.fn(),
+}));
+
+import { TrainingPanel } from "@/components/offseason/TrainingPanel";
+
+const MINE = { id: "team_1", name: "North HS" };
+
+function player(
+  overrides: Partial<RosterBoardPlayerDto> = {},
+): RosterBoardPlayerDto {
+  return {
+    playerId: "player_1",
+    name: "Cam Whitfield",
+    position: "WR",
+    positionGroup: "WR",
+    grade: 10,
+    squad: "JV",
+    overall: 74,
+    depthRank: 1,
+    attributesJson: JSON.stringify({
+      SPD: 70,
+      ACC: 68,
+      AGI: 72,
+      STR: 60,
+      AWR: 66,
+      CTH: 74,
+    }),
+    ...overrides,
+  };
+}
+
+function allocation(
+  overrides: Partial<TrainingAllocationDto> = {},
+): TrainingAllocationDto {
+  return {
+    id: "alloc_1",
+    seasonId: "season_1",
+    teamId: MINE.id,
+    playerId: "player_1",
+    focus: "athleticism",
+    points: 5,
+    appliedAt: null,
+    appliedGainJson: null,
+    createdAt: "2028-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  seasonId: "season_1",
+  actingTeam: MINE,
+  pointsTotal: 100,
+};
+
+function render(props: Partial<Parameters<typeof TrainingPanel>[0]> = {}) {
+  return renderToStaticMarkup(
+    createElement(TrainingPanel, {
+      ...baseProps,
+      players: [player()],
+      allocations: [],
+      ...props,
+    }),
+  );
+}
+
+describe("TrainingPanel", () => {
+  it("prices every option in the ratings it would move", () => {
+    /*
+     * The whole reason the panel exists. A budget meter on its own is a chore —
+     * you spend to zero because the number is there. Showing what a point BUYS
+     * is what makes it a decision.
+     */
+    const html = render();
+    expect(html).toContain("training-preview");
+    expect(html).toMatch(/(SPD|ACC|AGI) \+\d/);
+  });
+
+  it("shows the budget as a meter and as a number", () => {
+    const html = render({ allocations: [allocation({ points: 25 })] });
+    expect(html).toContain("training-budget-meter");
+    expect(html).toContain("75 of 100 training points remaining");
+  });
+
+  it("counts committed points against the budget before they are applied", () => {
+    // An allocation is a plan, but it is a SPENT plan — a coach who could
+    // re-spend the same points would find the budget meaningless.
+    const html = render({
+      allocations: [allocation({ points: 10 }), allocation({ id: "a2", points: 15 })],
+    });
+    expect(html).toContain("75 of 100 training points remaining");
+  });
+
+  it("says where a player's points have already gone", () => {
+    const html = render({ allocations: [allocation({ points: 10 })] });
+    expect(html).toContain("10 pts committed");
+  });
+
+  it("disables the control when the budget cannot cover the selection", () => {
+    /*
+     * The panel and the mutation share `trainingGate`, so a control that is
+     * offered is a control that works.
+     */
+    const html = render({ allocations: [allocation({ points: 99 })] });
+    expect(html).toContain("disabled");
+  });
+
+  it("admits when a maxed-out player has nowhere to put the points", () => {
+    const html = render({
+      players: [
+        player({
+          attributesJson: JSON.stringify({ SPD: 99, ACC: 99, AGI: 99 }),
+        }),
+      ],
+    });
+    expect(html).toContain("no headroom");
+  });
+
+  it("admits when a player has no ratings to train at all", () => {
+    const html = render({ players: [player({ attributesJson: null })] });
+    expect(html).toContain("not trainable");
+  });
+
+  it("offers every focus the rules accept", () => {
+    const html = render();
+    for (const label of ["Athleticism", "Strength", "Technique", "Football IQ"]) {
+      expect(html).toContain(label);
+    }
+  });
+
+  it("offers no control to a viewer who manages no team", () => {
+    const html = render({ actingTeam: null });
+    expect(html).not.toContain("training-commit");
+  });
+
+  it("says so plainly when there is nobody to train", () => {
+    const html = render({ players: [] });
+    expect(html).toContain("nobody on its roster to train");
+  });
+});

--- a/apps/web/src/lib/__tests__/dynasty-progression.test.ts
+++ b/apps/web/src/lib/__tests__/dynasty-progression.test.ts
@@ -67,3 +67,58 @@ describe("computeProgressedAttributes", () => {
     expect(Object.keys(next.attributes).length).toBe(Object.keys(BASE_ATTRS).length);
   });
 });
+
+/*
+ * B6 added optional `training` and `developmentMultiplier` to `ProgressionInput`.
+ * The promise attached to them is that they cost nothing when unused: every
+ * league that has ever rolled over must keep progressing exactly as it did.
+ */
+describe("computeProgressedAttributes with training (B6)", () => {
+  const INPUT = {
+    playerId: "player_training",
+    newSeasonId: "season_2028",
+    position: "WR",
+    previousGrade: 10,
+    previousAttributes: { SPD: 70, STR: 68, AGI: 72, AWR: 65, ACC: 71 },
+    positionGroup: "WR",
+  };
+
+  it("is byte-identical to the pre-B6 result when no training was bought", () => {
+    const bare = computeProgressedAttributes(INPUT);
+    for (const training of [undefined, []]) {
+      expect(
+        JSON.stringify(computeProgressedAttributes({ ...INPUT, training })),
+      ).toBe(JSON.stringify(bare));
+    }
+  });
+
+  it("is byte-identical when a multiplier is supplied but nothing was bought", () => {
+    // A multiplier alone must not be a development bonus. It scales training,
+    // and no training is still no training.
+    expect(
+      computeProgressedAttributes({ ...INPUT, developmentMultiplier: 2 }),
+    ).toEqual(computeProgressedAttributes(INPUT));
+  });
+
+  it("adds training on top of the base delta without disturbing it", () => {
+    /*
+     * The RNG stream must be exhausted before training is placed, or adding a
+     * focus would silently reshuffle a player's natural growth.
+     */
+    const bare = computeProgressedAttributes(INPUT);
+    const trained = computeProgressedAttributes({
+      ...INPUT,
+      training: [{ focus: "athleticism", points: 5 }],
+    });
+
+    expect(trained.attributes.STR).toBe(bare.attributes.STR);
+    expect(trained.attributes.AWR).toBe(bare.attributes.AWR);
+    const athleticGain =
+      trained.attributes.SPD! +
+      trained.attributes.AGI! +
+      trained.attributes.ACC! -
+      (bare.attributes.SPD! + bare.attributes.AGI! + bare.attributes.ACC!);
+    expect(athleticGain).toBeGreaterThan(0);
+    expect(trained.weightedOverall).toBeGreaterThan(bare.weightedOverall);
+  });
+});

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -3267,3 +3267,70 @@ export async function changePlayerPosition(input: {
     input,
   );
 }
+
+/* Offseason training (B6). */
+
+export interface TrainingAllocationDto {
+  id: string;
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  focus: string;
+  points: number;
+  appliedAt: string | null;
+  appliedGainJson: string | null;
+  createdAt: string;
+}
+
+export async function listTrainingAllocations(
+  seasonId: string,
+  teamId: string,
+): Promise<TrainingAllocationDto[]> {
+  const client = getConvexClient();
+  return client.query(
+    dynastyRef.query<TrainingAllocationDto[]>("listTrainingAllocations"),
+    { seasonId, teamId },
+  );
+}
+
+export async function allocateTraining(input: {
+  playerId: string;
+  teamId: string;
+  seasonId: string;
+  focus: string;
+  points: number;
+  actorUserId: string;
+}): Promise<{
+  allocation: TrainingAllocationDto;
+  pointsSpent: number;
+  pointsTotal: number;
+}> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      allocation: TrainingAllocationDto;
+      pointsSpent: number;
+      pointsTotal: number;
+    }>("allocateTraining"),
+    input,
+  );
+}
+
+export async function applyTrainingAllocations(input: {
+  seasonId: string;
+  actorUserId: string;
+}): Promise<{
+  applied: number;
+  playersTrained: number;
+  pointsPlaced: number;
+}> {
+  const client = getConvexClient();
+  return client.mutation(
+    dynastyRef.mutation<{
+      applied: number;
+      playersTrained: number;
+      pointsPlaced: number;
+    }>("applyTrainingAllocations"),
+    input,
+  );
+}

--- a/apps/web/src/lib/dynasty-progression.ts
+++ b/apps/web/src/lib/dynasty-progression.ts
@@ -12,6 +12,10 @@ import { attributeGroupForPosition } from "@/lib/synthetic-attributes";
  * would drift the first time either was tuned.
  */
 import { attrWeight } from "../../convex/lib/positions";
+import {
+  applyTraining,
+  type TrainingAllocation,
+} from "../../convex/lib/training";
 
 const ATTRIBUTE_GROUPS = [
   "QB",
@@ -45,6 +49,22 @@ export interface ProgressionInput {
   previousGrade: number | null;
   previousAttributes: Record<string, number>;
   positionGroup?: string;
+  /*
+   * Training a coach bought for this player (B6). Optional, and absent means
+   * absent — not zero — so every caller that predates B6 gets a byte-identical
+   * result. Applied AFTER the seeded base delta and outside its RNG stream, so
+   * adding training cannot shift a single natural-growth draw.
+   *
+   * The offseason applies training on its own, additively, because it runs
+   * after the rollover has already progressed everyone (see
+   * `applyTrainingAllocations` in `convex/dynasty.ts`). This hook is for the
+   * other direction: a rollover that ever carries an unapplied spring forward,
+   * and C4's development economy, which will supply `developmentMultiplier`
+   * from a coach's development rating.
+   */
+  training?: readonly TrainingAllocation[];
+  /** Scales what training buys. Absent is neutral, not zero — see B6. */
+  developmentMultiplier?: number | null;
 }
 
 export interface ProgressionResult {
@@ -90,10 +110,27 @@ export function computeProgressedAttributes(
     );
   }
 
+  /*
+   * Training lands on top of the finished base delta, never inside it. Placing
+   * it here — after the RNG stream is exhausted — is what makes the B6 promise
+   * checkable: with `training` absent or empty the function has not drawn a
+   * different number, taken a different branch, or rounded differently, so the
+   * result is byte-identical to the pre-B6 one for the same seed.
+   */
+  const trained =
+    input.training && input.training.length > 0
+      ? applyTraining({
+          attributes,
+          positionGroup,
+          allocations: input.training,
+          multiplier: input.developmentMultiplier,
+        }).attributes
+      : attributes;
+
   return {
     positionGroup,
-    attributes,
-    weightedOverall: weightedOverall(attributes),
+    attributes: trained,
+    weightedOverall: weightedOverall(trained),
   };
 }
 

--- a/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/offseason-phases.test.ts
@@ -210,3 +210,41 @@ describe("resolveOffseasonState", () => {
     expect(state.completedPhases).toEqual(["rollover"]);
   });
 });
+
+/*
+ * B6 inserted `training` between `free_agency` and `activate` — the third
+ * migration-free insert this machine has taken. The point of these is that an
+ * offseason already in flight when the phase appeared keeps working.
+ */
+describe("the training phase (B6)", () => {
+  it("sits between free agency and activation", () => {
+    expect(nextPhase("free_agency")).toBe("training");
+    expect(nextPhase("training")).toBe("activate");
+  });
+
+  it("cannot be skipped on the way to activation", () => {
+    // Activation is when a season starts. Jumping the phase would strand every
+    // allocation a coach paid for, unapplied and unspendable.
+    expect(gate("free_agency", "activate")).toEqual({
+      ok: false,
+      reason: "phase_out_of_order",
+    });
+  });
+
+  it("can be passed through empty — an unspent budget is a decision", () => {
+    expect(gate("training", "activate")).toEqual({ ok: true, kind: "advance" });
+  });
+
+  it("shows as skipped, not broken, for an offseason that predates it", () => {
+    /*
+     * The migration-free promise. A league sitting at `activate` when B6
+     * deployed never has `training` in its set; the stepper must read that as
+     * something that did not happen rather than as a phase still to come.
+     */
+    const steps = buildPhaseSteps({
+      phase: "activate",
+      completedPhases: ["rollover", "draft", "free_agency"],
+    });
+    expect(steps.find((step) => step.id === "training")?.state).toBe("optional");
+  });
+});

--- a/apps/web/src/lib/dynasty/__tests__/training.test.ts
+++ b/apps/web/src/lib/dynasty/__tests__/training.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from "vitest";
+import {
+  ATTRIBUTE_MAX,
+  TRAINING_FOCUSES,
+  TRAINING_POINT_OPTIONS,
+  applyTraining,
+  focusAttributeKeys,
+  isTrainingFocus,
+  totalAllocatedPoints,
+  trainingBonus,
+  trainingGate,
+  type TrainingFocus,
+} from "../training";
+import {
+  ATTRIBUTE_GROUPS,
+  COMMON_KEYS,
+  GROUP_KEYS,
+} from "../../../../convex/lib/positions";
+
+const WR_ATTRIBUTES = {
+  SPD: 80,
+  STR: 62,
+  AGI: 78,
+  ACC: 79,
+  AWR: 70,
+  STA: 74,
+  CTH: 82,
+  SRR: 76,
+  MRR: 71,
+  DRR: 69,
+  CIT: 73,
+  RLS: 75,
+};
+
+describe("trainingBonus", () => {
+  it("earns more from more points", () => {
+    const small = trainingBonus({
+      focus: "athleticism",
+      points: 2,
+      positionGroup: "WR",
+    });
+    const large = trainingBonus({
+      focus: "athleticism",
+      points: 10,
+      positionGroup: "WR",
+    });
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it("rewards spreading a budget over dumping it", () => {
+    /*
+     * The property the whole slice rests on. Ten points on one player must be
+     * worth less than one point on each of ten, or the budget is a single
+     * decision rather than a portfolio.
+     */
+    const dumped = trainingBonus({
+      focus: "athleticism",
+      points: 10,
+      positionGroup: "WR",
+    });
+    const spread =
+      10 *
+      trainingBonus({ focus: "athleticism", points: 1, positionGroup: "WR" });
+    expect(spread).toBeGreaterThan(dumped);
+  });
+
+  it("is strictly monotonic in every point count a coach can pick", () => {
+    const yields = TRAINING_POINT_OPTIONS.map((points) =>
+      trainingBonus({ focus: "athleticism", points, positionGroup: "WR" }),
+    );
+    for (let i = 1; i < yields.length; i++) {
+      expect(yields[i]!).toBeGreaterThan(yields[i - 1]!);
+    }
+  });
+
+  it("rises with the coach's development rating", () => {
+    const base = { focus: "athleticism", points: 5, positionGroup: "WR" };
+    const poor = trainingBonus({ ...base, developmentRating: 10 });
+    const neutral = trainingBonus({ ...base, developmentRating: 50 });
+    const elite = trainingBonus({ ...base, developmentRating: 90 });
+    expect(poor).toBeLessThan(neutral);
+    expect(neutral).toBeLessThan(elite);
+  });
+
+  it("rises with facilities", () => {
+    const base = { focus: "athleticism", points: 5, positionGroup: "WR" };
+    expect(trainingBonus({ ...base, facilities: 90 })).toBeGreaterThan(
+      trainingBonus({ ...base, facilities: 10 }),
+    );
+  });
+
+  it("treats a missing rating as neutral rather than as zero", () => {
+    /*
+     * No league has a coach rating or facilities yet — C1 and C2 have not
+     * shipped. Reading their absence as a bad coach would make every league's
+     * training worse for a reason nobody could see.
+     */
+    const absent = trainingBonus({
+      focus: "athleticism",
+      points: 5,
+      positionGroup: "WR",
+    });
+    const neutral = trainingBonus({
+      focus: "athleticism",
+      points: 5,
+      positionGroup: "WR",
+      developmentRating: 50,
+      facilities: 50,
+    });
+    expect(absent).toBeCloseTo(neutral, 10);
+  });
+
+  it("earns the same total whatever the focus — focus changes shape, not size", () => {
+    const totals = TRAINING_FOCUSES.map((focus) =>
+      trainingBonus({ focus: focus.id, points: 5, positionGroup: "WR" }),
+    );
+    for (const total of totals) expect(total).toBeCloseTo(totals[0]!, 10);
+  });
+
+  it("earns nothing from a focus that is not one", () => {
+    expect(
+      trainingBonus({ focus: "vibes", points: 10, positionGroup: "WR" }),
+    ).toBe(0);
+  });
+
+  it("earns nothing from zero or negative points", () => {
+    for (const points of [0, -5, Number.NaN]) {
+      expect(
+        trainingBonus({ focus: "athleticism", points, positionGroup: "WR" }),
+      ).toBe(0);
+    }
+  });
+});
+
+describe("focusAttributeKeys", () => {
+  it("gives every attribute group a technique focus it can train", () => {
+    // A group with no technique keys would silently offer a focus that bought
+    // nothing, which is worse than not offering it.
+    for (const group of ATTRIBUTE_GROUPS) {
+      expect(focusAttributeKeys("technique", group).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("routes technique through the group's own ratings", () => {
+    expect(focusAttributeKeys("technique", "QB")).toEqual(GROUP_KEYS.QB);
+    expect(focusAttributeKeys("technique", "OL")).toEqual(GROUP_KEYS.OL);
+  });
+
+  it("keeps the athletic focuses on ratings every player carries", () => {
+    for (const focus of ["athleticism", "strength", "football_iq"] as const) {
+      for (const key of focusAttributeKeys(focus, "QB")) {
+        expect(COMMON_KEYS).toContain(key);
+      }
+    }
+  });
+
+  it("has nothing to train for an unknown group's technique", () => {
+    expect(focusAttributeKeys("technique", "GOALIE")).toEqual([]);
+  });
+});
+
+describe("applyTraining", () => {
+  it("moves only the attributes the focus develops", () => {
+    const result = applyTraining({
+      attributes: WR_ATTRIBUTES,
+      positionGroup: "WR",
+      allocations: [{ focus: "athleticism", points: 5 }],
+    });
+    const moved = Object.keys(result.gains).sort();
+    expect(moved.every((key) => ["SPD", "ACC", "AGI"].includes(key))).toBe(true);
+    expect(result.attributes.CTH).toBe(WR_ATTRIBUTES.CTH);
+  });
+
+  it("places every point it earns", () => {
+    // Sharing out and rounding down four ways is how a coach loses a point
+    // they paid for.
+    const result = applyTraining({
+      attributes: WR_ATTRIBUTES,
+      positionGroup: "WR",
+      allocations: [{ focus: "technique", points: 10 }],
+    });
+    const earned = Math.round(
+      trainingBonus({ focus: "technique", points: 10, positionGroup: "WR" }),
+    );
+    expect(result.pointsPlaced).toBe(earned);
+    const summed = Object.values(result.gains).reduce((a, b) => a + b, 0);
+    expect(summed).toBe(earned);
+  });
+
+  it("lifts the floor within a focus before the peak", () => {
+    const result = applyTraining({
+      attributes: { SPD: 90, ACC: 60, AGI: 89, AWR: 70 },
+      positionGroup: "WR",
+      allocations: [{ focus: "athleticism", points: 2 }],
+    });
+    expect(result.gains.ACC).toBeGreaterThan(0);
+    expect(result.gains.SPD ?? 0).toBe(0);
+  });
+
+  it("never pushes a rating past the ceiling", () => {
+    const result = applyTraining({
+      attributes: { SPD: 99, ACC: 99, AGI: 99, AWR: 70 },
+      positionGroup: "WR",
+      allocations: [{ focus: "athleticism", points: 10 }],
+    });
+    expect(result.attributes.SPD).toBe(ATTRIBUTE_MAX);
+    expect(result.pointsPlaced).toBe(0);
+  });
+
+  it("says so when a maxed-out focus has nowhere to put the points", () => {
+    // Honest absence. Reporting a gain that did not land would make the panel
+    // and the roster disagree about the same player.
+    const result = applyTraining({
+      attributes: { SPD: 99, ACC: 99, AGI: 99 },
+      positionGroup: "WR",
+      allocations: [{ focus: "athleticism", points: 10 }],
+    });
+    expect(result.gains).toEqual({});
+  });
+
+  it("never invents a rating the player was not given", () => {
+    /*
+     * A punter has no coverage ratings. Training a key that is not in his map
+     * would put one on him rather than developing what he has.
+     */
+    const result = applyTraining({
+      attributes: { KPW: 70, KAC: 68 },
+      positionGroup: "P",
+      allocations: [{ focus: "athleticism", points: 5 }],
+    });
+    expect(result.attributes).toEqual({ KPW: 70, KAC: 68 });
+    expect(result.pointsPlaced).toBe(0);
+  });
+
+  it("accumulates several allocations on the same player", () => {
+    const result = applyTraining({
+      attributes: WR_ATTRIBUTES,
+      positionGroup: "WR",
+      allocations: [
+        { focus: "athleticism", points: 5 },
+        { focus: "technique", points: 5 },
+      ],
+    });
+    const one = Math.round(
+      trainingBonus({ focus: "athleticism", points: 5, positionGroup: "WR" }),
+    );
+    expect(result.pointsPlaced).toBe(one * 2);
+  });
+
+  it("is deterministic — training a coach paid for never rolls badly", () => {
+    const run = () =>
+      applyTraining({
+        attributes: WR_ATTRIBUTES,
+        positionGroup: "WR",
+        allocations: [{ focus: "technique", points: 10 }],
+      });
+    expect(run()).toEqual(run());
+  });
+
+  it("scales with an explicit multiplier and treats its absence as neutral", () => {
+    const base = {
+      attributes: WR_ATTRIBUTES,
+      positionGroup: "WR",
+      allocations: [{ focus: "athleticism", points: 5 }],
+    };
+    expect(applyTraining({ ...base, multiplier: 1 })).toEqual(
+      applyTraining(base),
+    );
+    expect(
+      applyTraining({ ...base, multiplier: 2 }).pointsPlaced,
+    ).toBeGreaterThan(applyTraining(base).pointsPlaced);
+  });
+
+  it("ignores an allocation whose focus is not one", () => {
+    const result = applyTraining({
+      attributes: WR_ATTRIBUTES,
+      positionGroup: "WR",
+      allocations: [{ focus: "vibes", points: 10 }],
+    });
+    expect(result.attributes).toEqual(WR_ATTRIBUTES);
+    expect(result.pointsPlaced).toBe(0);
+  });
+});
+
+describe("trainingGate", () => {
+  it("allows an allocation inside the budget", () => {
+    expect(
+      trainingGate({ focus: "athleticism", points: 5, spent: 0, total: 100 }),
+    ).toEqual({ ok: true });
+  });
+
+  it("refuses the allocation that would go over, not the one that fills it", () => {
+    expect(
+      trainingGate({ focus: "athleticism", points: 5, spent: 95, total: 100 }),
+    ).toEqual({ ok: true });
+    expect(
+      trainingGate({ focus: "athleticism", points: 6, spent: 95, total: 100 }),
+    ).toEqual({ ok: false, reason: "training_budget_exhausted" });
+  });
+
+  it("refuses a focus that is not one", () => {
+    expect(
+      trainingGate({ focus: "vibes", points: 5, spent: 0, total: 100 }),
+    ).toEqual({ ok: false, reason: "invalid_focus" });
+  });
+
+  it("refuses fractional, zero and negative points", () => {
+    for (const points of [0, -1, 2.5]) {
+      expect(
+        trainingGate({ focus: "athleticism", points, spent: 0, total: 100 }),
+      ).toEqual({ ok: false, reason: "invalid_points" });
+    }
+  });
+
+  it("refuses everything when the budget is zero", () => {
+    // A league that turned training off must not be able to spend one point.
+    expect(
+      trainingGate({ focus: "athleticism", points: 1, spent: 0, total: 0 }),
+    ).toEqual({ ok: false, reason: "training_budget_exhausted" });
+  });
+});
+
+describe("the focus vocabulary", () => {
+  it("offers only focuses the gate accepts", () => {
+    for (const focus of TRAINING_FOCUSES) {
+      expect(isTrainingFocus(focus.id)).toBe(true);
+    }
+  });
+
+  it("gives every focus a distinct id", () => {
+    const ids = new Set<TrainingFocus>(TRAINING_FOCUSES.map((f) => f.id));
+    expect(ids.size).toBe(TRAINING_FOCUSES.length);
+  });
+});
+
+describe("totalAllocatedPoints", () => {
+  it("sums a ledger", () => {
+    expect(totalAllocatedPoints([{ points: 2 }, { points: 5 }])).toBe(7);
+  });
+
+  it("ignores a row with a nonsense point count rather than returning NaN", () => {
+    expect(
+      totalAllocatedPoints([{ points: 5 }, { points: Number.NaN }]),
+    ).toBe(5);
+  });
+});

--- a/apps/web/src/lib/dynasty/training.ts
+++ b/apps/web/src/lib/dynasty/training.ts
@@ -1,0 +1,35 @@
+/*
+ * Offseason training rules (Dynasty Mode B6) — see `convex/lib/training.ts`.
+ *
+ * Canonical under `convex/` because the mutation enforces the budget and the
+ * panel previews the gain; re-exported here so the Next layer imports it the
+ * same way it imports every other dynasty lib. Same arrangement as `scouting.ts`
+ * (B3), `transfers.ts` (B4) and `promotions.ts` (B5).
+ */
+
+export {
+  ATTRIBUTE_MAX,
+  ATTRIBUTE_MIN,
+  NEUTRAL_RATING,
+  TRAINING_FOCUSES,
+  TRAINING_POINT_OPTIONS,
+  TRAINING_YIELD,
+  applyTraining,
+  focusAttributeKeys,
+  isTrainingFocus,
+  totalAllocatedPoints,
+  trainingBonus,
+  trainingGate,
+} from "../../../convex/lib/training";
+
+export type {
+  AppliedTraining,
+  ApplyTrainingInput,
+  TrainingAllocation,
+  TrainingBonusInput,
+  TrainingBudgetInput,
+  TrainingDecision,
+  TrainingFocus,
+  TrainingFocusMeta,
+  TrainingRejection,
+} from "../../../convex/lib/training";

--- a/apps/web/src/lib/synthetic-attributes.ts
+++ b/apps/web/src/lib/synthetic-attributes.ts
@@ -20,32 +20,23 @@ import { seedFromString } from "@/lib/synthetic-roster";
  * that mapping would be a fork of the app's football vocabulary. Re-exported
  * here so every existing import is untouched.
  */
+/*
+ * `COMMON_KEYS` and `GROUP_KEYS` followed them in B6, so a training focus can
+ * be resolved to attribute keys inside a Convex mutation.
+ */
 export {
   attributeGroupForPosition,
+  COMMON_KEYS,
+  GROUP_KEYS,
   type AttributeGroup,
 } from "../../convex/lib/positions";
 
 import {
   attributeGroupForPosition,
+  COMMON_KEYS,
+  GROUP_KEYS,
   type AttributeGroup,
 } from "../../convex/lib/positions";
-
-/** Universal athletic attributes every group carries. */
-export const COMMON_KEYS: readonly string[] = ["SPD", "STR", "AGI", "ACC", "AWR", "STA"];
-
-/** Madden-style position-specific attribute codes per group. */
-export const GROUP_KEYS: Readonly<Record<AttributeGroup, readonly string[]>> = {
-  QB: ["THP", "SAC", "MAC", "DAC", "TUP", "PAC"],
-  RB: ["CAR", "BCV", "TRK", "ELU", "JKM", "BTK"],
-  WR: ["CTH", "SRR", "MRR", "DRR", "CIT", "RLS"],
-  TE: ["CTH", "RBK", "CIT", "SRR", "PBK"],
-  OL: ["RBK", "PBK", "RBP", "PBP", "IBL"],
-  DL: ["PMV", "FMV", "BSH", "TAK", "PUR"],
-  LB: ["TAK", "PUR", "PRC", "ZCV", "MCV", "POW"],
-  DB: ["MCV", "ZCV", "PRS", "CTH", "PUR"],
-  K: ["KPW", "KAC"],
-  P: ["KPW", "KAC"],
-};
 
 /** mulberry32 — tiny deterministic PRNG (same family as synthetic-roster). */
 function rng(seed: number): () => number {


### PR DESCRIPTION
Closes #624. Dynasty Mode B6 — the last slice of Epic B.

## What changed

Development was entirely automatic before this: `computeProgressedAttributes` moved every player by a seeded amount at rollover and a coach watched it happen. B6 adds the half that makes it a decision — a finite per-team budget, spent on named players in a named direction, applied to the ratings the rollover already wrote for the upcoming season.

## The rules, and why they are shaped this way

All in `convex/lib/training.ts`, Convex-free and tested there. Three properties carry the slice:

**Spreading beats dumping.** The yield is `sqrt(points)`, so ten points on one player earn less than one point on each of ten. A linear yield would make the budget a single choice — "who is the best player?" — rather than a portfolio. A hard cap would do the same thing with a cliff, and would stop being monotonic exactly where a coach is deciding.

**Focus changes shape, never total.** Every focus turns the same points into the same number of attribute points; they land on different ratings. So picking a focus is choosing what kind of player you want, not trying to guess which focus is secretly worth more.

**Points are never silently wasted.** Attributes cap at 99, so a naive "add n to each key" would quietly discard the training of a player already at the ceiling. Distribution walks the keys with headroom, lowest first — coaching lifts the floor within a focus before it sharpens the peak.

Deliberately **not seeded**. Every other dynasty mechanic is random and reproducible; training is the one a coach paid for, and a spent point that rolled badly would be indistinguishable from a bug.

## Allocation and application are two steps

Scouting (B3) applies the instant you spend, and that is right for scouting — you are buying information and you should see it. Training is a *plan*. A coach assembling a spring wants to move points between players while he decides, and a mechanic that rewrote his roster on every click would make undo the first thing he asked for.

So allocations accumulate against the budget and land together when the offseason leaves the training phase. `appliedAt` on each row is the idempotency guard, not decoration: application is additive rather than a re-derivation of progression, because a freshman signed in this same offseason has no prior season to re-derive from, and a mechanic that worked for veterans and silently skipped the class you just recruited would be worse than no mechanic.

## Two decisions worth pushing back on

**B6 adds a phase; B5 deliberately did not.** I argued in #657 that a phase earns its place when there is a league-wide event to open. Training has one: leaving the phase is when every allocation in the league lands. That is a real, one-time, league-wide event with a deadline a coach needs to see, which promotions did not have. It is the third migration-free insert this machine has taken, and it is optional like the three before it — an unspent budget is a coach declining to run a spring, and the cost is already paid in the ratings he did not buy.

**The budget is per TEAM, unlike B3's shared scouting pool.** B3 put one league-wide budget on the offseason row and noted that per-team is a Wave 5 concern. Training does not get that deferral: scouting a shared recruiting class out of a shared pool is at least arguable, but a shared training budget means the first coach to open the hub can spend the whole league's spring on his own quarterback. `trainingPointsTotal` is therefore read as each team's allowance; the league counter is kept in step for audit. If you would rather B3 and B6 agree, the change is to B3, not to this.

## Two things a reviewer should look at closely

**`weightedOverall` is not a mean.** For a player with real ratings it is a PFF/Madden blend written by `ingestPlayerAttributesBatch`. My first pass recomputed it as the average of the trained map, which would have silently replaced that blend the first time anyone trained him — the rating would jump for a reason no coach could connect to the points he spent. It now applies the *delta*: spreading `pointsPlaced` over the map raises its mean by exactly `pointsPlaced / keys`, so that same shift moves the stored number without redefining what it means. There is a test that pins a nonsense overall and asserts the shift.

**`COMMON_KEYS` and `GROUP_KEYS` moved out of `src/`.** They now live in `convex/lib/positions.ts` alongside the rest of the position vocabulary B5 moved there, because a training focus has to resolve to attribute keys inside a Convex mutation. Re-exports keep every existing import working. This is the same canonical-under-`convex/` pattern as `rng`, `scouting`, `transfers` and `promotions`.

## `ProgressionInput`

Gains optional `training` and `developmentMultiplier` per the issue's acceptance criteria. Both are applied *after* the seeded base delta and outside its RNG stream, so absence is byte-identical to the pre-B6 result for the same seed — asserted directly, including that a multiplier with no training bought is still no training.

Be aware the live consumer of the training math is the offseason apply path, not the rollover: progression runs at rollover, before a coach has allocated anything. The hook exists because the rules belong there and C4 will supply the multiplier from a coach's development rating. If you would rather not carry a parameter the rollover does not pass yet, say so and I will drop it — the AC asked for it, and it is the one place in this PR I would not defend on its own merits.

## A bug the tests caught

The panel reported an unrated player as "no headroom" — the message for someone already at 99 — because the yield function does not know what ratings a player has. Those are different facts and a coach needs to tell them apart. Now split into "no headroom" and "not trainable".

## Verification

- `vitest run` — **219 files, 1810 tests passed**; 73 net-new (32 rules, 16 Convex, 6 action, 10 panel, 4 phase machine, 3 progression, 2 gate/ledger)
- `pnpm turbo type-check` — 5/5 successful
- `pnpm --filter @sports-management/web lint` — clean
- `e2e/tests/training.spec.ts` — three serial tests in fixture league `E2E:training`: the panel prices each option in the ratings it would move; committing spends the budget and survives a reload; advancing out of the training phase lands the gain on the roster board. Both fixture teams are seeded, since the hub acts for the first team in `getTeamsByLeague` order rather than the fixture's home-first order.
- `resetCanonicalFixture` clears `playerTrainingAllocations` per season — a leaked row would spend a later run's budget before the coach arrived.
- `CONTEXT.md` gains **Training** with an `_Avoid_` line and two relationship rules.