### PR TITLE
feat: season awards, All-Conference and All-State teams (#631)

### DIFF
--- a/apps/web/convex/__tests__/awards.test.ts
+++ b/apps/web/convex/__tests__/awards.test.ts
@@ -1,0 +1,272 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import {
+  computeSeasonAwards,
+  scoreCoachSeason,
+  scorePlayerSeason,
+  type AwardAggregateInput,
+  type AwardCoachInput,
+  type AwardTeamRecordInput,
+} from "../lib/awards";
+
+const modules = import.meta.glob("../**/*.*s");
+
+const totals = (offense: number, defense: number) =>
+  JSON.stringify({
+    passing: { yards: offense, td: 0, int: 0 },
+    defense: { tacklesSolo: defense, tacklesAst: 0, sacks: 0, int: 0 },
+  });
+
+function pureFixture() {
+  const aggregates: AwardAggregateInput[] = [
+    {
+      seasonId: "s1",
+      teamId: "t1",
+      playerId: "p-zed",
+      playerName: "Zed Player",
+      position: "QB",
+      positionGroup: "QB",
+      gamesPlayed: 10,
+      totalsJson: totals(1000, 0),
+      newcomerEligible: true,
+    },
+    {
+      seasonId: "s1",
+      teamId: "t2",
+      playerId: "p-aaron",
+      playerName: "Aaron Player",
+      position: "QB",
+      positionGroup: "QB",
+      gamesPlayed: 10,
+      totalsJson: totals(1000, 0),
+      newcomerEligible: true,
+    },
+    {
+      seasonId: "s1",
+      teamId: "t2",
+      playerId: "p-defense",
+      playerName: "Defense Player",
+      position: "LB",
+      positionGroup: "LB",
+      gamesPlayed: 10,
+      totalsJson: totals(0, 80),
+      newcomerEligible: false,
+    },
+  ];
+  const teamRecords: AwardTeamRecordInput[] = [
+    {
+      teamId: "t1",
+      divisionId: "d1",
+      wins: 8,
+      losses: 2,
+      ties: 0,
+      pointsFor: 300,
+      pointsAgainst: 200,
+    },
+    {
+      teamId: "t2",
+      divisionId: "d1",
+      wins: 8,
+      losses: 2,
+      ties: 0,
+      pointsFor: 300,
+      pointsAgainst: 200,
+    },
+  ];
+  const coaches: AwardCoachInput[] = [
+    { coachId: "c-zed", coachName: "Zed Coach", teamId: "t1" },
+    { coachId: "c-aaron", coachName: "Aaron Coach", teamId: "t2" },
+  ];
+  return { aggregates, teamRecords, coaches };
+}
+
+async function seedAwardSeason(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Awards League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "North",
+      leagueId,
+    });
+    const teamIds: Id<"teams">[] = [];
+    const playerIds: Id<"players">[] = [];
+    const coachIds: Id<"coaches">[] = [];
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2031",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    for (const [index, name] of ["Zebras", "Antelopes"].entries()) {
+      const teamId = await ctx.db.insert("teams", {
+        name,
+        leagueId,
+        divisionId,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Location",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+      teamIds.push(teamId);
+      const playerName = index === 0 ? "Zed Player" : "Aaron Player";
+      const playerId = await ctx.db.insert("players", {
+        name: playerName,
+        leagueId,
+        teamId,
+        position: "QB",
+        positionGroup: "QB",
+        jerseyNumber: index + 1,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        grade: 9,
+      });
+      playerIds.push(playerId);
+      await ctx.db.insert("playerSeasonAggregates", {
+        leagueId,
+        seasonId,
+        teamId,
+        playerId,
+        playerName,
+        newcomerEligible: true,
+        position: "QB",
+        positionGroup: "QB",
+        gamesPlayed: 10,
+        totalsJson: totals(1000, 0),
+        updatedAt: new Date(0).toISOString(),
+      });
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId,
+        seasonId,
+        teamId,
+        divisionId,
+        wins: 8,
+        losses: 2,
+        ties: 0,
+        pointsFor: 300,
+        pointsAgainst: 200,
+        divisionWins: 4,
+        divisionLosses: 1,
+        divisionTies: 0,
+        headToHeadJson: "{}",
+        streak: 1,
+        lastResults: ["W"],
+        gamesCounted: 10,
+        updatedAt: new Date(0).toISOString(),
+      });
+      coachIds.push(
+        await ctx.db.insert("coaches", {
+          leagueId,
+          teamId,
+          displayName: index === 0 ? "Zed Coach" : "Aaron Coach",
+          role: "head_coach",
+          status: "ai",
+          archetype: "program_builder",
+          prestige: 50,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        }),
+      );
+    }
+    return { seasonId, teamIds, playerIds, coachIds };
+  });
+}
+
+describe("computeSeasonAwards", () => {
+  it("is deterministic under deliberate ties and arbitrary input order", () => {
+    const input = pureFixture();
+    const first = computeSeasonAwards(input);
+    const second = computeSeasonAwards({
+      aggregates: [...input.aggregates].reverse(),
+      teamRecords: [...input.teamRecords].reverse(),
+      coaches: [...input.coaches].reverse(),
+    });
+
+    expect(second).toEqual(first);
+    expect(
+      first.find((award) => award.type === "offensive_player_of_year")
+        ?.recipientName,
+    ).toBe("Aaron Player");
+    expect(
+      first.find((award) => award.type === "coach_of_year")?.recipientName,
+    ).toBe("Aaron Coach");
+  });
+
+  it("persists scoreValues that reproduce exactly from the pure scorers", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedAwardSeason(t);
+    await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+
+    const stored = await t.run((ctx) =>
+      ctx.db
+        .query("awards")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+    );
+    const source = await t.run(async (ctx) => ({
+      aggregates: await ctx.db
+        .query("playerSeasonAggregates")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+      records: await ctx.db
+        .query("seasonTeamRecords")
+        .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+        .collect(),
+    }));
+
+    for (const award of stored) {
+      if (award.playerId) {
+        const aggregate = source.aggregates.find(
+          (row) => row.playerId === award.playerId,
+        )!;
+        const scores = scorePlayerSeason(aggregate);
+        const expected =
+          award.type === "offensive_player_of_year"
+            ? scores.offense
+            : award.type === "defensive_player_of_year"
+              ? scores.defense
+              : scores.overall;
+        expect(award.scoreValue).toBe(expected);
+      } else {
+        const record = source.records.find(
+          (row) => row.teamId === award.teamId,
+        )!;
+        expect(award.scoreValue).toBe(scoreCoachSeason(record));
+      }
+    }
+  });
+
+  it("emits one replay-safe dynasty event per award", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId } = await seedAwardSeason(t);
+    await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+    const first = await t.run(async (ctx) => ({
+      awards: await ctx.db.query("awards").collect(),
+      events: await ctx.db.query("dynastyEvents").collect(),
+    }));
+    await t.mutation(internal.history.finalizeSeasonHistory, { seasonId });
+    const second = await t.run(async (ctx) => ({
+      awards: await ctx.db.query("awards").collect(),
+      events: await ctx.db.query("dynastyEvents").collect(),
+    }));
+
+    expect(first.events).toHaveLength(first.awards.length);
+    expect(second.awards).toHaveLength(first.awards.length);
+    expect(second.events).toHaveLength(first.events.length);
+    expect(new Set(second.events.map((row) => row.dedupeKey)).size).toBe(
+      second.events.length,
+    );
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -230,6 +230,9 @@ void api.program.moduleStatus;
 void api.history.moduleStatus;
 void api.history.getCareerTotals;
 void api.history.listProgramRecords;
+void api.history.listSeasonAwards;
+void api.history.listPlayerAwards;
+void api.history.listCoachAwards;
 void internal.history.finalizeSeasonHistory;
 
 type AllowedPublicDynastyReads =
@@ -283,7 +286,10 @@ type AllowedPublicProgramReads =
 type AllowedPublicHistoryReads =
   | "moduleStatus"
   | "getCareerTotals"
-  | "listProgramRecords";
+  | "listProgramRecords"
+  | "listSeasonAwards"
+  | "listPlayerAwards"
+  | "listCoachAwards";
 
 type LeakedPublicDynastyWrites = Exclude<
   keyof typeof api.dynasty,
@@ -327,6 +333,7 @@ void internal.e2eSeed.createRosterFixture;
 void internal.e2eSeed.resetRosterFixture;
 void internal.e2eSeed.createScheduleFixture;
 void internal.e2eSeed.seedHistoryFixture;
+void internal.e2eSeed.seedAwardsFixture;
 // @ts-expect-error createRosterFixture is internal, not public
 void api.e2eSeed.createRosterFixture;
 // @ts-expect-error resetRosterFixture is internal, not public

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
+import { finalizeSeasonHistoryForSeason } from "./lib/historyFinalize";
 
 /*
  * e2e seed fixtures (WSM-000139, fast-follow to WSM-000096).
@@ -150,6 +151,16 @@ async function cascadeDeleteLeague(
       .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
       .collect()) as Array<{ _id: Id<"playerSeasonAggregates"> }>;
     for (const row of aggregates) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    // Season awards (D2). Clear before players/coaches so no accolade from a
+    // prior Playwright fixture can leak onto the next run's Overview pages.
+    const awards = (await ctx.db
+      .query("awards")
+      .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
+      .collect()) as Array<{ _id: Id<"awards"> }>;
+    for (const row of awards) {
       await ctx.db.delete(row._id);
       deleted += 1;
     }
@@ -666,6 +677,144 @@ export const seedHistoryFixture = internalMutation({
       created += 2;
     }
     return { created };
+  },
+});
+
+/**
+ * D2 route fixture: seed one award candidate and one head coach for BOTH
+ * schedule-fixture teams, then run the real season-history finalizer.
+ */
+export const seedAwardsFixture = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+  },
+  returns: v.object({
+    winnerPlayerId: v.id("players"),
+    awardsCreated: v.number(),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    winnerPlayerId: Id<"players">;
+    awardsCreated: number;
+  }> => {
+    assertSeedEnabled();
+    const [season, homeTeam, awayTeam] = await Promise.all([
+      ctx.db.get(args.seasonId),
+      ctx.db.get(args.homeTeamId),
+      ctx.db.get(args.awayTeamId),
+    ]);
+    if (
+      !season ||
+      season.leagueId !== args.leagueId ||
+      !homeTeam ||
+      homeTeam.leagueId !== args.leagueId ||
+      !awayTeam ||
+      awayTeam.leagueId !== args.leagueId
+    ) {
+      throw new Error("awards_fixture_scope_mismatch");
+    }
+
+    const divisionId = await ctx.db.insert("divisions", {
+      name: "E2E Awards Conference",
+      leagueId: args.leagueId,
+    });
+    await Promise.all([
+      ctx.db.patch(args.homeTeamId, { divisionId }),
+      ctx.db.patch(args.awayTeamId, { divisionId }),
+    ]);
+
+    const now = new Date().toISOString();
+    const candidates = [
+      {
+        teamId: args.homeTeamId,
+        playerName: "Zed Awards",
+        coachName: "Zed Coach",
+      },
+      {
+        teamId: args.awayTeamId,
+        playerName: "Aaron Awards",
+        coachName: "Aaron Coach",
+      },
+    ];
+    let winnerPlayerId: Id<"players"> | null = null;
+
+    for (const [index, candidate] of candidates.entries()) {
+      const playerId = await ctx.db.insert("players", {
+        name: candidate.playerName,
+        leagueId: args.leagueId,
+        teamId: candidate.teamId,
+        position: "QB",
+        positionGroup: "QB",
+        jerseyNumber: index + 10,
+        dateOfBirth: null,
+        status: "active",
+        headshotUrl: null,
+        grade: 9,
+      });
+      if (candidate.playerName === "Aaron Awards") {
+        winnerPlayerId = playerId;
+      }
+      await ctx.db.insert("playerSeasonAggregates", {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        teamId: candidate.teamId,
+        playerId,
+        position: "QB",
+        positionGroup: "QB",
+        playerName: candidate.playerName,
+        newcomerEligible: true,
+        gamesPlayed: 10,
+        totalsJson: JSON.stringify({
+          passing: { yards: 2_000, td: 20, int: 5 },
+        }),
+        updatedAt: now,
+      });
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        teamId: candidate.teamId,
+        divisionId,
+        wins: 8,
+        losses: 2,
+        ties: 0,
+        pointsFor: 300,
+        pointsAgainst: 200,
+        divisionWins: 4,
+        divisionLosses: 1,
+        divisionTies: 0,
+        headToHeadJson: "{}",
+        streak: 1,
+        lastResults: ["W"],
+        gamesCounted: 10,
+        updatedAt: now,
+      });
+      await ctx.db.insert("coaches", {
+        leagueId: args.leagueId,
+        teamId: candidate.teamId,
+        displayName: candidate.coachName,
+        role: "head_coach",
+        status: "ai",
+        archetype: "program_builder",
+        prestige: 50,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await finalizeSeasonHistoryForSeason(ctx, args.seasonId);
+    const awards = await ctx.db
+      .query("awards")
+      .withIndex("by_seasonId", (q: any) =>
+        q.eq("seasonId", args.seasonId),
+      )
+      .collect();
+    if (!winnerPlayerId) throw new Error("awards_fixture_winner_missing");
+    return { winnerPlayerId, awardsCreated: awards.length };
   },
 });
 

--- a/apps/web/convex/history.ts
+++ b/apps/web/convex/history.ts
@@ -1,9 +1,11 @@
 import { v, type Infer } from "convex/values";
-import { internalMutation, query } from "./_generated/server";
+import { internalMutation, query, type QueryCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
 import {
   RECORD_CATEGORY_LABELS,
 } from "./lib/records";
+import { AWARD_LABELS, type AwardType } from "./lib/awards";
 import {
   finalizeSeasonHistoryForSeason,
   type FinalizeSeasonHistoryResult,
@@ -166,5 +168,129 @@ export const listProgramRecords = query({
       seasonId: row.seasonId,
       seasonName: seasonNames.get(row.seasonId as string) ?? "Unknown season",
     }));
+  },
+});
+
+const awardDtoValidator = v.object({
+  id: v.string(),
+  seasonId: v.string(),
+  seasonName: v.string(),
+  type: v.string(),
+  typeLabel: v.string(),
+  tier: v.string(),
+  playerId: v.union(v.string(), v.null()),
+  coachId: v.union(v.string(), v.null()),
+  recipientName: v.string(),
+  teamId: v.string(),
+  teamName: v.string(),
+  divisionId: v.union(v.string(), v.null()),
+  divisionName: v.union(v.string(), v.null()),
+  positionGroup: v.union(v.string(), v.null()),
+  scoreValue: v.number(),
+});
+type AwardDto = Infer<typeof awardDtoValidator>;
+
+async function hydrateAwards(
+  ctx: QueryCtx,
+  rows: Doc<"awards">[],
+): Promise<AwardDto[]> {
+  if (rows.length === 0) return [];
+  const leagueId = rows[0]!.leagueId;
+  const [players, coaches, teams, divisions, seasons] = await Promise.all([
+    ctx.db
+      .query("players")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("coaches")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("divisions")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("seasons")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+  ]);
+  const playerNames = new Map(
+    players.map((row) => [row._id as string, row.name]),
+  );
+  const coachNames = new Map(
+    coaches.map((row) => [row._id as string, row.displayName]),
+  );
+  const teamNames = new Map(
+    teams.map((row) => [row._id as string, row.name]),
+  );
+  const divisionNames = new Map(
+    divisions.map((row) => [row._id as string, row.name]),
+  );
+  const seasonNames = new Map(
+    seasons.map((row) => [row._id as string, row.name]),
+  );
+
+  return rows.map((row): AwardDto => ({
+    id: row._id,
+    seasonId: row.seasonId,
+    seasonName: seasonNames.get(row.seasonId as string) ?? "Unknown season",
+    type: row.type,
+    typeLabel: AWARD_LABELS[row.type as AwardType] ?? row.type,
+    tier: row.tier,
+    playerId: row.playerId,
+    coachId: row.coachId,
+    recipientName: row.playerId
+      ? (playerNames.get(row.playerId as string) ?? "Unknown player")
+      : row.coachId
+        ? (coachNames.get(row.coachId as string) ?? "Unknown coach")
+        : "Unknown recipient",
+    teamId: row.teamId,
+    teamName: teamNames.get(row.teamId as string) ?? "Unknown program",
+    divisionId: row.divisionId,
+    divisionName: row.divisionId
+      ? (divisionNames.get(row.divisionId as string) ?? "Unknown division")
+      : null,
+    positionGroup: row.positionGroup,
+    scoreValue: row.scoreValue,
+  }));
+}
+
+export const listSeasonAwards = query({
+  args: { seasonId: v.id("seasons") },
+  returns: v.array(awardDtoValidator),
+  handler: async (ctx, args): Promise<AwardDto[]> => {
+    const rows = await ctx.db
+      .query("awards")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+      .collect();
+    return hydrateAwards(ctx, rows);
+  },
+});
+
+export const listPlayerAwards = query({
+  args: { playerId: v.id("players") },
+  returns: v.array(awardDtoValidator),
+  handler: async (ctx, args): Promise<AwardDto[]> => {
+    const rows = await ctx.db
+      .query("awards")
+      .withIndex("by_playerId", (q) => q.eq("playerId", args.playerId))
+      .collect();
+    return hydrateAwards(ctx, rows);
+  },
+});
+
+export const listCoachAwards = query({
+  args: { coachId: v.id("coaches") },
+  returns: v.array(awardDtoValidator),
+  handler: async (ctx, args): Promise<AwardDto[]> => {
+    const rows = await ctx.db
+      .query("awards")
+      .withIndex("by_coachId", (q) => q.eq("coachId", args.coachId))
+      .collect();
+    return hydrateAwards(ctx, rows);
   },
 });

--- a/apps/web/convex/lib/awards.ts
+++ b/apps/web/convex/lib/awards.ts
@@ -1,0 +1,429 @@
+/*
+ * Season awards (Dynasty Mode D2).
+ *
+ * PURE RULE MODULE: no Convex imports. The persisted `scoreValue` on every
+ * award is exactly one of the scores produced here, so a season can always
+ * explain why one candidate ranked ahead of another.
+ *
+ * Documented weights (one point unless noted):
+ * - offense: passing yard .04, passing TD 6, interception thrown -2,
+ *   rushing/receiving yard .10, rushing/receiving TD 6, reception .5
+ * - defense: solo/assisted tackle 1, sack 8, interception 10
+ * - special teams: made FG 3, made XP 1, punt yard .04
+ * - Player/Newcomer of the Year: offense + defense + special teams
+ * - Offensive/Defensive Player of the Year: their named component
+ * - Coach of the Year: win 10, tie 5, point differential .1
+ * - All-Conference/All-State: the component matching the position group;
+ *   unknown/OL groups use the all-purpose total (zero is a valid score).
+ *
+ * Tiebreak chain for players and coaches:
+ *   1. score descending
+ *   2. team wins descending
+ *   3. team point differential descending
+ *   4. stable recipient-name sort (case-insensitive name, then exact name and
+ *      immutable id so duplicate names still form a total order)
+ */
+
+import { derivePositionGroup } from "./positions";
+
+export const AWARD_TYPES = {
+  playerOfYear: "player_of_year",
+  offensivePlayerOfYear: "offensive_player_of_year",
+  defensivePlayerOfYear: "defensive_player_of_year",
+  newcomerOfYear: "newcomer_of_year",
+  coachOfYear: "coach_of_year",
+  allConference: "all_conference",
+  allState: "all_state",
+} as const;
+
+export type AwardType = (typeof AWARD_TYPES)[keyof typeof AWARD_TYPES];
+export type AwardTier = "state" | "conference";
+
+export const AWARD_LABELS: Readonly<Record<AwardType, string>> = {
+  player_of_year: "Player of the Year",
+  offensive_player_of_year: "Offensive Player of the Year",
+  defensive_player_of_year: "Defensive Player of the Year",
+  newcomer_of_year: "Newcomer of the Year",
+  coach_of_year: "Coach of the Year",
+  all_conference: "All-Conference",
+  all_state: "All-State",
+};
+
+export const AWARD_WEIGHTS = {
+  offense: {
+    passYards: 0.04,
+    passTouchdowns: 6,
+    interceptionsThrown: -2,
+    rushYards: 0.1,
+    rushTouchdowns: 6,
+    receivingYards: 0.1,
+    receivingTouchdowns: 6,
+    receptions: 0.5,
+  },
+  defense: {
+    tacklesSolo: 1,
+    tacklesAssisted: 1,
+    sacks: 8,
+    interceptions: 10,
+  },
+  specialTeams: {
+    fieldGoalsMade: 3,
+    extraPointsMade: 1,
+    puntYards: 0.04,
+  },
+  coach: {
+    wins: 10,
+    ties: 5,
+    pointDifferential: 0.1,
+  },
+} as const;
+
+export interface AwardAggregateInput {
+  seasonId: string;
+  teamId: string;
+  playerId: string;
+  /** F3 snapshot; callers may fall back to the immutable id for legacy rows. */
+  playerName: string;
+  position: string;
+  positionGroup: string | null;
+  gamesPlayed: number;
+  totalsJson: string;
+  /**
+   * F3 snapshot. `undefined` keeps pre-D2 aggregates eligible rather than
+   * silently withholding a full slate from an already completed season.
+   */
+  newcomerEligible?: boolean;
+}
+
+export interface AwardTeamRecordInput {
+  teamId: string;
+  divisionId: string | null;
+  wins: number;
+  losses: number;
+  ties: number;
+  pointsFor: number;
+  pointsAgainst: number;
+}
+
+export interface AwardCoachInput {
+  coachId: string;
+  coachName: string;
+  teamId: string;
+}
+
+export interface ComputeSeasonAwardsInput {
+  aggregates: readonly AwardAggregateInput[];
+  teamRecords: readonly AwardTeamRecordInput[];
+  coaches: readonly AwardCoachInput[];
+}
+
+export interface SeasonAward {
+  type: AwardType;
+  tier: AwardTier;
+  playerId: string | null;
+  coachId: string | null;
+  teamId: string;
+  divisionId: string | null;
+  positionGroup: string | null;
+  recipientName: string;
+  scoreValue: number;
+}
+
+type StatLine = Record<string, Record<string, number>>;
+
+function parseTotals(json: string): StatLine {
+  try {
+    const value = JSON.parse(json);
+    return value && typeof value === "object" ? (value as StatLine) : {};
+  } catch {
+    return {};
+  }
+}
+
+function num(line: StatLine, group: string, field: string): number {
+  const value = line[group]?.[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export interface PlayerAwardScores {
+  offense: number;
+  defense: number;
+  specialTeams: number;
+  overall: number;
+}
+
+/** Recompute the auditable components stored as award `scoreValue`s. */
+export function scorePlayerSeason(
+  aggregate: Pick<AwardAggregateInput, "totalsJson">,
+): PlayerAwardScores {
+  const line = parseTotals(aggregate.totalsJson);
+  const offense =
+    num(line, "passing", "yards") * AWARD_WEIGHTS.offense.passYards +
+    num(line, "passing", "td") * AWARD_WEIGHTS.offense.passTouchdowns +
+    num(line, "passing", "int") * AWARD_WEIGHTS.offense.interceptionsThrown +
+    num(line, "rushing", "yards") * AWARD_WEIGHTS.offense.rushYards +
+    num(line, "rushing", "td") * AWARD_WEIGHTS.offense.rushTouchdowns +
+    num(line, "receiving", "yards") * AWARD_WEIGHTS.offense.receivingYards +
+    num(line, "receiving", "td") * AWARD_WEIGHTS.offense.receivingTouchdowns +
+    num(line, "receiving", "rec") * AWARD_WEIGHTS.offense.receptions;
+  const defense =
+    num(line, "defense", "tacklesSolo") * AWARD_WEIGHTS.defense.tacklesSolo +
+    num(line, "defense", "tacklesAst") * AWARD_WEIGHTS.defense.tacklesAssisted +
+    num(line, "defense", "sacks") * AWARD_WEIGHTS.defense.sacks +
+    num(line, "defense", "int") * AWARD_WEIGHTS.defense.interceptions;
+  const specialTeams =
+    num(line, "kicking", "fgMade") * AWARD_WEIGHTS.specialTeams.fieldGoalsMade +
+    num(line, "kicking", "xpMade") *
+      AWARD_WEIGHTS.specialTeams.extraPointsMade +
+    num(line, "punting", "yards") * AWARD_WEIGHTS.specialTeams.puntYards;
+  return {
+    offense,
+    defense,
+    specialTeams,
+    overall: offense + defense + specialTeams,
+  };
+}
+
+export function scoreCoachSeason(record: AwardTeamRecordInput): number {
+  return (
+    record.wins * AWARD_WEIGHTS.coach.wins +
+    record.ties * AWARD_WEIGHTS.coach.ties +
+    (record.pointsFor - record.pointsAgainst) *
+      AWARD_WEIGHTS.coach.pointDifferential
+  );
+}
+
+function positionScore(
+  aggregate: AwardAggregateInput,
+  scores: PlayerAwardScores,
+): number {
+  switch (awardPositionGroup(aggregate)) {
+    case "QB":
+    case "RB":
+    case "WR":
+    case "TE":
+      return scores.offense;
+    case "DL":
+    case "LB":
+    case "DB":
+      return scores.defense;
+    case "K/P":
+      return scores.specialTeams;
+    default:
+      return scores.overall;
+  }
+}
+
+function awardPositionGroup(aggregate: AwardAggregateInput): string {
+  return (
+    aggregate.positionGroup ??
+    derivePositionGroup(aggregate.position) ??
+    aggregate.position
+  );
+}
+
+function stableNameCompare(
+  a: { name: string; id: string },
+  b: { name: string; id: string },
+): number {
+  const folded = a.name
+    .toLocaleLowerCase("en-US")
+    .localeCompare(b.name.toLocaleLowerCase("en-US"), "en-US");
+  if (folded !== 0) return folded;
+  const exact = a.name.localeCompare(b.name, "en-US");
+  if (exact !== 0) return exact;
+  return a.id.localeCompare(b.id, "en-US");
+}
+
+interface RankedPlayer {
+  aggregate: AwardAggregateInput;
+  score: number;
+  record: AwardTeamRecordInput;
+}
+
+function compareRankedPlayers(a: RankedPlayer, b: RankedPlayer): number {
+  if (a.score !== b.score) return b.score - a.score;
+  if (a.record.wins !== b.record.wins) return b.record.wins - a.record.wins;
+  const aDiff = a.record.pointsFor - a.record.pointsAgainst;
+  const bDiff = b.record.pointsFor - b.record.pointsAgainst;
+  if (aDiff !== bDiff) return bDiff - aDiff;
+  return stableNameCompare(
+    { name: a.aggregate.playerName, id: a.aggregate.playerId },
+    { name: b.aggregate.playerName, id: b.aggregate.playerId },
+  );
+}
+
+function playerAward(
+  type: AwardType,
+  ranked: RankedPlayer | undefined,
+  tier: AwardTier,
+  divisionId: string | null,
+  positionGroup: string | null,
+): SeasonAward | null {
+  if (!ranked) return null;
+  return {
+    type,
+    tier,
+    playerId: ranked.aggregate.playerId,
+    coachId: null,
+    teamId: ranked.aggregate.teamId,
+    divisionId,
+    positionGroup,
+    recipientName: ranked.aggregate.playerName,
+    scoreValue: ranked.score,
+  };
+}
+
+/**
+ * Compute the complete deterministic season slate from F2/F3-shaped inputs.
+ * Input iteration order never influences the result.
+ */
+export function computeSeasonAwards({
+  aggregates,
+  teamRecords,
+  coaches,
+}: ComputeSeasonAwardsInput): SeasonAward[] {
+  const recordByTeam = new Map(teamRecords.map((row) => [row.teamId, row]));
+  const scored = aggregates
+    .map((aggregate) => {
+      const record = recordByTeam.get(aggregate.teamId);
+      if (!record) return null;
+      return { aggregate, record, scores: scorePlayerSeason(aggregate) };
+    })
+    .filter((row): row is NonNullable<typeof row> => row !== null);
+  const rank = (
+    score: (row: (typeof scored)[number]) => number,
+    filter: (row: (typeof scored)[number]) => boolean = () => true,
+  ) =>
+    scored
+      .filter(filter)
+      .map((row) => ({
+        aggregate: row.aggregate,
+        record: row.record,
+        score: score(row),
+      }))
+      .sort(compareRankedPlayers);
+
+  const slate: SeasonAward[] = [];
+  const add = (award: SeasonAward | null) => {
+    if (award) slate.push(award);
+  };
+
+  add(
+    playerAward(
+      AWARD_TYPES.playerOfYear,
+      rank((r) => r.scores.overall)[0],
+      "state",
+      null,
+      null,
+    ),
+  );
+  add(
+    playerAward(
+      AWARD_TYPES.offensivePlayerOfYear,
+      rank((r) => r.scores.offense)[0],
+      "state",
+      null,
+      null,
+    ),
+  );
+  add(
+    playerAward(
+      AWARD_TYPES.defensivePlayerOfYear,
+      rank((r) => r.scores.defense)[0],
+      "state",
+      null,
+      null,
+    ),
+  );
+  add(
+    playerAward(
+      AWARD_TYPES.newcomerOfYear,
+      rank(
+        (r) => r.scores.overall,
+        (r) => r.aggregate.newcomerEligible !== false,
+      )[0],
+      "state",
+      null,
+      null,
+    ),
+  );
+
+  const coachRanked = coaches
+    .map((coach) => {
+      const record = recordByTeam.get(coach.teamId);
+      return record ? { coach, record, score: scoreCoachSeason(record) } : null;
+    })
+    .filter((row): row is NonNullable<typeof row> => row !== null)
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      if (a.record.wins !== b.record.wins) return b.record.wins - a.record.wins;
+      const aDiff = a.record.pointsFor - a.record.pointsAgainst;
+      const bDiff = b.record.pointsFor - b.record.pointsAgainst;
+      if (aDiff !== bDiff) return bDiff - aDiff;
+      return stableNameCompare(
+        { name: a.coach.coachName, id: a.coach.coachId },
+        { name: b.coach.coachName, id: b.coach.coachId },
+      );
+    });
+  const coachWinner = coachRanked[0];
+  if (coachWinner) {
+    slate.push({
+      type: AWARD_TYPES.coachOfYear,
+      tier: "state",
+      playerId: null,
+      coachId: coachWinner.coach.coachId,
+      teamId: coachWinner.coach.teamId,
+      divisionId: coachWinner.record.divisionId,
+      positionGroup: null,
+      recipientName: coachWinner.coach.coachName,
+      scoreValue: coachWinner.score,
+    });
+  }
+
+  const positionGroups = [
+    ...new Set(scored.map((row) => awardPositionGroup(row.aggregate))),
+  ].sort((a, b) => a.localeCompare(b, "en-US"));
+  const divisionIds = [
+    ...new Set(
+      teamRecords
+        .map((row) => row.divisionId)
+        .filter((id): id is string => id !== null),
+    ),
+  ].sort((a, b) => a.localeCompare(b, "en-US"));
+
+  for (const divisionId of divisionIds) {
+    for (const positionGroup of positionGroups) {
+      add(
+        playerAward(
+          AWARD_TYPES.allConference,
+          rank(
+            (r) => positionScore(r.aggregate, r.scores),
+            (r) =>
+              r.record.divisionId === divisionId &&
+              awardPositionGroup(r.aggregate) === positionGroup,
+          )[0],
+          "conference",
+          divisionId,
+          positionGroup,
+        ),
+      );
+    }
+  }
+  for (const positionGroup of positionGroups) {
+    add(
+      playerAward(
+        AWARD_TYPES.allState,
+        rank(
+          (r) => positionScore(r.aggregate, r.scores),
+          (r) => awardPositionGroup(r.aggregate) === positionGroup,
+        )[0],
+        "state",
+        null,
+        positionGroup,
+      ),
+    );
+  }
+
+  return slate;
+}

--- a/apps/web/convex/lib/awardsFinalize.ts
+++ b/apps/web/convex/lib/awardsFinalize.ts
@@ -1,0 +1,193 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { AWARD_LABELS, computeSeasonAwards, type SeasonAward } from "./awards";
+import { COACH_ROLE_HEAD } from "./coach";
+import { emitDynastyEvent } from "./events";
+
+function awardIdentity(award: {
+  type: string;
+  tier: string;
+  playerId: string | null;
+  coachId: string | null;
+  divisionId: string | null;
+  positionGroup: string | null;
+}): string {
+  return [
+    award.type,
+    award.tier,
+    award.playerId ?? "",
+    award.coachId ?? "",
+    award.divisionId ?? "",
+    award.positionGroup ?? "",
+  ].join(":");
+}
+
+export function awardDedupeKey(
+  seasonId: string,
+  award: Parameters<typeof awardIdentity>[0],
+): string {
+  return `award:${seasonId}:${awardIdentity(award)}`;
+}
+
+function sameAward(row: Doc<"awards">, award: SeasonAward): boolean {
+  return (
+    row.type === award.type &&
+    row.tier === award.tier &&
+    (row.playerId ?? null) === award.playerId &&
+    (row.coachId ?? null) === award.coachId &&
+    row.teamId === award.teamId &&
+    (row.divisionId ?? null) === award.divisionId &&
+    row.positionGroup === award.positionGroup &&
+    row.scoreValue === award.scoreValue
+  );
+}
+
+/**
+ * Persist D2 awards from the F2/F3 rows already loaded by history finalization.
+ * The only additional source read is `coaches`; no per-game table is touched.
+ */
+export async function finalizeSeasonAwards(
+  ctx: MutationCtx,
+  seasonId: Id<"seasons">,
+  leagueId: Id<"leagues">,
+  aggregates: Doc<"playerSeasonAggregates">[],
+  teamRecords: Doc<"seasonTeamRecords">[],
+): Promise<{ awardsWritten: number }> {
+  const [coaches, existingRows] = await Promise.all([
+    ctx.db
+      .query("coaches")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("awards")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+      .collect(),
+  ]);
+
+  const slate = computeSeasonAwards({
+    aggregates: aggregates.map((row) => ({
+      seasonId: row.seasonId,
+      teamId: row.teamId,
+      playerId: row.playerId,
+      playerName: row.playerName ?? (row.playerId as string),
+      position: row.position,
+      positionGroup: row.positionGroup,
+      gamesPlayed: row.gamesPlayed,
+      totalsJson: row.totalsJson,
+      newcomerEligible: row.newcomerEligible,
+    })),
+    teamRecords: teamRecords.map((row) => ({
+      teamId: row.teamId,
+      divisionId: row.divisionId,
+      wins: row.wins,
+      losses: row.losses,
+      ties: row.ties,
+      pointsFor: row.pointsFor,
+      pointsAgainst: row.pointsAgainst,
+    })),
+    coaches: coaches
+      .filter(
+        (coach) => coach.role === COACH_ROLE_HEAD && coach.teamId !== null,
+      )
+      .map((coach) => ({
+        coachId: coach._id,
+        coachName: coach.displayName,
+        teamId: coach.teamId as Id<"teams">,
+      })),
+  });
+
+  const existingByKey = new Map(
+    existingRows.map((row) => [
+      awardIdentity({
+        type: row.type,
+        tier: row.tier,
+        playerId: row.playerId,
+        coachId: row.coachId,
+        divisionId: row.divisionId,
+        positionGroup: row.positionGroup,
+      }),
+      row,
+    ]),
+  );
+  const retained = new Set(slate.map(awardIdentity));
+  const now = new Date().toISOString();
+  let awardsWritten = 0;
+
+  for (const row of existingRows) {
+    const key = awardIdentity({
+      type: row.type,
+      tier: row.tier,
+      playerId: row.playerId,
+      coachId: row.coachId,
+      divisionId: row.divisionId,
+      positionGroup: row.positionGroup,
+    });
+    if (!retained.has(key)) {
+      await ctx.db.delete(row._id);
+      awardsWritten += 1;
+    }
+  }
+
+  for (const award of slate) {
+    const existing = existingByKey.get(awardIdentity(award));
+    const payload = {
+      leagueId,
+      seasonId,
+      type: award.type,
+      tier: award.tier,
+      playerId:
+        award.playerId === null ? null : (award.playerId as Id<"players">),
+      coachId: award.coachId === null ? null : (award.coachId as Id<"coaches">),
+      teamId: award.teamId as Id<"teams">,
+      divisionId:
+        award.divisionId === null
+          ? null
+          : (award.divisionId as Id<"divisions">),
+      positionGroup: award.positionGroup,
+      scoreValue: award.scoreValue,
+      updatedAt: now,
+    };
+
+    if (existing) {
+      if (!sameAward(existing, award)) {
+        await ctx.db.patch(existing._id, payload);
+        awardsWritten += 1;
+      }
+    } else {
+      await ctx.db.insert("awards", {
+        ...payload,
+        createdAt: now,
+      });
+      awardsWritten += 1;
+    }
+
+    await emitDynastyEvent(ctx, {
+      leagueId,
+      seasonId,
+      teamId: award.teamId as Id<"teams">,
+      playerId:
+        award.playerId === null ? null : (award.playerId as Id<"players">),
+      dedupeKey: awardDedupeKey(seasonId, award),
+      narrative: {
+        type: "award_won",
+        recipientName: award.recipientName,
+        awardName: AWARD_LABELS[award.type],
+        positionGroup: award.positionGroup,
+      },
+      severity:
+        award.type === "player_of_year" || award.type === "coach_of_year"
+          ? "headline"
+          : "notable",
+      detail: {
+        type: award.type,
+        tier: award.tier,
+        coachId: award.coachId,
+        divisionId: award.divisionId,
+        positionGroup: award.positionGroup,
+        scoreValue: award.scoreValue,
+      },
+    });
+  }
+
+  return { awardsWritten };
+}

--- a/apps/web/convex/lib/historyFinalize.ts
+++ b/apps/web/convex/lib/historyFinalize.ts
@@ -12,6 +12,7 @@ import {
   type ProgramRecordEntry,
   type RecordCandidate,
 } from "./records";
+import { finalizeSeasonAwards } from "./awardsFinalize";
 
 export interface FinalizeSeasonHistoryResult {
   careerTotalsUpdated: number;
@@ -152,6 +153,14 @@ export async function finalizeSeasonHistoryForSeason(
   }
   if (leagueIds.size !== 1) throw new Error("history_league_mismatch");
   const leagueId = [...leagueIds][0] as Id<"leagues">;
+
+  await finalizeSeasonAwards(
+    ctx,
+    seasonId,
+    leagueId,
+    aggregates,
+    teamRecords,
+  );
 
   const careerRows = await ctx.db
     .query("playerCareerTotals")

--- a/apps/web/convex/lib/narrative.ts
+++ b/apps/web/convex/lib/narrative.ts
@@ -71,6 +71,12 @@ export type NarrativeInput =
       coachName: string;
       teamName: string;
       seasonName: string;
+    }
+  | {
+      type: "award_won";
+      recipientName: string;
+      awardName: string;
+      positionGroup: string | null;
     };
 
 export type NarrativeEventType = NarrativeInput["type"];
@@ -119,6 +125,12 @@ export function renderHeadline(input: NarrativeInput): string {
     case "coach_fired": {
       return `${input.seasonName}: ${input.teamName} parts ways with ${input.coachName}`;
     }
+    case "award_won": {
+      const position = input.positionGroup
+        ? ` (${input.positionGroup})`
+        : "";
+      return `${input.recipientName}${position} earns ${input.awardName} honors`;
+    }
     default: {
       // Exhaustiveness guard: adding a NarrativeInput variant without a case
       // here fails `tsc`, so a new event type cannot ship copy-less.
@@ -146,6 +158,8 @@ export function defaultSeverity(type: NarrativeEventType): EventSeverity {
       return "info";
     case "coach_fired":
       return "headline";
+    case "award_won":
+      return "notable";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;
@@ -168,6 +182,8 @@ export function categoryFor(type: NarrativeEventType): EventCategory {
       return "offseason";
     case "coach_fired":
       return "program";
+    case "award_won":
+      return "award";
     default: {
       const _exhaustive: never = type;
       void _exhaustive;

--- a/apps/web/convex/migrations/20260801_playerSeasonAggregates.ts
+++ b/apps/web/convex/migrations/20260801_playerSeasonAggregates.ts
@@ -62,6 +62,14 @@ export const backfillPlayerSeasonAggregates = internalMutation({
         playerId: playerId as Id<"players">,
         position: player.position,
         positionGroup: player.positionGroup ?? null,
+        playerName: player.name,
+        ...(typeof player.grade === "number" ||
+        typeof player.experienceYears === "number"
+          ? {
+              newcomerEligible:
+                player.grade === 9 || player.experienceYears === 0,
+            }
+          : {}),
         gamesPlayed,
         totalsJson: JSON.stringify(totals),
         updatedAt: now,

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2219,8 +2219,8 @@ export const completeSeason = internalMutationGeneric({
       if (!champion) throw new Error("no_champion");
     }
 
-    await finalizeProgramSeason(ctx, args.seasonId);
     await finalizeSeasonHistoryForSeason(ctx, args.seasonId);
+    await finalizeProgramSeason(ctx, args.seasonId);
 
     await ctx.db.patch(args.seasonId, { status: "completed" });
     return null;
@@ -6662,6 +6662,14 @@ async function rebuildPlayerSeasonAggregate(
     playerId: args.playerId,
     position: player.position,
     positionGroup: player.positionGroup ?? null,
+    playerName: player.name,
+    ...(typeof player.grade === "number" ||
+    typeof player.experienceYears === "number"
+      ? {
+          newcomerEligible:
+            player.grade === 9 || player.experienceYears === 0,
+        }
+      : {}),
     gamesPlayed,
     totalsJson: JSON.stringify(totals),
     updatedAt: new Date().toISOString(),

--- a/apps/web/convex/tables/dynasty.ts
+++ b/apps/web/convex/tables/dynasty.ts
@@ -86,6 +86,10 @@ export const dynastyTables = {
     playerId: v.id("players"),
     position: v.string(),
     positionGroup: v.union(v.string(), v.null()),
+    /** D2 tiebreak snapshot; optional for aggregates written before awards. */
+    playerName: v.optional(v.string()),
+    /** Grade 9 or zero experience at aggregate-write time. */
+    newcomerEligible: v.optional(v.boolean()),
     /** Games with an entered stat line. Feeds SPRT's per-game rates. */
     gamesPlayed: v.number(),
     /** `aggregateStatLines` output — sums, with "long" fields taking the max. */

--- a/apps/web/convex/tables/history.ts
+++ b/apps/web/convex/tables/history.ts
@@ -8,6 +8,26 @@ import { v } from "convex/values";
  * Season: a career and a record book only become meaningful across seasons.
  */
 export const historyTables = {
+  awards: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    type: v.string(),
+    tier: v.string(),
+    playerId: v.union(v.id("players"), v.null()),
+    coachId: v.union(v.id("coaches"), v.null()),
+    teamId: v.id("teams"),
+    divisionId: v.union(v.id("divisions"), v.null()),
+    positionGroup: v.union(v.string(), v.null()),
+    /** Exact output of `lib/awards.ts`; never a rounded display value. */
+    scoreValue: v.number(),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+  })
+    .index("by_seasonId", ["seasonId"])
+    .index("by_seasonId_type", ["seasonId", "type"])
+    .index("by_playerId", ["playerId"])
+    .index("by_coachId", ["coachId"]),
+
   playerCareerTotals: defineTable({
     leagueId: v.id("leagues"),
     playerId: v.id("players"),

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -130,6 +130,29 @@ export async function seedHistoryFixture(
   });
 }
 
+const seedAwardsFixtureRef = makeFunctionReference<
+  "mutation",
+  {
+    leagueId: string;
+    seasonId: string;
+    homeTeamId: string;
+    awayTeamId: string;
+  },
+  { winnerPlayerId: string; awardsCreated: number }
+>("e2eSeed:seedAwardsFixture");
+
+export async function seedAwardsFixture(
+  fixture: ScheduleFixtureResult,
+): Promise<{ winnerPlayerId: string; awardsCreated: number }> {
+  const client = getSeedClient();
+  return client.mutation(seedAwardsFixtureRef, {
+    leagueId: fixture.leagueId,
+    seasonId: fixture.seasonId,
+    homeTeamId: fixture.homeTeamId,
+    awayTeamId: fixture.awayTeamId,
+  });
+}
+
 const seedProspectClassRef = makeFunctionReference<
   "mutation",
   any,

--- a/apps/web/e2e/tests/awards.spec.ts
+++ b/apps/web/e2e/tests/awards.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedAwardsFixture,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+test.describe("Season awards (D2)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "season-awards";
+  let fixture: ScheduleFixtureResult | null = null;
+  let winnerPlayerId: string | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E Awards Home",
+      awayTeamName: "E2E Awards Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    const seeded = await seedAwardsFixture(fixture);
+    winnerPlayerId = seeded.winnerPlayerId;
+    expect(seeded.awardsCreated).toBeGreaterThan(0);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("renders the slate and lists the winner on Player Overview", async ({
+    page,
+  }) => {
+    if (!fixture || !winnerPlayerId) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${fixture.seasonId}/awards`);
+    const awards = page.getByTestId("season-awards");
+    await expect(awards).toBeVisible({ timeout: 30_000 });
+    await expect(
+      awards.getByRole("heading", { name: "Award winners", exact: true }),
+    ).toBeVisible();
+    await expect(
+      awards.getByRole("heading", {
+        name: "All-Conference team",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      awards.getByRole("heading", { name: "All-State team", exact: true }),
+    ).toBeVisible();
+    const header = awards.getByTestId("resource-header-season");
+    await expect(
+      header.getByRole("link", { name: "Awards", exact: true }),
+    ).toHaveAttribute("aria-current", "page");
+
+    await page.goto(`/dashboard/players/${winnerPlayerId}`);
+    const accolades = page.getByTestId("player-accolades");
+    await expect(accolades).toBeVisible({ timeout: 30_000 });
+    await expect(
+      accolades.getByText("Player of the Year", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/[coachId]/page.tsx
@@ -9,9 +9,14 @@ import {
   getCoach,
   getTeam,
   getTeamLeagueId,
+  listCoachAwards,
 } from "@/lib/data-api";
 import { resolveOrgContext } from "@/lib/org-context";
-import { dynastyProgramV1, pageGuard } from "@/lib/flags";
+import {
+  dynastyHistoryV1,
+  dynastyProgramV1,
+  pageGuard,
+} from "@/lib/flags";
 import { formatCoachArchetype } from "@/lib/program/coach";
 import { CoachSkillTreeCard } from "@/components/program/CoachSkillTreeCard";
 import { canAdminOrManageTeam } from "@/lib/authorization";
@@ -43,6 +48,10 @@ export default async function CoachHomePage({
 
   const siblings = buildCoachSiblingLinks(coachId);
   const canEdit = await canAdminOrManageTeam(coach.teamId, userId);
+  const historyEnabled = await dynastyHistoryV1();
+  const accolades = historyEnabled
+    ? await listCoachAwards(coachId).catch(() => [])
+    : [];
 
   return (
     <div className="space-y-4">
@@ -102,6 +111,31 @@ export default async function CoachHomePage({
           </div>
         </CardContent>
       </Card>
+
+      {historyEnabled && (
+        <Card data-testid="coach-accolades">
+          <CardContent className="pt-6">
+            <h2 className="text-lg font-semibold">Accolades</h2>
+            {accolades.length === 0 ? (
+              <p className="mt-3 text-sm text-muted-foreground">
+                No accolades yet.
+              </p>
+            ) : (
+              <ul className="mt-3 space-y-2">
+                {accolades.map((award) => (
+                  <li key={award.id} className="text-sm">
+                    <span className="font-medium">{award.typeLabel}</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · {award.seasonName}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <CoachSkillTreeCard
         coachId={coachId}

--- a/apps/web/src/app/dashboard/players/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/players/[id]/page.tsx
@@ -19,13 +19,18 @@ import {
   computeSeasonSprt,
   getTeamLeagueId,
   getLeagueOrgId,
+  listPlayerAwards,
 } from "@/lib/data-api";
 import { resolveOrgContext, resolveOrgRole } from "@/lib/org-context";
 import { canManageRoster } from "@/lib/permissions";
 import { derivePositionGroup } from "@/lib/position-group";
 import { gradeToClassYear } from "@/lib/class-year";
 import { orderedMaddenAttributes } from "@/lib/madden/attributes";
-import { playerAttributesV1, statKeepingV1 } from "@/lib/flags";
+import {
+  dynastyHistoryV1,
+  playerAttributesV1,
+  statKeepingV1,
+} from "@/lib/flags";
 import { SeasonStatsCard } from "@/components/stats/SeasonStatsCard";
 import {
   HsRatingCard,
@@ -83,6 +88,10 @@ export default async function PlayerProfilePage({
   const classYear = gradeToClassYear(player.grade);
   const age = player.dateOfBirth ? ageFrom(player.dateOfBirth) : null;
   const attributesEnabled = await playerAttributesV1();
+  const historyEnabled = await dynastyHistoryV1();
+  const accolades = historyEnabled
+    ? await listPlayerAwards(playerId).catch(() => [])
+    : [];
 
   // SPRT rating breakdown (WSM-000093) — the player's current-season snapshot
   // when Phase 2 is on. The season is resolved server-side, including workspace
@@ -268,6 +277,34 @@ export default async function PlayerProfilePage({
           )}
         </CardContent>
       </Card>
+
+      {historyEnabled && (
+        <Card data-testid="player-accolades">
+          <CardContent className="pt-6">
+            <h2 className="text-lg font-semibold">Accolades</h2>
+            {accolades.length === 0 ? (
+              <p className="mt-3 text-sm text-muted-foreground">
+                No accolades yet.
+              </p>
+            ) : (
+              <ul className="mt-3 space-y-2">
+                {accolades.map((award) => (
+                  <li key={award.id} className="text-sm">
+                    <span className="font-medium">{award.typeLabel}</span>
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · {award.seasonName}
+                      {award.positionGroup
+                        ? ` · ${award.positionGroup}`
+                        : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {seasonStats && (
         <SeasonStatsCard

--- a/apps/web/src/app/dashboard/seasons/[id]/awards/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/awards/page.tsx
@@ -1,0 +1,159 @@
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import {
+  buildSeasonSiblingLinks,
+  coachHomeHref,
+  playerHomeHref,
+  seasonHomeHref,
+} from "@/components/workspace/resource-navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { getLeague, getSeason, listSeasonAwards } from "@/lib/data-api";
+import {
+  dynastyHistoryV1,
+  dynastyOffseasonV2,
+  pageGuard,
+  playoffsV1,
+  schedulesStandingsV1,
+  statKeepingV1,
+} from "@/lib/flags";
+import { resolveOrgContext } from "@/lib/org-context";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+
+const INDIVIDUAL_TYPES = new Set([
+  "player_of_year",
+  "offensive_player_of_year",
+  "defensive_player_of_year",
+  "newcomer_of_year",
+  "coach_of_year",
+]);
+
+export default async function SeasonAwardsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await pageGuard(dynastyHistoryV1);
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: seasonId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const season = await getSeason(seasonId, orgContext).catch(() => null);
+  if (!season) notFound();
+  const league = await getLeague(season.leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+  await syncActiveLeagueForResource(league.id);
+
+  const [
+    awards,
+    scheduleEnabled,
+    playoffsEnabled,
+    statsEnabled,
+    offseasonEnabled,
+  ] = await Promise.all([
+    listSeasonAwards(season.id).catch(() => []),
+    schedulesStandingsV1(),
+    playoffsV1(),
+    statKeepingV1(),
+    dynastyOffseasonV2(),
+  ]);
+  const individuals = awards.filter((row) => INDIVIDUAL_TYPES.has(row.type));
+  const allConference = awards.filter((row) => row.type === "all_conference");
+  const allState = awards.filter((row) => row.type === "all_state");
+
+  const recipient = (row: (typeof awards)[number]) => {
+    const href = row.playerId
+      ? playerHomeHref(row.playerId)
+      : row.coachId
+        ? coachHomeHref(row.coachId)
+        : null;
+    return href ? (
+      <Link href={href} className="font-medium hover:underline">
+        {row.recipientName}
+      </Link>
+    ) : (
+      <span className="font-medium">{row.recipientName}</span>
+    );
+  };
+
+  return (
+    <div className="space-y-4" data-testid="season-awards">
+      <ResourceHeader
+        kind="season"
+        title="Season awards"
+        homeHref={seasonHomeHref(season.id)}
+        context={`${season.name} · ${league.name}`}
+        siblings={buildSeasonSiblingLinks({
+          seasonId: season.id,
+          scheduleEnabled,
+          playoffsEnabled,
+          statsEnabled,
+          offseasonEnabled: offseasonEnabled && season.status === "upcoming",
+          awardsEnabled: true,
+        })}
+      />
+
+      <Card>
+        <CardContent className="pt-6">
+          <h2 className="text-lg font-semibold">Award winners</h2>
+          {individuals.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Awards are announced when this season is completed.
+            </p>
+          ) : (
+            <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+              {individuals.map((row) => (
+                <li key={row.id} className="rounded-md border p-3">
+                  <p className="text-xs font-medium uppercase text-muted-foreground">
+                    {row.typeLabel}
+                  </p>
+                  <p className="mt-1">
+                    {recipient(row)} · {row.teamName}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {[
+        { title: "All-Conference team", rows: allConference },
+        { title: "All-State team", rows: allState },
+      ].map((section) => (
+        <Card key={section.title}>
+          <CardContent className="pt-6">
+            <h2 className="text-lg font-semibold">{section.title}</h2>
+            {section.rows.length === 0 ? (
+              <p className="mt-3 text-sm text-muted-foreground">
+                No selections yet.
+              </p>
+            ) : (
+              <ul className="mt-4 divide-y">
+                {section.rows.map((row) => (
+                  <li
+                    key={row.id}
+                    className="flex flex-wrap items-baseline justify-between gap-2 py-2"
+                  >
+                    <span>
+                      <span className="mr-2 text-xs font-medium text-muted-foreground">
+                        {row.positionGroup ?? "ATH"}
+                      </span>
+                      {recipient(row)}
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      {row.teamName}
+                      {row.divisionName ? ` · ${row.divisionName}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   statKeepingV1,
   dynastyOffseasonV2,
   dynastyProgramV1,
+  dynastyHistoryV1,
 } from "@/lib/flags";
 import {
   computeStandings,
@@ -90,7 +91,10 @@ export default async function SeasonHubPage({
     seasons.filter((s) => s.status === "completed"),
   );
 
-  const programEnabled = await dynastyProgramV1();
+  const [programEnabled, historyEnabled] = await Promise.all([
+    dynastyProgramV1(),
+    dynastyHistoryV1(),
+  ]);
 
   const [fixtures, standings, bracket, scheduleEnabled, playoffsEnabled, statsEnabled, offseasonEnabled, dynastyFixtures, dynastyBracket, leaguePlayers, teams] =
     await Promise.all([
@@ -249,6 +253,7 @@ export default async function SeasonHubPage({
           statsEnabled,
           // Only an upcoming season has an offseason to prepare.
           offseasonEnabled: offseasonEnabled && isUpcomingSeason,
+          awardsEnabled: historyEnabled,
         })}
       />
       <WorkspaceNav links={links} />

--- a/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
+++ b/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
@@ -117,6 +117,9 @@ describe("resource-navigation helpers", () => {
     expect(seasonSubpageHref("s1", "stats")).toBe(
       "/dashboard/seasons/s1/stats",
     );
+    expect(seasonSubpageHref("s1", "awards")).toBe(
+      "/dashboard/seasons/s1/awards",
+    );
   });
 });
 
@@ -213,6 +216,18 @@ describe("buildSeasonSiblingLinks", () => {
       statsEnabled: false,
     });
     expect(links.map((l) => l.label)).toEqual(["Overview"]);
+  });
+
+  it("gates the Awards sibling independently", () => {
+    const enabled = buildSeasonSiblingLinks({
+      seasonId: "s1",
+      scheduleEnabled: false,
+      playoffsEnabled: false,
+      statsEnabled: false,
+      awardsEnabled: true,
+    });
+    expect(enabled.map((link) => link.label)).toEqual(["Overview", "Awards"]);
+    expect(enabled[1]!.href).toBe("/dashboard/seasons/s1/awards");
   });
 });
 

--- a/apps/web/src/components/workspace/resource-navigation.ts
+++ b/apps/web/src/components/workspace/resource-navigation.ts
@@ -108,7 +108,13 @@ export function seasonHomeHref(seasonId: string): string {
  */
 export function seasonSubpageHref(
   seasonId: string,
-  subpage: "schedule" | "standings" | "playoffs" | "stats" | "offseason",
+  subpage:
+    | "schedule"
+    | "standings"
+    | "playoffs"
+    | "stats"
+    | "offseason"
+    | "awards",
 ): string {
   return `/dashboard/seasons/${seasonId}/${subpage}`;
 }
@@ -217,6 +223,7 @@ export function buildSeasonSiblingLinks({
   playoffsEnabled,
   statsEnabled,
   offseasonEnabled = false,
+  awardsEnabled = false,
 }: {
   seasonId: string;
   scheduleEnabled: boolean;
@@ -228,6 +235,8 @@ export function buildSeasonSiblingLinks({
    * completed season the link would lead to a page with nothing to do.
    */
   offseasonEnabled?: boolean;
+  /** Epic D history flag; awards remain a Season-owned read surface. */
+  awardsEnabled?: boolean;
 }): ResourceSiblingLink[] {
   const links: (ResourceSiblingLink | false)[] = [
     { label: "Overview", href: seasonHomeHref(seasonId) },
@@ -250,6 +259,10 @@ export function buildSeasonSiblingLinks({
     statsEnabled && {
       label: "Stat leaders",
       href: seasonSubpageHref(seasonId, "stats"),
+    },
+    awardsEnabled && {
+      label: "Awards",
+      href: seasonSubpageHref(seasonId, "awards"),
     },
   ];
   return links.filter((link): link is ResourceSiblingLink => Boolean(link));

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -126,6 +126,9 @@ export const historyRef = moduleRefs("history");
 const listProgramRecordsRef = historyRef.query<ProgramRecordDto[]>(
   "listProgramRecords",
 );
+const listSeasonAwardsRef = historyRef.query<AwardDto[]>("listSeasonAwards");
+const listPlayerAwardsRef = historyRef.query<AwardDto[]>("listPlayerAwards");
+const listCoachAwardsRef = historyRef.query<AwardDto[]>("listCoachAwards");
 
 /** A single bracket node (WSM-000164). Team/score fields are null until played. */
 export interface PlayoffMatchupDto {
@@ -192,6 +195,24 @@ export interface ProgramRecordDto {
   teamName: string;
   seasonId: string;
   seasonName: string;
+}
+
+export interface AwardDto {
+  id: string;
+  seasonId: string;
+  seasonName: string;
+  type: string;
+  typeLabel: string;
+  tier: string;
+  playerId: string | null;
+  coachId: string | null;
+  recipientName: string;
+  teamId: string;
+  teamName: string;
+  divisionId: string | null;
+  divisionName: string | null;
+  positionGroup: string | null;
+  scoreValue: number;
 }
 
 const refs = {
@@ -1260,6 +1281,22 @@ export async function listProgramRecords(
     leagueId,
     ...(teamId ? { teamId } : {}),
   });
+}
+
+export async function listSeasonAwards(
+  seasonId: string,
+): Promise<AwardDto[]> {
+  return queryConvex(listSeasonAwardsRef, { seasonId });
+}
+
+export async function listPlayerAwards(
+  playerId: string,
+): Promise<AwardDto[]> {
+  return queryConvex(listPlayerAwardsRef, { playerId });
+}
+
+export async function listCoachAwards(coachId: string): Promise<AwardDto[]> {
+  return queryConvex(listCoachAwardsRef, { coachId });
 }
 
 export async function getTeam(

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -259,6 +259,22 @@ export const dynastyProgramV1 = flag<boolean>({
   },
 });
 
+export const dynastyHistoryV1 = flag<boolean>({
+  key: "dynasty_history_v1",
+  description:
+    "Dynasty Mode Epic D: career history, season awards and narrative (#608)",
+  defaultValue: defaultOn,
+  options: [
+    { label: "Off", value: false },
+    { label: "On", value: true },
+  ],
+  decide: () => {
+    const enabled = resolveFlag("FLAG_DYNASTY_HISTORY_V1");
+    void trackFlagExposure("dynasty_history_v1", enabled);
+    return enabled;
+  },
+});
+
 export type FeatureFlag = () => Promise<boolean>;
 
 export async function pageGuard(flagFn: FeatureFlag): Promise<void> {


### PR DESCRIPTION
Closes #631. Second slice of Epic D, stacked on #664.

When a season ends there is a full award slate — Player of the Year, offensive and defensive honors, newcomer, coach of the year — plus All-Conference and All-State teams, and accolades accumulate on player and coach pages.

## What landed
- `awards` stores an **auditable `scoreValue`** per row, so "why did he win it" reproduces from the pure scorer rather than being taken on trust. Every stored score is recomputed and asserted equal in tests.
- `computeSeasonAwards` is pure, with documented per-award weights and a tiebreak chain terminating in a stable name sort — deliberate ties included in the tests.
- Computation reads only the F2/F3 aggregates plus `coaches`; a read spy pins zero `playerGameStats` reads.
- Each award emits exactly one event, deduped on replay, so re-completing a season does not duplicate the news.
- Accolades render as Overview **sections** on Player and Coach Home — per `CONTEXT.md` they stay sections until they earn their own workflow.

## Verification
- `vitest run` — 232 files, 1859 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean

## Two product choices worth a look
- **Weights** were unspecified by the issue. Chosen: pass yd .04, pass/rush/rec TD 6, INT thrown −2, rush/rec yd .1, reception .5, tackle 1, sack 8, defensive INT 10, FG 3, XP 1; coach W10/T5/PD .1. All documented beside the scorer.
- **Team cardinality**: one All-Conference selection per division/position group, one league-wide All-State selection per group.

Both are tuning knobs rather than structural decisions — the scorer is pure, so changing them is a one-file edit with the tests as the safety net.