### PR TITLE
feat: scheme fit and weekly gameplanning (#627)

### DIFF
--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -269,8 +269,11 @@ type AllowedPublicProgramReads =
   | "moduleStatus"
   | "listTeamPrograms"
   | "getTeamProgram"
+  | "listFixtureGameplans"
+  | "listGameplansBySeason"
   | "getCoach"
   | "listCoachesByTeam"
+  | "listCoachesByLeague"
   | "listCoachSeasons"
   | "getSeasonGoalProgress";
 type AllowedPublicHistoryReads = "moduleStatus";

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -296,6 +296,14 @@ async function cascadeDeleteLeague(
       .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
       .collect()) as Array<{ _id: Id<"fixtures"> }>;
     for (const fixture of seasonFixtures) {
+      const gameplanRows = (await ctx.db
+        .query("fixtureTeamGameplans")
+        .withIndex("by_fixtureId", (q: any) => q.eq("fixtureId", fixture._id))
+        .collect()) as Array<{ _id: Id<"fixtureTeamGameplans"> }>;
+      for (const row of gameplanRows) {
+        await ctx.db.delete(row._id);
+        deleted += 1;
+      }
       const results = (await ctx.db
         .query("gameResults")
         .withIndex("by_fixtureId", (q: any) => q.eq("fixtureId", fixture._id))

--- a/apps/web/convex/lib/resolveProgram.ts
+++ b/apps/web/convex/lib/resolveProgram.ts
@@ -42,3 +42,19 @@ export function resolveProgram(
     boosterConfidence: doc.boosterConfidence ?? null,
   };
 }
+
+/**
+ * Coach aggression wins when both are set (C1 over A6 team row).
+ */
+export function resolveAggression(
+  coachAggression: number | null | undefined,
+  programAggression: number | null | undefined,
+): number | undefined {
+  if (typeof coachAggression === "number" && Number.isFinite(coachAggression)) {
+    return Math.max(0, Math.min(100, Math.round(coachAggression)));
+  }
+  if (typeof programAggression === "number" && Number.isFinite(programAggression)) {
+    return Math.max(0, Math.min(100, Math.round(programAggression)));
+  }
+  return undefined;
+}

--- a/apps/web/convex/program.ts
+++ b/apps/web/convex/program.ts
@@ -227,6 +227,124 @@ export const setTeamProgram = internalMutation({
 });
 
 /*
+ * ── Weekly gameplans (C3) ───────────────────────────────────────────────────
+ */
+
+const fixtureGameplanValidator = v.object({
+  id: v.string(),
+  leagueId: v.string(),
+  seasonId: v.string(),
+  fixtureId: v.string(),
+  teamId: v.string(),
+  focus: v.union(v.string(), v.null()),
+  updatedAt: v.string(),
+});
+
+type FixtureGameplanDto = Infer<typeof fixtureGameplanValidator>;
+
+function toFixtureGameplanDto(row: {
+  _id: string;
+  leagueId: string;
+  seasonId: string;
+  fixtureId: string;
+  teamId: string;
+  focus?: string;
+  updatedAt: string;
+}): FixtureGameplanDto {
+  return {
+    id: row._id,
+    leagueId: row.leagueId,
+    seasonId: row.seasonId,
+    fixtureId: row.fixtureId,
+    teamId: row.teamId,
+    focus: row.focus ?? null,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export const listFixtureGameplans = query({
+  args: { fixtureId: v.id("fixtures") },
+  returns: v.array(fixtureGameplanValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("fixtureTeamGameplans")
+      .withIndex("by_fixtureId", (q) => q.eq("fixtureId", args.fixtureId))
+      .collect();
+    return rows.map(toFixtureGameplanDto);
+  },
+});
+
+export const listGameplansBySeason = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(fixtureGameplanValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("fixtureTeamGameplans")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    return rows.map(toFixtureGameplanDto);
+  },
+});
+
+export const setFixtureGameplan = internalMutation({
+  args: {
+    fixtureId: v.id("fixtures"),
+    teamId: v.id("teams"),
+    actorUserId: v.string(),
+    focus: v.optional(v.string()),
+  },
+  returns: fixtureGameplanValidator,
+  handler: async (ctx, args) => {
+    const fixture = await ctx.db.get(args.fixtureId);
+    if (!fixture) throw new Error("fixture_not_found");
+    if (
+      fixture.homeTeamId !== args.teamId &&
+      fixture.awayTeamId !== args.teamId
+    ) {
+      throw new Error("team_not_in_fixture");
+    }
+    const team = await ctx.db.get(args.teamId);
+    if (!team) throw new Error("team_not_found");
+    const season = await ctx.db.get(fixture.seasonId);
+    if (!season) throw new Error("season_not_found");
+    if (team.leagueId !== season.leagueId) throw new Error("team_not_in_league");
+
+    const now = new Date().toISOString();
+    const existing = await ctx.db
+      .query("fixtureTeamGameplans")
+      .withIndex("by_fixtureId_teamId", (q) =>
+        q.eq("fixtureId", args.fixtureId).eq("teamId", args.teamId),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        focus: args.focus,
+        updatedAt: now,
+        updatedBy: args.actorUserId,
+      });
+      const updated = await ctx.db.get(existing._id);
+      if (!updated) throw new Error("gameplan_not_found");
+      return toFixtureGameplanDto(updated);
+    }
+
+    const id = await ctx.db.insert("fixtureTeamGameplans", {
+      leagueId: season.leagueId,
+      seasonId: fixture.seasonId,
+      fixtureId: args.fixtureId,
+      teamId: args.teamId,
+      focus: args.focus,
+      createdAt: now,
+      updatedAt: now,
+      updatedBy: args.actorUserId,
+    });
+    const created = await ctx.db.get(id);
+    if (!created) throw new Error("gameplan_not_found");
+    return toFixtureGameplanDto(created);
+  },
+});
+
+/*
  * ── Coaches (C1) ───────────────────────────────────────────────────────────
  */
 
@@ -361,6 +479,18 @@ export const listCoachesByTeam = query({
     const rows = await ctx.db
       .query("coaches")
       .withIndex("by_teamId", (q) => q.eq("teamId", args.teamId))
+      .collect();
+    return rows.map(toCoachDto);
+  },
+});
+
+export const listCoachesByLeague = query({
+  args: { leagueId: v.id("leagues") },
+  returns: v.array(coachDtoValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("coaches")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
       .collect();
     return rows.map(toCoachDto);
   },

--- a/apps/web/convex/tables/program.ts
+++ b/apps/web/convex/tables/program.ts
@@ -131,4 +131,24 @@ export const programTables = {
   })
     .index("by_coach_season", ["coachId", "seasonId"])
     .index("by_season_team", ["seasonId", "teamId"]),
+
+  /*
+   * Weekly gameplan per (fixture, team) — C3.
+   *
+   * Lives on the fixture surface, not season program rows. A team can run the
+   * same scheme all year and still change emphasis week to week.
+   */
+  fixtureTeamGameplans: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    fixtureId: v.id("fixtures"),
+    teamId: v.id("teams"),
+    focus: v.optional(v.string()),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    updatedBy: v.string(),
+  })
+    .index("by_fixtureId", ["fixtureId"])
+    .index("by_fixtureId_teamId", ["fixtureId", "teamId"])
+    .index("by_seasonId", ["seasonId"]),
 };

--- a/apps/web/e2e/tests/team-scheme.spec.ts
+++ b/apps/web/e2e/tests/team-scheme.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+test.describe("Team scheme selection (C3 / A6 gap)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "team-scheme";
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E Scheme Home",
+      awayTeamName: "E2E Scheme Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+  });
+
+  test.afterAll(async () => {
+    await teardown?.();
+  });
+
+  test("saves from Team Home and allows a low-fit scheme", async ({ page }) => {
+    test.skip(!fixture, "fixture not ready");
+    await setupClerkTestingToken({ page });
+
+    await page.goto(`/dashboard/teams/${fixture!.homeTeamId}`);
+    const card = page.getByTestId("team-scheme-card");
+    await expect(card).toBeVisible({ timeout: 30_000 });
+
+    await page.getByTestId("team-scheme-offense").selectOption("air_raid");
+    await page.getByTestId("team-scheme-defense").selectOption("four_two_five");
+    await page.getByTestId("team-scheme-save").click();
+    await expect(page.getByText("Scheme saved.")).toBeVisible();
+
+    await page.getByTestId("team-scheme-offense").selectOption("flexbone");
+    await page.getByTestId("team-scheme-save").click();
+    await expect(page.getByText("Scheme saved.")).toBeVisible();
+    await expect(page.getByTestId("team-scheme-offense")).toHaveValue("flexbone");
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/fixture-gameplan.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/fixture-gameplan.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockAuthorizeTeamMutation,
+  mockSetFixtureGameplan,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockAuthorizeTeamMutation: vi.fn(),
+  mockSetFixtureGameplan: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({
+  authorizeTeamMutation: mockAuthorizeTeamMutation,
+}));
+vi.mock("@/lib/data-api", () => ({
+  setFixtureGameplan: mockSetFixtureGameplan,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { saveFixtureGameplanAction } from "../fixture-gameplan";
+
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockAuthorizeTeamMutation.mockImplementation(async (teamId: string) => ({
+    userId: "coach_a",
+    role: "coach",
+    isAuthorized: teamId === TEAM_A,
+  }));
+  mockSetFixtureGameplan.mockResolvedValue({
+    id: "gp_1",
+    leagueId: "league_1",
+    seasonId: "season_1",
+    fixtureId: "fx_1",
+    teamId: TEAM_A,
+    focus: "establish_run",
+    updatedAt: "2028-01-01T00:00:00.000Z",
+  });
+});
+
+describe("saveFixtureGameplanAction", () => {
+  it("rejects setting a gameplan for another team", async () => {
+    const result = await saveFixtureGameplanAction({
+      fixtureId: "fx_1",
+      seasonId: "season_1",
+      teamId: TEAM_B,
+      focus: "attack_pass",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockSetFixtureGameplan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/team-program.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/team-program.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockAuth, mockAuthorizeTeamMutation, mockSetTeamProgram, mockRevalidatePath } =
+  vi.hoisted(() => ({
+    mockAuth: vi.fn(),
+    mockAuthorizeTeamMutation: vi.fn(),
+    mockSetTeamProgram: vi.fn(),
+    mockRevalidatePath: vi.fn(),
+  }));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
+vi.mock("@/lib/authorization", () => ({
+  authorizeTeamMutation: mockAuthorizeTeamMutation,
+}));
+vi.mock("@/lib/data-api", () => ({
+  setTeamProgram: mockSetTeamProgram,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mockRevalidatePath }));
+
+import { saveTeamProgramAction } from "../team-program";
+
+const TEAM_A = "team_a";
+const TEAM_B = "team_b";
+const SEASON = "season_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ userId: "coach_a" });
+  mockAuthorizeTeamMutation.mockImplementation(async (teamId: string) => ({
+    userId: "coach_a",
+    role: "coach",
+    isAuthorized: teamId === TEAM_A,
+  }));
+  mockSetTeamProgram.mockResolvedValue({
+    id: "prog_1",
+    leagueId: "league_1",
+    seasonId: SEASON,
+    teamId: TEAM_A,
+    offenseScheme: "flexbone",
+    defenseScheme: null,
+    tempo: null,
+    blitzRate: null,
+    aggression: null,
+    prestige: null,
+    facilitiesTier: null,
+    seasonGoalsJson: null,
+    jobSecurity: null,
+    boosterConfidence: null,
+    updatedAt: "2028-01-01T00:00:00.000Z",
+  });
+});
+
+describe("saveTeamProgramAction", () => {
+  it("rejects a coach saving another team's scheme", async () => {
+    const result = await saveTeamProgramAction({
+      seasonId: SEASON,
+      teamId: TEAM_B,
+      offenseScheme: "air_raid",
+    });
+    expect(result).toEqual({ ok: false, error: "not_authorized" });
+    expect(mockSetTeamProgram).not.toHaveBeenCalled();
+  });
+
+  it("allows saving for the caller's team", async () => {
+    const result = await saveTeamProgramAction({
+      seasonId: SEASON,
+      teamId: TEAM_A,
+      offenseScheme: "flexbone",
+    });
+    expect(result.ok).toBe(true);
+    expect(mockSetTeamProgram).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/fixture-gameplan.ts
+++ b/apps/web/src/app/dashboard/_actions/fixture-gameplan.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { authorizeTeamMutation } from "@/lib/authorization";
+import {
+  setFixtureGameplan,
+  type FixtureGameplanDto,
+} from "@/lib/data-api";
+import { isGameplanFocus } from "@/lib/program/gameplan";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+export async function saveFixtureGameplanAction(input: {
+  fixtureId: string;
+  seasonId: string;
+  teamId: string;
+  focus?: string;
+}): Promise<ActionResult<FixtureGameplanDto>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const gate = await authorizeTeamMutation(input.teamId, userId);
+  if (!gate.isAuthorized) return { ok: false, error: "not_authorized" };
+
+  if (input.focus !== undefined && !isGameplanFocus(input.focus)) {
+    return { ok: false, error: "unknown_gameplan_focus" };
+  }
+
+  try {
+    const data = await setFixtureGameplan({
+      fixtureId: input.fixtureId,
+      teamId: input.teamId,
+      actorUserId: userId,
+      focus: input.focus,
+    });
+    revalidatePath(`/dashboard/seasons/${input.seasonId}/schedule`);
+    return { ok: true, data };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -23,6 +23,8 @@ const {
   mockListRivalries,
   mockListActiveInjuries,
   mockListTeamPrograms,
+  mockListCoachesByLeague,
+  mockListFixtureGameplans,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -44,6 +46,8 @@ const {
   mockListRivalries: vi.fn(),
   mockListActiveInjuries: vi.fn(),
   mockListTeamPrograms: vi.fn(),
+  mockListCoachesByLeague: vi.fn(),
+  mockListFixtureGameplans: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
@@ -56,6 +60,8 @@ vi.mock("@/lib/data-api", () => ({
   listRivalries: mockListRivalries,
   listActiveInjuries: mockListActiveInjuries,
   listTeamPrograms: mockListTeamPrograms,
+  listCoachesByLeague: mockListCoachesByLeague,
+  listFixtureGameplans: mockListFixtureGameplans,
   getFixture: mockGetFixture,
   recordGameResult: mockRecordGameResult,
   upsertGamePlayLog: mockUpsertGamePlayLog,
@@ -138,6 +144,8 @@ function authorize() {
   mockListRivalries.mockResolvedValue([]);
   mockListActiveInjuries.mockResolvedValue([]);
   mockListTeamPrograms.mockResolvedValue([]);
+  mockListCoachesByLeague.mockResolvedValue([]);
+  mockListFixtureGameplans.mockResolvedValue([]);
   mockAuth.mockResolvedValue({ userId: USER });
   mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
   mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });

--- a/apps/web/src/app/dashboard/seasons/[id]/schedule/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/schedule/page.tsx
@@ -8,6 +8,7 @@ import {
   liveScoringV1,
   playoffsV1,
   syntheticRostersV1,
+  dynastySimV2,
 } from "@/lib/flags";
 import {
   getLeague,
@@ -21,6 +22,7 @@ import {
   getTeamsByLeague,
   getPlayers,
   listFixturesBySeason,
+  listGameplansBySeason,
   computeStandings,
   type PublicGameStream,
 } from "@/lib/data-api";
@@ -142,6 +144,17 @@ export default async function SeasonSchedulePage({
     : { target: DEFAULT_TARGET_ROSTER_SIZE, teams: [] };
 
   const fixtures = await listFixturesBySeason(season.id);
+  const gameplansEnabled = await dynastySimV2();
+  const seasonGameplans = gameplansEnabled
+    ? await listGameplansBySeason(season.id).catch(() => [])
+    : [];
+  const gameplansByFixtureId = new Map<string, typeof seasonGameplans>();
+  for (const row of seasonGameplans) {
+    const list = gameplansByFixtureId.get(row.fixtureId) ?? [];
+    list.push(row);
+    gameplansByFixtureId.set(row.fixtureId, list);
+  }
+  const manageableTeamIds = isAdmin ? teams.map((t) => t.id) : [];
 
   const seasonStarted = isSeasonStarted(season, fixtures);
 
@@ -219,6 +232,10 @@ export default async function SeasonSchedulePage({
       liveEnabled={liveEnabled}
       streams={streams}
       recordByTeamId={recordByTeamId}
+      seasonId={season.id}
+      gameplansEnabled={gameplansEnabled}
+      gameplansByFixtureId={gameplansByFixtureId}
+      manageableTeamIds={manageableTeamIds}
     />
   );
   const weekViews: ScheduleWeekView[] = weekGroups.map((group) => ({
@@ -400,6 +417,10 @@ function FixtureTable({
   liveEnabled,
   streams,
   recordByTeamId,
+  seasonId,
+  gameplansEnabled,
+  gameplansByFixtureId,
+  manageableTeamIds,
 }: {
   rows: FixtureRow[];
   leagueId: string;
@@ -411,6 +432,10 @@ function FixtureTable({
   liveEnabled: boolean;
   streams: Map<string, PublicGameStream | null>;
   recordByTeamId: Map<string, string>;
+  seasonId: string;
+  gameplansEnabled: boolean;
+  gameplansByFixtureId: Map<string, import("@/lib/data-api").FixtureGameplanDto[]>;
+  manageableTeamIds: string[];
 }) {
   return (
     <div className="overflow-x-auto">
@@ -452,6 +477,10 @@ function FixtureTable({
               statsEnabled={statsEnabled}
               liveEnabled={liveEnabled}
               stream={streams.get(fixture.id)}
+              seasonId={seasonId}
+              gameplansEnabled={gameplansEnabled}
+              gameplansByFixtureId={gameplansByFixtureId}
+              manageableTeamIds={manageableTeamIds}
             />
           ))}
         </tbody>

--- a/apps/web/src/app/dashboard/teams/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/teams/[id]/page.tsx
@@ -134,6 +134,13 @@ export default async function TeamDetailPage({
     );
   }
 
+  const rosterForFit = {
+    players: players.map((p) => ({
+      position: p.position,
+      overall: snapshots.get(p.id)?.weightedOverall ?? maddenOveralls.get(p.id) ?? null,
+    })),
+  };
+
   const siblingLinks = buildTeamSiblingLinks({
     teamId: id,
     rosterEnabled,
@@ -155,6 +162,7 @@ export default async function TeamDetailPage({
           teamId={id}
           program={program}
           canManage={canManage}
+          rosterForFit={rosterForFit}
         />
       )}
 

--- a/apps/web/src/components/dynasty/FixtureGameplanPanel.tsx
+++ b/apps/web/src/components/dynasty/FixtureGameplanPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { saveFixtureGameplanAction } from "@/app/dashboard/_actions/fixture-gameplan";
+import {
+  GAMEPLAN_FOCUS_OPTIONS,
+  type GameplanFocus,
+} from "@/lib/program/gameplan";
+import type { FixtureGameplanDto } from "@/lib/data-api";
+
+const UNSET = "";
+
+export interface FixtureGameplanPanelProps {
+  fixtureId: string;
+  seasonId: string;
+  teamId: string;
+  teamLabel: string;
+  initial: FixtureGameplanDto | null;
+  canManage: boolean;
+}
+
+export function FixtureGameplanPanel({
+  fixtureId,
+  seasonId,
+  teamId,
+  teamLabel,
+  initial,
+  canManage,
+}: FixtureGameplanPanelProps) {
+  const [focus, setFocus] = useState(initial?.focus ?? UNSET);
+  const [saved, setSaved] = useState(initial);
+  const [pending, startTransition] = useTransition();
+
+  if (!canManage && !saved?.focus) return null;
+
+  function save() {
+    startTransition(async () => {
+      const result = await saveFixtureGameplanAction({
+        fixtureId,
+        seasonId,
+        teamId,
+        focus: focus === UNSET ? undefined : focus,
+      });
+      if (!result.ok) {
+        toast.error(`Could not save gameplan: ${result.error}`);
+        return;
+      }
+      setSaved(result.data);
+      toast.success("Gameplan saved.");
+    });
+  }
+
+  return (
+    <div
+      className="rounded-md border border-border p-3"
+      data-testid={`fixture-gameplan-${teamId}`}
+    >
+      <p className="text-caption-12 text-text-muted">{teamLabel} gameplan</p>
+      {canManage ? (
+        <div className="mt-2 flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-caption-12 text-text-muted">Focus</span>
+            <select
+              className="h-9 min-w-[10rem] rounded-control border border-border bg-surface px-2 text-body-15"
+              value={focus}
+              data-testid={`fixture-gameplan-focus-${teamId}`}
+              onChange={(e) => setFocus(e.target.value)}
+            >
+              <option value={UNSET}>No gameplan</option>
+              {GAMEPLAN_FOCUS_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option.replaceAll("_", " ")}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button
+            size="sm"
+            disabled={pending}
+            data-testid={`fixture-gameplan-save-${teamId}`}
+            onClick={save}
+          >
+            {pending ? "Saving…" : "Save gameplan"}
+          </Button>
+        </div>
+      ) : (
+        <p className="mt-1 text-body-15" data-testid={`fixture-gameplan-readonly-${teamId}`}>
+          {(saved?.focus as GameplanFocus | null)?.replaceAll("_", " ") ??
+            "No gameplan"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dynasty/TeamSchemeCard.tsx
+++ b/apps/web/src/components/dynasty/TeamSchemeCard.tsx
@@ -9,6 +9,8 @@ import { saveTeamProgramAction } from "@/app/dashboard/_actions/team-program";
 import {
   DEFENSE_SCHEME_LIST,
   OFFENSE_SCHEME_LIST,
+  schemeFit,
+  type SchemeFitRoster,
 } from "@/lib/program/schemes";
 import type { TeamProgramDto } from "@/lib/data-api";
 
@@ -32,6 +34,7 @@ export interface TeamSchemeCardProps {
   program: TeamProgramDto | null;
   /** False for a viewer who cannot manage this team — the card is read-only. */
   canManage: boolean;
+  rosterForFit?: SchemeFitRoster;
 }
 
 function dialLabel(value: number | null): string {
@@ -40,11 +43,16 @@ function dialLabel(value: number | null): string {
   return String(value);
 }
 
+function fitLabel(value: number): string {
+  return `${Math.round(value * 100)}% roster fit`;
+}
+
 export function TeamSchemeCard({
   seasonId,
   teamId,
   program,
   canManage,
+  rosterForFit = { players: [] },
 }: TeamSchemeCardProps) {
   const [offense, setOffense] = useState(program?.offenseScheme ?? UNSET);
   const [defense, setDefense] = useState(program?.defenseScheme ?? UNSET);
@@ -55,6 +63,11 @@ export function TeamSchemeCard({
   );
   const [saved, setSaved] = useState<TeamProgramDto | null>(program);
   const [pending, startTransition] = useTransition();
+
+  const offenseFit =
+    offense && offense !== UNSET ? schemeFit(offense, rosterForFit) : null;
+  const defenseFit =
+    defense && defense !== UNSET ? schemeFit(defense, rosterForFit) : null;
 
   function save() {
     startTransition(async () => {
@@ -201,6 +214,18 @@ export function TeamSchemeCard({
             <p className="text-caption-12 text-text-muted">
               {OFFENSE_SCHEME_LIST.find((s) => s.id === offense)?.blurb ??
                 "No offensive scheme set."}
+              {offenseFit !== null ? (
+                <span data-testid="team-scheme-offense-fit">
+                  {" "}
+                  · {fitLabel(offenseFit)}
+                </span>
+              ) : null}
+              {defenseFit !== null ? (
+                <span data-testid="team-scheme-defense-fit">
+                  {" "}
+                  · Defense {fitLabel(defenseFit)}
+                </span>
+              ) : null}
             </p>
           </>
         )}

--- a/apps/web/src/components/games/GameContextDrawer.tsx
+++ b/apps/web/src/components/games/GameContextDrawer.tsx
@@ -18,6 +18,8 @@ import {
   gameDrawerMatchupLabel,
 } from "@/lib/game-drawer-projection";
 import { cn } from "@/lib/utils";
+import { FixtureGameplanPanel } from "@/components/dynasty/FixtureGameplanPanel";
+import type { FixtureGameplanDto } from "@/lib/data-api";
 
 export interface GameContextDrawerProps {
   projection: GameDrawerProjection | null;
@@ -25,6 +27,10 @@ export interface GameContextDrawerProps {
   onOpenChange: (open: boolean) => void;
   /** Element to restore focus to when the drawer closes. */
   restoreFocusRef?: React.RefObject<HTMLElement | null>;
+  seasonId?: string;
+  gameplansEnabled?: boolean;
+  gameplans?: FixtureGameplanDto[];
+  manageableTeamIds?: readonly string[];
 }
 
 function TeamBlock({
@@ -89,6 +95,10 @@ export function GameContextDrawer({
   open,
   onOpenChange,
   restoreFocusRef,
+  seasonId,
+  gameplansEnabled,
+  gameplans = [],
+  manageableTeamIds = [],
 }: GameContextDrawerProps) {
   const titleId = React.useId();
   const isFinal = projection ? gameDrawerIsFinal(projection) : false;
@@ -183,6 +193,37 @@ export function GameContextDrawer({
                 </div>
               ) : null}
             </dl>
+
+            {gameplansEnabled &&
+            projection.fixtureId &&
+            seasonId &&
+            projection.home.id &&
+            projection.away.id ? (
+              <div className="space-y-2" data-testid="fixture-gameplan-section">
+                <FixtureGameplanPanel
+                  fixtureId={projection.fixtureId}
+                  seasonId={seasonId}
+                  teamId={projection.home.id}
+                  teamLabel={projection.home.name}
+                  initial={
+                    gameplans.find((g) => g.teamId === projection.home.id) ??
+                    null
+                  }
+                  canManage={manageableTeamIds.includes(projection.home.id)}
+                />
+                <FixtureGameplanPanel
+                  fixtureId={projection.fixtureId}
+                  seasonId={seasonId}
+                  teamId={projection.away.id}
+                  teamLabel={projection.away.name}
+                  initial={
+                    gameplans.find((g) => g.teamId === projection.away.id) ??
+                    null
+                  }
+                  canManage={manageableTeamIds.includes(projection.away.id)}
+                />
+              </div>
+            ) : null}
 
             {isFinal && !canOpenGamecast ? (
               <p className="text-sm text-muted-foreground">

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -16,6 +16,7 @@ import GoLiveControl from "@/components/schedule/GoLiveControl";
 import ClipsControl from "@/components/schedule/ClipsControl";
 import { SimulateGameButton } from "@/components/schedule/SimulateControls";
 import type { PublicGameStream } from "@/lib/data-api";
+import type { FixtureGameplanDto } from "@/lib/data-api";
 import type { GameResultDto } from "@sports-management/shared-types";
 import type { FixtureDto } from "@sports-management/shared-types";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,10 @@ export interface ScheduleFixtureRowProps {
   statsEnabled: boolean;
   liveEnabled: boolean;
   stream: PublicGameStream | null | undefined;
+  seasonId: string;
+  gameplansEnabled?: boolean;
+  gameplansByFixtureId?: ReadonlyMap<string, FixtureGameplanDto[]>;
+  manageableTeamIds?: readonly string[];
 }
 
 function MatchupCell({
@@ -78,6 +83,10 @@ export function ScheduleFixtureRow({
   statsEnabled,
   liveEnabled,
   stream,
+  seasonId,
+  gameplansEnabled,
+  gameplansByFixtureId,
+  manageableTeamIds = [],
 }: ScheduleFixtureRowProps) {
   const [open, setOpen] = React.useState(false);
   const restoreFocusRef = React.useRef<HTMLElement | null>(null);
@@ -160,6 +169,10 @@ export function ScheduleFixtureRow({
             open={open}
             onOpenChange={setOpen}
             restoreFocusRef={restoreFocusRef}
+            seasonId={seasonId}
+            gameplansEnabled={gameplansEnabled}
+            gameplans={gameplansByFixtureId?.get(fixture.id) ?? []}
+            manageableTeamIds={manageableTeamIds}
           />
         </td>
         {isAdmin ? (

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -2991,6 +2991,49 @@ export async function setTeamProgram(input: {
   );
 }
 
+export interface FixtureGameplanDto {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  fixtureId: string;
+  teamId: string;
+  focus: string | null;
+  updatedAt: string;
+}
+
+export async function listFixtureGameplans(
+  fixtureId: string,
+): Promise<FixtureGameplanDto[]> {
+  const client = getConvexClient();
+  return client.query(
+    programRef.query<FixtureGameplanDto[]>("listFixtureGameplans"),
+    { fixtureId },
+  );
+}
+
+export async function listGameplansBySeason(
+  seasonId: string,
+): Promise<FixtureGameplanDto[]> {
+  const client = getConvexClient();
+  return client.query(
+    programRef.query<FixtureGameplanDto[]>("listGameplansBySeason"),
+    { seasonId },
+  );
+}
+
+export async function setFixtureGameplan(input: {
+  fixtureId: string;
+  teamId: string;
+  actorUserId: string;
+  focus?: string;
+}): Promise<FixtureGameplanDto> {
+  const client = getConvexClient();
+  return client.mutation(
+    programRef.mutation<FixtureGameplanDto>("setFixtureGameplan"),
+    input,
+  );
+}
+
 /*
  * Coaches (C1). Typed refs on the program module.
  */
@@ -3043,6 +3086,13 @@ export async function listCoachesByTeam(teamId: string): Promise<CoachDto[]> {
   const client = getConvexClient();
   return client.query(programRef.query<CoachDto[]>("listCoachesByTeam"), {
     teamId,
+  });
+}
+
+export async function listCoachesByLeague(leagueId: string): Promise<CoachDto[]> {
+  const client = getConvexClient();
+  return client.query(programRef.query<CoachDto[]>("listCoachesByLeague"), {
+    leagueId,
   });
 }
 

--- a/apps/web/src/lib/pbp/__tests__/schemes.test.ts
+++ b/apps/web/src/lib/pbp/__tests__/schemes.test.ts
@@ -456,6 +456,27 @@ describe("scheme distribution", () => {
       expect(Math.abs(mean - baseline) / baseline).toBeLessThan(0.25);
     }
   });
+
+  it("never moves a matchup more than 25% off baseline with gameplans layered on", () => {
+    const baseline = meanPoints(undefined, undefined);
+    const focus = "attack_pass" as const;
+    let total = 0;
+    const games = 6;
+    for (let seed = 1; seed <= games; seed++) {
+      const log = simulateGameLog({
+        home: {
+          ...buildTeam("home", 70, { offense: "spread" }),
+          gameplan: focus,
+        },
+        away: buildTeam("away", 70, { defense: "three_four" }),
+        seed,
+        features: ALL_GATES,
+      });
+      total += log.homeScore + log.awayScore;
+    }
+    const meanWithPlan = total / games;
+    expect(Math.abs(meanWithPlan - baseline) / baseline).toBeLessThan(0.25);
+  });
 });
 
 describe("coach aggression", () => {

--- a/apps/web/src/lib/pbp/engine.ts
+++ b/apps/web/src/lib/pbp/engine.ts
@@ -29,9 +29,14 @@ import {
 import { homeFieldEdge as crowdHomeFieldEdge } from "./crowd";
 import {
   NEUTRAL_SCHEME_MODIFIERS,
+  layerSchemeModifiers,
   schemeModifiers,
   type SchemeModifiers,
 } from "./schemes";
+import {
+  gameplanModifiers,
+  isGameplanFocus,
+} from "@/lib/program/gameplan";
 import {
   NEUTRAL_MODIFIERS,
   weatherModifiers,
@@ -215,6 +220,21 @@ function schemeMods(state: GameState): SchemeModifiers {
   return state.possession === "home"
     ? state.homeSchemeMods
     : state.awaySchemeMods;
+}
+
+function possessionSchemeModifiers(
+  offense: TeamSimProfile,
+  defense: TeamSimProfile,
+  schemesEnabled: boolean,
+): SchemeModifiers {
+  if (!schemesEnabled) return NEUTRAL_SCHEME_MODIFIERS;
+  const base = schemeModifiers(offense.scheme, defense.scheme);
+  const focus = offense.gameplan;
+  if (!focus || !isGameplanFocus(focus)) return base;
+  const weekly = gameplanModifiers(focus, {
+    defenseScheme: defense.scheme?.defense,
+  });
+  return layerSchemeModifiers(base, weekly);
 }
 
 function offenseTeamId(state: GameState): string {
@@ -1758,11 +1778,11 @@ function simulateGameLog(input: PbpGameInput): PbpGameLog {
      */
     homeSchemeMods:
       input.features?.schemes === true
-        ? schemeModifiers(input.home.scheme, input.away.scheme)
+        ? possessionSchemeModifiers(input.home, input.away, true)
         : NEUTRAL_SCHEME_MODIFIERS,
     awaySchemeMods:
       input.features?.schemes === true
-        ? schemeModifiers(input.away.scheme, input.home.scheme)
+        ? possessionSchemeModifiers(input.away, input.home, true)
         : NEUTRAL_SCHEME_MODIFIERS,
     decisive: input.decisive ?? false,
     quarter: 1,

--- a/apps/web/src/lib/pbp/schemes.ts
+++ b/apps/web/src/lib/pbp/schemes.ts
@@ -208,3 +208,20 @@ export function isNeutralScheme(mods: SchemeModifiers): boolean {
     mods.fumbleRate === 1
   );
 }
+
+/** Layer a weekly gameplan on top of season scheme modifiers (C3). */
+export function layerSchemeModifiers(
+  base: SchemeModifiers,
+  overlay: SchemeModifiers,
+): SchemeModifiers {
+  return {
+    passRateDelta: base.passRateDelta + overlay.passRateDelta,
+    tempo: base.tempo * overlay.tempo,
+    explosiveRate: base.explosiveRate * overlay.explosiveRate,
+    sackRate: base.sackRate * overlay.sackRate,
+    passAccuracy: base.passAccuracy * overlay.passAccuracy,
+    interceptionRate: base.interceptionRate * overlay.interceptionRate,
+    rushYards: base.rushYards * overlay.rushYards,
+    fumbleRate: base.fumbleRate * overlay.fumbleRate,
+  };
+}

--- a/apps/web/src/lib/pbp/types.ts
+++ b/apps/web/src/lib/pbp/types.ts
@@ -57,6 +57,11 @@ export interface TeamSimProfile {
    * Read only under `features.schemes`.
    */
   scheme?: TeamSchemeProfile;
+  /**
+   * Weekly emphasis for this fixture (C3). Absent means no gameplan was set.
+   * Read only under `features.schemes`.
+   */
+  gameplan?: string;
 }
 
 import type { SimulationFlavor } from "@/lib/simulation-flavor";

--- a/apps/web/src/lib/program/__tests__/c3-gameplan.test.ts
+++ b/apps/web/src/lib/program/__tests__/c3-gameplan.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFENSE_SCHEME_LIST,
+  OFFENSE_SCHEME_LIST,
+  schemeFit,
+  type SchemeFitRoster,
+} from "@/lib/program/schemes";
+import {
+  GAMEPLAN_FOCUS_OPTIONS,
+  NEUTRAL_GAMEPLAN_MODIFIERS,
+  gameplanModifiers,
+} from "@/lib/program/gameplan";
+import { NEUTRAL_SCHEME_MODIFIERS } from "@/lib/pbp/schemes";
+
+const EMPTY: SchemeFitRoster = { players: [] };
+const UNRATED: SchemeFitRoster = {
+  players: [{ position: "WR" }, { position: "RB" }],
+};
+
+describe("schemeFit", () => {
+  it("returns [0, 1] for every scheme and roster pair, including degenerate rosters", () => {
+    const rosters = [EMPTY, UNRATED];
+    for (const spec of OFFENSE_SCHEME_LIST) {
+      for (const roster of rosters) {
+        const fit = schemeFit(spec.id, roster);
+        expect(fit).toBeGreaterThanOrEqual(0);
+        expect(fit).toBeLessThanOrEqual(1);
+        expect(Number.isNaN(fit)).toBe(false);
+      }
+    }
+    for (const spec of DEFENSE_SCHEME_LIST) {
+      for (const roster of rosters) {
+        const fit = schemeFit(spec.id, roster);
+        expect(fit).toBeGreaterThanOrEqual(0);
+        expect(fit).toBeLessThanOrEqual(1);
+        expect(Number.isNaN(fit)).toBe(false);
+      }
+    }
+  });
+
+  it("ranks flexbone above air raid for a power-run roster and the reverse for receivers", () => {
+    const powerRun: SchemeFitRoster = {
+      players: [
+        { position: "RB", weightLbs: 235, overall: 80 },
+        { position: "FB", weightLbs: 250, overall: 78 },
+        { position: "RB", weightLbs: 228, overall: 76 },
+        { position: "WR", overall: 70 },
+      ],
+    };
+    const airRaidRoster: SchemeFitRoster = {
+      players: [
+        { position: "WR", overall: 88 },
+        { position: "WR", overall: 86 },
+        { position: "WR", overall: 84 },
+        { position: "WR", overall: 82 },
+        { position: "QB", overall: 90 },
+      ],
+    };
+
+    expect(schemeFit("flexbone", powerRun)).toBeGreaterThan(
+      schemeFit("air_raid", powerRun),
+    );
+    expect(schemeFit("air_raid", airRaidRoster)).toBeGreaterThan(
+      schemeFit("flexbone", airRaidRoster),
+    );
+  });
+});
+
+describe("gameplanModifiers", () => {
+  it("is exactly neutral when focus is absent", () => {
+    expect(gameplanModifiers(undefined, { defenseScheme: "four_two_five" })).toEqual(
+      NEUTRAL_GAMEPLAN_MODIFIERS,
+    );
+    expect(gameplanModifiers(null, undefined)).toEqual(NEUTRAL_GAMEPLAN_MODIFIERS);
+    expect(gameplanModifiers("balanced", { defenseScheme: "forty_six" })).toEqual(
+      NEUTRAL_GAMEPLAN_MODIFIERS,
+    );
+    expect(NEUTRAL_GAMEPLAN_MODIFIERS).toEqual(NEUTRAL_SCHEME_MODIFIERS);
+  });
+
+  it("covers every focus option without leaving the identity contract", () => {
+    for (const focus of GAMEPLAN_FOCUS_OPTIONS) {
+      const mods = gameplanModifiers(focus, { defenseScheme: "balanced" });
+      expect(mods.passRateDelta).toEqual(expect.any(Number));
+      expect(mods.tempo).toEqual(expect.any(Number));
+      expect(Number.isFinite(mods.explosiveRate)).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/lib/program/__tests__/resolve-aggression.test.ts
+++ b/apps/web/src/lib/program/__tests__/resolve-aggression.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { resolveAggression } from "@/lib/program/resolveProgram";
+
+describe("resolveAggression", () => {
+  it("prefers coach aggression over the team program row", () => {
+    expect(resolveAggression(88, 40)).toBe(88);
+    expect(resolveAggression(null, 40)).toBe(40);
+    expect(resolveAggression(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/program/gameplan.ts
+++ b/apps/web/src/lib/program/gameplan.ts
@@ -1,0 +1,113 @@
+/*
+ * Weekly gameplan (Dynasty Mode C3).
+ *
+ * Pure opponent-specific emphasis layered on top of season schemes. Like
+ * `schemes.ts` ↔ `pbp/schemes.ts`, this module states intent; the simulator
+ * translates it into engine numbers.
+ */
+
+import {
+  defenseTendencies,
+  type DefenseTendencies,
+} from "@/lib/program/schemes";
+
+/** Same shape the simulator consumes via `pbp/schemes.SchemeModifiers`. */
+export interface GameplanModifiers {
+  passRateDelta: number;
+  tempo: number;
+  explosiveRate: number;
+  sackRate: number;
+  passAccuracy: number;
+  interceptionRate: number;
+  rushYards: number;
+  fumbleRate: number;
+}
+
+export const NEUTRAL_GAMEPLAN_MODIFIERS: Readonly<GameplanModifiers> =
+  Object.freeze({
+    passRateDelta: 0,
+    tempo: 1,
+    explosiveRate: 1,
+    sackRate: 1,
+    passAccuracy: 1,
+    interceptionRate: 1,
+    rushYards: 1,
+    fumbleRate: 1,
+  });
+
+export const GAMEPLAN_FOCUS_OPTIONS = [
+  "balanced",
+  "establish_run",
+  "attack_pass",
+  "tempo_up",
+  "control_clock",
+  "take_shots",
+] as const;
+
+export type GameplanFocus = (typeof GAMEPLAN_FOCUS_OPTIONS)[number];
+
+export function isGameplanFocus(value: string): value is GameplanFocus {
+  return (GAMEPLAN_FOCUS_OPTIONS as readonly string[]).includes(value);
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+/**
+ * Weekly emphasis against an opponent's stored schemes.
+ *
+ * An absent focus returns the exact identity — every multiplier 1, every delta
+ * 0 — matching `schemeModifiers(undefined, undefined)`.
+ */
+export function gameplanModifiers(
+  focus: GameplanFocus | null | undefined,
+  opponent: { defenseScheme?: string | null } | null | undefined,
+): GameplanModifiers {
+  if (!focus || focus === "balanced") {
+    return { ...NEUTRAL_GAMEPLAN_MODIFIERS };
+  }
+
+  const def: DefenseTendencies = defenseTendencies(opponent?.defenseScheme);
+
+  switch (focus) {
+    case "establish_run":
+      return {
+        ...NEUTRAL_GAMEPLAN_MODIFIERS,
+        passRateDelta: -0.06 - def.runFit * 0.04,
+        rushYards: clamp(1 + 0.08 - def.runFit * 0.05, 0.85, 1.2),
+        tempo: clamp(1 + 0.05, 0.9, 1.15),
+      };
+    case "attack_pass":
+      return {
+        ...NEUTRAL_GAMEPLAN_MODIFIERS,
+        passRateDelta: 0.07 + def.blitz * 0.03,
+        tempo: clamp(1 - 0.06 - def.blitz * 0.04, 0.75, 1),
+        sackRate: clamp(1 - def.blitz * 0.08, 0.85, 1.05),
+      };
+    case "tempo_up":
+      return {
+        ...NEUTRAL_GAMEPLAN_MODIFIERS,
+        tempo: 0.88,
+        passRateDelta: 0.04,
+        explosiveRate: clamp(1 + def.coverage * 0.05, 0.95, 1.15),
+      };
+    case "control_clock":
+      return {
+        ...NEUTRAL_GAMEPLAN_MODIFIERS,
+        tempo: 1.12,
+        passRateDelta: -0.05,
+        rushYards: clamp(1 + 0.05, 1, 1.15),
+      };
+    case "take_shots":
+      return {
+        ...NEUTRAL_GAMEPLAN_MODIFIERS,
+        passRateDelta: 0.05,
+        explosiveRate: clamp(1 + 0.12 - def.coverage * 0.08, 0.9, 1.25),
+        passAccuracy: clamp(1 - 0.06 - def.coverage * 0.04, 0.82, 1),
+        interceptionRate: clamp(1 + def.coverage * 0.06, 1, 1.2),
+      };
+    default:
+      return { ...NEUTRAL_GAMEPLAN_MODIFIERS };
+  }
+}

--- a/apps/web/src/lib/program/resolveProgram.ts
+++ b/apps/web/src/lib/program/resolveProgram.ts
@@ -3,6 +3,7 @@
  */
 
 export { resolveProgram } from "../../../convex/lib/resolveProgram";
+export { resolveAggression } from "../../../convex/lib/resolveProgram";
 
 export type {
   ResolvedProgram,

--- a/apps/web/src/lib/program/schemes.ts
+++ b/apps/web/src/lib/program/schemes.ts
@@ -222,3 +222,187 @@ export const OFFENSE_SCHEME_LIST: readonly OffenseSchemeSpec[] = Object.freeze(
 export const DEFENSE_SCHEME_LIST: readonly DefenseSchemeSpec[] = Object.freeze(
   Object.values(DEFENSE_SCHEMES),
 );
+
+/*
+ * ── Scheme fit (C3) ───────────────────────────────────────────────────────
+ *
+ * Advisory only — surfaced in the UI, never enforced on save. Fit compares a
+ * roster's implied style to what a scheme wants, not whether the team is good.
+ */
+
+export interface SchemeFitPlayer {
+  position?: string | null;
+  /** 0–99; absent means this player does not contribute rated weight. */
+  overall?: number | null;
+  weightLbs?: number | null;
+}
+
+export interface SchemeFitRoster {
+  players: readonly SchemeFitPlayer[];
+}
+
+const PASS_POSITIONS = new Set([
+  "QB",
+  "WR",
+  "TE",
+  "SLOT",
+  "SE",
+  "FL",
+  "SL",
+  "QB/WR",
+]);
+const RUN_POSITIONS = new Set([
+  "RB",
+  "HB",
+  "FB",
+  "TB",
+  "ATH",
+  "OL",
+  "OT",
+  "OG",
+  "C",
+  "G",
+  "T",
+]);
+
+function positionGroup(position: string | null | undefined): "pass" | "run" | "other" {
+  if (!position) return "other";
+  const code = position.trim().toUpperCase().split("/")[0] ?? "";
+  if (PASS_POSITIONS.has(code) || code.startsWith("WR")) return "pass";
+  if (RUN_POSITIONS.has(code) || code.startsWith("RB") || code.startsWith("OL"))
+    return "run";
+  return "other";
+}
+
+function playerWeight(player: SchemeFitPlayer): number {
+  if (typeof player.overall === "number" && Number.isFinite(player.overall)) {
+    return Math.max(0.25, player.overall / 50);
+  }
+  return 1;
+}
+
+function rosterOffenseProfile(roster: SchemeFitRoster): OffenseTendencies {
+  let passMass = 0;
+  let runMass = 0;
+  let heavyBacks = 0;
+  let receivers = 0;
+
+  for (const player of roster.players) {
+    const w = playerWeight(player);
+    const group = positionGroup(player.position);
+    if (group === "pass") {
+      passMass += w * 1.2;
+      receivers += 1;
+    } else if (group === "run") {
+      runMass += w * 1.2;
+      if (
+        (typeof player.weightLbs === "number" && player.weightLbs >= 210) ||
+        positionGroup(player.position) === "run"
+      ) {
+        heavyBacks += w;
+      }
+    } else {
+      passMass += w * 0.2;
+      runMass += w * 0.2;
+    }
+  }
+
+  const total = passMass + runMass;
+  if (total <= 0) return { ...NEUTRAL_OFFENSE_TENDENCIES };
+
+  const passShare = passMass / total;
+  const runShare = runMass / total;
+  const sizeRunBias =
+    heavyBacks > receivers
+      ? clampTendency((heavyBacks - receivers) / Math.max(1, roster.players.length))
+      : 0;
+
+  return {
+    passBias: clampTendency((passShare - runShare) * 1.4),
+    tempo: clampTendency(receivers > heavyBacks ? 0.35 : heavyBacks > 0 ? -0.25 : 0),
+    vertical: clampTendency(passShare > 0.62 ? 0.35 : 0),
+    ballSecurity: clampTendency(runShare > 0.55 ? 0.15 : 0),
+  };
+}
+
+function rosterDefenseProfile(roster: SchemeFitRoster): DefenseTendencies {
+  let db = 0;
+  let lb = 0;
+  let dl = 0;
+  for (const player of roster.players) {
+    const w = playerWeight(player);
+    const code = (player.position ?? "").trim().toUpperCase();
+    if (code.startsWith("CB") || code.startsWith("S") || code === "DB") db += w;
+    else if (code.startsWith("LB")) lb += w;
+    else if (code.startsWith("DL") || code.startsWith("DE") || code.startsWith("DT"))
+      dl += w;
+  }
+  const total = db + lb + dl;
+  if (total <= 0) return { ...NEUTRAL_DEFENSE_TENDENCIES };
+  const dbShare = db / total;
+  const boxShare = (dl + lb) / total;
+  return {
+    blitz: clampTendency(lb / total - 0.33),
+    coverage: clampTendency(dbShare - 0.33),
+    runFit: clampTendency(boxShare - 0.45),
+  };
+}
+
+function clampTendency(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function tendencySimilarity(
+  roster: OffenseTendencies | DefenseTendencies,
+  scheme: OffenseTendencies | DefenseTendencies,
+): number {
+  const keys = Object.keys(roster) as Array<keyof typeof roster>;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (const key of keys) {
+    const a = roster[key];
+    const b = scheme[key];
+    dot += a * b;
+    normA += a * a;
+    normB += b * b;
+  }
+  if (normA === 0 && normB === 0) return 0.5;
+  if (normA === 0 || normB === 0) return 0.5;
+  const cosine = dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  if (!Number.isFinite(cosine)) return 0.5;
+  return clamp01((cosine + 1) / 2);
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * How well a roster suits a scheme id (0 = poor, 1 = excellent).
+ *
+ * Total: empty rosters and rosters with no rated players still return a finite
+ * value in [0, 1]. Unknown scheme ids use neutral tendencies.
+ */
+export function schemeFit(schemeId: string, roster: SchemeFitRoster): number {
+  const players = roster?.players ?? [];
+  const safeRoster: SchemeFitRoster = { players };
+
+  if (isOffenseSchemeId(schemeId)) {
+    const fit = tendencySimilarity(
+      rosterOffenseProfile(safeRoster),
+      OFFENSE_SCHEMES[schemeId].tendencies,
+    );
+    return clamp01(fit);
+  }
+  if (isDefenseSchemeId(schemeId)) {
+    const fit = tendencySimilarity(
+      rosterDefenseProfile(safeRoster),
+      DEFENSE_SCHEMES[schemeId].tendencies,
+    );
+    return clamp01(fit);
+  }
+  return 0.5;
+}

--- a/apps/web/src/lib/sim-context.ts
+++ b/apps/web/src/lib/sim-context.ts
@@ -1,6 +1,7 @@
 import {
   getDynastyConfig,
   listActiveInjuries,
+  listCoachesByLeague,
   listRivalries,
   listTeamPrograms,
 } from "@/lib/data-api";
@@ -8,6 +9,8 @@ import type { DynastyConfig } from "@/lib/dynasty-config";
 import type { PbpFeatureGates, TeamSimProfile } from "@/lib/pbp";
 import { deriveWeather, type Weather } from "@/lib/pbp/weather";
 import { rivalryPairKey } from "@/lib/rivalries";
+import { COACH_ROLE_HEAD } from "@/lib/program/coach";
+import { resolveAggression } from "@/lib/program/resolveProgram";
 
 /*
  * What a simulated game is allowed to model (Dynasty Mode — sim activation).
@@ -107,14 +110,20 @@ export async function loadSeasonSimContext(input: {
   seasonId: string;
   flagEnabled: boolean;
 }): Promise<SeasonSimContext> {
-  const [config, rivalries, injuries, programs] = await Promise.all([
+  const [config, rivalries, injuries, programs, coaches] = await Promise.all([
     getDynastyConfig(input.leagueId).catch(() => null),
     listRivalries(input.leagueId).catch(() => []),
     listActiveInjuries(input.seasonId).catch(() => []),
     listTeamPrograms(input.seasonId).catch(() => []),
+    listCoachesByLeague(input.leagueId).catch(() => []),
   ]);
 
   const features = config ? resolveSimFeatures(input.flagEnabled, config) : {};
+  const coachAggressionByTeam = new Map(
+    coaches
+      .filter((c) => c.teamId && c.role === COACH_ROLE_HEAD)
+      .map((c) => [c.teamId as string, c.aggression]),
+  );
   return {
     leagueId: input.leagueId,
     features,
@@ -142,16 +151,22 @@ export async function loadSeasonSimContext(input: {
      */
     schemes: new Map(
       features.schemes === true
-        ? programs.map((p) => [
-            p.teamId,
-            {
-              ...(p.offenseScheme !== null ? { offense: p.offenseScheme } : {}),
-              ...(p.defenseScheme !== null ? { defense: p.defenseScheme } : {}),
-              ...(p.tempo !== null ? { tempo: p.tempo } : {}),
-              ...(p.blitzRate !== null ? { blitzRate: p.blitzRate } : {}),
-              ...(p.aggression !== null ? { aggression: p.aggression } : {}),
-            } satisfies TeamSchemeAssignment,
-          ])
+        ? programs.map((p) => {
+            const aggression = resolveAggression(
+              coachAggressionByTeam.get(p.teamId ?? "") ?? null,
+              p.aggression,
+            );
+            return [
+              p.teamId,
+              {
+                ...(p.offenseScheme !== null ? { offense: p.offenseScheme } : {}),
+                ...(p.defenseScheme !== null ? { defense: p.defenseScheme } : {}),
+                ...(p.tempo !== null ? { tempo: p.tempo } : {}),
+                ...(p.blitzRate !== null ? { blitzRate: p.blitzRate } : {}),
+                ...(typeof aggression === "number" ? { aggression } : {}),
+              } satisfies TeamSchemeAssignment,
+            ];
+          })
         : [],
     ),
   };

--- a/apps/web/src/lib/simulate-fixture.ts
+++ b/apps/web/src/lib/simulate-fixture.ts
@@ -1,6 +1,7 @@
 import type { FixtureDto } from "@sports-management/shared-types";
 import {
   bulkUpsertPlayerGameStats,
+  listFixtureGameplans,
   recordGameInjuries,
   recordGameResult,
   upsertGamePlayLog,
@@ -26,6 +27,7 @@ import {
   fixtureSimConditions,
   type SeasonSimContext,
 } from "@/lib/sim-context";
+import { isGameplanFocus } from "@/lib/program/gameplan";
 
 export interface SimulateFixtureInput {
   fixture: FixtureDto;
@@ -104,13 +106,31 @@ export async function simulateAndPersistFixture(
   const homeFit = applyTeamProgram(fit(home), input.simContext);
   const awayFit = applyTeamProgram(fit(away), input.simContext);
 
+  const gameplans =
+    input.simContext.features.schemes === true
+      ? await listFixtureGameplans(fixture.id).catch(() => [])
+      : [];
+  const focusFor = (teamId: string) => {
+    const row = gameplans.find((g) => g.teamId === teamId);
+    const focus = row?.focus;
+    return focus && isGameplanFocus(focus) ? focus : undefined;
+  };
+  const homeWithPlan =
+    focusFor(fixture.homeTeamId) !== undefined
+      ? { ...homeFit, gameplan: focusFor(fixture.homeTeamId) }
+      : homeFit;
+  const awayWithPlan =
+    focusFor(fixture.awayTeamId) !== undefined
+      ? { ...awayFit, gameplan: focusFor(fixture.awayTeamId) }
+      : awayFit;
+
   const rosterEmpty =
-    homeFit.players.length === 0 || awayFit.players.length === 0;
+    homeWithPlan.players.length === 0 || awayWithPlan.players.length === 0;
 
   if (rosterEmpty) {
     const { homeScore, awayScore } = simulateScore({
-      homeStrength: homeFit.strength,
-      awayStrength: awayFit.strength,
+      homeStrength: homeWithPlan.strength,
+      awayStrength: awayWithPlan.strength,
       seed,
       decisive,
       flavor,
@@ -131,8 +151,8 @@ export async function simulateAndPersistFixture(
    */
   const conditions = fixtureSimConditions(input.simContext, fixture);
   const log = simulateGameLog({
-    home: homeFit,
-    away: awayFit,
+    home: homeWithPlan,
+    away: awayWithPlan,
     seed,
     decisive,
     flavor,


### PR DESCRIPTION
Closes #627. Third slice of Epic C.

A scheme is who your program is; a gameplan is what you do about Friday's opponent. This adds the weekly layer on top of the seasonal one.

**Scope-reduced by design** — A6 (#653) already shipped the scheme catalog, the `teamSeasonPrograms` table and the Team Home selection UI, so this slice extends them rather than rebuilding.

## What landed
- `schemeFit` on the existing catalog, total over every scheme × roster pair including an empty roster and one with no rated players.
- Fit is **surfaced, never enforced** — a low-fit scheme still saves. A coach may run what they want badly; that is a dynasty, not a validator.
- `gameplanModifiers` is pure, and an absent gameplan returns **exactly the identity** — the same contract `schemeModifiers` already holds, and for the same reason: absence must never read as an average.
- Gameplans persist per `(fixture, team)` on the fixture surface. No new navigation destination — `shell-nav.ts` and the season sibling links are untouched.
- `aggression` now resolves coach-first with a fallback to the team row, so a league that set it under A6 keeps what it set.

## Closes A6's two deliberate gaps
- Playwright now covers scheme selection saving from Team Home.
- A unit test proves a coach of team A cannot call `saveTeamProgramAction` for team B. The per-`teamId` gate was written in A6 but nothing proved it.

## Verification
- `vitest run` — 228 files, 1841 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean

Scheme selection deliberately stays under `FLAG_DYNASTY_SIM_V2` rather than moving to `FLAG_DYNASTY_PROGRAM_V1`; moving it would hide an already-shipped surface from leagues running Epic A.