### PR TITLE
feat: program prestige, season goals and job security (#626)

### DIFF
--- a/apps/web/convex/__tests__/completeSeasonProgram.test.ts
+++ b/apps/web/convex/__tests__/completeSeasonProgram.test.ts
@@ -1,0 +1,163 @@
+/// <reference types="vite/client" />
+import { describe, it, expect, vi } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import * as goalsModule from "../lib/goals";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedLeagueWithCoaches(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Program League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const teamA = await ctx.db.insert("teams", {
+      name: "Alphas",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Loc",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const teamB = await ctx.db.insert("teams", {
+      name: "Betas",
+      leagueId,
+      divisionId: null,
+      city: "City",
+      stadium: "Stadium",
+      foundedYear: null,
+      location: "Loc",
+      logoUrl: null,
+      rosterLimit: 53,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: "2026-09-01",
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+
+    for (const teamId of [teamA, teamB]) {
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId,
+        seasonId,
+        teamId,
+        divisionId: null,
+        wins: 6,
+        losses: 4,
+        ties: 0,
+        pointsFor: 280,
+        pointsAgainst: 220,
+        divisionWins: 3,
+        divisionLosses: 2,
+        divisionTies: 0,
+        headToHeadJson: "{}",
+        streak: 1,
+        lastResults: ["W"],
+        gamesCounted: 10,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    return { leagueId, seasonId, teamA, teamB };
+  });
+}
+
+describe("completeSeason program finalize (C2)", () => {
+  it("writes program, coach-season and finalized fields once per team", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seedLeagueWithCoaches(t);
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+
+    const programs = await t.run((ctx) =>
+      ctx.db
+        .query("teamSeasonPrograms")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+    );
+    expect(programs).toHaveLength(2);
+    for (const row of programs) {
+      expect(row.prestige).toBeTypeOf("number");
+      expect(row.seasonGoalsJson).toBeTruthy();
+      expect(row.jobSecurity).toBeTypeOf("number");
+    }
+
+    const coachSeasons = await t.run((ctx) =>
+      ctx.db.query("coachSeasons").collect(),
+    );
+    expect(coachSeasons).toHaveLength(2);
+    for (const row of coachSeasons) {
+      expect(row.finalizedAt).toBeTruthy();
+      expect(row.goalsMetJson).toBeTruthy();
+      expect(row.prestigeDelta).toBeTypeOf("number");
+    }
+  });
+
+  it("is idempotent on re-completion", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seedLeagueWithCoaches(t);
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+    const firstPrograms = await t.run((ctx) =>
+      ctx.db
+        .query("teamSeasonPrograms")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+    );
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+    const secondPrograms = await t.run((ctx) =>
+      ctx.db
+        .query("teamSeasonPrograms")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+    );
+
+    expect(secondPrograms).toHaveLength(firstPrograms.length);
+    expect(secondPrograms.map((r) => r._id).sort()).toEqual(
+      firstPrograms.map((r) => r._id).sort(),
+    );
+  });
+
+  it("goal evaluation performs zero reads of playerGameStats or fixtures", async () => {
+    const evaluateSpy = vi.spyOn(goalsModule, "evaluateGoals");
+    evaluateSpy.mockClear();
+
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seedLeagueWithCoaches(t);
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+
+    let fixtureReads = 0;
+    let gameStatReads = 0;
+
+    await t.run(async (ctx) => {
+      const originalQuery = ctx.db.query.bind(ctx.db);
+      ctx.db.query = ((tableName: string) => {
+        if (tableName === "fixtures") fixtureReads += 1;
+        if (tableName === "playerGameStats") gameStatReads += 1;
+        return originalQuery(tableName as never);
+      }) as unknown as typeof ctx.db.query;
+
+      const { finalizeProgramSeason } = await import("../lib/programFinalize");
+      await finalizeProgramSeason(ctx, seasonId as Id<"seasons">);
+    });
+
+    expect(evaluateSpy).toHaveBeenCalled();
+    expect(fixtureReads).toBe(0);
+    expect(gameStatReads).toBe(0);
+    evaluateSpy.mockRestore();
+  });
+});

--- a/apps/web/convex/__tests__/moduleNaming.test.ts
+++ b/apps/web/convex/__tests__/moduleNaming.test.ts
@@ -1,0 +1,42 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/*
+ * Convex rejects a module path component containing anything but alphanumerics,
+ * underscores and periods. A file named `job-security.ts` is a perfectly good
+ * TypeScript module and a perfectly invalid Convex one, so nothing local fails:
+ * `tsc` is happy, vitest is happy, and the push dies at
+ *
+ *   InvalidConfig: lib/job-security.js is not a valid path to a Convex module
+ *
+ * which surfaces ~15 minutes into CI as an e2e failure with no stack trace.
+ *
+ * The convention under `convex/` is therefore camelCase — `offseasonPhases.ts`,
+ * `dynastyConfig.ts`, `teamRecords.ts`. Files under `src/` are unaffected and
+ * may keep kebab-case; only the Convex side is constrained.
+ */
+
+const CONVEX_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const IGNORED = new Set(["_generated", "node_modules", "__tests__"]);
+
+function collectModulePaths(dir: string, prefix = ""): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    if (IGNORED.has(entry)) return [];
+    const full = join(dir, entry);
+    const rel = prefix ? `${prefix}/${entry}` : entry;
+    if (statSync(full).isDirectory()) return collectModulePaths(full, rel);
+    return entry.endsWith(".ts") ? [rel] : [];
+  });
+}
+
+describe("convex module naming", () => {
+  it("uses no path component Convex would reject", () => {
+    const offenders = collectModulePaths(CONVEX_ROOT).filter((path) =>
+      path.split("/").some((part) => !/^[A-Za-z0-9_.]+$/.test(part)),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -271,7 +271,8 @@ type AllowedPublicProgramReads =
   | "getTeamProgram"
   | "getCoach"
   | "listCoachesByTeam"
-  | "listCoachSeasons";
+  | "listCoachSeasons"
+  | "getSeasonGoalProgress";
 type AllowedPublicHistoryReads = "moduleStatus";
 
 type LeakedPublicDynastyWrites = Exclude<

--- a/apps/web/convex/lib/coach.ts
+++ b/apps/web/convex/lib/coach.ts
@@ -10,6 +10,7 @@ import { mulberry32, seedFor } from "./rng";
 
 export const COACH_ROLE_HEAD = "head_coach" as const;
 export const COACH_STATUS_AI = "ai" as const;
+export const COACH_STATUS_FIRED = "fired" as const;
 
 export const COACH_ARCHETYPES = [
   "program_builder",

--- a/apps/web/convex/lib/goals.ts
+++ b/apps/web/convex/lib/goals.ts
@@ -1,0 +1,207 @@
+/*
+ * Season goals (Dynasty Mode C2) — pure, Convex-free.
+ *
+ * Goals are generated deterministically per `(teamId, seasonId)` and evaluated
+ * from persisted F2/F3 aggregates only — never from per-game tables.
+ */
+
+import { mulberry32, seedFor } from "./rng";
+
+export type GoalStatus = "met" | "missed" | "partial";
+
+export type GoalMetric =
+  | "wins"
+  | "win_pct"
+  | "points_for"
+  | "points_against_max"
+  | "team_passing_yards"
+  | "team_rushing_yards"
+  | "team_total_touchdowns";
+
+export interface SeasonGoal {
+  id: string;
+  metric: GoalMetric;
+  label: string;
+  target: number;
+}
+
+export interface EvaluatedGoal extends SeasonGoal {
+  status: GoalStatus;
+  actual: number;
+}
+
+export interface TeamSeasonRecordInput {
+  wins: number;
+  losses: number;
+  ties: number;
+  pointsFor: number;
+  pointsAgainst: number;
+}
+
+export interface PlayerSeasonAggregateInput {
+  totalsJson: string;
+}
+
+const GOAL_CATALOG: readonly Omit<SeasonGoal, "id">[] = [
+  { metric: "wins", label: "Win at least {target} games", target: 7 },
+  { metric: "wins", label: "Win at least {target} games", target: 9 },
+  { metric: "win_pct", label: "Finish above {target}% win rate", target: 55 },
+  { metric: "points_for", label: "Score at least {target} points", target: 280 },
+  { metric: "points_against_max", label: "Allow fewer than {target} points", target: 220 },
+  {
+    metric: "team_passing_yards",
+    label: "Throw for {target}+ yards as a team",
+    target: 2200,
+  },
+  {
+    metric: "team_rushing_yards",
+    label: "Rush for {target}+ yards as a team",
+    target: 1600,
+  },
+  {
+    metric: "team_total_touchdowns",
+    label: "Score {target}+ touchdowns",
+    target: 35,
+  },
+] as const;
+
+function formatLabel(template: string, target: number): string {
+  return template.replace("{target}", String(target));
+}
+
+function pickGoalCount(teamId: string, seasonId: string): number {
+  const rand = mulberry32(seedFor("goals", teamId, seasonId, "count"));
+  return 3 + Math.floor(rand() * 3);
+}
+
+/** Deterministic 3–5 goals for a team season. */
+export function generateGoals(teamId: string, seasonId: string): SeasonGoal[] {
+  const rand = mulberry32(seedFor("goals", teamId, seasonId, "pick"));
+  const count = pickGoalCount(teamId, seasonId);
+  const indices = GOAL_CATALOG.map((_, i) => i);
+  for (let i = indices.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = indices[i]!;
+    indices[i] = indices[j]!;
+    indices[j] = tmp;
+  }
+  const picked = indices.slice(0, count);
+  return picked.map((index, slot) => {
+    const entry = GOAL_CATALOG[index]!;
+    return {
+      id: `${entry.metric}_${entry.target}_${slot}`,
+      metric: entry.metric,
+      label: formatLabel(entry.label, entry.target),
+      target: entry.target,
+    };
+  });
+}
+
+function sumTeamStat(
+  aggregates: readonly PlayerSeasonAggregateInput[],
+  group: string,
+  field: string,
+): number {
+  let total = 0;
+  for (const row of aggregates) {
+    try {
+      const parsed = JSON.parse(row.totalsJson) as Record<
+        string,
+        Record<string, number>
+      >;
+      const value = parsed[group]?.[field];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        total += value;
+      }
+    } catch {
+      // ignore bad json
+    }
+  }
+  return total;
+}
+
+function teamTouchdowns(aggregates: readonly PlayerSeasonAggregateInput[]): number {
+  let total = 0;
+  for (const row of aggregates) {
+    try {
+      const parsed = JSON.parse(row.totalsJson) as Record<
+        string,
+        Record<string, number>
+      >;
+      for (const group of Object.values(parsed)) {
+        if (!group || typeof group !== "object") continue;
+        for (const [field, value] of Object.entries(group)) {
+          if (
+            typeof value === "number" &&
+            field.toLowerCase().includes("touchdown")
+          ) {
+            total += value;
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return total;
+}
+
+function metricActual(
+  metric: GoalMetric,
+  record: TeamSeasonRecordInput,
+  aggregates: readonly PlayerSeasonAggregateInput[],
+): number {
+  const games = record.wins + record.losses + record.ties;
+  switch (metric) {
+    case "wins":
+      return record.wins;
+    case "win_pct":
+      return games > 0 ? Math.round((record.wins / games) * 100) : 0;
+    case "points_for":
+      return record.pointsFor;
+    case "points_against_max":
+      return record.pointsAgainst;
+    case "team_passing_yards":
+      return sumTeamStat(aggregates, "passing", "yards");
+    case "team_rushing_yards":
+      return sumTeamStat(aggregates, "rushing", "yards");
+    case "team_total_touchdowns":
+      return teamTouchdowns(aggregates);
+    default: {
+      const _exhaustive: never = metric;
+      void _exhaustive;
+      return 0;
+    }
+  }
+}
+
+function evaluateOne(
+  goal: SeasonGoal,
+  record: TeamSeasonRecordInput,
+  aggregates: readonly PlayerSeasonAggregateInput[],
+): EvaluatedGoal {
+  const actual = metricActual(goal.metric, record, aggregates);
+  let status: GoalStatus = "missed";
+
+  if (goal.metric === "points_against_max") {
+    if (actual < goal.target) status = "met";
+    else if (actual <= goal.target + 25) status = "partial";
+  } else if (goal.metric === "win_pct") {
+    if (actual >= goal.target) status = "met";
+    else if (actual >= goal.target - 8) status = "partial";
+  } else if (actual >= goal.target) {
+    status = "met";
+  } else if (actual >= goal.target * 0.85) {
+    status = "partial";
+  }
+
+  return { ...goal, status, actual };
+}
+
+export function evaluateGoals(
+  goals: readonly SeasonGoal[],
+  record: TeamSeasonRecordInput,
+  aggregates: readonly PlayerSeasonAggregateInput[],
+): EvaluatedGoal[] {
+  return goals.map((goal) => evaluateOne(goal, record, aggregates));
+}

--- a/apps/web/convex/lib/jobSecurity.ts
+++ b/apps/web/convex/lib/jobSecurity.ts
@@ -1,0 +1,52 @@
+/*
+ * Coach job security (Dynasty Mode C2) — pure, Convex-free.
+ *
+ * The seat heats and cools from goal results; firing is a separate decision
+ * gated by `jobSecurityEnabled` at the mutation layer.
+ */
+
+import type { EvaluatedGoal } from "./goals";
+
+export const JOB_SECURITY_MIN = 0;
+export const JOB_SECURITY_MAX = 100;
+export const JOB_SECURITY_NEUTRAL = 50;
+export const JOB_SECURITY_FIRE_THRESHOLD = 12;
+
+export interface JobSecurityInput {
+  current: number | null;
+  evaluatedGoals: readonly EvaluatedGoal[];
+  wins: number;
+  losses: number;
+  ties: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+export function computeJobSecurity(input: JobSecurityInput): number {
+  let value = input.current ?? JOB_SECURITY_NEUTRAL;
+  for (const goal of input.evaluatedGoals) {
+    if (goal.status === "met") value += 6;
+    else if (goal.status === "partial") value += 2;
+    else value -= 9;
+  }
+
+  const games = input.wins + input.losses + input.ties;
+  if (games > 0) {
+    const winPct = input.wins / games;
+    if (winPct >= 0.65) value += 4;
+    else if (winPct < 0.35) value -= 6;
+  }
+
+  return clamp(value, JOB_SECURITY_MIN, JOB_SECURITY_MAX);
+}
+
+export function shouldFireCoach(
+  jobSecurity: number,
+  jobSecurityEnabled: boolean,
+): boolean {
+  if (!jobSecurityEnabled) return false;
+  return jobSecurity < JOB_SECURITY_FIRE_THRESHOLD;
+}

--- a/apps/web/convex/lib/narrative.ts
+++ b/apps/web/convex/lib/narrative.ts
@@ -65,6 +65,12 @@ export type NarrativeInput =
       playerName: string;
       teamName: string;
       position: string;
+    }
+  | {
+      type: "coach_fired";
+      coachName: string;
+      teamName: string;
+      seasonName: string;
     };
 
 export type NarrativeEventType = NarrativeInput["type"];
@@ -110,6 +116,9 @@ export function renderHeadline(input: NarrativeInput): string {
       // is exactly the kind of thing a dynasty should remember.
       return `${input.teamName} keeps ${input.playerName} (${input.position})`;
     }
+    case "coach_fired": {
+      return `${input.seasonName}: ${input.teamName} parts ways with ${input.coachName}`;
+    }
     default: {
       // Exhaustiveness guard: adding a NarrativeInput variant without a case
       // here fails `tsc`, so a new event type cannot ship copy-less.
@@ -135,6 +144,8 @@ export function defaultSeverity(type: NarrativeEventType): EventSeverity {
       return "notable";
     case "transfer_retained":
       return "info";
+    case "coach_fired":
+      return "headline";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;
@@ -155,6 +166,8 @@ export function categoryFor(type: NarrativeEventType): EventCategory {
     case "transfer_completed":
     case "transfer_retained":
       return "offseason";
+    case "coach_fired":
+      return "program";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;

--- a/apps/web/convex/lib/prestige.ts
+++ b/apps/web/convex/lib/prestige.ts
@@ -1,0 +1,79 @@
+/*
+ * Program prestige (Dynasty Mode C2) — pure, Convex-free.
+ *
+ * ## Properties
+ *
+ * 1. **Bounded swing.** A single season moves prestige by at most 12 points so
+ *    one catastrophic year cannot erase a decade of brand equity in one step.
+ * 2. **Hard rails.** Prestige always lives in 0..100 after a season closes.
+ * 3. **Hysteresis.** Blue-blood programs shed less on a bad year; rebuilding
+ *    programs gain less on a lone good year — multi-year arcs matter.
+ */
+
+import type { EvaluatedGoal } from "./goals";
+
+export const PRESTIGE_MIN = 0;
+export const PRESTIGE_MAX = 100;
+export const PRESTIGE_DELTA_CAP = 12;
+/** Neutral prestige when a program has never been modelled. */
+export const PRESTIGE_NEUTRAL = 50;
+
+export interface PrestigeSeasonOutcome {
+  wins: number;
+  losses: number;
+  ties: number;
+  evaluatedGoals: readonly EvaluatedGoal[];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+function goalScore(goals: readonly EvaluatedGoal[]): number {
+  if (goals.length === 0) return 0;
+  let points = 0;
+  for (const goal of goals) {
+    if (goal.status === "met") points += 2;
+    else if (goal.status === "partial") points += 1;
+    else points -= 1;
+  }
+  return points / goals.length;
+}
+
+/** Raw delta before cap and hysteresis, from record + goals only. */
+export function rawPrestigeDelta(outcome: PrestigeSeasonOutcome): number {
+  const games = outcome.wins + outcome.losses + outcome.ties;
+  const winPct = games > 0 ? outcome.wins / games : 0;
+  const recordComponent = (winPct - 0.5) * 24;
+  const goalComponent = goalScore(outcome.evaluatedGoals) * 4;
+  return recordComponent + goalComponent;
+}
+
+export interface ApplyPrestigeResult {
+  prestige: number;
+  delta: number;
+}
+
+/**
+ * Apply a season outcome to program prestige. Uses `current ?? PRESTIGE_NEUTRAL`
+ * only for arithmetic — callers persist explicit prestige when they first model
+ * a program.
+ */
+export function applyPrestigeDelta(
+  current: number | null,
+  outcome: PrestigeSeasonOutcome,
+): ApplyPrestigeResult {
+  const base = current ?? PRESTIGE_NEUTRAL;
+  let delta = rawPrestigeDelta(outcome);
+
+  if (base >= 70 && delta < 0) {
+    delta *= 0.55;
+  } else if (base <= 30 && delta > 0) {
+    delta *= 0.55;
+  }
+
+  delta = clamp(delta, -PRESTIGE_DELTA_CAP, PRESTIGE_DELTA_CAP);
+  const prestige = clamp(base + delta, PRESTIGE_MIN, PRESTIGE_MAX);
+  return { prestige, delta: prestige - base };
+}

--- a/apps/web/convex/lib/programFinalize.ts
+++ b/apps/web/convex/lib/programFinalize.ts
@@ -1,0 +1,247 @@
+/*
+ * Season-end program evaluation (Dynasty Mode C2).
+ *
+ * Called from `completeSeason` once per league season. Reads indexed F2/F3
+ * caches only — goal evaluation never touches `playerGameStats` or `fixtures`.
+ */
+
+import type { MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { emitDynastyEvent } from "./events";
+import {
+  COACH_ROLE_HEAD,
+  COACH_STATUS_AI,
+  COACH_STATUS_FIRED,
+  generateAiHeadCoachProfile,
+} from "./coach";
+import { resolveDynastyConfig } from "./dynastyConfig";
+import {
+  evaluateGoals,
+  generateGoals,
+  type EvaluatedGoal,
+  type SeasonGoal,
+} from "./goals";
+import { applyPrestigeDelta } from "./prestige";
+import { computeJobSecurity, shouldFireCoach } from "./jobSecurity";
+import { resolveProgram } from "./resolveProgram";
+
+export function coachFiredDedupeKey(coachId: string, seasonId: string): string {
+  return `coach_fired:${coachId}:${seasonId}`;
+}
+
+export interface FinalizeProgramSeasonResult {
+  teamsProcessed: number;
+  coachesFired: number;
+}
+
+export async function finalizeProgramSeason(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+): Promise<FinalizeProgramSeasonResult> {
+  const season = await ctx.db.get(seasonId);
+  if (!season) throw new Error("season_not_found");
+
+  const configRow = await ctx.db
+    .query("dynastyConfig")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+    .unique();
+  const config = resolveDynastyConfig(configRow);
+
+  const teams = await ctx.db
+    .query("teams")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", season.leagueId))
+    .collect();
+
+  const aggregateRows = await ctx.db
+    .query("playerSeasonAggregates")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+
+  const aggregatesByTeam = new Map<string, typeof aggregateRows>();
+  for (const row of aggregateRows) {
+    const key = row.teamId as string;
+    const list = aggregatesByTeam.get(key) ?? [];
+    list.push(row);
+    aggregatesByTeam.set(key, list);
+  }
+
+  const now = new Date().toISOString();
+  let coachesFired = 0;
+
+  for (const team of teams) {
+    const record = await ctx.db
+      .query("seasonTeamRecords")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", seasonId).eq("teamId", team._id),
+      )
+      .unique();
+
+    const teamAggregates = aggregatesByTeam.get(team._id as string) ?? [];
+
+    const programRow = await ctx.db
+      .query("teamSeasonPrograms")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", seasonId).eq("teamId", team._id),
+      )
+      .unique();
+
+    const resolved = resolveProgram(programRow);
+    const goals: SeasonGoal[] = programRow?.seasonGoalsJson
+      ? (JSON.parse(programRow.seasonGoalsJson) as SeasonGoal[])
+      : generateGoals(team._id as string, seasonId as string);
+
+    const recordInput = record
+      ? {
+          wins: record.wins,
+          losses: record.losses,
+          ties: record.ties,
+          pointsFor: record.pointsFor,
+          pointsAgainst: record.pointsAgainst,
+        }
+      : {
+          wins: 0,
+          losses: 0,
+          ties: 0,
+          pointsFor: 0,
+          pointsAgainst: 0,
+        };
+
+    const evaluated: EvaluatedGoal[] = evaluateGoals(
+      goals,
+      recordInput,
+      teamAggregates.map((row) => ({ totalsJson: row.totalsJson })),
+    );
+
+    const { prestige, delta: prestigeDelta } = applyPrestigeDelta(
+      resolved.prestige,
+      {
+        wins: recordInput.wins,
+        losses: recordInput.losses,
+        ties: recordInput.ties,
+        evaluatedGoals: evaluated,
+      },
+    );
+
+    const jobSecurity = computeJobSecurity({
+      current: resolved.jobSecurity,
+      evaluatedGoals: evaluated,
+      wins: recordInput.wins,
+      losses: recordInput.losses,
+      ties: recordInput.ties,
+    });
+
+    const metCount = evaluated.filter((g) => g.status === "met").length;
+    const boosterConfidence = Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(
+          (resolved.boosterConfidence ?? 50) +
+            (metCount - evaluated.length / 2) * 5,
+        ),
+      ),
+    );
+
+    const programPatch = {
+      prestige,
+      seasonGoalsJson: JSON.stringify(goals),
+      jobSecurity,
+      boosterConfidence,
+      updatedAt: now,
+      updatedBy: "system:completeSeason",
+    };
+
+    if (programRow) {
+      await ctx.db.patch(programRow._id, programPatch);
+    } else {
+      await ctx.db.insert("teamSeasonPrograms", {
+        leagueId: season.leagueId,
+        seasonId,
+        teamId: team._id,
+        createdAt: now,
+        ...programPatch,
+      });
+    }
+
+    const headCoach = await ctx.db
+      .query("coaches")
+      .withIndex("by_teamId_role", (q) =>
+        q.eq("teamId", team._id).eq("role", COACH_ROLE_HEAD),
+      )
+      .unique();
+
+    if (headCoach) {
+      const coachSeason = await ctx.db
+        .query("coachSeasons")
+        .withIndex("by_coach_season", (q) =>
+          q.eq("coachId", headCoach._id).eq("seasonId", seasonId),
+        )
+        .unique();
+
+      const coachSeasonPayload = {
+        wins: recordInput.wins,
+        losses: recordInput.losses,
+        ties: recordInput.ties,
+        goalsMetJson: JSON.stringify(evaluated),
+        prestigeDelta,
+        finalizedAt: now,
+      };
+
+      if (coachSeason) {
+        await ctx.db.patch(coachSeason._id, coachSeasonPayload);
+      } else {
+        await ctx.db.insert("coachSeasons", {
+          coachId: headCoach._id,
+          seasonId,
+          teamId: team._id,
+          ...coachSeasonPayload,
+        });
+      }
+
+      if (shouldFireCoach(jobSecurity, config.jobSecurityEnabled)) {
+        await ctx.db.patch(headCoach._id, {
+          status: COACH_STATUS_FIRED,
+          teamId: null,
+          updatedAt: now,
+        });
+        coachesFired += 1;
+
+        await emitDynastyEvent(ctx, {
+          leagueId: season.leagueId,
+          seasonId,
+          teamId: team._id,
+          dedupeKey: coachFiredDedupeKey(headCoach._id as string, seasonId as string),
+          narrative: {
+            type: "coach_fired",
+            coachName: headCoach.displayName,
+            teamName: team.name,
+            seasonName: season.name,
+          },
+        });
+
+        const profile = generateAiHeadCoachProfile(team._id as string);
+        await ctx.db.insert("coaches", {
+          leagueId: season.leagueId,
+          teamId: team._id,
+          displayName: profile.displayName,
+          role: COACH_ROLE_HEAD,
+          status: COACH_STATUS_AI,
+          archetype: profile.archetype,
+          offensiveSchemePreference: profile.offensiveSchemePreference ?? undefined,
+          defensiveSchemePreference: profile.defensiveSchemePreference ?? undefined,
+          aggression: profile.aggression,
+          clockManagement: profile.clockManagement,
+          developmentRating: profile.developmentRating,
+          recruitingRating: profile.recruitingRating,
+          gameplanRating: profile.gameplanRating,
+          prestige: profile.prestige,
+          skillPoints: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+  }
+
+  return { teamsProcessed: teams.length, coachesFired };
+}

--- a/apps/web/convex/lib/resolveProgram.ts
+++ b/apps/web/convex/lib/resolveProgram.ts
@@ -1,0 +1,44 @@
+/*
+ * Program row resolver (Dynasty Mode C2) — pure, Convex-free.
+ *
+ * A team with no `teamSeasonPrograms` row is fully valid: it runs no scheme and
+ * carries no prestige/goals until someone models them. `null` fields mean "not
+ * modelled", never a silent default that reads as real data in the UI.
+ */
+
+export interface TeamSeasonProgramFields {
+  prestige?: number;
+  facilitiesTier?: number;
+  seasonGoalsJson?: string;
+  jobSecurity?: number;
+  boosterConfidence?: number;
+}
+
+export interface ResolvedProgram {
+  prestige: number | null;
+  facilitiesTier: number | null;
+  seasonGoalsJson: string | null;
+  jobSecurity: number | null;
+  boosterConfidence: number | null;
+}
+
+export function resolveProgram(
+  doc: TeamSeasonProgramFields | null | undefined,
+): ResolvedProgram {
+  if (!doc) {
+    return {
+      prestige: null,
+      facilitiesTier: null,
+      seasonGoalsJson: null,
+      jobSecurity: null,
+      boosterConfidence: null,
+    };
+  }
+  return {
+    prestige: doc.prestige ?? null,
+    facilitiesTier: doc.facilitiesTier ?? null,
+    seasonGoalsJson: doc.seasonGoalsJson ?? null,
+    jobSecurity: doc.jobSecurity ?? null,
+    boosterConfidence: doc.boosterConfidence ?? null,
+  };
+}

--- a/apps/web/convex/program.ts
+++ b/apps/web/convex/program.ts
@@ -7,6 +7,7 @@ import {
   COACH_STATUS_AI,
   generateAiHeadCoachProfile,
 } from "./lib/coach";
+import { evaluateGoals, generateGoals } from "./lib/goals";
 import type { Id } from "./_generated/dataModel";
 
 /*
@@ -48,12 +49,17 @@ const teamProgramValidator = v.object({
   id: v.string(),
   leagueId: v.string(),
   seasonId: v.string(),
-  teamId: v.string(),
+  teamId: v.union(v.string(), v.null()),
   offenseScheme: v.union(v.string(), v.null()),
   defenseScheme: v.union(v.string(), v.null()),
   tempo: v.union(v.number(), v.null()),
   blitzRate: v.union(v.number(), v.null()),
   aggression: v.union(v.number(), v.null()),
+  prestige: v.union(v.number(), v.null()),
+  facilitiesTier: v.union(v.number(), v.null()),
+  seasonGoalsJson: v.union(v.string(), v.null()),
+  jobSecurity: v.union(v.number(), v.null()),
+  boosterConfidence: v.union(v.number(), v.null()),
   updatedAt: v.string(),
 });
 
@@ -77,6 +83,11 @@ function toTeamProgramDto(row: {
   tempo?: number;
   blitzRate?: number;
   aggression?: number;
+  prestige?: number;
+  facilitiesTier?: number;
+  seasonGoalsJson?: string;
+  jobSecurity?: number;
+  boosterConfidence?: number;
   updatedAt: string;
 }): TeamProgramDto {
   return {
@@ -97,6 +108,11 @@ function toTeamProgramDto(row: {
     tempo: row.tempo ?? null,
     blitzRate: row.blitzRate ?? null,
     aggression: row.aggression ?? null,
+    prestige: row.prestige ?? null,
+    facilitiesTier: row.facilitiesTier ?? null,
+    seasonGoalsJson: row.seasonGoalsJson ?? null,
+    jobSecurity: row.jobSecurity ?? null,
+    boosterConfidence: row.boosterConfidence ?? null,
     updatedAt: row.updatedAt,
   };
 }
@@ -217,7 +233,7 @@ export const setTeamProgram = internalMutation({
 const coachDtoValidator = v.object({
   id: v.string(),
   leagueId: v.string(),
-  teamId: v.string(),
+  teamId: v.union(v.string(), v.null()),
   userId: v.union(v.string(), v.null()),
   displayName: v.string(),
   role: v.string(),
@@ -242,7 +258,7 @@ type CoachDto = Infer<typeof coachDtoValidator>;
 function toCoachDto(row: {
   _id: string;
   leagueId: string;
-  teamId: string;
+  teamId: string | null;
   userId?: string;
   displayName: string;
   role: string;
@@ -264,7 +280,7 @@ function toCoachDto(row: {
   return {
     id: row._id,
     leagueId: row.leagueId,
-    teamId: row.teamId,
+    teamId: row.teamId ?? null,
     userId: row.userId ?? null,
     displayName: row.displayName,
     role: row.role,
@@ -289,7 +305,7 @@ const coachSeasonDtoValidator = v.object({
   id: v.string(),
   coachId: v.string(),
   seasonId: v.string(),
-  teamId: v.string(),
+  teamId: v.union(v.string(), v.null()),
   wins: v.number(),
   losses: v.number(),
   ties: v.number(),
@@ -359,6 +375,75 @@ export const listCoachSeasons = query({
       .withIndex("by_coach_season", (q) => q.eq("coachId", args.coachId))
       .collect();
     return rows.map(toCoachSeasonDto);
+  },
+});
+
+const evaluatedGoalValidator = v.object({
+  id: v.string(),
+  metric: v.string(),
+  label: v.string(),
+  target: v.number(),
+  status: v.union(
+    v.literal("met"),
+    v.literal("missed"),
+    v.literal("partial"),
+  ),
+  actual: v.number(),
+});
+
+type EvaluatedGoalDto = Infer<typeof evaluatedGoalValidator>;
+
+export const getSeasonGoalProgress = query({
+  args: {
+    seasonId: v.id("seasons"),
+    teamId: v.id("teams"),
+  },
+  returns: v.array(evaluatedGoalValidator),
+  handler: async (ctx, args): Promise<EvaluatedGoalDto[]> => {
+    const program = await ctx.db
+      .query("teamSeasonPrograms")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .unique();
+
+    const goals = program?.seasonGoalsJson
+      ? (JSON.parse(program.seasonGoalsJson) as ReturnType<typeof generateGoals>)
+      : generateGoals(args.teamId as string, args.seasonId as string);
+
+    const record = await ctx.db
+      .query("seasonTeamRecords")
+      .withIndex("by_seasonId_teamId", (q) =>
+        q.eq("seasonId", args.seasonId).eq("teamId", args.teamId),
+      )
+      .unique();
+
+    const recordInput = record
+      ? {
+          wins: record.wins,
+          losses: record.losses,
+          ties: record.ties,
+          pointsFor: record.pointsFor,
+          pointsAgainst: record.pointsAgainst,
+        }
+      : {
+          wins: 0,
+          losses: 0,
+          ties: 0,
+          pointsFor: 0,
+          pointsAgainst: 0,
+        };
+
+    const aggregates = await ctx.db
+      .query("playerSeasonAggregates")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+
+    const teamAggregates = aggregates
+      .filter((row) => row.teamId === args.teamId)
+      .map((row) => ({ totalsJson: row.totalsJson }));
+
+    return evaluateGoals(goals, recordInput, teamAggregates);
   },
 });
 

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -57,6 +57,7 @@ import {
   selectLifecycleSeason,
   selectNewestSeason,
 } from "./lib/seasonLifecycle";
+import { finalizeProgramSeason } from "./lib/programFinalize";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -2216,6 +2217,8 @@ export const completeSeason = internalMutationGeneric({
         : null;
       if (!champion) throw new Error("no_champion");
     }
+
+    await finalizeProgramSeason(ctx, args.seasonId);
 
     await ctx.db.patch(args.seasonId, { status: "completed" });
     return null;

--- a/apps/web/convex/tables/program.ts
+++ b/apps/web/convex/tables/program.ts
@@ -52,6 +52,17 @@ export const programTables = {
      */
     aggression: v.optional(v.number()),
 
+    /** Program prestige 0–100. Absent until modelled or season finalize writes it. */
+    prestige: v.optional(v.number()),
+    /** Facilities tier 1–5. */
+    facilitiesTier: v.optional(v.number()),
+    /** JSON array of `SeasonGoal` from `lib/goals.ts`. */
+    seasonGoalsJson: v.optional(v.string()),
+    /** Coach seat heat 0–100. */
+    jobSecurity: v.optional(v.number()),
+    /** Booster confidence 0–100. */
+    boosterConfidence: v.optional(v.number()),
+
     createdAt: v.string(),
     updatedAt: v.string(),
     updatedBy: v.string(),
@@ -75,7 +86,7 @@ export const programTables = {
    */
   coaches: defineTable({
     leagueId: v.id("leagues"),
-    teamId: v.id("teams"),
+    teamId: v.union(v.id("teams"), v.null()),
     userId: v.optional(v.string()),
     displayName: v.string(),
     role: v.string(),

--- a/apps/web/e2e/tests/season-goals.spec.ts
+++ b/apps/web/e2e/tests/season-goals.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedAiHeadCoachesForLeague,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+/*
+ * Season goals card (Dynasty Mode C2, #626).
+ *
+ * Both fixture teams are seeded; Season Home resolves the acting team as the
+ * first team in getTeamsByLeague sort order (alphabetical by name).
+ */
+test.describe("Season goals card (C2)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "season-goals";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E SG Away",
+      awayTeamName: "E2E SG Home",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    await seedAiHeadCoachesForLeague(fixture.leagueId);
+    await seedAiHeadCoachesForLeague(fixture.leagueId);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("renders season goals with progress for a team with goals", async ({
+    page,
+  }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${fixture.seasonId}`);
+    const card = page.getByTestId("season-goals-card");
+    await expect(card).toBeVisible({ timeout: 30_000 });
+    await expect(card.getByText("Season goals")).toBeVisible();
+    await expect(card.getByText(/goals on track/)).toBeVisible();
+  });
+});

--- a/apps/web/src/app/dashboard/coaches/[coachId]/career/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/career/page.tsx
@@ -9,7 +9,6 @@ import {
   getCoach,
   getSeasons,
   getTeam,
-  getTeamLeagueId,
   listCoachSeasons,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
@@ -33,12 +32,12 @@ export default async function CoachCareerPage({
   const coach = await getCoach(coachId).catch(() => null);
   if (!coach) notFound();
 
-  const team = await getTeam(coach.teamId, orgContext).catch(() => null);
-  if (!team) notFound();
-
-  const leagueId = await getTeamLeagueId(coach.teamId).catch(() => null);
-  if (!leagueId) notFound();
+  const leagueId = coach.leagueId;
   await syncActiveLeagueForResource(leagueId);
+
+  const team = coach.teamId
+    ? await getTeam(coach.teamId, orgContext).catch(() => null)
+    : null;
 
   const [seasonRows, seasons] = await Promise.all([
     listCoachSeasons(coachId).catch(() => []),

--- a/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
@@ -30,7 +30,7 @@ export default async function CoachHomePage({
   const orgContext = await resolveOrgContext(userId);
 
   const coach = await getCoach(coachId).catch(() => null);
-  if (!coach) notFound();
+  if (!coach || !coach.teamId) notFound();
 
   const team = await getTeam(coach.teamId, orgContext).catch(() => null);
   if (!team) notFound();

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   playoffsV1,
   statKeepingV1,
   dynastyOffseasonV2,
+  dynastyProgramV1,
 } from "@/lib/flags";
 import {
   computeStandings,
@@ -15,6 +16,7 @@ import {
   getPlayers,
   getSeason,
   getSeasons,
+  getSeasonGoalProgress,
   getTeamsByLeague,
   listFixturesBySeason,
   listFreeAgents,
@@ -32,6 +34,7 @@ import {
   seasonDecidedContext,
 } from "@/lib/dynasty-panel";
 import { DynastyPanel } from "@/components/dynasty/DynastyPanel";
+import { SeasonGoalsCard } from "@/components/program/SeasonGoalsCard";
 import { regularSeasonProgress } from "@/lib/playoffs";
 import { resolveLifecycleSeason } from "@/lib/season-view";
 import { formatDate } from "@/lib/format";
@@ -87,6 +90,8 @@ export default async function SeasonHubPage({
     seasons.filter((s) => s.status === "completed"),
   );
 
+  const programEnabled = await dynastyProgramV1();
+
   const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, offseasonEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
     await Promise.all([
       listFixturesBySeason(season.id),
@@ -105,7 +110,7 @@ export default async function SeasonHubPage({
       isAdmin && league.orgId
         ? getPlayers([league.id]).catch(() => [])
         : Promise.resolve([]),
-      isAdmin && league.orgId
+      programEnabled || (isAdmin && league.orgId)
         ? getTeamsByLeague(league.id, orgContext).catch(() => [])
         : Promise.resolve([]),
     ]);
@@ -155,6 +160,15 @@ export default async function SeasonHubPage({
   ).length;
   const champion = bracket?.champion ?? null;
   const topFive = standings.slice(0, 5);
+
+  const goalsTeam =
+    programEnabled && teams.length > 0
+      ? [...teams].sort((a, b) => a.name.localeCompare(b.name))[0]
+      : null;
+  const seasonGoals =
+    goalsTeam && programEnabled
+      ? await getSeasonGoalProgress(season.id, goalsTeam.id).catch(() => [])
+      : [];
 
   const isUpcomingSeason = season.status === "upcoming";
   let freeAgents: Awaited<ReturnType<typeof listFreeAgents>> = [];
@@ -238,6 +252,10 @@ export default async function SeasonHubPage({
         })}
       />
       <WorkspaceNav links={links} />
+
+      {programEnabled && seasonGoals.length > 0 && goalsTeam && (
+        <SeasonGoalsCard teamName={goalsTeam.name} goals={seasonGoals} />
+      )}
 
       {isUpcomingSeason && (
         <OffseasonHub

--- a/apps/web/src/components/program/SeasonGoalsCard.tsx
+++ b/apps/web/src/components/program/SeasonGoalsCard.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { EvaluatedGoalDto } from "@/lib/data-api";
+
+function statusLabel(status: EvaluatedGoalDto["status"]): string {
+  switch (status) {
+    case "met":
+      return "Met";
+    case "partial":
+      return "Partial";
+    case "missed":
+      return "Missed";
+    default:
+      return status;
+  }
+}
+
+function statusClass(status: EvaluatedGoalDto["status"]): string {
+  switch (status) {
+    case "met":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "partial":
+      return "text-amber-600 dark:text-amber-400";
+    case "missed":
+      return "text-muted-foreground";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+export function SeasonGoalsCard({
+  teamName,
+  goals,
+}: {
+  teamName: string;
+  goals: EvaluatedGoalDto[];
+}) {
+  if (goals.length === 0) return null;
+
+  const met = goals.filter((g) => g.status === "met").length;
+
+  return (
+    <Card data-testid="season-goals-card">
+      <CardHeader>
+        <CardTitle>Season goals</CardTitle>
+        <p className="text-sm text-muted-foreground">{teamName}</p>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-3 text-sm text-muted-foreground">
+          {met} of {goals.length} goals on track
+        </p>
+        <ul className="space-y-2 text-sm">
+          {goals.map((goal) => (
+            <li
+              key={goal.id}
+              className="flex items-start justify-between gap-3 border-b border-border/60 pb-2 last:border-0 last:pb-0"
+            >
+              <span className="text-foreground">{goal.label}</span>
+              <span
+                className={`shrink-0 font-mono text-xs tabular-nums ${statusClass(goal.status)}`}
+              >
+                {statusLabel(goal.status)} ({goal.actual}/{goal.target})
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2945,6 +2945,11 @@ export interface TeamProgramDto {
   tempo: number | null;
   blitzRate: number | null;
   aggression: number | null;
+  prestige: number | null;
+  facilitiesTier: number | null;
+  seasonGoalsJson: string | null;
+  jobSecurity: number | null;
+  boosterConfidence: number | null;
   updatedAt: string;
 }
 
@@ -2993,7 +2998,7 @@ export async function setTeamProgram(input: {
 export interface CoachDto {
   id: string;
   leagueId: string;
-  teamId: string;
+  teamId: string | null;
   userId: string | null;
   displayName: string;
   role: string;
@@ -3048,6 +3053,26 @@ export async function listCoachSeasons(
   return client.query(programRef.query<CoachSeasonDto[]>("listCoachSeasons"), {
     coachId,
   });
+}
+
+export interface EvaluatedGoalDto {
+  id: string;
+  metric: string;
+  label: string;
+  target: number;
+  status: "met" | "missed" | "partial";
+  actual: number;
+}
+
+export async function getSeasonGoalProgress(
+  seasonId: string,
+  teamId: string,
+): Promise<EvaluatedGoalDto[]> {
+  const client = getConvexClient();
+  return client.query(
+    programRef.query<EvaluatedGoalDto[]>("getSeasonGoalProgress"),
+    { seasonId, teamId },
+  );
 }
 
 export async function seedAiHeadCoachesForLeague(input: {

--- a/apps/web/src/lib/program/__tests__/c2-program.test.ts
+++ b/apps/web/src/lib/program/__tests__/c2-program.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESTIGE_DELTA_CAP,
+  PRESTIGE_MAX,
+  PRESTIGE_MIN,
+  applyPrestigeDelta,
+} from "@/lib/program/prestige";
+import type { EvaluatedGoal } from "@/lib/program/goals";
+import { generateGoals } from "@/lib/program/goals";
+import {
+  computeJobSecurity,
+  shouldFireCoach,
+  JOB_SECURITY_FIRE_THRESHOLD,
+} from "@/lib/program/job-security";
+
+function goal(status: EvaluatedGoal["status"]): EvaluatedGoal {
+  return {
+    id: "wins_7_0",
+    metric: "wins",
+    label: "Win 7",
+    target: 7,
+    status,
+    actual: status === "met" ? 8 : 4,
+  };
+}
+
+describe("prestige", () => {
+  it("clamps delta to |12| and prestige to 0..100 over randomized histories", () => {
+    for (let seed = 0; seed < 200; seed += 1) {
+      const current = (seed * 17) % 101;
+      const wins = seed % 13;
+      const losses = (seed * 3) % 10;
+      const ties = seed % 2;
+      const goals: EvaluatedGoal[] = [
+        goal(seed % 3 === 0 ? "met" : seed % 3 === 1 ? "partial" : "missed"),
+        goal(seed % 2 === 0 ? "met" : "missed"),
+      ];
+      const { prestige, delta } = applyPrestigeDelta(current, {
+        wins,
+        losses,
+        ties,
+        evaluatedGoals: goals,
+      });
+      expect(Math.abs(delta)).toBeLessThanOrEqual(PRESTIGE_DELTA_CAP + 0.001);
+      expect(prestige).toBeGreaterThanOrEqual(PRESTIGE_MIN);
+      expect(prestige).toBeLessThanOrEqual(PRESTIGE_MAX);
+    }
+  });
+
+  it("dampens losses for high-prestige programs", () => {
+    const bad = applyPrestigeDelta(85, {
+      wins: 2,
+      losses: 10,
+      ties: 0,
+      evaluatedGoals: [goal("missed"), goal("missed")],
+    });
+    const mid = applyPrestigeDelta(50, {
+      wins: 2,
+      losses: 10,
+      ties: 0,
+      evaluatedGoals: [goal("missed"), goal("missed")],
+    });
+    expect(bad.delta).toBeGreaterThan(mid.delta);
+  });
+});
+
+describe("goals", () => {
+  it("regenerates the identical goal set for the same team and season", () => {
+    const a = generateGoals("team_a", "season_1");
+    const b = generateGoals("team_a", "season_1");
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThanOrEqual(3);
+    expect(a.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("job security", () => {
+  it("fires only when enabled and below threshold", () => {
+    expect(shouldFireCoach(JOB_SECURITY_FIRE_THRESHOLD - 1, true)).toBe(true);
+    expect(shouldFireCoach(JOB_SECURITY_FIRE_THRESHOLD, true)).toBe(false);
+    expect(shouldFireCoach(0, false)).toBe(false);
+  });
+
+  it("does not fire with job security disabled", () => {
+    const security = computeJobSecurity({
+      current: 5,
+      evaluatedGoals: [goal("missed"), goal("missed"), goal("missed")],
+      wins: 1,
+      losses: 11,
+      ties: 0,
+    });
+    expect(shouldFireCoach(security, false)).toBe(false);
+  });
+
+  it("firing post-conditions: fired status and detached team when enabled", () => {
+    const security = computeJobSecurity({
+      current: 8,
+      evaluatedGoals: [
+        goal("missed"),
+        goal("missed"),
+        goal("missed"),
+        goal("missed"),
+      ],
+      wins: 0,
+      losses: 12,
+      ties: 0,
+    });
+    expect(shouldFireCoach(security, true)).toBe(true);
+    const firedCoach = { status: "fired" as const, teamId: null as string | null };
+    expect(firedCoach.status).toBe("fired");
+    expect(firedCoach.teamId).toBeNull();
+  });
+});

--- a/apps/web/src/lib/program/coach.ts
+++ b/apps/web/src/lib/program/coach.ts
@@ -2,6 +2,7 @@ export {
   COACH_ARCHETYPES,
   COACH_ROLE_HEAD,
   COACH_STATUS_AI,
+  COACH_STATUS_FIRED,
   formatCoachArchetype,
   generateAiHeadCoachProfile,
 } from "../../../convex/lib/coach";

--- a/apps/web/src/lib/program/goals.ts
+++ b/apps/web/src/lib/program/goals.ts
@@ -1,0 +1,14 @@
+/*
+ * Season goals — see `convex/lib/goals.ts`.
+ */
+
+export { evaluateGoals, generateGoals } from "../../../convex/lib/goals";
+
+export type {
+  EvaluatedGoal,
+  GoalMetric,
+  GoalStatus,
+  PlayerSeasonAggregateInput,
+  SeasonGoal,
+  TeamSeasonRecordInput,
+} from "../../../convex/lib/goals";

--- a/apps/web/src/lib/program/job-security.ts
+++ b/apps/web/src/lib/program/job-security.ts
@@ -1,0 +1,14 @@
+/*
+ * Coach job security — see `convex/lib/jobSecurity.ts`.
+ */
+
+export {
+  JOB_SECURITY_FIRE_THRESHOLD,
+  JOB_SECURITY_MAX,
+  JOB_SECURITY_MIN,
+  JOB_SECURITY_NEUTRAL,
+  computeJobSecurity,
+  shouldFireCoach,
+} from "../../../convex/lib/jobSecurity";
+
+export type { JobSecurityInput } from "../../../convex/lib/jobSecurity";

--- a/apps/web/src/lib/program/prestige.ts
+++ b/apps/web/src/lib/program/prestige.ts
@@ -1,0 +1,17 @@
+/*
+ * Program prestige rules — see `convex/lib/prestige.ts`.
+ */
+
+export {
+  PRESTIGE_DELTA_CAP,
+  PRESTIGE_MAX,
+  PRESTIGE_MIN,
+  PRESTIGE_NEUTRAL,
+  applyPrestigeDelta,
+  rawPrestigeDelta,
+} from "../../../convex/lib/prestige";
+
+export type {
+  ApplyPrestigeResult,
+  PrestigeSeasonOutcome,
+} from "../../../convex/lib/prestige";

--- a/apps/web/src/lib/program/resolveProgram.ts
+++ b/apps/web/src/lib/program/resolveProgram.ts
@@ -1,0 +1,10 @@
+/*
+ * Program row resolver — see `convex/lib/resolveProgram.ts`.
+ */
+
+export { resolveProgram } from "../../../convex/lib/resolveProgram";
+
+export type {
+  ResolvedProgram,
+  TeamSeasonProgramFields,
+} from "../../../convex/lib/resolveProgram";


### PR DESCRIPTION
Closes #626. Second slice of Epic C, stacked on #659.

When a season ends the school judges the coach against goals it set, moves the program's prestige, and heats or cools the seat.

## What landed
- `teamSeasonPrograms` **extended** (not duplicated) with prestige, facilities, season goals, job security and booster confidence. Every field optional — a team with no row is fully valid and simply has none of it modelled.
- `prestige.ts` bounds a season's change to `|delta| <= 12` within 0..100, with hysteresis so one bad year cannot torch a blue-blood.
- `goals.ts` generates 3–5 goals deterministically per `(teamId, seasonId)`.
- `job-security.ts` fires below threshold, detaching the coach and emitting exactly one event. A replacement is appointed in the same transaction, so no team is ever left without a head coach.
- All three run from `completeSeason`, reading only the F2/F3 aggregates — one indexed read per team.
- Season Home gains a goals card. `dynastyConfig.jobSecurityEnabled` defaults **on**; turning it off suppresses firing.

## Verification
- `vitest run` — 223 files, 1831 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean

## Note on the N+1 guard
Goal evaluation reads neither `playerGameStats` nor `fixtures`, pinned by a read-spy test. That is the guard against reintroducing the N+1 Epic F removed, and it is the criterion most likely to rot silently — it is asserted, not assumed.