### PR TITLE
feat: coach skill tree and development economy (#629)

### DIFF
--- a/apps/web/convex/__tests__/completeSeasonProgram.test.ts
+++ b/apps/web/convex/__tests__/completeSeasonProgram.test.ts
@@ -5,6 +5,7 @@ import schema from "../schema";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import * as goalsModule from "../lib/goals";
+import { computeSeasonSkillPointsAward } from "../lib/coachSkills";
 
 const modules = import.meta.glob("../**/*.*s");
 
@@ -159,5 +160,39 @@ describe("completeSeason program finalize (C2)", () => {
     expect(fixtureReads).toBe(0);
     expect(gameStatReads).toBe(0);
     evaluateSpy.mockRestore();
+  });
+
+  it("awards skill points matching the pure calculation", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId } = await seedLeagueWithCoaches(t);
+    await t.mutation(internal.program.seedAiHeadCoachesForLeague, { leagueId });
+
+    await t.mutation(internal.sports.completeSeason, { seasonId, force: true });
+
+    const coachRows = await t.run((ctx) => ctx.db.query("coaches").collect());
+    expect(coachRows.length).toBeGreaterThan(0);
+
+    for (const coach of coachRows) {
+      const coachSeason = await t.run((ctx) =>
+        ctx.db
+          .query("coachSeasons")
+          .withIndex("by_coach_season", (q) =>
+            q.eq("coachId", coach._id).eq("seasonId", seasonId),
+          )
+          .unique(),
+      );
+      expect(coachSeason?.skillPointsAwarded).toBeTypeOf("number");
+      const goals = coachSeason?.goalsMetJson
+        ? (JSON.parse(coachSeason.goalsMetJson) as ReturnType<
+            typeof goalsModule.evaluateGoals
+          >)
+        : [];
+      const expected = computeSeasonSkillPointsAward({
+        evaluatedGoals: goals,
+        prestigeDelta: coachSeason?.prestigeDelta ?? 0,
+      });
+      expect(coachSeason?.skillPointsAwarded).toBe(expected);
+      expect(coach.skillPoints).toBe(expected);
+    }
   });
 });

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -52,6 +52,7 @@ void internal.sports.rebuildSeasonPlayerAggregates;
 void internal.dynasty.setDynastyConfig;
 void internal.program.setTeamProgram;
 void internal.program.seedAiHeadCoachesForLeague;
+void internal.program.spendCoachSkillPoints;
 void internal.sports.assignPlayerToRoster;
 void internal.sports.forkTeamToWorkspace;
 void internal.sports.forkDivisionToWorkspace;

--- a/apps/web/convex/dynasty.ts
+++ b/apps/web/convex/dynasty.ts
@@ -38,6 +38,11 @@ import {
 import { MAX_TARGET_ROSTER_SIZE } from "./lib/offseason";
 import { emitDynastyEvent } from "./lib/events";
 import { transferResolvedDedupeKey } from "./lib/narrative";
+import { COACH_ROLE_HEAD } from "./lib/coach";
+import {
+  coachSkillsStateFromRow,
+  ratingsFromSkillState,
+} from "./lib/coachSkills";
 
 /*
  * Dynasty Mode — offseason pipeline (Epic B).
@@ -75,6 +80,21 @@ export const moduleStatus = query({
     ready: true,
   }),
 });
+
+async function headCoachDevelopmentRatingForTeam(
+  ctx: MutationCtx,
+  teamId: Id<"teams">,
+): Promise<number | undefined> {
+  const coach = await ctx.db
+    .query("coaches")
+    .withIndex("by_teamId_role", (q) =>
+      q.eq("teamId", teamId).eq("role", COACH_ROLE_HEAD),
+    )
+    .unique();
+  if (!coach) return undefined;
+  const ratings = ratingsFromSkillState(coachSkillsStateFromRow(coach));
+  return ratings.developmentRating ?? undefined;
+}
 
 /*
  * ── Per-league Dynasty settings (F5) ────────────────────────────────────────
@@ -1867,6 +1887,10 @@ export const applyTrainingAllocations = internalMutation({
       const attributes = parseAttributes(snapshot.attributesJson);
       const positionGroup =
         snapshot.positionGroup || attributeGroupForPosition(player.position);
+      const developmentRating = await headCoachDevelopmentRatingForTeam(
+        ctx,
+        rows[0]!.teamId,
+      );
       const result = applyTraining({
         attributes,
         positionGroup,
@@ -1874,6 +1898,7 @@ export const applyTrainingAllocations = internalMutation({
           focus: row.focus,
           points: row.points,
         })),
+        developmentRating,
       });
 
       if (result.pointsPlaced > 0) {

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -963,3 +963,18 @@ export const seedAiHeadCoaches = internalMutation({
     });
   },
 });
+
+/** E2E-only: grant spendable skill points on a coach (C4). */
+export const grantCoachSkillPoints = internalMutation({
+  args: {
+    coachId: v.id("coaches"),
+    skillPoints: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const points = Math.max(0, Math.floor(args.skillPoints));
+    await ctx.db.patch(args.coachId, { skillPoints: points });
+    return null;
+  },
+});

--- a/apps/web/convex/lib/coachSkills.ts
+++ b/apps/web/convex/lib/coachSkills.ts
@@ -1,0 +1,265 @@
+/*
+ * Coach skill tree (Dynasty Mode C4) — pure, Convex-free.
+ *
+ * Skill points are earned at season finalization and spent on nodes that raise
+ * development, recruiting and gameplan ratings. Gameplay reads those ratings
+ * through the existing B6/B3 helpers; until a coach unlocks a branch, ratings
+ * stay absent so training and prospect generation match pre-C4 behavior.
+ */
+import type { EvaluatedGoal } from "./goals";
+import { NEUTRAL_RATING } from "./training";
+
+export type SkillBranch = "development" | "recruiting" | "gameplanning";
+
+export interface SkillNodeEffect {
+  developmentRating?: number;
+  recruitingRating?: number;
+  gameplanRating?: number;
+}
+
+export interface SkillNode {
+  id: string;
+  branch: SkillBranch;
+  label: string;
+  description: string;
+  cost: number;
+  prerequisites: readonly string[];
+  effect: SkillNodeEffect;
+}
+
+export interface CoachSkillsState {
+  skillPoints: number;
+  unlockedNodeIds: readonly string[];
+}
+
+export interface CoachSkillRatings {
+  developmentRating: number | null;
+  recruitingRating: number | null;
+  gameplanRating: number | null;
+}
+
+export type SkillSpendRejection =
+  | "unknown_node"
+  | "prerequisites_not_met"
+  | "insufficient_points"
+  | "already_unlocked";
+
+export type ApplySkillResult =
+  | { ok: true; state: CoachSkillsState; ratings: CoachSkillRatings }
+  | { ok: false; reason: SkillSpendRejection };
+
+export const COACH_SKILL_NODES: readonly SkillNode[] = [
+  {
+    id: "dev_fundamentals",
+    branch: "development",
+    label: "Fundamentals",
+    description: "Teach technique in every drill.",
+    cost: 1,
+    prerequisites: [],
+    effect: { developmentRating: 5 },
+  },
+  {
+    id: "dev_pipeline",
+    branch: "development",
+    label: "Pipeline",
+    description: "Identify and grow depth before it is needed.",
+    cost: 1,
+    prerequisites: ["dev_fundamentals"],
+    effect: { developmentRating: 5 },
+  },
+  {
+    id: "dev_elite",
+    branch: "development",
+    label: "Elite development",
+    description: "Turn starters into All-Conference players.",
+    cost: 1,
+    prerequisites: ["dev_pipeline"],
+    effect: { developmentRating: 10 },
+  },
+  {
+    id: "rec_network",
+    branch: "recruiting",
+    label: "Regional network",
+    description: "Relationships with high-school coaches.",
+    cost: 1,
+    prerequisites: [],
+    effect: { recruitingRating: 5 },
+  },
+  {
+    id: "rec_scouting",
+    branch: "recruiting",
+    label: "Scouting staff",
+    description: "More eyes on Friday nights.",
+    cost: 1,
+    prerequisites: ["rec_network"],
+    effect: { recruitingRating: 5 },
+  },
+  {
+    id: "rec_national",
+    branch: "recruiting",
+    label: "National reach",
+    description: "Compete for prospects outside your footprint.",
+    cost: 1,
+    prerequisites: ["rec_scouting"],
+    effect: { recruitingRating: 10 },
+  },
+  {
+    id: "gp_film",
+    branch: "gameplanning",
+    label: "Film study",
+    description: "Find tendencies before kickoff.",
+    cost: 1,
+    prerequisites: [],
+    effect: { gameplanRating: 5 },
+  },
+  {
+    id: "gp_adjustments",
+    branch: "gameplanning",
+    label: "Halftime adjustments",
+    description: "Answer what the opponent showed in Q1.",
+    cost: 1,
+    prerequisites: ["gp_film"],
+    effect: { gameplanRating: 5 },
+  },
+  {
+    id: "gp_mastery",
+    branch: "gameplanning",
+    label: "Gameplan mastery",
+    description: "Win the chess match week after week.",
+    cost: 1,
+    prerequisites: ["gp_adjustments"],
+    effect: { gameplanRating: 10 },
+  },
+] as const;
+
+const NODE_BY_ID = new Map(COACH_SKILL_NODES.map((node) => [node.id, node]));
+
+export function getSkillNode(nodeId: string): SkillNode | undefined {
+  return NODE_BY_ID.get(nodeId);
+}
+
+export function parseUnlockedNodesJson(
+  json: string | null | undefined,
+): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function coachSkillsStateFromRow(input: {
+  skillPoints?: number | null;
+  unlockedNodesJson?: string | null;
+}): CoachSkillsState {
+  return {
+    skillPoints:
+      typeof input.skillPoints === "number" && Number.isFinite(input.skillPoints)
+        ? Math.max(0, Math.floor(input.skillPoints))
+        : 0,
+    unlockedNodeIds: parseUnlockedNodesJson(input.unlockedNodesJson),
+  };
+}
+
+/** Ratings contributed by unlocked nodes only; absent branches stay null. */
+export function ratingsFromSkillState(
+  state: CoachSkillsState,
+): CoachSkillRatings {
+  const unlocked = new Set(state.unlockedNodeIds);
+  let development = 0;
+  let recruiting = 0;
+  let gameplan = 0;
+  let hasDevelopment = false;
+  let hasRecruiting = false;
+  let hasGameplan = false;
+
+  for (const node of COACH_SKILL_NODES) {
+    if (!unlocked.has(node.id)) continue;
+    if (node.effect.developmentRating) {
+      hasDevelopment = true;
+      development += node.effect.developmentRating;
+    }
+    if (node.effect.recruitingRating) {
+      hasRecruiting = true;
+      recruiting += node.effect.recruitingRating;
+    }
+    if (node.effect.gameplanRating) {
+      hasGameplan = true;
+      gameplan += node.effect.gameplanRating;
+    }
+  }
+
+  return {
+    developmentRating: hasDevelopment ? NEUTRAL_RATING + development : null,
+    recruitingRating: hasRecruiting ? NEUTRAL_RATING + recruiting : null,
+    gameplanRating: hasGameplan ? NEUTRAL_RATING + gameplan : null,
+  };
+}
+
+export function prerequisitesMet(
+  state: CoachSkillsState,
+  node: SkillNode,
+): boolean {
+  const unlocked = new Set(state.unlockedNodeIds);
+  return node.prerequisites.every((id) => unlocked.has(id));
+}
+
+/**
+ * Spend one node. Idempotent per nodeId: a repeat spend returns the same state
+ * without charging again.
+ */
+export function applySkill(
+  state: CoachSkillsState,
+  nodeId: string,
+): ApplySkillResult {
+  const node = getSkillNode(nodeId);
+  if (!node) return { ok: false, reason: "unknown_node" };
+
+  const unlocked = new Set(state.unlockedNodeIds);
+  if (unlocked.has(nodeId)) {
+    return {
+      ok: true,
+      state,
+      ratings: ratingsFromSkillState(state),
+    };
+  }
+
+  if (!prerequisitesMet(state, node)) {
+    return { ok: false, reason: "prerequisites_not_met" };
+  }
+  if (state.skillPoints < node.cost) {
+    return { ok: false, reason: "insufficient_points" };
+  }
+
+  const next: CoachSkillsState = {
+    skillPoints: state.skillPoints - node.cost,
+    unlockedNodeIds: [...state.unlockedNodeIds, nodeId].sort(),
+  };
+  return {
+    ok: true,
+    state: next,
+    ratings: ratingsFromSkillState(next),
+  };
+}
+
+export interface SeasonSkillPointsInput {
+  evaluatedGoals: readonly EvaluatedGoal[];
+  prestigeDelta: number;
+}
+
+/** Pure award used at season finalization and in convex-test. */
+export function computeSeasonSkillPointsAward(
+  input: SeasonSkillPointsInput,
+): number {
+  const met = input.evaluatedGoals.filter((g) => g.status === "met").length;
+  const prestigeBonus =
+    input.prestigeDelta > 0 ? Math.floor(input.prestigeDelta / 4) : 0;
+  return met + prestigeBonus;
+}
+
+export function serializeUnlockedNodes(nodeIds: readonly string[]): string {
+  return JSON.stringify([...nodeIds].sort());
+}

--- a/apps/web/convex/lib/programFinalize.ts
+++ b/apps/web/convex/lib/programFinalize.ts
@@ -24,6 +24,12 @@ import {
 import { applyPrestigeDelta } from "./prestige";
 import { computeJobSecurity, shouldFireCoach } from "./jobSecurity";
 import { resolveProgram } from "./resolveProgram";
+import {
+  computeSeasonSkillPointsAward,
+  ratingsFromSkillState,
+  coachSkillsStateFromRow,
+  serializeUnlockedNodes,
+} from "./coachSkills";
 
 export function coachFiredDedupeKey(coachId: string, seasonId: string): string {
   return `coach_fired:${coachId}:${seasonId}`;
@@ -178,12 +184,28 @@ export async function finalizeProgramSeason(
         )
         .unique();
 
+      const skillPointsAward = computeSeasonSkillPointsAward({
+        evaluatedGoals: evaluated,
+        prestigeDelta,
+      });
+      const previousAward = coachSeason?.skillPointsAwarded ?? 0;
+      const currentPoints =
+        typeof headCoach.skillPoints === "number" &&
+        Number.isFinite(headCoach.skillPoints)
+          ? Math.max(0, headCoach.skillPoints)
+          : 0;
+      const nextSkillPoints = Math.max(
+        0,
+        currentPoints - previousAward + skillPointsAward,
+      );
+
       const coachSeasonPayload = {
         wins: recordInput.wins,
         losses: recordInput.losses,
         ties: recordInput.ties,
         goalsMetJson: JSON.stringify(evaluated),
         prestigeDelta,
+        skillPointsAwarded: skillPointsAward,
         finalizedAt: now,
       };
 
@@ -197,6 +219,33 @@ export async function finalizeProgramSeason(
           ...coachSeasonPayload,
         });
       }
+
+      const skillRatings = ratingsFromSkillState(
+        coachSkillsStateFromRow({
+          skillPoints: nextSkillPoints,
+          unlockedNodesJson: headCoach.unlockedNodesJson,
+        }),
+      );
+      const coachPatch: {
+        skillPoints: number;
+        updatedAt: string;
+        developmentRating?: number;
+        recruitingRating?: number;
+        gameplanRating?: number;
+      } = {
+        skillPoints: nextSkillPoints,
+        updatedAt: now,
+      };
+      if (skillRatings.developmentRating !== null) {
+        coachPatch.developmentRating = skillRatings.developmentRating;
+      }
+      if (skillRatings.recruitingRating !== null) {
+        coachPatch.recruitingRating = skillRatings.recruitingRating;
+      }
+      if (skillRatings.gameplanRating !== null) {
+        coachPatch.gameplanRating = skillRatings.gameplanRating;
+      }
+      await ctx.db.patch(headCoach._id, coachPatch);
 
       if (shouldFireCoach(jobSecurity, config.jobSecurityEnabled)) {
         await ctx.db.patch(headCoach._id, {

--- a/apps/web/convex/lib/scouting.ts
+++ b/apps/web/convex/lib/scouting.ts
@@ -29,6 +29,7 @@
  * `convex/lib/rng.ts`. Re-reading a prospect never reshuffles his range.
  */
 import { rngFor } from "./rng";
+import { NEUTRAL_RATING } from "./training";
 
 /** Ratings live on the same 40–99 scale as `generateSyntheticAttributes`. */
 export const OVERALL_MIN = 40;
@@ -91,6 +92,24 @@ export function nextScoutCost(scoutLevel: number): number | null {
 export function clampScoutLevel(level: number): number {
   if (!Number.isFinite(level)) return MIN_SCOUT_LEVEL;
   return Math.max(MIN_SCOUT_LEVEL, Math.min(MAX_SCOUT_LEVEL, Math.round(level)));
+}
+
+/**
+ * Extra tilt applied when generating a recruiting class from coach investment.
+ * Absent rating is zero — pre-C4 classes are unchanged.
+ */
+export function recruitingClassTilt(
+  recruitingRating: number | null | undefined,
+): number {
+  if (
+    recruitingRating === null ||
+    recruitingRating === undefined ||
+    !Number.isFinite(recruitingRating)
+  ) {
+    return 0;
+  }
+  const clamped = Math.max(0, Math.min(100, recruitingRating));
+  return Math.round((clamped - NEUTRAL_RATING) / 5);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/apps/web/convex/program.ts
+++ b/apps/web/convex/program.ts
@@ -8,6 +8,11 @@ import {
   generateAiHeadCoachProfile,
 } from "./lib/coach";
 import { evaluateGoals, generateGoals } from "./lib/goals";
+import {
+  applySkill,
+  coachSkillsStateFromRow,
+  serializeUnlockedNodes,
+} from "./lib/coachSkills";
 import type { Id } from "./_generated/dataModel";
 
 /*
@@ -430,6 +435,7 @@ const coachSeasonDtoValidator = v.object({
   playoffResult: v.union(v.string(), v.null()),
   goalsMetJson: v.union(v.string(), v.null()),
   prestigeDelta: v.union(v.number(), v.null()),
+  skillPointsAwarded: v.union(v.number(), v.null()),
   finalizedAt: v.union(v.string(), v.null()),
 });
 
@@ -446,6 +452,7 @@ function toCoachSeasonDto(row: {
   playoffResult?: string;
   goalsMetJson?: string;
   prestigeDelta?: number;
+  skillPointsAwarded?: number;
   finalizedAt?: string;
 }): CoachSeasonDto {
   return {
@@ -459,6 +466,7 @@ function toCoachSeasonDto(row: {
     playoffResult: row.playoffResult ?? null,
     goalsMetJson: row.goalsMetJson ?? null,
     prestigeDelta: row.prestigeDelta ?? null,
+    skillPointsAwarded: row.skillPointsAwarded ?? null,
     finalizedAt: row.finalizedAt ?? null,
   };
 }
@@ -679,5 +687,52 @@ export const seedAiHeadCoachesForLeague = internalMutation({
       coachSeasonsCreated,
       teamsScanned: teams.length,
     };
+  },
+});
+
+export const spendCoachSkillPoints = internalMutation({
+  args: {
+    coachId: v.id("coaches"),
+    teamId: v.id("teams"),
+    nodeId: v.string(),
+    actorUserId: v.string(),
+  },
+  returns: coachDtoValidator,
+  handler: async (ctx, args) => {
+    const coach = await ctx.db.get(args.coachId);
+    if (!coach) throw new Error("coach_not_found");
+    if (coach.teamId !== args.teamId) throw new Error("coach_not_on_team");
+
+    const state = coachSkillsStateFromRow(coach);
+    const result = applySkill(state, args.nodeId);
+    if (!result.ok) throw new Error(result.reason);
+
+    const now = new Date().toISOString();
+    const patch: {
+      skillPoints: number;
+      unlockedNodesJson: string;
+      updatedAt: string;
+      developmentRating?: number;
+      recruitingRating?: number;
+      gameplanRating?: number;
+    } = {
+      skillPoints: result.state.skillPoints,
+      unlockedNodesJson: serializeUnlockedNodes(result.state.unlockedNodeIds),
+      updatedAt: now,
+    };
+    if (result.ratings.developmentRating !== null) {
+      patch.developmentRating = result.ratings.developmentRating;
+    }
+    if (result.ratings.recruitingRating !== null) {
+      patch.recruitingRating = result.ratings.recruitingRating;
+    }
+    if (result.ratings.gameplanRating !== null) {
+      patch.gameplanRating = result.ratings.gameplanRating;
+    }
+
+    await ctx.db.patch(args.coachId, patch);
+    const updated = await ctx.db.get(args.coachId);
+    if (!updated) throw new Error("coach_not_found");
+    return toCoachDto(updated);
   },
 });

--- a/apps/web/convex/tables/program.ts
+++ b/apps/web/convex/tables/program.ts
@@ -127,6 +127,7 @@ export const programTables = {
     playoffResult: v.optional(v.string()),
     goalsMetJson: v.optional(v.string()),
     prestigeDelta: v.optional(v.number()),
+    skillPointsAwarded: v.optional(v.number()),
     finalizedAt: v.optional(v.string()),
   })
     .index("by_coach_season", ["coachId", "seasonId"])

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -194,3 +194,29 @@ export async function seedAiHeadCoachesForLeague(leagueId: string): Promise<void
   const client = getSeedClient();
   await client.mutation(seedAiHeadCoachesRef, { leagueId });
 }
+
+const grantCoachSkillPointsRef = makeFunctionReference<
+  "mutation",
+  { coachId: string; skillPoints: number },
+  null
+>("e2eSeed:grantCoachSkillPoints");
+
+export async function grantCoachSkillPoints(
+  coachId: string,
+  skillPoints: number,
+): Promise<void> {
+  const client = getSeedClient();
+  await client.mutation(grantCoachSkillPointsRef, { coachId, skillPoints });
+}
+
+const listCoachesByTeamRef = makeFunctionReference<
+  "query",
+  { teamId: string },
+  Array<{ id: string }>
+>("program:listCoachesByTeam");
+
+export async function listCoachIdsForTeam(teamId: string): Promise<string[]> {
+  const client = getSeedClient();
+  const rows = await client.query(listCoachesByTeamRef, { teamId });
+  return rows.map((row) => row.id);
+}

--- a/apps/web/e2e/tests/coach-skills.spec.ts
+++ b/apps/web/e2e/tests/coach-skills.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  grantCoachSkillPoints,
+  listCoachIdsForTeam,
+  seedAiHeadCoachesForLeague,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId, getTestOrgIdB } from "../helpers/seed-roster";
+import { signInTestUser } from "../helpers/clerk-signin";
+
+test.describe("Coach skill tree (C4)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "coach-skills";
+  const LEAGUE_NAME = `E2E:${FIXTURE_KEY}`;
+
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+  let homeCoachId: string | null = null;
+  let awayCoachId: string | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E CS Home",
+      awayTeamName: "E2E CS Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    await seedAiHeadCoachesForLeague(fixture.leagueId);
+    const homeCoaches = await listCoachIdsForTeam(fixture.homeTeamId);
+    const awayCoaches = await listCoachIdsForTeam(fixture.awayTeamId);
+    homeCoachId = homeCoaches[0] ?? null;
+    awayCoachId = awayCoaches[0] ?? null;
+    if (homeCoachId) await grantCoachSkillPoints(homeCoachId, 3);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("org admin spends a skill point on Coach Home", async ({ page }) => {
+    if (!fixture || !homeCoachId) test.skip();
+
+    await page.goto(`/dashboard/coaches/${homeCoachId}`);
+    const tree = page.getByTestId("coach-skill-tree");
+    await expect(tree).toBeVisible({ timeout: 30_000 });
+
+    const unlock = page.getByTestId("skill-spend-dev_fundamentals");
+    await expect(unlock).toBeEnabled();
+    await unlock.click();
+
+    await expect(
+      page.getByTestId("skill-node-dev_fundamentals").getByRole("button", {
+        name: "Owned",
+      }),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  // This block signs in as the org-B user itself, so it must not inherit the
+  // shared signed-in storageState — `clerk.signIn` throws "already signed in"
+  // otherwise (WSM-000172). Start from a clean, signed-out context. Nesting
+  // keeps the outer fixture's beforeAll/afterAll, so the coach ids still exist.
+  test.describe("as a coach outside the league org", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test("cannot spend on another program's coach", async ({ page }) => {
+      const orgIdB = getTestOrgIdB();
+      test.skip(!orgIdB || !awayCoachId, "E2E_CLERK_ORG_ID_B required");
+      await signInTestUser(page, { userVariant: "B" });
+      await page.goto(`/dashboard/coaches/${awayCoachId}`);
+      await expect(page.getByRole("heading", { name: /^404$/ })).toBeVisible();
+      await expect(page.getByTestId("coach-skill-tree")).toHaveCount(0);
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -22,6 +22,7 @@ const {
   mockHealSeasonInjuries,
   mockCreateProspectClass,
   mockGetDynastyConfig,
+  mockListCoachesByLeague,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockResolveOrgContext: vi.fn(),
@@ -44,6 +45,7 @@ const {
   mockHealSeasonInjuries: vi.fn(),
   mockCreateProspectClass: vi.fn(),
   mockGetDynastyConfig: vi.fn(),
+  mockListCoachesByLeague: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
@@ -70,6 +72,7 @@ vi.mock("@/lib/data-api", () => ({
   healSeasonInjuries: mockHealSeasonInjuries,
   createProspectClass: mockCreateProspectClass,
   getDynastyConfig: mockGetDynastyConfig,
+  listCoachesByLeague: mockListCoachesByLeague,
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
@@ -115,6 +118,7 @@ beforeEach(() => {
   });
   mockGetLeagueOrgId.mockResolvedValue(ORG);
   mockResolveOrgRole.mockResolvedValue("admin");
+  mockListCoachesByLeague.mockResolvedValue([]);
   mockGetSeasons.mockResolvedValue([ACTIVE]);
   mockBeginSeasonRollover.mockResolvedValue({
     rolloverId: "rollover_1",

--- a/apps/web/src/app/dashboard/_actions/coach-skills.ts
+++ b/apps/web/src/app/dashboard/_actions/coach-skills.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { canAdminOrManageTeam } from "@/lib/authorization";
+import { spendCoachSkillPoints } from "@/lib/data-api";
+
+type ActionResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+function messageOf(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const known = [
+    "coach_not_found",
+    "coach_not_on_team",
+    "unknown_node",
+    "prerequisites_not_met",
+    "insufficient_points",
+    "already_unlocked",
+    "not_authorized",
+  ];
+  return known.find((reason) => raw.includes(reason)) ?? raw;
+}
+
+export async function spendCoachSkillPointsAction(input: {
+  coachId: string;
+  teamId: string;
+  nodeId: string;
+}): Promise<ActionResult<{ skillPoints: number | null }>> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+  if (!(await canAdminOrManageTeam(input.teamId, userId))) {
+    return { ok: false, error: "not_authorized" };
+  }
+
+  try {
+    const coach = await spendCoachSkillPoints({
+      coachId: input.coachId,
+      teamId: input.teamId,
+      nodeId: input.nodeId,
+      actorUserId: userId,
+    });
+    revalidatePath(`/dashboard/coaches/${input.coachId}`);
+    return { ok: true, data: { skillPoints: coach.skillPoints } };
+  } catch (error) {
+    return { ok: false, error: messageOf(error) };
+  }
+}

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -23,6 +23,7 @@ import {
   healSeasonInjuries,
   createProspectClass,
   getDynastyConfig,
+  listCoachesByLeague,
 } from "@/lib/data-api";
 import { activeNonGraduatedNames } from "@/lib/dynasty";
 import {
@@ -30,6 +31,10 @@ import {
   prospectClassSize,
 } from "@/lib/dynasty/prospects";
 import { computeProgressedAttributes } from "@/lib/dynasty-progression";
+import {
+  coachSkillsStateFromRow,
+  ratingsFromSkillState,
+} from "@/lib/program/coach-skills";
 import { resolveLifecycleSeason } from "@/lib/season-view";
 import {
   generateSyntheticRoster,
@@ -59,6 +64,24 @@ function hasReachedRolloverStage(stage: string, expected: string): boolean {
   return (
     ROLLOVER_STAGES.indexOf(stage as (typeof ROLLOVER_STAGES)[number]) >=
     ROLLOVER_STAGES.indexOf(expected as (typeof ROLLOVER_STAGES)[number])
+  );
+}
+
+function leagueRecruitingRatingForProspects(
+  coaches: Array<{
+    skillPoints?: number | null;
+    unlockedNodesJson?: string | null;
+  }>,
+): number | undefined {
+  const ratings = coaches
+    .map(
+      (coach) =>
+        ratingsFromSkillState(coachSkillsStateFromRow(coach)).recruitingRating,
+    )
+    .filter((rating): rating is number => rating !== null);
+  if (ratings.length === 0) return undefined;
+  return Math.round(
+    ratings.reduce((sum, rating) => sum + rating, 0) / ratings.length,
   );
 }
 
@@ -537,10 +560,15 @@ export async function startNextSeasonAction(input: {
               input.leagueId,
               orgContext,
             ).catch(() => []);
+            const coaches = await listCoachesByLeague(input.leagueId).catch(
+              () => [],
+            );
+            const recruitingRating = leagueRecruitingRatingForProspects(coaches);
             const prospects = generateProspectClass({
               seasonId: nextSeasonId,
               count: prospectClassSize(teams.length),
               excludeNames: activeNonGraduatedNames(leaguePlayers),
+              recruitingRating,
             });
             const created = await createProspectClass({
               leagueId: input.leagueId,

--- a/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
@@ -13,6 +13,8 @@ import {
 import { resolveOrgContext } from "@/lib/org-context";
 import { dynastyProgramV1, pageGuard } from "@/lib/flags";
 import { formatCoachArchetype } from "@/lib/program/coach";
+import { CoachSkillTreeCard } from "@/components/program/CoachSkillTreeCard";
+import { canAdminOrManageTeam } from "@/lib/authorization";
 import { Card, CardContent } from "@/components/ui/card";
 import { syncActiveLeagueForResource } from "@/lib/active-league-server";
 
@@ -40,6 +42,7 @@ export default async function CoachHomePage({
   await syncActiveLeagueForResource(leagueId);
 
   const siblings = buildCoachSiblingLinks(coachId);
+  const canEdit = await canAdminOrManageTeam(coach.teamId, userId);
 
   return (
     <div className="space-y-4">
@@ -99,6 +102,14 @@ export default async function CoachHomePage({
           </div>
         </CardContent>
       </Card>
+
+      <CoachSkillTreeCard
+        coachId={coachId}
+        teamId={coach.teamId}
+        skillPoints={coach.skillPoints}
+        unlockedNodesJson={coach.unlockedNodesJson}
+        canEdit={canEdit}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/program/CoachSkillTreeCard.tsx
+++ b/apps/web/src/components/program/CoachSkillTreeCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useTransition } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  COACH_SKILL_NODES,
+  parseUnlockedNodesJson,
+  prerequisitesMet,
+  type CoachSkillsState,
+} from "@/lib/program/coach-skills";
+import { spendCoachSkillPointsAction } from "@/app/dashboard/_actions/coach-skills";
+
+export function CoachSkillTreeCard({
+  coachId,
+  teamId,
+  skillPoints,
+  unlockedNodesJson,
+  canEdit,
+}: {
+  coachId: string;
+  teamId: string;
+  skillPoints: number | null;
+  unlockedNodesJson: string | null;
+  canEdit: boolean;
+}) {
+  const [pending, startTransition] = useTransition();
+  const state: CoachSkillsState = {
+    skillPoints: skillPoints ?? 0,
+    unlockedNodeIds: parseUnlockedNodesJson(unlockedNodesJson),
+  };
+  const unlocked = new Set(state.unlockedNodeIds);
+
+  function spend(nodeId: string) {
+    if (!canEdit) return;
+    startTransition(async () => {
+      await spendCoachSkillPointsAction({ coachId, teamId, nodeId });
+    });
+  }
+
+  const branches = [
+    { key: "development" as const, title: "Development" },
+    { key: "recruiting" as const, title: "Recruiting" },
+    { key: "gameplanning" as const, title: "Gameplanning" },
+  ];
+
+  return (
+    <Card data-testid="coach-skill-tree">
+      <CardHeader>
+        <CardTitle>Skill tree</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          {state.skillPoints} skill point{state.skillPoints === 1 ? "" : "s"}{" "}
+          available
+        </p>
+      </CardHeader>
+      <CardContent className="grid gap-6 md:grid-cols-3">
+        {branches.map((branch) => (
+          <div key={branch.key} className="space-y-2">
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              {branch.title}
+            </p>
+            <ul className="space-y-2">
+              {COACH_SKILL_NODES.filter((n) => n.branch === branch.key).map(
+                (node) => {
+                  const isUnlocked = unlocked.has(node.id);
+                  const prereqsOk = prerequisitesMet(state, node);
+                  const canAfford = state.skillPoints >= node.cost;
+                  const canSpend =
+                    canEdit && !isUnlocked && prereqsOk && canAfford && !pending;
+
+                  return (
+                    <li
+                      key={node.id}
+                      className="rounded-md border border-border/60 p-3 text-sm"
+                      data-testid={`skill-node-${node.id}`}
+                    >
+                      <div className="font-medium">{node.label}</div>
+                      <p className="text-xs text-muted-foreground">
+                        {node.description}
+                      </p>
+                      <p className="mt-1 text-xs tabular-nums text-muted-foreground">
+                        Cost: {node.cost}
+                        {isUnlocked ? " · Unlocked" : ""}
+                      </p>
+                      {canEdit && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={isUnlocked ? "secondary" : "default"}
+                          className="mt-2"
+                          disabled={!canSpend}
+                          data-testid={`skill-spend-${node.id}`}
+                          onClick={() => spend(node.id)}
+                        >
+                          {isUnlocked ? "Owned" : "Unlock"}
+                        </Button>
+                      )}
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -3072,6 +3072,7 @@ export interface CoachSeasonDto {
   playoffResult: string | null;
   goalsMetJson: string | null;
   prestigeDelta: number | null;
+  skillPointsAwarded: number | null;
   finalizedAt: string | null;
 }
 
@@ -3122,6 +3123,19 @@ export async function getSeasonGoalProgress(
   return client.query(
     programRef.query<EvaluatedGoalDto[]>("getSeasonGoalProgress"),
     { seasonId, teamId },
+  );
+}
+
+export async function spendCoachSkillPoints(input: {
+  coachId: string;
+  teamId: string;
+  nodeId: string;
+  actorUserId: string;
+}): Promise<CoachDto> {
+  const client = getConvexClient();
+  return client.mutation(
+    programRef.mutation<CoachDto>("spendCoachSkillPoints"),
+    input,
   );
 }
 

--- a/apps/web/src/lib/dynasty/prospects.ts
+++ b/apps/web/src/lib/dynasty/prospects.ts
@@ -33,6 +33,7 @@ import { rngFor, seedFor } from "@/lib/rng";
 import {
   OVERALL_MAX,
   OVERALL_MIN,
+  recruitingClassTilt,
   type PotentialTier,
 } from "@/lib/dynasty/scouting";
 
@@ -103,6 +104,11 @@ export interface GenerateProspectClassInput {
   count: number;
   /** Names already in the league, so a prospect never shares one. */
   excludeNames?: string[];
+  /**
+   * Head-coach recruiting investment (0–100). Absent leaves class generation
+   * identical to pre-C4; see `recruitingClassTilt` in `convex/lib/scouting.ts`.
+   */
+  recruitingRating?: number | null;
 }
 
 /**
@@ -162,7 +168,9 @@ export function generateProspectClass(
      * 45–95 so the top of the board is genuinely worth the points.
      */
     const shape = rngFor("prospects", prospectKey, "shape");
-    const tilt = Math.round((shape() - 0.55) * 18);
+    const tilt =
+      Math.round((shape() - 0.55) * 18) +
+      recruitingClassTilt(input.recruitingRating);
     const trueAttributes: Record<string, number> = {};
     for (const [key, value] of Object.entries(attributes.attributes)) {
       trueAttributes[key] = Math.round(

--- a/apps/web/src/lib/dynasty/scouting.ts
+++ b/apps/web/src/lib/dynasty/scouting.ts
@@ -22,6 +22,7 @@ export {
   clampScoutLevel,
   isPotentialTier,
   nextScoutCost,
+  recruitingClassTilt,
   scoutingBand,
   scoutingBands,
 } from "../../../convex/lib/scouting";

--- a/apps/web/src/lib/program/__tests__/coach-skills.test.ts
+++ b/apps/web/src/lib/program/__tests__/coach-skills.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  COACH_SKILL_NODES,
+  applySkill,
+  computeSeasonSkillPointsAward,
+  getSkillNode,
+  ratingsFromSkillState,
+  type CoachSkillsState,
+} from "@/lib/program/coach-skills";
+import { trainingBonus } from "@/lib/dynasty/training";
+import { generateProspectClass } from "@/lib/dynasty/prospects";
+
+describe("coach skill tree nodes", () => {
+  it("each node has prerequisites and effect wired consistently", () => {
+    for (const node of COACH_SKILL_NODES) {
+      expect(getSkillNode(node.id)).toEqual(node);
+      for (const prereq of node.prerequisites) {
+        expect(getSkillNode(prereq)).toBeDefined();
+      }
+      const empty: CoachSkillsState = { skillPoints: 10, unlockedNodeIds: [] };
+      if (node.prerequisites.length > 0) {
+        expect(applySkill(empty, node.id).ok).toBe(false);
+      }
+      let state: CoachSkillsState = { skillPoints: 20, unlockedNodeIds: [] };
+      const unlockChain = (targetId: string) => {
+        const target = getSkillNode(targetId);
+        if (!target) return;
+        for (const prereq of target.prerequisites) unlockChain(prereq);
+        if (!state.unlockedNodeIds.includes(targetId)) {
+          const step = applySkill(state, targetId);
+          expect(step.ok).toBe(true);
+          if (step.ok) state = step.state;
+        }
+      };
+      unlockChain(node.id);
+      const unlock = applySkill(state, node.id);
+      expect(unlock.ok).toBe(true);
+      if (unlock.ok) {
+        const ratings = ratingsFromSkillState(unlock.state);
+        if (node.effect.developmentRating) {
+          expect(ratings.developmentRating).toBeGreaterThan(50);
+        }
+        if (node.effect.recruitingRating) {
+          expect(ratings.recruitingRating).toBeGreaterThan(50);
+        }
+        if (node.effect.gameplanRating) {
+          expect(ratings.gameplanRating).toBeGreaterThan(50);
+        }
+      }
+    }
+  });
+
+  it("spending the same node twice applies one effect and keeps balance non-negative", () => {
+    let state: CoachSkillsState = { skillPoints: 5, unlockedNodeIds: [] };
+    const first = applySkill(state, "dev_fundamentals");
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    state = first.state;
+    const second = applySkill(state, "dev_fundamentals");
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.state.skillPoints).toBe(state.skillPoints);
+    expect(second.state.unlockedNodeIds).toEqual(state.unlockedNodeIds);
+    expect(second.state.skillPoints).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("computeSeasonSkillPointsAward", () => {
+  it("awards met goals plus prestige bonus", () => {
+    const award = computeSeasonSkillPointsAward({
+      evaluatedGoals: [
+        {
+          id: "g1",
+          metric: "wins",
+          label: "Win 7",
+          target: 7,
+          status: "met",
+          actual: 8,
+        },
+        {
+          id: "g2",
+          metric: "wins",
+          label: "Win 8",
+          target: 8,
+          status: "missed",
+          actual: 4,
+        },
+      ],
+      prestigeDelta: 9,
+    });
+    expect(award).toBe(1 + Math.floor(9 / 4));
+  });
+});
+
+describe("coach ratings feed B6 and B3", () => {
+  const baseTraining = {
+    focus: "athleticism",
+    points: 10,
+    positionGroup: "RB",
+  };
+
+  it("higher development rating yields larger training bonus", () => {
+    const low = trainingBonus({ ...baseTraining, developmentRating: 55 });
+    const high = trainingBonus({ ...baseTraining, developmentRating: 75 });
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it("zero skill investment matches neutral training (no developmentRating)", () => {
+    const neutral = trainingBonus(baseTraining);
+    const withNeutralRating = trainingBonus({
+      ...baseTraining,
+      developmentRating: 50,
+    });
+    expect(withNeutralRating).toBe(neutral);
+  });
+
+  it("higher recruiting rating yields stronger prospect class for a fixed seed", () => {
+    const weak = generateProspectClass({
+      seasonId: "season_skill_test",
+      count: 24,
+      recruitingRating: 50,
+    });
+    const strong = generateProspectClass({
+      seasonId: "season_skill_test",
+      count: 24,
+      recruitingRating: 80,
+    });
+    const avg = (rows: typeof weak) =>
+      rows.reduce((sum, p) => sum + p.trueOverall, 0) / rows.length;
+    expect(avg(strong)).toBeGreaterThan(avg(weak));
+  });
+});

--- a/apps/web/src/lib/program/coach-skills.ts
+++ b/apps/web/src/lib/program/coach-skills.ts
@@ -1,0 +1,26 @@
+/*
+ * Coach skill tree (Dynasty Mode C4) — see `convex/lib/coachSkills.ts`.
+ */
+
+export {
+  COACH_SKILL_NODES,
+  applySkill,
+  coachSkillsStateFromRow,
+  computeSeasonSkillPointsAward,
+  getSkillNode,
+  parseUnlockedNodesJson,
+  prerequisitesMet,
+  ratingsFromSkillState,
+  serializeUnlockedNodes,
+} from "../../../convex/lib/coachSkills";
+
+export type {
+  ApplySkillResult,
+  CoachSkillRatings,
+  CoachSkillsState,
+  SeasonSkillPointsInput,
+  SkillBranch,
+  SkillNode,
+  SkillNodeEffect,
+  SkillSpendRejection,
+} from "../../../convex/lib/coachSkills";


### PR DESCRIPTION
Closes #629. Final slice of Epic C.

Meeting the goals your school set earns skill points; spending them on development, recruiting or gameplanning compounds across seasons. This closes the loop B6 opened — development stops being a flat constant and becomes a consequence of how the coach has invested.

## What landed
- `coachSkills.ts` defines the tree and `applySkill` as a pure state transition, canonical under `convex/` and re-exported from `src/`.
- Points are awarded at season finalization from goals met and prestige gained.
- `spendCoachSkillPoints` is **idempotent per `(coachId, nodeId)`** and can never drive the balance negative.
- `developmentRating` feeds B6's training multiplier and `recruitingRating` feeds B3 class quality — both wired through the existing functions rather than duplicating their maths.
- Skill tree renders on Coach Home, editable only by the coach's owner or an org admin.

## The invariant that matters
A coach with nothing unlocked resolves to a **null** development rating, so `trainingBonus` runs exactly as it does today. Absence of investment is neutral, not average — the same honest-absence contract the rest of Dynasty Mode holds. B6 parity is asserted, not assumed.

## Verification
- `vitest run` — 229 files, 1848 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean

## One scoping note
The e2e "a different coach is refused" case is implemented as a cross-org refusal rather than a same-league coach-owns-another-team refusal, because the Wave-5 multi-coach binding does not exist yet. The per-`teamId` authorization it will eventually exercise is unit-tested directly.