### PR TITLE
feat: career totals and the program record book (#630)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,6 +112,14 @@ _Avoid_: Playbook, formation, strategy, system
 The program-facing surface for one coach at `/dashboard/coaches/[coachId]`, with Overview and Career siblings, reached from Team Home Staff rather than the sidebar.
 _Avoid_: Staff page, coaching staff hub, manager profile
 
+**Program History**:
+The League-owned, cross-season history of its Teams and Players, browsed from League Home.
+_Avoid_: Season history, recap, archive
+
+**Record Book**:
+The Program History view at `/dashboard/leagues/[leagueId]/history` that ranks League-wide and per-Team season achievements.
+_Avoid_: Stat leaders, standings, season records
+
 ## Relationships
 
 - An operator may access zero or more **Leagues**
@@ -163,6 +171,7 @@ _Avoid_: Staff page, coaching staff hub, manager profile
 - An Active Season shortcut also makes its League the **Active League** before opening **Season Home**
 - An upcoming or completed Season never substitutes for a missing **Active Season**; League Home instead links to **Seasons Home** and offers valid admin lifecycle actions
 - A child page’s **Resource Header** identifies and links its parent Home and provides sibling subpage navigation
+- **Program History** and its **Record Book** are League-owned, not Season-owned: ADR 0001 moves season-scoped competition views under Season Home, while history spans Seasons, so League Home is its correct parent
 
 ## Example dialogue
 

--- a/apps/web/convex/__tests__/history.test.ts
+++ b/apps/web/convex/__tests__/history.test.ts
@@ -1,0 +1,277 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { finalizeSeasonHistoryForSeason } from "../lib/historyFinalize";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedHistorySeason(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "History League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const teamIds: Id<"teams">[] = [];
+    for (const name of ["Alphas", "Betas"]) {
+      teamIds.push(
+        await ctx.db.insert("teams", {
+          name,
+          leagueId,
+          divisionId: null,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Location",
+          logoUrl: null,
+          rosterLimit: 53,
+        }),
+      );
+    }
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const playerIds: Id<"players">[] = [];
+    for (let index = 0; index < teamIds.length; index++) {
+      const teamId = teamIds[index]!;
+      const playerId = await ctx.db.insert("players", {
+        name: `Player ${index + 1}`,
+        leagueId,
+        teamId,
+        position: "QB",
+        positionGroup: null,
+        jerseyNumber: index + 1,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+      });
+      playerIds.push(playerId);
+      await ctx.db.insert("playerSeasonAggregates", {
+        leagueId,
+        seasonId,
+        teamId,
+        playerId,
+        position: "QB",
+        positionGroup: null,
+        gamesPlayed: 10,
+        totalsJson: JSON.stringify({
+          passing: { yards: 2000 + index * 100, td: 20 + index },
+          rushing: { yards: 200 + index * 10, long: 40 + index },
+        }),
+        updatedAt: new Date(0).toISOString(),
+      });
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId,
+        seasonId,
+        teamId,
+        divisionId: null,
+        wins: 8 + index,
+        losses: 2 - index,
+        ties: 0,
+        pointsFor: 300 + index * 20,
+        pointsAgainst: 200,
+        divisionWins: 4,
+        divisionLosses: 1,
+        divisionTies: 0,
+        headToHeadJson: "{}",
+        streak: 1,
+        lastResults: ["W"],
+        gamesCounted: 10,
+        updatedAt: new Date(0).toISOString(),
+      });
+    }
+    return { leagueId, seasonId, teamIds, playerIds };
+  });
+}
+
+async function historySnapshot(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ({
+    careers: await ctx.db.query("playerCareerTotals").collect(),
+    records: await ctx.db.query("programRecords").collect(),
+  }));
+}
+
+describe("finalizeSeasonHistory", () => {
+  it("is idempotent: a second run leaves career totals and records unchanged", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedHistorySeason(t);
+
+    await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+    const first = await historySnapshot(t);
+    await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+    const second = await historySnapshot(t);
+
+    expect(second).toEqual(first);
+    expect(first.careers).toHaveLength(2);
+    expect(first.records.length).toBeGreaterThan(0);
+  });
+
+  it("is invoked by completeSeason without changing its null return shape", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedHistorySeason(t);
+
+    const result = await t.mutation(internal.sports.completeSeason, {
+      seasonId,
+      force: true,
+    });
+    expect(result).toBeNull();
+    const snapshot = await historySnapshot(t);
+    expect(snapshot.careers).toHaveLength(2);
+    expect(snapshot.records.length).toBeGreaterThan(0);
+  });
+
+  it("performs zero reads of playerGameStats or gamePlayLogs", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedHistorySeason(t);
+    const reads = new Map<string, number>();
+
+    await t.run(async (ctx) => {
+      const originalQuery = ctx.db.query.bind(ctx.db);
+      ctx.db.query = ((tableName: string) => {
+        reads.set(tableName, (reads.get(tableName) ?? 0) + 1);
+        return originalQuery(tableName as never);
+      }) as unknown as typeof ctx.db.query;
+      await finalizeSeasonHistoryForSeason(
+        ctx as unknown as MutationCtx,
+        seasonId,
+      );
+    });
+
+    expect(reads.get("playerGameStats") ?? 0).toBe(0);
+    expect(reads.get("gamePlayLogs") ?? 0).toBe(0);
+    expect(reads.get("playerSeasonAggregates")).toBe(1);
+    expect(reads.get("seasonTeamRecords")).toBe(1);
+  });
+
+  it("property: every career key equals the sum across random multi-season histories", async () => {
+    const t = convexTest(schema, modules);
+    let state = 0x630d1;
+    const randomInt = (max: number) => {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      return state % max;
+    };
+
+    for (let history = 0; history < 12; history++) {
+      const seeded = await t.run(async (ctx) => {
+        const leagueId = await ctx.db.insert("leagues", {
+          name: `Property League ${history}`,
+          orgId: null,
+          isPublic: true,
+          inviteToken: null,
+        });
+        const teamId = await ctx.db.insert("teams", {
+          name: `Team ${history}`,
+          leagueId,
+          divisionId: null,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Location",
+          logoUrl: null,
+          rosterLimit: 53,
+        });
+        const playerIds: Id<"players">[] = [];
+        for (let player = 0; player < 3; player++) {
+          playerIds.push(
+            await ctx.db.insert("players", {
+              name: `H${history} Player ${player}`,
+              leagueId,
+              teamId,
+              position: "ATH",
+              positionGroup: null,
+              jerseyNumber: player + 1,
+              dateOfBirth: null,
+              status: "active",
+              headshotUrl: null,
+            }),
+          );
+        }
+        const expected = new Map<string, Record<string, Record<string, number>>>(
+          playerIds.map((id) => [id as string, {}]),
+        );
+        const seasonIds: Id<"seasons">[] = [];
+        const seasonCount = 2 + randomInt(4);
+        for (let season = 0; season < seasonCount; season++) {
+          const seasonId = await ctx.db.insert("seasons", {
+            name: `${2030 + season}`,
+            leagueId,
+            startDate: null,
+            endDate: null,
+            status: "completed",
+            rosterLocked: false,
+          });
+          seasonIds.push(seasonId);
+          for (const playerId of playerIds) {
+            const totals = {
+              passing: {
+                yards: randomInt(3000),
+                td: randomInt(40),
+              },
+              rushing: {
+                yards: randomInt(1200),
+                long: randomInt(90),
+              },
+              defense: {
+                sacks: randomInt(15),
+                int: randomInt(8),
+              },
+            };
+            const playerExpected = expected.get(playerId as string)!;
+            for (const [group, fields] of Object.entries(totals)) {
+              const target = (playerExpected[group] =
+                playerExpected[group] ?? {});
+              for (const [key, value] of Object.entries(fields)) {
+                target[key] = (target[key] ?? 0) + value;
+              }
+            }
+            await ctx.db.insert("playerSeasonAggregates", {
+              leagueId,
+              seasonId,
+              teamId,
+              playerId,
+              position: "ATH",
+              positionGroup: null,
+              gamesPlayed: 10,
+              totalsJson: JSON.stringify(totals),
+              updatedAt: new Date(0).toISOString(),
+            });
+          }
+        }
+        return {
+          leagueId,
+          playerIds,
+          seasonIds,
+          expected: Object.fromEntries(expected),
+        };
+      });
+
+      for (const seasonId of seeded.seasonIds) {
+        await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+      }
+      await t.run(async (ctx) => {
+        const rows = await ctx.db
+          .query("playerCareerTotals")
+          .withIndex("by_leagueId", (q) =>
+            q.eq("leagueId", seeded.leagueId),
+          )
+          .collect();
+        expect(rows).toHaveLength(seeded.playerIds.length);
+        for (const row of rows) {
+          expect(JSON.parse(row.totalsJson)).toEqual(
+            seeded.expected[row.playerId as string],
+          );
+        }
+      });
+    }
+  });
+});

--- a/apps/web/convex/__tests__/schemaComposition.test.ts
+++ b/apps/web/convex/__tests__/schemaComposition.test.ts
@@ -9,6 +9,7 @@ import { mediaTables } from "../tables/media";
 import { offseasonTables } from "../tables/offseason";
 import { dynastyTables } from "../tables/dynasty";
 import { programTables } from "../tables/program";
+import { historyTables } from "../tables/history";
 
 /*
  * Schema composition guard (Dynasty Mode F1).
@@ -31,6 +32,7 @@ const groups = {
   offseason: offseasonTables,
   dynasty: dynastyTables,
   program: programTables,
+  history: historyTables,
 } as const;
 
 type Exportable = { export(): string };

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -228,6 +228,9 @@ void api.dynasty.moduleStatus;
 void api.sim.moduleStatus;
 void api.program.moduleStatus;
 void api.history.moduleStatus;
+void api.history.getCareerTotals;
+void api.history.listProgramRecords;
+void internal.history.finalizeSeasonHistory;
 
 type AllowedPublicDynastyReads =
   | "moduleStatus"
@@ -277,7 +280,10 @@ type AllowedPublicProgramReads =
   | "listCoachesByLeague"
   | "listCoachSeasons"
   | "getSeasonGoalProgress";
-type AllowedPublicHistoryReads = "moduleStatus";
+type AllowedPublicHistoryReads =
+  | "moduleStatus"
+  | "getCareerTotals"
+  | "listProgramRecords";
 
 type LeakedPublicDynastyWrites = Exclude<
   keyof typeof api.dynasty,
@@ -320,12 +326,15 @@ void _noLeakedPublicHistoryWrites;
 void internal.e2eSeed.createRosterFixture;
 void internal.e2eSeed.resetRosterFixture;
 void internal.e2eSeed.createScheduleFixture;
+void internal.e2eSeed.seedHistoryFixture;
 // @ts-expect-error createRosterFixture is internal, not public
 void api.e2eSeed.createRosterFixture;
 // @ts-expect-error resetRosterFixture is internal, not public
 void api.e2eSeed.resetRosterFixture;
 // @ts-expect-error createScheduleFixture is internal, not public
 void api.e2eSeed.createScheduleFixture;
+// @ts-expect-error seedHistoryFixture is internal, not public
+void api.e2eSeed.seedHistoryFixture;
 
 // --- Data migrations MUST be internal too (WSM-000079) ---
 // Backfills/migrations write rows; they're run manually with an admin/deploy

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -211,6 +211,26 @@ async function cascadeDeleteLeague(
     await ctx.db.delete(row._id);
     deleted += 1;
   }
+  // Cross-season history (D1). Both tables are League-owned, so one indexed
+  // pass clears every career and both the League/Team record-book scopes.
+  const careerTotals = (await ctx.db
+    .query("playerCareerTotals")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"playerCareerTotals"> }>;
+  for (const row of careerTotals) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
+  const programRecords = (await ctx.db
+    .query("programRecords")
+    .withIndex("by_leagueId_category_rank", (q: any) =>
+      q.eq("leagueId", leagueId),
+    )
+    .collect()) as Array<{ _id: Id<"programRecords"> }>;
+  for (const row of programRecords) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
   // Per-league Dynasty settings (F5). A row left behind would carry one spec's
   // toggles into the next run.
   const configRows = (await ctx.db
@@ -564,6 +584,88 @@ export const createScheduleFixture = internalMutation({
       homeTeamName,
       awayTeamName,
     };
+  },
+});
+
+/**
+ * D1 route fixture: seed a league-wide row plus one Team-scoped row for BOTH
+ * schedule-fixture teams. The route spec can therefore prove the view switcher
+ * renders each program without completing/simulating a season.
+ */
+export const seedHistoryFixture = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+  },
+  returns: v.object({ created: v.number() }),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const [season, homeTeam, awayTeam] = await Promise.all([
+      ctx.db.get(args.seasonId),
+      ctx.db.get(args.homeTeamId),
+      ctx.db.get(args.awayTeamId),
+    ]);
+    if (
+      !season ||
+      season.leagueId !== args.leagueId ||
+      !homeTeam ||
+      homeTeam.leagueId !== args.leagueId ||
+      !awayTeam ||
+      awayTeam.leagueId !== args.leagueId
+    ) {
+      throw new Error("history_fixture_scope_mismatch");
+    }
+
+    const prior = await ctx.db
+      .query("programRecords")
+      .withIndex("by_leagueId_category_rank", (q) =>
+        q.eq("leagueId", args.leagueId),
+      )
+      .collect();
+    for (const row of prior) await ctx.db.delete(row._id);
+
+    const now = new Date().toISOString();
+    const teams = [
+      { teamId: args.homeTeamId, value: 9, leagueRank: 1 },
+      { teamId: args.awayTeamId, value: 8, leagueRank: 2 },
+    ];
+    let created = 0;
+    for (const team of teams) {
+      const stableKey = [
+        "season",
+        "teamWins",
+        args.seasonId,
+        team.teamId,
+        "team",
+      ].join(":");
+      await ctx.db.insert("programRecords", {
+        leagueId: args.leagueId,
+        category: "teamWins",
+        span: "season",
+        rank: team.leagueRank,
+        value: team.value,
+        holderTeamId: team.teamId,
+        seasonId: args.seasonId,
+        stableKey,
+        updatedAt: now,
+      });
+      await ctx.db.insert("programRecords", {
+        leagueId: args.leagueId,
+        teamId: team.teamId,
+        category: "teamWins",
+        span: "season",
+        rank: 1,
+        value: team.value,
+        holderTeamId: team.teamId,
+        seasonId: args.seasonId,
+        stableKey,
+        updatedAt: now,
+      });
+      created += 2;
+    }
+    return { created };
   },
 });
 

--- a/apps/web/convex/history.ts
+++ b/apps/web/convex/history.ts
@@ -1,5 +1,13 @@
-import { query } from "./_generated/server";
+import { v, type Infer } from "convex/values";
+import { internalMutation, query } from "./_generated/server";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
+import {
+  RECORD_CATEGORY_LABELS,
+} from "./lib/records";
+import {
+  finalizeSeasonHistoryForSeason,
+  type FinalizeSeasonHistoryResult,
+} from "./lib/historyFinalize";
 
 /*
  * Dynasty Mode — history, awards and narrative (Epic D).
@@ -34,4 +42,129 @@ export const moduleStatus = query({
     epic: "D",
     ready: true,
   }),
+});
+
+const finalizeSeasonHistoryResultValidator = v.object({
+  careerTotalsUpdated: v.number(),
+  recordsUpdated: v.number(),
+  recordsBroken: v.number(),
+});
+
+export const finalizeSeasonHistory = internalMutation({
+  args: { seasonId: v.id("seasons") },
+  returns: finalizeSeasonHistoryResultValidator,
+  handler: async (ctx, args): Promise<FinalizeSeasonHistoryResult> =>
+    finalizeSeasonHistoryForSeason(ctx, args.seasonId),
+});
+
+const careerTotalsDtoValidator = v.object({
+  playerId: v.string(),
+  totalsJson: v.string(),
+  updatedAt: v.string(),
+});
+type CareerTotalsDto = Infer<typeof careerTotalsDtoValidator>;
+
+export const getCareerTotals = query({
+  args: { playerId: v.id("players") },
+  returns: v.union(careerTotalsDtoValidator, v.null()),
+  handler: async (ctx, args): Promise<CareerTotalsDto | null> => {
+    const row = await ctx.db
+      .query("playerCareerTotals")
+      .withIndex("by_playerId", (q) => q.eq("playerId", args.playerId))
+      .unique();
+    return row
+      ? {
+          playerId: row.playerId,
+          totalsJson: row.totalsJson,
+          updatedAt: row.updatedAt,
+        }
+      : null;
+  },
+});
+
+const programRecordDtoValidator = v.object({
+  id: v.string(),
+  category: v.string(),
+  categoryLabel: v.string(),
+  rank: v.number(),
+  value: v.number(),
+  playerId: v.union(v.string(), v.null()),
+  playerName: v.union(v.string(), v.null()),
+  teamId: v.string(),
+  teamName: v.string(),
+  seasonId: v.string(),
+  seasonName: v.string(),
+});
+type ProgramRecordDto = Infer<typeof programRecordDtoValidator>;
+
+export const listProgramRecords = query({
+  args: {
+    leagueId: v.id("leagues"),
+    teamId: v.optional(v.id("teams")),
+  },
+  returns: v.array(programRecordDtoValidator),
+  handler: async (ctx, args): Promise<ProgramRecordDto[]> => {
+    const rows = args.teamId
+      ? (
+          await ctx.db
+            .query("programRecords")
+            .withIndex("by_teamId_category_rank", (q) =>
+              q.eq("teamId", args.teamId),
+            )
+            .collect()
+        ).filter((row) => row.leagueId === args.leagueId)
+      : (
+          await ctx.db
+            .query("programRecords")
+            .withIndex("by_leagueId_category_rank", (q) =>
+              q.eq("leagueId", args.leagueId),
+            )
+            .collect()
+        ).filter((row) => row.teamId === undefined);
+    if (rows.length === 0) return [];
+
+    const [players, teams, seasons] = await Promise.all([
+      ctx.db
+        .query("players")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+      ctx.db
+        .query("teams")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+      ctx.db
+        .query("seasons")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+    ]);
+    const playerNames = new Map(
+      players.map((player) => [player._id as string, player.name]),
+    );
+    const teamNames = new Map(
+      teams.map((team) => [team._id as string, team.name]),
+    );
+    const seasonNames = new Map(
+      seasons.map((season) => [season._id as string, season.name]),
+    );
+
+    return rows.map((row): ProgramRecordDto => ({
+      id: row._id,
+      category: row.category,
+      categoryLabel:
+        RECORD_CATEGORY_LABELS[
+          row.category as keyof typeof RECORD_CATEGORY_LABELS
+        ] ?? row.category,
+      rank: row.rank,
+      value: row.value,
+      playerId: row.playerId ?? null,
+      playerName: row.playerId
+        ? (playerNames.get(row.playerId as string) ?? null)
+        : null,
+      teamId: row.holderTeamId,
+      teamName:
+        teamNames.get(row.holderTeamId as string) ?? "Unknown program",
+      seasonId: row.seasonId,
+      seasonName: seasonNames.get(row.seasonId as string) ?? "Unknown season",
+    }));
+  },
 });

--- a/apps/web/convex/lib/__tests__/records.test.ts
+++ b/apps/web/convex/lib/__tests__/records.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeTopN,
+  recordCandidatesFromSeason,
+  type RecordCandidate,
+} from "../records";
+
+function candidate(
+  category: string,
+  value: number,
+  key: string,
+  overrides: Partial<RecordCandidate> = {},
+): RecordCandidate {
+  return {
+    category,
+    span: "season",
+    value,
+    seasonId: "season-1",
+    teamId: "team-1",
+    playerId: `player-${key}`,
+    stableKey: key,
+    ...overrides,
+  };
+}
+
+describe("recordCandidatesFromSeason", () => {
+  it("builds player and team candidates from F3/F2 rows", () => {
+    const result = recordCandidatesFromSeason(
+      [
+        {
+          seasonId: "s1",
+          teamId: "t1",
+          playerId: "p1",
+          totalsJson: JSON.stringify({
+            passing: { yards: 2200, td: 24 },
+            defense: { tacklesSolo: 3, tacklesAst: 2 },
+          }),
+        },
+      ],
+      [
+        {
+          seasonId: "s1",
+          teamId: "t1",
+          wins: 9,
+          pointsFor: 310,
+          pointsAgainst: 210,
+        },
+      ],
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: "passYards", value: 2200 }),
+        expect.objectContaining({ category: "passTD", value: 24 }),
+        expect.objectContaining({ category: "tackles", value: 5 }),
+        expect.objectContaining({ category: "teamWins", value: 9 }),
+        expect.objectContaining({ category: "teamPointsFor", value: 310 }),
+        expect.objectContaining({
+          category: "teamPointDifferential",
+          value: 100,
+        }),
+      ]),
+    );
+  });
+});
+
+describe("mergeTopN", () => {
+  it("caps every category at ten with contiguous unique ranks and descending values", () => {
+    const candidates = [
+      ...Array.from({ length: 18 }, (_, index) =>
+        candidate("passYards", 100 - (index % 4), `pass-${index}`, {
+          seasonId: `season-${index % 3}`,
+          teamId: `team-${index % 5}`,
+        }),
+      ),
+      ...Array.from({ length: 14 }, (_, index) =>
+        candidate("rushYards", 50 - (index % 3), `rush-${index}`, {
+          seasonId: `season-${index % 4}`,
+          teamId: `team-${index % 2}`,
+        }),
+      ),
+    ];
+
+    const { entries } = mergeTopN([], candidates, 10);
+    for (const category of ["passYards", "rushYards"]) {
+      const rows = entries.filter((entry) => entry.category === category);
+      expect(rows.length).toBeLessThanOrEqual(10);
+      expect(rows.map((entry) => entry.rank)).toEqual(
+        Array.from({ length: rows.length }, (_, index) => index + 1),
+      );
+      expect(new Set(rows.map((entry) => entry.rank)).size).toBe(rows.length);
+      for (let index = 1; index < rows.length; index++) {
+        expect(rows[index - 1]!.value).toBeGreaterThanOrEqual(
+          rows[index]!.value,
+        );
+      }
+    }
+  });
+
+  it("uses a deterministic terminal key for ties and reports no break on retry", () => {
+    const tied = [
+      candidate("passYards", 100, "z", { playerId: "same" }),
+      candidate("passYards", 100, "a", { playerId: "same" }),
+      candidate("passYards", 100, "m", { playerId: "same" }),
+    ];
+    const first = mergeTopN([], tied, 10);
+    expect(first.entries.map((entry) => entry.stableKey)).toEqual([
+      "a",
+      "m",
+      "z",
+    ]);
+    expect(first.broken).toHaveLength(3);
+
+    const retried = mergeTopN(first.entries, tied, 10);
+    expect(retried.entries).toEqual(first.entries);
+    expect(retried.broken).toEqual([]);
+  });
+});

--- a/apps/web/convex/lib/careerTotals.ts
+++ b/apps/web/convex/lib/careerTotals.ts
@@ -1,0 +1,85 @@
+type StatGroup = Record<string, number>;
+export type CareerStatLine = Record<string, StatGroup>;
+export type CareerSeasonTotals = Record<string, CareerStatLine>;
+
+function canonicalStatLine(line: CareerStatLine): CareerStatLine {
+  return Object.fromEntries(
+    Object.keys(line)
+      .sort()
+      .map((group) => [
+        group,
+        Object.fromEntries(
+          Object.entries(line[group] ?? {})
+            .filter((entry): entry is [string, number] => {
+              const value = entry[1];
+              return typeof value === "number" && Number.isFinite(value);
+            })
+            .sort(([a], [b]) => a.localeCompare(b)),
+        ),
+      ]),
+  );
+}
+
+export function parseCareerStatLine(json: string): CareerStatLine {
+  try {
+    const value = JSON.parse(json);
+    return value && typeof value === "object"
+      ? canonicalStatLine(value as CareerStatLine)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function parseCareerSeasonTotals(json: string): CareerSeasonTotals {
+  try {
+    const value = JSON.parse(json);
+    if (!value || typeof value !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(value as Record<string, CareerStatLine>).map(
+        ([seasonId, totals]) => [seasonId, canonicalStatLine(totals)],
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Career totals are literal sums of season totals for every numeric key.
+ *
+ * This deliberately differs from per-game → season aggregation, where a
+ * `long` field uses MAX. D1's contract is that every persisted season value is
+ * folded into the career value exactly once.
+ */
+export function sumCareerSeasonTotals(
+  seasons: CareerSeasonTotals,
+): CareerStatLine {
+  const total: CareerStatLine = {};
+  for (const seasonId of Object.keys(seasons).sort()) {
+    const line = seasons[seasonId] ?? {};
+    for (const [group, fields] of Object.entries(line)) {
+      const target = (total[group] = total[group] ?? {});
+      for (const [field, value] of Object.entries(fields)) {
+        if (typeof value !== "number" || !Number.isFinite(value)) continue;
+        target[field] = (target[field] ?? 0) + value;
+      }
+    }
+  }
+  return canonicalStatLine(total);
+}
+
+export function serializeCareerSeasonTotals(
+  seasons: CareerSeasonTotals,
+): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.keys(seasons)
+        .sort()
+        .map((seasonId) => [
+          seasonId,
+          canonicalStatLine(seasons[seasonId] ?? {}),
+        ]),
+    ),
+  );
+}

--- a/apps/web/convex/lib/historyFinalize.ts
+++ b/apps/web/convex/lib/historyFinalize.ts
@@ -1,0 +1,257 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import {
+  parseCareerSeasonTotals,
+  parseCareerStatLine,
+  serializeCareerSeasonTotals,
+  sumCareerSeasonTotals,
+} from "./careerTotals";
+import {
+  mergeTopN,
+  recordCandidatesFromSeason,
+  type ProgramRecordEntry,
+  type RecordCandidate,
+} from "./records";
+
+export interface FinalizeSeasonHistoryResult {
+  careerTotalsUpdated: number;
+  recordsUpdated: number;
+  recordsBroken: number;
+}
+
+function recordEntryFromRow(
+  row: Doc<"programRecords">,
+): ProgramRecordEntry {
+  return {
+    category: row.category,
+    span: "season",
+    rank: row.rank,
+    value: row.value,
+    seasonId: row.seasonId,
+    teamId: row.holderTeamId,
+    playerId: row.playerId ?? null,
+    stableKey: row.stableKey,
+  };
+}
+
+function sameRecord(
+  row: Doc<"programRecords">,
+  entry: ProgramRecordEntry,
+): boolean {
+  return (
+    row.category === entry.category &&
+    row.span === entry.span &&
+    row.rank === entry.rank &&
+    row.value === entry.value &&
+    (row.playerId ?? null) === entry.playerId &&
+    row.holderTeamId === entry.teamId &&
+    row.seasonId === entry.seasonId &&
+    row.stableKey === entry.stableKey
+  );
+}
+
+async function persistRecordScope(
+  ctx: MutationCtx,
+  leagueId: Id<"leagues">,
+  scopeTeamId: Id<"teams"> | undefined,
+  existingRows: Doc<"programRecords">[],
+  candidates: RecordCandidate[],
+  now: string,
+): Promise<{ updated: number; broken: number }> {
+  const { entries, broken } = mergeTopN(
+    existingRows.map(recordEntryFromRow),
+    candidates,
+    10,
+  );
+  const existingByKey = new Map(
+    existingRows.map((row) => [row.stableKey, row]),
+  );
+  const retainedKeys = new Set(entries.map((entry) => entry.stableKey));
+  let updated = 0;
+
+  for (const row of existingRows) {
+    if (!retainedKeys.has(row.stableKey)) {
+      await ctx.db.delete(row._id);
+      updated += 1;
+    }
+  }
+
+  for (const entry of entries) {
+    const existing = existingByKey.get(entry.stableKey);
+    if (existing) {
+      if (!sameRecord(existing, entry)) {
+        await ctx.db.patch(existing._id, {
+          category: entry.category,
+          span: entry.span,
+          rank: entry.rank,
+          value: entry.value,
+          playerId:
+            entry.playerId === null
+              ? undefined
+              : (entry.playerId as Id<"players">),
+          holderTeamId: entry.teamId as Id<"teams">,
+          seasonId: entry.seasonId as Id<"seasons">,
+          updatedAt: now,
+        });
+        updated += 1;
+      }
+      continue;
+    }
+
+    await ctx.db.insert("programRecords", {
+      leagueId,
+      ...(scopeTeamId ? { teamId: scopeTeamId } : {}),
+      category: entry.category,
+      span: entry.span,
+      rank: entry.rank,
+      value: entry.value,
+      ...(entry.playerId === null
+        ? {}
+        : { playerId: entry.playerId as Id<"players"> }),
+      holderTeamId: entry.teamId as Id<"teams">,
+      seasonId: entry.seasonId as Id<"seasons">,
+      stableKey: entry.stableKey,
+      updatedAt: now,
+    });
+    updated += 1;
+  }
+
+  return { updated, broken: broken.length };
+}
+
+/**
+ * Materialize one completed season's F2/F3 caches into cross-season history.
+ *
+ * Source reads are exactly one indexed batch of player aggregates and one
+ * indexed batch of team records. Existing materialized rows are loaded once
+ * per League; there is no player-by-player `get` or source-table scan.
+ */
+export async function finalizeSeasonHistoryForSeason(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+): Promise<FinalizeSeasonHistoryResult> {
+  const aggregates = await ctx.db
+    .query("playerSeasonAggregates")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+  const teamRecords = await ctx.db
+    .query("seasonTeamRecords")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+    .collect();
+
+  const leagueIds = new Set<string>([
+    ...aggregates.map((row) => row.leagueId as string),
+    ...teamRecords.map((row) => row.leagueId as string),
+  ]);
+  if (leagueIds.size === 0) {
+    return {
+      careerTotalsUpdated: 0,
+      recordsUpdated: 0,
+      recordsBroken: 0,
+    };
+  }
+  if (leagueIds.size !== 1) throw new Error("history_league_mismatch");
+  const leagueId = [...leagueIds][0] as Id<"leagues">;
+
+  const careerRows = await ctx.db
+    .query("playerCareerTotals")
+    .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+    .collect();
+  const existingRecordRows = await ctx.db
+    .query("programRecords")
+    .withIndex("by_leagueId_category_rank", (q) =>
+      q.eq("leagueId", leagueId),
+    )
+    .collect();
+
+  const careerByPlayerId = new Map(
+    careerRows.map((row) => [row.playerId as string, row]),
+  );
+  const now = new Date().toISOString();
+  let careerTotalsUpdated = 0;
+
+  for (const aggregate of aggregates) {
+    const existing = careerByPlayerId.get(aggregate.playerId as string);
+    const seasons = existing
+      ? parseCareerSeasonTotals(existing.seasonTotalsJson)
+      : {};
+    seasons[seasonId as string] = parseCareerStatLine(aggregate.totalsJson);
+    const seasonTotalsJson = serializeCareerSeasonTotals(seasons);
+    const totalsJson = JSON.stringify(sumCareerSeasonTotals(seasons));
+
+    if (existing) {
+      if (
+        existing.seasonTotalsJson !== seasonTotalsJson ||
+        existing.totalsJson !== totalsJson
+      ) {
+        await ctx.db.patch(existing._id, {
+          seasonTotalsJson,
+          totalsJson,
+          updatedAt: now,
+        });
+        careerTotalsUpdated += 1;
+      }
+    } else {
+      const id = await ctx.db.insert("playerCareerTotals", {
+        leagueId,
+        playerId: aggregate.playerId,
+        totalsJson,
+        seasonTotalsJson,
+        updatedAt: now,
+      });
+      careerByPlayerId.set(aggregate.playerId as string, {
+        _id: id,
+        _creationTime: 0,
+        leagueId,
+        playerId: aggregate.playerId,
+        totalsJson,
+        seasonTotalsJson,
+        updatedAt: now,
+      });
+      careerTotalsUpdated += 1;
+    }
+  }
+
+  const candidates = recordCandidatesFromSeason(aggregates, teamRecords);
+  const leagueRows = existingRecordRows.filter(
+    (row) => row.teamId === undefined,
+  );
+  const leagueResult = await persistRecordScope(
+    ctx,
+    leagueId,
+    undefined,
+    leagueRows,
+    candidates,
+    now,
+  );
+  let recordsUpdated = leagueResult.updated;
+  let recordsBroken = leagueResult.broken;
+
+  const rowsByTeam = new Map<string, Doc<"programRecords">[]>();
+  for (const row of existingRecordRows) {
+    if (!row.teamId) continue;
+    const rows = rowsByTeam.get(row.teamId as string) ?? [];
+    rows.push(row);
+    rowsByTeam.set(row.teamId as string, rows);
+  }
+  const candidatesByTeam = new Map<string, RecordCandidate[]>();
+  for (const candidate of candidates) {
+    const rows = candidatesByTeam.get(candidate.teamId) ?? [];
+    rows.push(candidate);
+    candidatesByTeam.set(candidate.teamId, rows);
+  }
+  for (const [teamId, teamCandidates] of candidatesByTeam) {
+    const result = await persistRecordScope(
+      ctx,
+      leagueId,
+      teamId as Id<"teams">,
+      rowsByTeam.get(teamId) ?? [],
+      teamCandidates,
+      now,
+    );
+    recordsUpdated += result.updated;
+    recordsBroken += result.broken;
+  }
+
+  return { careerTotalsUpdated, recordsUpdated, recordsBroken };
+}

--- a/apps/web/convex/lib/records.ts
+++ b/apps/web/convex/lib/records.ts
@@ -1,0 +1,188 @@
+import { categoryValues } from "./statLeaders";
+import { parseCareerStatLine } from "./careerTotals";
+
+export const RECORD_CATEGORY_LABELS = {
+  passYards: "Passing yards",
+  passTD: "Passing touchdowns",
+  rushYards: "Rushing yards",
+  rushTD: "Rushing touchdowns",
+  recYards: "Receiving yards",
+  receptions: "Receptions",
+  tackles: "Tackles",
+  sacks: "Sacks",
+  interceptions: "Interceptions",
+  teamWins: "Team wins",
+  teamPointsFor: "Team points scored",
+  teamPointDifferential: "Team point differential",
+} as const;
+
+export interface SeasonAggregateForRecords {
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  totalsJson: string;
+}
+
+export interface SeasonTeamRecordForRecords {
+  seasonId: string;
+  teamId: string;
+  wins: number;
+  pointsFor: number;
+  pointsAgainst: number;
+}
+
+export interface RecordCandidate {
+  category: string;
+  span: "season";
+  value: number;
+  seasonId: string;
+  teamId: string;
+  playerId: string | null;
+  stableKey: string;
+}
+
+export interface ProgramRecordEntry extends RecordCandidate {
+  rank: number;
+}
+
+function playerCandidate(
+  aggregate: SeasonAggregateForRecords,
+  category: string,
+  value: number,
+): RecordCandidate {
+  return {
+    category,
+    span: "season",
+    value,
+    seasonId: aggregate.seasonId,
+    teamId: aggregate.teamId,
+    playerId: aggregate.playerId,
+    stableKey: [
+      "season",
+      category,
+      aggregate.seasonId,
+      aggregate.teamId,
+      aggregate.playerId,
+    ].join(":"),
+  };
+}
+
+function teamCandidate(
+  record: SeasonTeamRecordForRecords,
+  category: string,
+  value: number,
+): RecordCandidate {
+  return {
+    category,
+    span: "season",
+    value,
+    seasonId: record.seasonId,
+    teamId: record.teamId,
+    playerId: null,
+    stableKey: ["season", category, record.seasonId, record.teamId, "team"].join(
+      ":",
+    ),
+  };
+}
+
+/**
+ * Flatten one completed season's F2/F3 caches into record-book candidates.
+ * Zero/negative rows are omitted: they cannot be a positive achievement and
+ * would otherwise fill an empty book with tied zeroes.
+ */
+export function recordCandidatesFromSeason(
+  aggregates: readonly SeasonAggregateForRecords[],
+  teamRecords: readonly SeasonTeamRecordForRecords[],
+): RecordCandidate[] {
+  const candidates: RecordCandidate[] = [];
+
+  for (const aggregate of aggregates) {
+    const values = categoryValues(parseCareerStatLine(aggregate.totalsJson));
+    for (const category of Object.keys(RECORD_CATEGORY_LABELS)) {
+      if (category.startsWith("team")) continue;
+      const value = values[category] ?? 0;
+      if (Number.isFinite(value) && value > 0) {
+        candidates.push(playerCandidate(aggregate, category, value));
+      }
+    }
+  }
+
+  for (const record of teamRecords) {
+    const values = {
+      teamWins: record.wins,
+      teamPointsFor: record.pointsFor,
+      teamPointDifferential: record.pointsFor - record.pointsAgainst,
+    };
+    for (const [category, value] of Object.entries(values)) {
+      if (Number.isFinite(value) && value > 0) {
+        candidates.push(teamCandidate(record, category, value));
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function compareRecordEntries(
+  a: RecordCandidate,
+  b: RecordCandidate,
+): number {
+  if (a.value !== b.value) return b.value - a.value;
+  const season = a.seasonId.localeCompare(b.seasonId);
+  if (season !== 0) return season;
+  const team = a.teamId.localeCompare(b.teamId);
+  if (team !== 0) return team;
+  const player = (a.playerId ?? "").localeCompare(b.playerId ?? "");
+  if (player !== 0) return player;
+  // Final deterministic key: distinct entries can never compare as an
+  // accidental tie, so Array.sort cannot inherit database iteration order.
+  return a.stableKey.localeCompare(b.stableKey);
+}
+
+/**
+ * Merge record candidates into a deterministic top-N per category.
+ *
+ * Candidate stable keys overwrite the same prior entry, so retrying a season
+ * replaces its contribution rather than duplicating it. `broken` contains only
+ * candidates that newly enter/improve the retained book; an unchanged retry
+ * therefore returns an empty array.
+ */
+export function mergeTopN(
+  existing: readonly ProgramRecordEntry[],
+  candidates: readonly RecordCandidate[],
+  limit = 10,
+): { entries: ProgramRecordEntry[]; broken: ProgramRecordEntry[] } {
+  const safeLimit = Math.max(0, Math.floor(limit));
+  const previousByKey = new Map(existing.map((entry) => [entry.stableKey, entry]));
+  const mergedByKey = new Map<string, RecordCandidate>();
+  for (const entry of existing) mergedByKey.set(entry.stableKey, entry);
+  for (const candidate of candidates) {
+    mergedByKey.set(candidate.stableKey, candidate);
+  }
+
+  const categories = new Map<string, RecordCandidate[]>();
+  for (const entry of mergedByKey.values()) {
+    const category = categories.get(entry.category) ?? [];
+    category.push(entry);
+    categories.set(entry.category, category);
+  }
+
+  const entries: ProgramRecordEntry[] = [];
+  for (const category of [...categories.keys()].sort()) {
+    const ranked = [...(categories.get(category) ?? [])]
+      .sort(compareRecordEntries)
+      .slice(0, safeLimit)
+      .map((entry, index) => ({ ...entry, rank: index + 1 }));
+    entries.push(...ranked);
+  }
+
+  const candidateKeys = new Set(candidates.map((entry) => entry.stableKey));
+  const broken = entries.filter((entry) => {
+    if (!candidateKeys.has(entry.stableKey)) return false;
+    const previous = previousByKey.get(entry.stableKey);
+    if (!previous) return true;
+    return entry.value > previous.value || entry.rank < previous.rank;
+  });
+
+  return { entries, broken };
+}

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -8,6 +8,7 @@ import { mediaTables } from "./tables/media";
 import { offseasonTables } from "./tables/offseason";
 import { dynastyTables } from "./tables/dynasty";
 import { programTables } from "./tables/program";
+import { historyTables } from "./tables/history";
 
 /*
  * The schema is composed from grouped table modules under `convex/tables/`
@@ -34,4 +35,5 @@ export default defineSchema({
   ...offseasonTables,
   ...dynastyTables,
   ...programTables,
+  ...historyTables,
 });

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -58,6 +58,7 @@ import {
   selectNewestSeason,
 } from "./lib/seasonLifecycle";
 import { finalizeProgramSeason } from "./lib/programFinalize";
+import { finalizeSeasonHistoryForSeason } from "./lib/historyFinalize";
 
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
@@ -2196,7 +2197,7 @@ export const setActiveSeason = internalMutationGeneric({
 export const completeSeason = internalMutationGeneric({
   args: { seasonId: v.id("seasons"), force: v.optional(v.boolean()) },
   returns: v.null(),
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<null> => {
     const season = await ctx.db.get(args.seasonId);
     if (!season) throw new Error("season_not_found");
     if (season.status === "completed") return null;
@@ -2219,6 +2220,7 @@ export const completeSeason = internalMutationGeneric({
     }
 
     await finalizeProgramSeason(ctx, args.seasonId);
+    await finalizeSeasonHistoryForSeason(ctx, args.seasonId);
 
     await ctx.db.patch(args.seasonId, { status: "completed" });
     return null;

--- a/apps/web/convex/tables/history.ts
+++ b/apps/web/convex/tables/history.ts
@@ -1,0 +1,47 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * Cross-season Dynasty Mode history (Epic D).
+ *
+ * Unlike competition caches, these rows belong to a League rather than a
+ * Season: a career and a record book only become meaningful across seasons.
+ */
+export const historyTables = {
+  playerCareerTotals: defineTable({
+    leagueId: v.id("leagues"),
+    playerId: v.id("players"),
+    /** Sum of every finalized per-season aggregate for this player. */
+    totalsJson: v.string(),
+    /**
+     * JSON `{ [seasonId]: totals }`. Replacing one season's contribution before
+     * re-summing is what makes season finalization retry-safe.
+     */
+    seasonTotalsJson: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_playerId", ["playerId"])
+    .index("by_leagueId", ["leagueId"]),
+
+  programRecords: defineTable({
+    leagueId: v.id("leagues"),
+    /**
+     * Absent for the league-wide book; present for one Team's book. League and
+     * Team rows are intentionally separate because their ranks differ.
+     */
+    teamId: v.optional(v.id("teams")),
+    category: v.string(),
+    span: v.string(),
+    rank: v.number(),
+    value: v.number(),
+    playerId: v.optional(v.id("players")),
+    /** Team whose player/performance produced the entry (also present on league rows). */
+    holderTeamId: v.id("teams"),
+    seasonId: v.id("seasons"),
+    /** Deterministic identity used to de-duplicate a retried finalization. */
+    stableKey: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_leagueId_category_rank", ["leagueId", "category", "rank"])
+    .index("by_teamId_category_rank", ["teamId", "category", "rank"]),
+};

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -107,6 +107,29 @@ export async function withScheduleFixture(
   };
 }
 
+const seedHistoryFixtureRef = makeFunctionReference<
+  "mutation",
+  {
+    leagueId: string;
+    seasonId: string;
+    homeTeamId: string;
+    awayTeamId: string;
+  },
+  { created: number }
+>("e2eSeed:seedHistoryFixture");
+
+export async function seedHistoryFixture(
+  fixture: ScheduleFixtureResult,
+): Promise<{ created: number }> {
+  const client = getSeedClient();
+  return client.mutation(seedHistoryFixtureRef, {
+    leagueId: fixture.leagueId,
+    seasonId: fixture.seasonId,
+    homeTeamId: fixture.homeTeamId,
+    awayTeamId: fixture.awayTeamId,
+  });
+}
+
 const seedProspectClassRef = makeFunctionReference<
   "mutation",
   any,

--- a/apps/web/e2e/tests/history.spec.ts
+++ b/apps/web/e2e/tests/history.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedHistoryFixture,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+/*
+ * Record Book (D1, #630).
+ *
+ * Its own fixture league prevents completed-season history from leaking into
+ * shared canonical specs. Both fixture Teams receive records so the per-Team
+ * view is covered, not just the League tab.
+ */
+test.describe("League record book (D1)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "history-record-book";
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E History Home",
+      awayTeamName: "E2E History Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+    await seedHistoryFixture(fixture);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("renders League and both Team record-book views", async ({ page }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/leagues/${fixture.leagueId}/history`);
+    const book = page.getByTestId("record-book");
+    await expect(book).toBeVisible({ timeout: 30_000 });
+    await expect(
+      book.getByRole("heading", { name: "Record book", exact: true }),
+    ).toBeVisible();
+    await expect(book.getByText("Team wins", { exact: true })).toBeVisible();
+
+    const views = book.getByTestId("record-book-views");
+    await expect(
+      views.getByRole("link", { name: "E2E History Home", exact: true }),
+    ).toBeVisible();
+    const away = views.getByRole("link", {
+      name: "E2E History Away",
+      exact: true,
+    });
+    await expect(away).toBeVisible();
+    await away.click();
+
+    await expect(
+      book.getByText("E2E History Away records", { exact: true }),
+    ).toBeVisible();
+    await expect(book.getByText("8", { exact: true })).toBeVisible();
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/history/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/history/page.tsx
@@ -1,0 +1,182 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import {
+  getLeague,
+  getTeamsByLeague,
+  listProgramRecords,
+  type ProgramRecordDto,
+} from "@/lib/data-api";
+import { resolveOrgContext } from "@/lib/org-context";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import {
+  leagueHomeHref,
+  leagueSubpageHref,
+} from "@/components/workspace/resource-navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function groupByCategory(
+  records: ProgramRecordDto[],
+): Array<{ category: string; label: string; rows: ProgramRecordDto[] }> {
+  const groups = new Map<
+    string,
+    { category: string; label: string; rows: ProgramRecordDto[] }
+  >();
+  for (const record of records) {
+    const group = groups.get(record.category) ?? {
+      category: record.category,
+      label: record.categoryLabel,
+      rows: [],
+    };
+    group.rows.push(record);
+    groups.set(record.category, group);
+  }
+  return [...groups.values()];
+}
+
+export default async function LeagueHistoryPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ team?: string | string[] }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const [{ id }, query] = await Promise.all([params, searchParams]);
+  const orgContext = await resolveOrgContext(userId);
+  const league = await getLeague(id, orgContext).catch(() => null);
+  if (!league) notFound();
+  await syncActiveLeagueForResource(league.id);
+
+  const teams = await getTeamsByLeague(id, orgContext).catch(() => []);
+  const requestedTeamId =
+    typeof query.team === "string" ? query.team : null;
+  const selectedTeam =
+    teams.find((team) => team.id === requestedTeamId) ?? null;
+  const records = await listProgramRecords(
+    id,
+    selectedTeam?.id ?? null,
+    orgContext,
+  ).catch(() => []);
+  const groups = groupByCategory(records);
+  const historyHref = leagueSubpageHref(id, "history", null);
+
+  return (
+    <div className="space-y-4" data-testid="record-book">
+      <ResourceHeader
+        kind="league"
+        title="Record book"
+        homeHref={leagueHomeHref(id)}
+        context={league.name}
+        siblings={[
+          { label: "Overview", href: leagueHomeHref(id) },
+          { label: "Record book", href: historyHref },
+        ]}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {selectedTeam ? `${selectedTeam.name} records` : "League records"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <nav
+            aria-label="Record book views"
+            className="mb-6 flex flex-wrap gap-2"
+            data-testid="record-book-views"
+          >
+            <Button
+              asChild
+              size="sm"
+              variant={selectedTeam ? "outline" : "default"}
+            >
+              <Link href={historyHref}>League records</Link>
+            </Button>
+            {teams.map((team) => (
+              <Button
+                asChild
+                key={team.id}
+                size="sm"
+                variant={selectedTeam?.id === team.id ? "default" : "outline"}
+              >
+                <Link href={`${historyHref}?team=${team.id}`}>{team.name}</Link>
+              </Button>
+            ))}
+          </nav>
+
+          {groups.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No completed-season records yet.
+            </p>
+          ) : (
+            <div className="grid gap-6 xl:grid-cols-2">
+              {groups.map((group) => (
+                <section
+                  key={group.category}
+                  aria-labelledby={`record-category-${group.category}`}
+                  className="overflow-hidden rounded-lg border"
+                >
+                  <h2
+                    id={`record-category-${group.category}`}
+                    className="border-b bg-muted/30 px-4 py-3 font-semibold"
+                  >
+                    {group.label}
+                  </h2>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-14">Rank</TableHead>
+                        <TableHead>Holder</TableHead>
+                        <TableHead>Season</TableHead>
+                        <TableHead className="text-right">Value</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {group.rows.map((record) => (
+                        <TableRow key={record.id}>
+                          <TableCell>{record.rank}</TableCell>
+                          <TableCell>
+                            <div className="font-medium">
+                              {record.playerName ?? record.teamName}
+                            </div>
+                            {record.playerName ? (
+                              <div className="text-xs text-muted-foreground">
+                                {record.teamName}
+                              </div>
+                            ) : null}
+                          </TableCell>
+                          <TableCell>{record.seasonName}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {record.value.toLocaleString()}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </section>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/leagues/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/page.tsx
@@ -34,6 +34,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ResourceHeader } from "@/components/workspace/ResourceHeader";
 import {
   leagueHomeHref,
+  leagueSubpageHref,
   leagueSettingsHref,
   seasonHomeHref,
 } from "@/components/workspace/resource-navigation";
@@ -205,6 +206,13 @@ export default async function LeagueInfoPage({
             {seasons.length} season{seasons.length === 1 ? "" : "s"}
           </>
         }
+        siblings={[
+          { label: "Overview", href: leagueHomeHref(id) },
+          {
+            label: "Record book",
+            href: leagueSubpageHref(id, "history", null),
+          },
+        ]}
         actions={
           <>
             {activeSeason ? (

--- a/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
+++ b/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
@@ -88,6 +88,9 @@ describe("resource-navigation helpers", () => {
     expect(leagueSubpageHref("l1", "schedule", null)).toBe(
       "/dashboard/leagues/l1/schedule",
     );
+    expect(leagueSubpageHref("l1", "history", "s1")).toBe(
+      "/dashboard/leagues/l1/history",
+    );
   });
 
   it("builds team, player, and season subpage hrefs", () => {

--- a/apps/web/src/components/workspace/resource-navigation.ts
+++ b/apps/web/src/components/workspace/resource-navigation.ts
@@ -120,10 +120,19 @@ export function seasonSubpageHref(
  */
 export function leagueSubpageHref(
   leagueId: string,
-  subpage: "schedule" | "standings" | "playoffs" | "stats" | "manage",
+  subpage:
+    | "schedule"
+    | "standings"
+    | "playoffs"
+    | "stats"
+    | "manage"
+    | "history",
   activeSeasonId: string | null,
 ): string {
-  const query = activeSeasonId ? `?season=${activeSeasonId}` : "";
+  const query =
+    subpage !== "history" && activeSeasonId
+      ? `?season=${activeSeasonId}`
+      : "";
   return `/dashboard/leagues/${leagueId}/${subpage}${query}`;
 }
 

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -123,6 +123,10 @@ export const simRef = moduleRefs("sim");
 export const programRef = moduleRefs("program");
 export const historyRef = moduleRefs("history");
 
+const listProgramRecordsRef = historyRef.query<ProgramRecordDto[]>(
+  "listProgramRecords",
+);
+
 /** A single bracket node (WSM-000164). Team/score fields are null until played. */
 export interface PlayoffMatchupDto {
   id: string;
@@ -174,6 +178,20 @@ export interface SeasonStatCategoryLeaders {
   key: string;
   label: string;
   leaders: StatLeaderEntry[];
+}
+
+export interface ProgramRecordDto {
+  id: string;
+  category: string;
+  categoryLabel: string;
+  rank: number;
+  value: number;
+  playerId: string | null;
+  playerName: string | null;
+  teamId: string;
+  teamName: string;
+  seasonId: string;
+  seasonName: string;
 }
 
 const refs = {
@@ -1230,6 +1248,18 @@ export async function getTeamsByLeague(
 ): Promise<TeamDto[]> {
   requireLeagueAccessLocal(leagueId, orgContext);
   return queryConvex(refs.listTeamsByLeague, { leagueId });
+}
+
+export async function listProgramRecords(
+  leagueId: string,
+  teamId: string | null,
+  orgContext: OrgContext,
+): Promise<ProgramRecordDto[]> {
+  requireLeagueAccessLocal(leagueId, orgContext);
+  return queryConvex(listProgramRecordsRef, {
+    leagueId,
+    ...(teamId ? { teamId } : {}),
+  });
 }
 
 export async function getTeam(


### PR DESCRIPTION
Closes #630. First slice of Epic D.

When a season completes each player's totals fold into a career record and the league and team record books update, so a decade-old league has a history worth browsing.

## What landed
- `playerCareerTotals` and `programRecords`, the latter indexed by category and rank for both league and team scopes.
- `finalizeSeasonHistory` runs from `completeSeason` and is idempotent — running it twice leaves totals and records unchanged.
- `mergeTopN` returns the records it broke, which D4's news feed consumes. Entries are keyed by a stable key, so re-finalizing a season replaces rather than duplicates; ranks stay contiguous 1..n with values monotonically non-increasing, and the tiebreak chain terminates in a stable sort.
- `/dashboard/leagues/[id]/history` renders the record book with league and per-team views.
- **Program History** and **Record Book** added to `CONTEXT.md`.

## Why history is League-owned
It spans seasons, so League Home is its correct parent. That does **not** violate ADR 0001, which moves *season-scoped competition* views under Season Home.

## The invariant that matters
Finalization reads only the F2/F3 aggregates — **zero reads of `playerGameStats` or `gamePlayLogs`**, pinned by a read spy. That is the guard against reintroducing the N+1 class Epic F removed, and it is the criterion most likely to rot silently, so it is asserted rather than assumed.

## Verification
- `vitest run` — 231 files, 1855 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean