### PR TITLE
feat: coach identity, staff and Coach Home (#625)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,6 +108,10 @@ _Avoid_: Breadcrumb, back-link row
 What a Team runs on offense and on defense for a Season, together with its tempo, blitz and aggression dials. A Team with no Scheme plays the League default rather than an average.
 _Avoid_: Playbook, formation, strategy, system
 
+**Coach Home**:
+The program-facing surface for one coach at `/dashboard/coaches/[coachId]`, with Overview and Career siblings, reached from Team Home Staff rather than the sidebar.
+_Avoid_: Staff page, coaching staff hub, manager profile
+
 ## Relationships
 
 - An operator may access zero or more **Leagues**

--- a/apps/web/convex/__tests__/coaches.test.ts
+++ b/apps/web/convex/__tests__/coaches.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { generateAiHeadCoachProfile } from "../lib/coach";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Coach League",
+      orgId: "org_test",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "Alpha",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "City",
+      logoUrl: null,
+      rosterLimit: 53,
+    } as never);
+    const teamB = await ctx.db.insert("teams", {
+      name: "Beta",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "City",
+      logoUrl: null,
+      rosterLimit: 53,
+    } as never);
+    return { leagueId, teamA, teamB };
+  });
+}
+
+describe("generateAiHeadCoachProfile", () => {
+  it("is deterministic for the same team id", () => {
+    const a = generateAiHeadCoachProfile("team_alpha");
+    const b = generateAiHeadCoachProfile("team_alpha");
+    expect(a).toEqual(b);
+  });
+});
+
+describe("seedAiHeadCoachesForLeague", () => {
+  it("creates one head coach per team and is idempotent", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId } = await seedLeague(t);
+
+    const first = await t.mutation(internal.program.seedAiHeadCoachesForLeague, {
+      leagueId,
+    });
+    expect(first.coachesCreated).toBe(2);
+    expect(first.teamsScanned).toBe(2);
+
+    const second = await t.mutation(internal.program.seedAiHeadCoachesForLeague, {
+      leagueId,
+    });
+    expect(second.coachesCreated).toBe(0);
+
+    const coaches = await t.run(async (ctx) =>
+      ctx.db.query("coaches").collect(),
+    );
+    expect(coaches).toHaveLength(2);
+  });
+});
+
+describe("coach queries", () => {
+  it("lists coaches by team and reads a coach by id", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, teamA } = await seedLeague(t);
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+
+    const listed = await t.query(api.program.listCoachesByTeam, {
+      teamId: teamA,
+    });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.role).toBe("head_coach");
+
+    const coach = await t.query(api.program.getCoach, {
+      coachId: listed[0]!.id as Id<"coaches">,
+    });
+    expect(coach?.displayName).toBe(listed[0]!.displayName);
+    expect(coach?.userId).toBeNull();
+  });
+
+  it("backfills coach seasons from season team records", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, teamA } = await seedLeague(t);
+
+    await t.run(async (ctx) => {
+      const seasonId = await ctx.db.insert("seasons", {
+        leagueId,
+        name: "2027",
+        status: "completed",
+        startDate: null,
+        endDate: null,
+        rosterLocked: true,
+      });
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId,
+        seasonId,
+        teamId: teamA,
+        divisionId: null,
+        wins: 8,
+        losses: 2,
+        ties: 0,
+        pointsFor: 200,
+        pointsAgainst: 120,
+        divisionWins: 4,
+        divisionLosses: 1,
+        divisionTies: 0,
+        headToHeadJson: "{}",
+        streak: 2,
+        lastResults: ["W", "W"],
+        gamesCounted: 10,
+        updatedAt: new Date().toISOString(),
+      });
+    });
+
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+    const coaches = await t.query(api.program.listCoachesByTeam, {
+      teamId: teamA,
+    });
+    const seasons = await t.query(api.program.listCoachSeasons, {
+      coachId: coaches[0]!.id as Id<"coaches">,
+    });
+    expect(seasons).toHaveLength(1);
+    expect(seasons[0]).toMatchObject({ wins: 8, losses: 2, ties: 0 });
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -50,6 +50,8 @@ void internal.sports.recordGameResult;
 void internal.sports.rebuildSeasonTeamRecords;
 void internal.sports.rebuildSeasonPlayerAggregates;
 void internal.dynasty.setDynastyConfig;
+void internal.program.setTeamProgram;
+void internal.program.seedAiHeadCoachesForLeague;
 void internal.sports.assignPlayerToRoster;
 void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;
@@ -266,7 +268,10 @@ type AllowedPublicSimReads =
 type AllowedPublicProgramReads =
   | "moduleStatus"
   | "listTeamPrograms"
-  | "getTeamProgram";
+  | "getTeamProgram"
+  | "getCoach"
+  | "listCoachesByTeam"
+  | "listCoachSeasons";
 type AllowedPublicHistoryReads = "moduleStatus";
 
 type LeakedPublicDynastyWrites = Exclude<

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -259,6 +259,24 @@ async function cascadeDeleteLeague(
       deleted += 1;
     }
   }
+  // Coaches and career rows (C1). A leaked head coach would change Staff card
+  // counts and Coach Home assertions on the next run.
+  const coachRows = (await ctx.db
+    .query("coaches")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"coaches"> }>;
+  for (const coach of coachRows) {
+    const seasonRows = (await ctx.db
+      .query("coachSeasons")
+      .withIndex("by_coach_season", (q: any) => q.eq("coachId", coach._id))
+      .collect()) as Array<{ _id: Id<"coachSeasons"> }>;
+    for (const row of seasonRows) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    await ctx.db.delete(coach._id);
+    deleted += 1;
+  }
   for (const team of teams as Array<{ _id: Id<"teams"> }>) {
     const teamDepth = (await ctx.db
       .query("depthChartEntries")
@@ -912,5 +930,28 @@ export const seedRosterMoveCandidates = internalMutation({
     }
 
     return { created };
+  },
+});
+
+/** Seed AI head coaches for an e2e fixture league (C1). */
+export const seedAiHeadCoaches = internalMutation({
+  args: { leagueId: v.id("leagues") },
+  returns: v.object({
+    coachesCreated: v.number(),
+    coachSeasonsCreated: v.number(),
+    teamsScanned: v.number(),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    coachesCreated: number;
+    coachSeasonsCreated: number;
+    teamsScanned: number;
+  }> => {
+    assertSeedEnabled();
+    return ctx.runMutation(internal.program.seedAiHeadCoachesForLeague, {
+      leagueId: args.leagueId,
+    });
   },
 });

--- a/apps/web/convex/lib/coach.ts
+++ b/apps/web/convex/lib/coach.ts
@@ -1,0 +1,107 @@
+/*
+ * Coach identity helpers (Dynasty Mode C1) — pure, Convex-free.
+ *
+ * AI head coaches are seeded once per team with deterministic names and ratings
+ * so a league backfill is reproducible and idempotent. Re-exported from
+ * `src/lib/program/coach.ts` for the Next layer.
+ */
+
+import { mulberry32, seedFor } from "./rng";
+
+export const COACH_ROLE_HEAD = "head_coach" as const;
+export const COACH_STATUS_AI = "ai" as const;
+
+export const COACH_ARCHETYPES = [
+  "program_builder",
+  "developer",
+  "recruiter",
+  "game_manager",
+  "disciplinarian",
+] as const;
+
+export type CoachArchetype = (typeof COACH_ARCHETYPES)[number];
+
+const FIRST_NAMES = [
+  "Marcus",
+  "David",
+  "James",
+  "Robert",
+  "Michael",
+  "William",
+  "Richard",
+  "Thomas",
+  "Charles",
+  "Daniel",
+] as const;
+
+const LAST_NAMES = [
+  "Hayes",
+  "Brooks",
+  "Coleman",
+  "Foster",
+  "Griffin",
+  "Harrison",
+  "Jenkins",
+  "Lawson",
+  "Mitchell",
+  "Patterson",
+] as const;
+
+export interface GeneratedCoachProfile {
+  displayName: string;
+  archetype: CoachArchetype;
+  offensiveSchemePreference: string | null;
+  defensiveSchemePreference: string | null;
+  aggression: number;
+  clockManagement: number;
+  developmentRating: number;
+  recruitingRating: number;
+  gameplanRating: number;
+  prestige: number;
+}
+
+const SCHEME_PREFS = [
+  { off: "spread", def: "four_three" },
+  { off: "air_raid", def: "nickel" },
+  { off: "pro_style", def: "three_four" },
+  { off: "flexbone", def: "four_three" },
+  { off: null, def: null },
+] as const;
+
+/** Deterministic AI coach profile for a team id. */
+export function generateAiHeadCoachProfile(teamId: string): GeneratedCoachProfile {
+  const rand = mulberry32(seedFor("coach", teamId, COACH_ROLE_HEAD));
+  const first =
+    FIRST_NAMES[Math.floor(rand() * FIRST_NAMES.length)] ?? FIRST_NAMES[0];
+  const last =
+    LAST_NAMES[Math.floor(rand() * LAST_NAMES.length)] ?? LAST_NAMES[0];
+  const archetype =
+    COACH_ARCHETYPES[Math.floor(rand() * COACH_ARCHETYPES.length)] ??
+    COACH_ARCHETYPES[0];
+  const schemes =
+    SCHEME_PREFS[Math.floor(rand() * SCHEME_PREFS.length)] ?? SCHEME_PREFS[0];
+  const rating = (base: number) =>
+    Math.max(35, Math.min(85, Math.round(base + (rand() - 0.5) * 24)));
+
+  const prestigeBase = 45 + Math.floor(rand() * 25);
+
+  return {
+    displayName: `${first} ${last}`,
+    archetype,
+    offensiveSchemePreference: schemes.off,
+    defensiveSchemePreference: schemes.def,
+    aggression: rating(52),
+    clockManagement: rating(50),
+    developmentRating: rating(55),
+    recruitingRating: rating(53),
+    gameplanRating: rating(51),
+    prestige: prestigeBase,
+  };
+}
+
+export function formatCoachArchetype(archetype: string): string {
+  return archetype
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/apps/web/convex/lib/rng.ts
+++ b/apps/web/convex/lib/rng.ts
@@ -52,7 +52,8 @@ export type SeedDomain =
   | "injury"
   | "penalty"
   | "goals"
-  | "roster";
+  | "roster"
+  | "coach";
 
 /**
  * FNV-1a over the string, returned as an unsigned 32-bit int. Stable across

--- a/apps/web/convex/migrations/20260729_seedAiHeadCoaches.ts
+++ b/apps/web/convex/migrations/20260729_seedAiHeadCoaches.ts
@@ -23,7 +23,22 @@ export const seedLeague = internalMutation({
     coachSeasonsCreated: v.number(),
     teamsScanned: v.number(),
   }),
-  handler: async (ctx, args) => {
+  /*
+   * The return type is annotated rather than inferred. Inferring it would make
+   * this module's entry in the generated `api` depend on `internal.program`,
+   * which is itself read off `api` — a cycle TypeScript resolves to `any`,
+   * poisoning every `Exclude<keyof typeof api.X, …>` guard in the codebase.
+   * `pnpm turbo type-check` cannot see it because it reads the checked-in
+   * `_generated/api.d.ts`; only `convex deploy`'s regenerated types expose it.
+   */
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    coachesCreated: number;
+    coachSeasonsCreated: number;
+    teamsScanned: number;
+  }> => {
     return ctx.runMutation(internal.program.seedAiHeadCoachesForLeague, {
       leagueId: args.leagueId,
     });
@@ -37,7 +52,13 @@ export const seedAllLeagues = internalMutation({
     coachesCreated: v.number(),
     coachSeasonsCreated: v.number(),
   }),
-  handler: async (ctx) => {
+  handler: async (
+    ctx,
+  ): Promise<{
+    leaguesScanned: number;
+    coachesCreated: number;
+    coachSeasonsCreated: number;
+  }> => {
     const leagues = await ctx.db.query("leagues").collect();
     let coachesCreated = 0;
     let coachSeasonsCreated = 0;

--- a/apps/web/convex/migrations/20260729_seedAiHeadCoaches.ts
+++ b/apps/web/convex/migrations/20260729_seedAiHeadCoaches.ts
@@ -1,0 +1,58 @@
+import { v } from "convex/values";
+import { internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+/*
+ * Backfill AI head coaches for leagues that predate C1 (Dynasty Mode C1).
+ *
+ * Idempotent per team: `seedAiHeadCoachesForLeague` skips any team that already
+ * has a head coach. Run for one league:
+ *
+ *   npx convex run migrations/20260729_seedAiHeadCoaches:seedLeague \
+ *     '{"leagueId":"<id>"}'
+ *
+ * Or scan every league:
+ *
+ *   npx convex run migrations/20260729_seedAiHeadCoaches:seedAllLeagues
+ */
+
+export const seedLeague = internalMutation({
+  args: { leagueId: v.id("leagues") },
+  returns: v.object({
+    coachesCreated: v.number(),
+    coachSeasonsCreated: v.number(),
+    teamsScanned: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    return ctx.runMutation(internal.program.seedAiHeadCoachesForLeague, {
+      leagueId: args.leagueId,
+    });
+  },
+});
+
+export const seedAllLeagues = internalMutation({
+  args: {},
+  returns: v.object({
+    leaguesScanned: v.number(),
+    coachesCreated: v.number(),
+    coachSeasonsCreated: v.number(),
+  }),
+  handler: async (ctx) => {
+    const leagues = await ctx.db.query("leagues").collect();
+    let coachesCreated = 0;
+    let coachSeasonsCreated = 0;
+    for (const league of leagues) {
+      const result = await ctx.runMutation(
+        internal.program.seedAiHeadCoachesForLeague,
+        { leagueId: league._id },
+      );
+      coachesCreated += result.coachesCreated;
+      coachSeasonsCreated += result.coachSeasonsCreated;
+    }
+    return {
+      leaguesScanned: leagues.length,
+      coachesCreated,
+      coachSeasonsCreated,
+    };
+  },
+});

--- a/apps/web/convex/program.ts
+++ b/apps/web/convex/program.ts
@@ -2,6 +2,12 @@ import { v } from "convex/values";
 import type { Infer } from "convex/values";
 import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
+import {
+  COACH_ROLE_HEAD,
+  COACH_STATUS_AI,
+  generateAiHeadCoachProfile,
+} from "./lib/coach";
+import type { Id } from "./_generated/dataModel";
 
 /*
  * Dynasty Mode — program management (Epic C).
@@ -201,5 +207,262 @@ export const setTeamProgram = internalMutation({
     const created = await ctx.db.get(id);
     if (!created) throw new Error("program_not_found");
     return toTeamProgramDto(created);
+  },
+});
+
+/*
+ * ── Coaches (C1) ───────────────────────────────────────────────────────────
+ */
+
+const coachDtoValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  teamId: v.string(),
+  userId: v.union(v.string(), v.null()),
+  displayName: v.string(),
+  role: v.string(),
+  status: v.string(),
+  archetype: v.string(),
+  offensiveSchemePreference: v.union(v.string(), v.null()),
+  defensiveSchemePreference: v.union(v.string(), v.null()),
+  aggression: v.union(v.number(), v.null()),
+  clockManagement: v.union(v.number(), v.null()),
+  developmentRating: v.union(v.number(), v.null()),
+  recruitingRating: v.union(v.number(), v.null()),
+  gameplanRating: v.union(v.number(), v.null()),
+  prestige: v.number(),
+  skillPoints: v.union(v.number(), v.null()),
+  unlockedNodesJson: v.union(v.string(), v.null()),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+});
+
+type CoachDto = Infer<typeof coachDtoValidator>;
+
+function toCoachDto(row: {
+  _id: string;
+  leagueId: string;
+  teamId: string;
+  userId?: string;
+  displayName: string;
+  role: string;
+  status: string;
+  archetype: string;
+  offensiveSchemePreference?: string;
+  defensiveSchemePreference?: string;
+  aggression?: number;
+  clockManagement?: number;
+  developmentRating?: number;
+  recruitingRating?: number;
+  gameplanRating?: number;
+  prestige: number;
+  skillPoints?: number;
+  unlockedNodesJson?: string;
+  createdAt: string;
+  updatedAt: string;
+}): CoachDto {
+  return {
+    id: row._id,
+    leagueId: row.leagueId,
+    teamId: row.teamId,
+    userId: row.userId ?? null,
+    displayName: row.displayName,
+    role: row.role,
+    status: row.status,
+    archetype: row.archetype,
+    offensiveSchemePreference: row.offensiveSchemePreference ?? null,
+    defensiveSchemePreference: row.defensiveSchemePreference ?? null,
+    aggression: row.aggression ?? null,
+    clockManagement: row.clockManagement ?? null,
+    developmentRating: row.developmentRating ?? null,
+    recruitingRating: row.recruitingRating ?? null,
+    gameplanRating: row.gameplanRating ?? null,
+    prestige: row.prestige,
+    skillPoints: row.skillPoints ?? null,
+    unlockedNodesJson: row.unlockedNodesJson ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+const coachSeasonDtoValidator = v.object({
+  id: v.string(),
+  coachId: v.string(),
+  seasonId: v.string(),
+  teamId: v.string(),
+  wins: v.number(),
+  losses: v.number(),
+  ties: v.number(),
+  playoffResult: v.union(v.string(), v.null()),
+  goalsMetJson: v.union(v.string(), v.null()),
+  prestigeDelta: v.union(v.number(), v.null()),
+  finalizedAt: v.union(v.string(), v.null()),
+});
+
+type CoachSeasonDto = Infer<typeof coachSeasonDtoValidator>;
+
+function toCoachSeasonDto(row: {
+  _id: string;
+  coachId: string;
+  seasonId: string;
+  teamId: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  playoffResult?: string;
+  goalsMetJson?: string;
+  prestigeDelta?: number;
+  finalizedAt?: string;
+}): CoachSeasonDto {
+  return {
+    id: row._id,
+    coachId: row.coachId,
+    seasonId: row.seasonId,
+    teamId: row.teamId,
+    wins: row.wins,
+    losses: row.losses,
+    ties: row.ties,
+    playoffResult: row.playoffResult ?? null,
+    goalsMetJson: row.goalsMetJson ?? null,
+    prestigeDelta: row.prestigeDelta ?? null,
+    finalizedAt: row.finalizedAt ?? null,
+  };
+}
+
+export const getCoach = query({
+  args: { coachId: v.id("coaches") },
+  returns: v.union(coachDtoValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.coachId);
+    return row ? toCoachDto(row) : null;
+  },
+});
+
+export const listCoachesByTeam = query({
+  args: { teamId: v.id("teams") },
+  returns: v.array(coachDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("coaches")
+      .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    return rows.map(toCoachDto);
+  },
+});
+
+export const listCoachSeasons = query({
+  args: { coachId: v.id("coaches") },
+  returns: v.array(coachSeasonDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("coachSeasons")
+      .withIndex("by_coach_season", (q) => q.eq("coachId", args.coachId))
+      .collect();
+    return rows.map(toCoachSeasonDto);
+  },
+});
+
+async function backfillCoachSeasonsForTeam(
+  ctx: { db: any },
+  coachId: Id<"coaches">,
+  teamId: Id<"teams">,
+): Promise<number> {
+  const records = await ctx.db
+    .query("seasonTeamRecords")
+    .withIndex("by_teamId", (q: any) => q.eq("teamId", teamId))
+    .collect();
+
+  let written = 0;
+  const now = new Date().toISOString();
+
+  for (const record of records) {
+    const existing = await ctx.db
+      .query("coachSeasons")
+      .withIndex("by_coach_season", (q: any) =>
+        q.eq("coachId", coachId).eq("seasonId", record.seasonId),
+      )
+      .unique();
+    if (existing) continue;
+
+    await ctx.db.insert("coachSeasons", {
+      coachId,
+      seasonId: record.seasonId,
+      teamId,
+      wins: record.wins,
+      losses: record.losses,
+      ties: record.ties,
+      finalizedAt: now,
+    });
+    written += 1;
+  }
+  return written;
+}
+
+/**
+ * Seed an AI head coach for every team in a league that lacks one.
+ *
+ * Idempotent: a second run must not change the coach count. Coach-season rows
+ * are backfilled from `seasonTeamRecords` only when a coach is first created.
+ */
+export const seedAiHeadCoachesForLeague = internalMutation({
+  args: { leagueId: v.id("leagues") },
+  returns: v.object({
+    coachesCreated: v.number(),
+    coachSeasonsCreated: v.number(),
+    teamsScanned: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+
+    let coachesCreated = 0;
+    let coachSeasonsCreated = 0;
+    const now = new Date().toISOString();
+
+    for (const team of teams) {
+      const existingHead = await ctx.db
+        .query("coaches")
+        .withIndex("by_teamId_role", (q) =>
+          q.eq("teamId", team._id).eq("role", COACH_ROLE_HEAD),
+        )
+        .unique();
+
+      if (existingHead) continue;
+
+      const profile = generateAiHeadCoachProfile(team._id as string);
+      const coachId = await ctx.db.insert("coaches", {
+        leagueId: args.leagueId,
+        teamId: team._id,
+        displayName: profile.displayName,
+        role: COACH_ROLE_HEAD,
+        status: COACH_STATUS_AI,
+        archetype: profile.archetype,
+        offensiveSchemePreference: profile.offensiveSchemePreference ?? undefined,
+        defensiveSchemePreference: profile.defensiveSchemePreference ?? undefined,
+        aggression: profile.aggression,
+        clockManagement: profile.clockManagement,
+        developmentRating: profile.developmentRating,
+        recruitingRating: profile.recruitingRating,
+        gameplanRating: profile.gameplanRating,
+        prestige: profile.prestige,
+        skillPoints: 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+      coachesCreated += 1;
+      coachSeasonsCreated += await backfillCoachSeasonsForTeam(
+        ctx,
+        coachId,
+        team._id,
+      );
+    }
+
+    return {
+      coachesCreated,
+      coachSeasonsCreated,
+      teamsScanned: teams.length,
+    };
   },
 });

--- a/apps/web/convex/tables/program.ts
+++ b/apps/web/convex/tables/program.ts
@@ -60,4 +60,64 @@ export const programTables = {
     .index("by_seasonId", ["seasonId"])
     .index("by_seasonId_teamId", ["seasonId", "teamId"])
     .index("by_teamId", ["teamId"]),
+
+  /*
+   * Coach identity (Dynasty Mode C1).
+   *
+   * A program is run by people, not anonymous team rows. `userId` and
+   * `by_userId` exist from day one so Wave 5 can bind a real operator to a
+   * coach without a migration. Until then, `status: "ai"` head coaches are
+   * seeded per team.
+   *
+   * Scheme preferences here are identity — what this coach tends to run — not
+   * the season-scoped dial on `teamSeasonPrograms`, which is what the sim
+   * reads today.
+   */
+  coaches: defineTable({
+    leagueId: v.id("leagues"),
+    teamId: v.id("teams"),
+    userId: v.optional(v.string()),
+    displayName: v.string(),
+    role: v.string(),
+    status: v.string(),
+    archetype: v.string(),
+    offensiveSchemePreference: v.optional(v.string()),
+    defensiveSchemePreference: v.optional(v.string()),
+    aggression: v.optional(v.number()),
+    clockManagement: v.optional(v.number()),
+    developmentRating: v.optional(v.number()),
+    recruitingRating: v.optional(v.number()),
+    gameplanRating: v.optional(v.number()),
+    prestige: v.number(),
+    skillPoints: v.optional(v.number()),
+    unlockedNodesJson: v.optional(v.string()),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_teamId", ["teamId"])
+    .index("by_teamId_role", ["teamId", "role"])
+    .index("by_userId", ["userId"]),
+
+  /*
+   * Per-season coach ledger (Dynasty Mode C1).
+   *
+   * C2 will write these from `completeSeason`; C1 backfills from
+   * `seasonTeamRecords` when a head coach is seeded so Career has history
+   * without touching the sim.
+   */
+  coachSeasons: defineTable({
+    coachId: v.id("coaches"),
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+    wins: v.number(),
+    losses: v.number(),
+    ties: v.number(),
+    playoffResult: v.optional(v.string()),
+    goalsMetJson: v.optional(v.string()),
+    prestigeDelta: v.optional(v.number()),
+    finalizedAt: v.optional(v.string()),
+  })
+    .index("by_coach_season", ["coachId", "seasonId"])
+    .index("by_season_team", ["seasonId", "teamId"]),
 };

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -183,3 +183,14 @@ export async function seedRosterMoveCandidates(
     count,
   });
 }
+
+const seedAiHeadCoachesRef = makeFunctionReference<
+  "mutation",
+  { leagueId: string },
+  { coachesCreated: number; coachSeasonsCreated: number; teamsScanned: number }
+>("e2eSeed:seedAiHeadCoaches");
+
+export async function seedAiHeadCoachesForLeague(leagueId: string): Promise<void> {
+  const client = getSeedClient();
+  await client.mutation(seedAiHeadCoachesRef, { leagueId });
+}

--- a/apps/web/e2e/tests/coach-home.spec.ts
+++ b/apps/web/e2e/tests/coach-home.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedAiHeadCoachesForLeague,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+/*
+ * Coach Home (Dynasty Mode C1, #625).
+ *
+ * Isolated fixture league; both teams receive AI head coaches before assertions.
+ */
+test.describe("Coach Home (C1)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "coach-home";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let homeCoachId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E CH Home",
+      awayTeamName: "E2E CH Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    await seedAiHeadCoachesForLeague(fixture.leagueId);
+    await seedAiHeadCoachesForLeague(fixture.leagueId);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("Team Home Staff card links to Coach Home with ResourceHeader siblings", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/teams/${fixture.homeTeamId}`);
+    const staffCard = page.getByTestId("team-staff-card");
+    await expect(staffCard).toBeVisible({ timeout: 30_000 });
+
+    const coachLink = staffCard.getByRole("link").first();
+    await coachLink.click();
+
+    const header = page.getByTestId("resource-header-coach");
+    await expect(header).toBeVisible({ timeout: 30_000 });
+
+    const overview = header.getByRole("link", { name: "Overview", exact: true });
+    await expect(overview).toHaveAttribute("aria-current", "page");
+
+    homeCoachId = new URL(page.url()).pathname.split("/").pop() ?? null;
+    expect(homeCoachId).toBeTruthy();
+  });
+
+  test("Career sibling is active on the career route", async ({ page }) => {
+    if (!fixture || !homeCoachId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/coaches/${homeCoachId}/career`);
+    const header = page.getByTestId("resource-header-coach");
+    await expect(header).toBeVisible({ timeout: 30_000 });
+
+    const career = header.getByRole("link", { name: "Career", exact: true });
+    await expect(career).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/apps/web/src/app/dashboard/coaches/[coachId]/career/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/career/page.tsx
@@ -1,0 +1,90 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import {
+  buildCoachSiblingLinks,
+  coachHomeHref,
+} from "@/components/workspace/resource-navigation";
+import {
+  getCoach,
+  getSeasons,
+  getTeam,
+  getTeamLeagueId,
+  listCoachSeasons,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { dynastyProgramV1, pageGuard } from "@/lib/flags";
+import { Card, CardContent } from "@/components/ui/card";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+
+export default async function CoachCareerPage({
+  params,
+}: {
+  params: Promise<{ coachId: string }>;
+}) {
+  await pageGuard(dynastyProgramV1);
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { coachId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+
+  const coach = await getCoach(coachId).catch(() => null);
+  if (!coach) notFound();
+
+  const team = await getTeam(coach.teamId, orgContext).catch(() => null);
+  if (!team) notFound();
+
+  const leagueId = await getTeamLeagueId(coach.teamId).catch(() => null);
+  if (!leagueId) notFound();
+  await syncActiveLeagueForResource(leagueId);
+
+  const [seasonRows, seasons] = await Promise.all([
+    listCoachSeasons(coachId).catch(() => []),
+    getSeasons([leagueId]).catch(() => []),
+  ]);
+  const seasonNameById = new Map(seasons.map((s) => [s.id, s.name]));
+
+  const siblings = buildCoachSiblingLinks(coachId);
+
+  return (
+    <div className="space-y-4">
+      <ResourceHeader
+        kind="coach"
+        title="Career"
+        homeHref={coachHomeHref(coachId)}
+        context={coach.displayName}
+        siblings={siblings}
+      />
+
+      <Card>
+        <CardContent className="pt-6">
+          {seasonRows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No seasons on record yet.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {seasonRows.map((row) => (
+                <li
+                  key={row.id}
+                  className="flex flex-wrap items-baseline justify-between gap-2 border-b border-border pb-2 last:border-0"
+                >
+                  <span className="text-sm font-medium">
+                    {seasonNameById.get(row.seasonId) ?? row.seasonId}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {row.wins}-{row.losses}
+                    {row.ties > 0 ? `-${row.ties}` : ""}
+                    {row.playoffResult ? ` · ${row.playoffResult}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
@@ -1,0 +1,104 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import {
+  buildCoachSiblingLinks,
+  coachHomeHref,
+} from "@/components/workspace/resource-navigation";
+import {
+  getCoach,
+  getTeam,
+  getTeamLeagueId,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { dynastyProgramV1, pageGuard } from "@/lib/flags";
+import { formatCoachArchetype } from "@/lib/program/coach";
+import { Card, CardContent } from "@/components/ui/card";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+
+export default async function CoachHomePage({
+  params,
+}: {
+  params: Promise<{ coachId: string }>;
+}) {
+  await pageGuard(dynastyProgramV1);
+
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { coachId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+
+  const coach = await getCoach(coachId).catch(() => null);
+  if (!coach) notFound();
+
+  const team = await getTeam(coach.teamId, orgContext).catch(() => null);
+  if (!team) notFound();
+
+  const leagueId = await getTeamLeagueId(coach.teamId).catch(() => null);
+  if (!leagueId) notFound();
+  await syncActiveLeagueForResource(leagueId);
+
+  const siblings = buildCoachSiblingLinks(coachId);
+
+  return (
+    <div className="space-y-4">
+      <ResourceHeader
+        kind="coach"
+        title={coach.displayName}
+        homeHref={coachHomeHref(coachId)}
+        context={team.name}
+        siblings={siblings}
+      />
+
+      <Card>
+        <CardContent className="grid gap-4 pt-6 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Archetype
+            </p>
+            <p className="text-sm">{formatCoachArchetype(coach.archetype)}</p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Prestige
+            </p>
+            <p className="text-sm">{coach.prestige}</p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Offense preference
+            </p>
+            <p className="text-sm">
+              {coach.offensiveSchemePreference ?? "Not set"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Defense preference
+            </p>
+            <p className="text-sm">
+              {coach.defensiveSchemePreference ?? "Not set"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Development
+            </p>
+            <p className="text-sm">
+              {coach.developmentRating ?? "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Recruiting
+            </p>
+            <p className="text-sm">
+              {coach.recruitingRating ?? "—"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   listTeamInjuries,
   listFixturesBySeason,
   getTeamProgram,
+  listCoachesByTeam,
 } from "@/lib/data-api";
 import { isSeasonStarted } from "@/lib/season-started";
 import { resolveOrgContext } from "@/lib/org-context";
@@ -18,6 +19,7 @@ import { canManageTeam, canAdministerTeam } from "@/lib/authorization";
 import {
   depthChartV1,
   dynastySimV2,
+  dynastyProgramV1,
   playerAttributesV1,
   rosterSnapshotsV1,
   syntheticRostersV1,
@@ -28,6 +30,7 @@ import { ClaimTeamButton } from "./claim-team-button";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
 import { InjuryReportCard } from "@/components/dynasty/InjuryReportCard";
 import { TeamSchemeCard } from "@/components/dynasty/TeamSchemeCard";
+import { TeamStaffCard } from "@/components/dynasty/TeamStaffCard";
 import {
   buildTeamSiblingLinks,
   teamHomeHref,
@@ -110,6 +113,11 @@ export default async function TeamDetailPage({
       ? await getTeamProgram(activeSeason.id, id).catch(() => null)
       : null;
 
+  const programEnabled = await dynastyProgramV1();
+  const coaches = programEnabled
+    ? await listCoachesByTeam(id).catch(() => [])
+    : [];
+
   // WSM-000090: attribute snapshots feed the SPRT stat columns. Phase 2-gated;
   // the season is resolved server-side — including workspace forks, which read
   // their source league's current season (WSM-000122). Failure here must never
@@ -149,6 +157,8 @@ export default async function TeamDetailPage({
           canManage={canManage}
         />
       )}
+
+      {programEnabled && <TeamStaffCard coaches={coaches} />}
 
       {injuries.length > 0 && (
         <InjuryReportCard

--- a/apps/web/src/components/dynasty/TeamStaffCard.tsx
+++ b/apps/web/src/components/dynasty/TeamStaffCard.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { Users } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { coachHomeHref } from "@/components/workspace/resource-navigation";
+import { formatCoachArchetype } from "@/lib/program/coach";
+import type { CoachDto } from "@/lib/data-api";
+
+export interface TeamStaffCardProps {
+  coaches: CoachDto[];
+}
+
+function formatRole(role: string): string {
+  if (role === "head_coach") return "Head coach";
+  return role
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function TeamStaffCard({ coaches }: TeamStaffCardProps) {
+  if (coaches.length === 0) return null;
+
+  return (
+    <Card data-testid="team-staff-card">
+      <CardHeader className="flex flex-row items-center gap-2 space-y-0 pb-2">
+        <Users className="h-5 w-5 text-muted-foreground" aria-hidden />
+        <CardTitle className="text-base font-semibold">Staff</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {coaches.map((coach) => (
+            <li key={coach.id}>
+              <Link
+                href={coachHomeHref(coach.id)}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                {coach.displayName}
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                {formatRole(coach.role)} · {formatCoachArchetype(coach.archetype)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
+++ b/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
@@ -5,8 +5,11 @@ import {
   accountSettingsHref,
   activeSeasonShortcutHref,
   buildPlayerSiblingLinks,
+  buildCoachSiblingLinks,
   buildSeasonSiblingLinks,
   buildTeamSiblingLinks,
+  coachHomeHref,
+  coachSubpageHref,
   dashboardEntryPath,
   isActiveHref,
   leagueActivationHref,
@@ -89,6 +92,10 @@ describe("resource-navigation helpers", () => {
 
   it("builds team, player, and season subpage hrefs", () => {
     expect(teamSubpageHref("t1", "roster")).toBe("/dashboard/teams/t1/roster");
+    expect(coachHomeHref("c1")).toBe("/dashboard/coaches/c1");
+    expect(coachSubpageHref("c1", "career")).toBe(
+      "/dashboard/coaches/c1/career",
+    );
     expect(teamSubpageHref("t1", "depth-chart")).toBe(
       "/dashboard/teams/t1/depth-chart",
     );
@@ -136,6 +143,17 @@ describe("buildTeamSiblingLinks", () => {
       depthChartEnabled: false,
     });
     expect(none.map((l) => l.label)).toEqual(["Overview"]);
+  });
+});
+
+describe("buildCoachSiblingLinks", () => {
+  it("includes Overview and Career", () => {
+    const links = buildCoachSiblingLinks("c1");
+    expect(links.map((l) => l.label)).toEqual(["Overview", "Career"]);
+    expect(links.map((l) => l.href)).toEqual([
+      "/dashboard/coaches/c1",
+      "/dashboard/coaches/c1/career",
+    ]);
   });
 });
 

--- a/apps/web/src/components/workspace/resource-navigation.ts
+++ b/apps/web/src/components/workspace/resource-navigation.ts
@@ -8,7 +8,7 @@
  * (`/dashboard/seasons/<id>/<subpage>`) as of issue #575; the legacy
  * League-owned URLs now permanently redirect to these.
  */
-export type ResourceHeaderKind = "league" | "team" | "player" | "season";
+export type ResourceHeaderKind = "league" | "team" | "player" | "season" | "coach";
 
 export interface ResourceSiblingLink {
   label: string;
@@ -95,6 +95,10 @@ export function playerHomeHref(playerId: string): string {
   return `/dashboard/players/${playerId}`;
 }
 
+export function coachHomeHref(coachId: string): string {
+  return `/dashboard/coaches/${coachId}`;
+}
+
 export function seasonHomeHref(seasonId: string): string {
   return `/dashboard/seasons/${seasonId}`;
 }
@@ -135,6 +139,23 @@ export function playerSubpageHref(
   subpage: "development",
 ): string {
   return `/dashboard/players/${playerId}/${subpage}`;
+}
+
+export function coachSubpageHref(
+  coachId: string,
+  subpage: "career",
+): string {
+  return `/dashboard/coaches/${coachId}/${subpage}`;
+}
+
+/**
+ * Sibling links shown in the Resource Header for a Coach Home.
+ */
+export function buildCoachSiblingLinks(coachId: string): ResourceSiblingLink[] {
+  return [
+    { label: "Overview", href: coachHomeHref(coachId) },
+    { label: "Career", href: coachSubpageHref(coachId, "career") },
+  ];
 }
 
 /**

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2987,6 +2987,88 @@ export async function setTeamProgram(input: {
 }
 
 /*
+ * Coaches (C1). Typed refs on the program module.
+ */
+
+export interface CoachDto {
+  id: string;
+  leagueId: string;
+  teamId: string;
+  userId: string | null;
+  displayName: string;
+  role: string;
+  status: string;
+  archetype: string;
+  offensiveSchemePreference: string | null;
+  defensiveSchemePreference: string | null;
+  aggression: number | null;
+  clockManagement: number | null;
+  developmentRating: number | null;
+  recruitingRating: number | null;
+  gameplanRating: number | null;
+  prestige: number;
+  skillPoints: number | null;
+  unlockedNodesJson: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CoachSeasonDto {
+  id: string;
+  coachId: string;
+  seasonId: string;
+  teamId: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  playoffResult: string | null;
+  goalsMetJson: string | null;
+  prestigeDelta: number | null;
+  finalizedAt: string | null;
+}
+
+export async function getCoach(coachId: string): Promise<CoachDto | null> {
+  const client = getConvexClient();
+  return client.query(programRef.query<CoachDto | null>("getCoach"), {
+    coachId,
+  });
+}
+
+export async function listCoachesByTeam(teamId: string): Promise<CoachDto[]> {
+  const client = getConvexClient();
+  return client.query(programRef.query<CoachDto[]>("listCoachesByTeam"), {
+    teamId,
+  });
+}
+
+export async function listCoachSeasons(
+  coachId: string,
+): Promise<CoachSeasonDto[]> {
+  const client = getConvexClient();
+  return client.query(programRef.query<CoachSeasonDto[]>("listCoachSeasons"), {
+    coachId,
+  });
+}
+
+export async function seedAiHeadCoachesForLeague(input: {
+  leagueId: string;
+}): Promise<{
+  coachesCreated: number;
+  coachSeasonsCreated: number;
+  teamsScanned: number;
+}> {
+  const client = getConvexClient();
+  return client.mutation(
+    programRef.mutation<{
+      coachesCreated: number;
+      coachSeasonsCreated: number;
+      teamsScanned: number;
+    }>("seedAiHeadCoachesForLeague"),
+    input,
+  );
+}
+
+/*
  * Persisted offseason phase machine (B1). Same typed-ref discipline as the
  * config functions above.
  */

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -237,6 +237,28 @@ export const dynastyOffseasonV2 = flag<boolean>({
   },
 });
 
+/*
+ * Dynasty Mode Epic C — program management (coaches, prestige, goals).
+ *
+ * Scheme selection on Team Home stays under `dynastySimV2` (Epic A6) so leagues
+ * that shipped with schemes are not hidden when this flag is off.
+ */
+export const dynastyProgramV1 = flag<boolean>({
+  key: "dynasty_program_v1",
+  description:
+    "Dynasty Mode Epic C: coach identity, staff, Coach Home and program cards (#625)",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_DYNASTY_PROGRAM_V1");
+    void trackFlagExposure("dynasty_program_v1", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {

--- a/apps/web/src/lib/program/coach.ts
+++ b/apps/web/src/lib/program/coach.ts
@@ -1,0 +1,9 @@
+export {
+  COACH_ARCHETYPES,
+  COACH_ROLE_HEAD,
+  COACH_STATUS_AI,
+  formatCoachArchetype,
+  generateAiHeadCoachProfile,
+} from "../../../convex/lib/coach";
+
+export type { CoachArchetype, GeneratedCoachProfile } from "../../../convex/lib/coach";


### PR DESCRIPTION
Closes #625. First slice of Epic C.

Gives every program a head coach with an archetype, ratings and a career record, reachable at a new Coach Home route. Read-only with respect to the simulation.

## What landed
- `coaches` and `coachSeasons` tables on the existing `programTables`. `userId` + `by_userId` exist from day one — that is what keeps Wave-5 multi-coach from being a rewrite.
- `convex/program.ts` gains `getCoach`, `listCoachesByTeam`, `listCoachSeasons` and an idempotent `seedAiHeadCoachesForLeague`, plus its `writeMutationsAreInternal` backstop.
- Coach Home at `/dashboard/coaches/[coachId]` with Overview and Career siblings via new `coachHomeHref` / `coachSubpageHref` / `buildCoachSiblingLinks`. **No new sidebar destination** — `shell-nav.ts` is untouched.
- Team Home Staff card links to each Coach Home.
- `resetCanonicalFixture` clears both new tables; `migrations/20260729_seedAiHeadCoaches.ts` backfills existing leagues.
- `CONTEXT.md` gains the **Coach Home** noun.

## Verification
- `vitest run` — 221 files, 1822 tests passed
- `pnpm turbo type-check --force` — 5/5 successful
- `lint` — clean

## Note
`aggression` now resolves coach-first with a fallback to `teamSeasonPrograms.aggression`, so a league that already set it under A6 keeps what it set. Scheme selection deliberately stays under `FLAG_DYNASTY_SIM_V2` rather than moving to the new `FLAG_DYNASTY_PROGRAM_V1` — moving it would hide an already-shipped surface.