### PR TITLE
feat: weekly polls and power rankings (#632)

### DIFF
--- a/apps/web/convex/__tests__/weeklyPolls.test.ts
+++ b/apps/web/convex/__tests__/weeklyPolls.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { computeWeeklyPollForSeason } from "../lib/weeklyPolls";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedRecords(t: ReturnType<typeof convexTest>, count = 12) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Poll League",
+      orgId: null,
+      isPublic: true,
+      inviteToken: null,
+    });
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2032",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    const teamIds: Id<"teams">[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const teamId = await ctx.db.insert("teams", {
+        name: `Poll Team ${index + 1}`,
+        leagueId,
+        divisionId: null,
+        city: "City",
+        stadium: "Stadium",
+        foundedYear: null,
+        location: "Location",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+      teamIds.push(teamId);
+    }
+    for (const [index, teamId] of teamIds.entries()) {
+      const opponent = teamIds[(index + 1) % teamIds.length]!;
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId,
+        seasonId,
+        teamId,
+        divisionId: null,
+        wins: count - index,
+        losses: index,
+        ties: 0,
+        pointsFor: 300 - index * 5,
+        pointsAgainst: 150 + index * 5,
+        divisionWins: 0,
+        divisionLosses: 0,
+        divisionTies: 0,
+        headToHeadJson: JSON.stringify({
+          [opponent]: { w: index % 2, l: (index + 1) % 2, t: 0 },
+        }),
+        streak: 1,
+        lastResults: ["W"],
+        gamesCounted: count,
+        updatedAt: new Date(0).toISOString(),
+      });
+    }
+    return { leagueId, seasonId, teamIds };
+  });
+}
+
+describe("weekly polls persistence", () => {
+  it("reads one indexed team-record batch and never scans fixtures", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId, teamIds } = await seedRecords(t);
+    const reads = new Map<string, number>();
+
+    await t.run(async (ctx) => {
+      const originalQuery = ctx.db.query.bind(ctx.db);
+      ctx.db.query = ((tableName: string) => {
+        reads.set(tableName, (reads.get(tableName) ?? 0) + 1);
+        return originalQuery(tableName as never);
+      }) as unknown as typeof ctx.db.query;
+      await computeWeeklyPollForSeason(ctx as unknown as MutationCtx, {
+        leagueId,
+        seasonId,
+        week: 1,
+      });
+    });
+
+    const rows = await t.run((ctx) => ctx.db.query("weeklyPolls").collect());
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]!.rankingsJson)).toHaveLength(teamIds.length);
+    expect(reads.get("seasonTeamRecords")).toBe(1);
+    expect(reads.get("fixtures") ?? 0).toBe(0);
+    expect(reads.get("gameResults") ?? 0).toBe(0);
+  });
+
+  it("stores honest week-one absence and returns team names through the query", async () => {
+    const t = convexTest(schema, modules);
+    const { leagueId, seasonId, teamIds } = await seedRecords(t, 4);
+
+    await t.mutation(internal.history.computeWeeklyPoll, {
+      leagueId,
+      seasonId,
+      week: 1,
+    });
+    const poll = await t.query(api.history.getWeeklyPoll, { seasonId });
+
+    expect(poll?.rankings).toHaveLength(teamIds.length);
+    expect(poll?.rankings.every((row) => row.previousRank === null)).toBe(true);
+    expect(poll?.rankings.map((row) => row.rank)).toEqual([1, 2, 3, 4]);
+    expect(poll?.rankings.every((row) => row.teamName.startsWith("Poll Team ")))
+      .toBe(true);
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -233,7 +233,9 @@ void api.history.listProgramRecords;
 void api.history.listSeasonAwards;
 void api.history.listPlayerAwards;
 void api.history.listCoachAwards;
+void api.history.getWeeklyPoll;
 void internal.history.finalizeSeasonHistory;
+void internal.history.computeWeeklyPoll;
 
 type AllowedPublicDynastyReads =
   | "moduleStatus"
@@ -289,7 +291,8 @@ type AllowedPublicHistoryReads =
   | "listProgramRecords"
   | "listSeasonAwards"
   | "listPlayerAwards"
-  | "listCoachAwards";
+  | "listCoachAwards"
+  | "getWeeklyPoll";
 
 type LeakedPublicDynastyWrites = Exclude<
   keyof typeof api.dynasty,

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -1,8 +1,9 @@
-import { v } from "convex/values";
+import { v, type Infer } from "convex/values";
 import { internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { finalizeSeasonHistoryForSeason } from "./lib/historyFinalize";
+import { computeWeeklyPollForSeason } from "./lib/weeklyPolls";
 
 /*
  * e2e seed fixtures (WSM-000139, fast-follow to WSM-000096).
@@ -161,6 +162,16 @@ async function cascadeDeleteLeague(
       .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
       .collect()) as Array<{ _id: Id<"awards"> }>;
     for (const row of awards) {
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }
+    // Weekly polls (D3). The rankings JSON retains team ids, so it must be
+    // removed before the fixture's teams and season are deleted.
+    const weeklyPolls = (await ctx.db
+      .query("weeklyPolls")
+      .withIndex("by_seasonId", (q: any) => q.eq("seasonId", season._id))
+      .collect()) as Array<{ _id: Id<"weeklyPolls"> }>;
+    for (const row of weeklyPolls) {
       await ctx.db.delete(row._id);
       deleted += 1;
     }
@@ -815,6 +826,103 @@ export const seedAwardsFixture = internalMutation({
       .collect();
     if (!winnerPlayerId) throw new Error("awards_fixture_winner_missing");
     return { winnerPlayerId, awardsCreated: awards.length };
+  },
+});
+
+/**
+ * D3 route fixture: seed one persisted record for BOTH schedule-fixture teams,
+ * then run the real weekly-poll materializer.
+ */
+const seedRankingsFixtureResultValidator = v.object({
+  rankingsCreated: v.number(),
+});
+type SeedRankingsFixtureResult = Infer<
+  typeof seedRankingsFixtureResultValidator
+>;
+
+export const seedRankingsFixture = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+  },
+  returns: seedRankingsFixtureResultValidator,
+  handler: async (
+    ctx,
+    args,
+  ): Promise<SeedRankingsFixtureResult> => {
+    assertSeedEnabled();
+    const [season, homeTeam, awayTeam] = await Promise.all([
+      ctx.db.get(args.seasonId),
+      ctx.db.get(args.homeTeamId),
+      ctx.db.get(args.awayTeamId),
+    ]);
+    if (
+      !season ||
+      season.leagueId !== args.leagueId ||
+      !homeTeam ||
+      homeTeam.leagueId !== args.leagueId ||
+      !awayTeam ||
+      awayTeam.leagueId !== args.leagueId
+    ) {
+      throw new Error("rankings_fixture_scope_mismatch");
+    }
+
+    const now = new Date().toISOString();
+    const records = [
+      {
+        teamId: args.homeTeamId,
+        opponentTeamId: args.awayTeamId,
+        wins: 1,
+        losses: 0,
+        pointsFor: 28,
+        pointsAgainst: 14,
+        result: "W",
+      },
+      {
+        teamId: args.awayTeamId,
+        opponentTeamId: args.homeTeamId,
+        wins: 0,
+        losses: 1,
+        pointsFor: 14,
+        pointsAgainst: 28,
+        result: "L",
+      },
+    ] as const;
+    for (const record of records) {
+      await ctx.db.insert("seasonTeamRecords", {
+        leagueId: args.leagueId,
+        seasonId: args.seasonId,
+        teamId: record.teamId,
+        divisionId: null,
+        wins: record.wins,
+        losses: record.losses,
+        ties: 0,
+        pointsFor: record.pointsFor,
+        pointsAgainst: record.pointsAgainst,
+        divisionWins: 0,
+        divisionLosses: 0,
+        divisionTies: 0,
+        headToHeadJson: JSON.stringify({
+          [record.opponentTeamId]: {
+            w: record.wins,
+            l: record.losses,
+            t: 0,
+          },
+        }),
+        streak: record.result === "W" ? 1 : -1,
+        lastResults: [record.result],
+        gamesCounted: 1,
+        updatedAt: now,
+      });
+    }
+    const result = await computeWeeklyPollForSeason(ctx, {
+      leagueId: args.leagueId,
+      seasonId: args.seasonId,
+      week: 1,
+    });
+    return { rankingsCreated: result.rankings };
   },
 });
 

--- a/apps/web/convex/history.ts
+++ b/apps/web/convex/history.ts
@@ -10,6 +10,8 @@ import {
   finalizeSeasonHistoryForSeason,
   type FinalizeSeasonHistoryResult,
 } from "./lib/historyFinalize";
+import { computeWeeklyPollForSeason } from "./lib/weeklyPolls";
+import type { PowerRanking } from "./lib/powerRankings";
 
 /*
  * Dynasty Mode — history, awards and narrative (Epic D).
@@ -57,6 +59,125 @@ export const finalizeSeasonHistory = internalMutation({
   returns: finalizeSeasonHistoryResultValidator,
   handler: async (ctx, args): Promise<FinalizeSeasonHistoryResult> =>
     finalizeSeasonHistoryForSeason(ctx, args.seasonId),
+});
+
+const weeklyPollWriteResultValidator = v.object({
+  rankings: v.number(),
+  written: v.boolean(),
+});
+type WeeklyPollWriteDto = Infer<typeof weeklyPollWriteResultValidator>;
+
+export const computeWeeklyPoll = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    week: v.number(),
+  },
+  returns: weeklyPollWriteResultValidator,
+  handler: async (ctx, args): Promise<WeeklyPollWriteDto> => {
+    if (!Number.isInteger(args.week) || args.week < 1) {
+      throw new Error("invalid_poll_week");
+    }
+    return computeWeeklyPollForSeason(ctx, args);
+  },
+});
+
+const weeklyPollRankingDtoValidator = v.object({
+  teamId: v.string(),
+  teamName: v.string(),
+  rank: v.number(),
+  previousRank: v.union(v.number(), v.null()),
+  points: v.number(),
+  record: v.object({
+    wins: v.number(),
+    losses: v.number(),
+    ties: v.number(),
+  }),
+  trend: v.union(
+    v.literal("up"),
+    v.literal("down"),
+    v.literal("same"),
+    v.literal("new"),
+  ),
+});
+const weeklyPollDtoValidator = v.object({
+  week: v.number(),
+  publishedAt: v.string(),
+  rankings: v.array(weeklyPollRankingDtoValidator),
+});
+type WeeklyPollDto = Infer<typeof weeklyPollDtoValidator>;
+
+function parseRankings(json: string): PowerRanking[] {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((row): row is PowerRanking => {
+      if (!row || typeof row !== "object") return false;
+      const ranking = row as Partial<PowerRanking>;
+      return (
+        typeof ranking.teamId === "string" &&
+        typeof ranking.rank === "number" &&
+        (ranking.previousRank === null ||
+          typeof ranking.previousRank === "number") &&
+        typeof ranking.points === "number" &&
+        Boolean(ranking.record) &&
+        typeof ranking.record?.wins === "number" &&
+        typeof ranking.record?.losses === "number" &&
+        typeof ranking.record?.ties === "number" &&
+        (ranking.trend === "up" ||
+          ranking.trend === "down" ||
+          ranking.trend === "same" ||
+          ranking.trend === "new")
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+export const getWeeklyPoll = query({
+  args: {
+    seasonId: v.id("seasons"),
+    week: v.optional(v.number()),
+  },
+  returns: v.union(weeklyPollDtoValidator, v.null()),
+  handler: async (ctx, args): Promise<WeeklyPollDto | null> => {
+    const requestedWeek = args.week;
+    const row =
+      requestedWeek !== undefined
+        ? await ctx.db
+            .query("weeklyPolls")
+            .withIndex("by_seasonId_week", (q) =>
+              q.eq("seasonId", args.seasonId).eq("week", requestedWeek),
+            )
+            .unique()
+        : await ctx.db
+            .query("weeklyPolls")
+            .withIndex("by_seasonId_week", (q) =>
+              q.eq("seasonId", args.seasonId),
+            )
+            .order("desc")
+            .first();
+    if (!row) return null;
+
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", row.leagueId))
+      .collect();
+    const teamNames = new Map(
+      teams.map((team) => [team._id as string, team.name]),
+    );
+    return {
+      week: row.week,
+      publishedAt: row.publishedAt,
+      rankings: parseRankings(row.rankingsJson).map(
+        (ranking): WeeklyPollDto["rankings"][number] => ({
+          ...ranking,
+          teamName: teamNames.get(ranking.teamId) ?? "Unknown program",
+        }),
+      ),
+    };
+  },
 });
 
 const careerTotalsDtoValidator = v.object({

--- a/apps/web/convex/lib/powerRankings.ts
+++ b/apps/web/convex/lib/powerRankings.ts
@@ -1,0 +1,257 @@
+/**
+ * Weekly power rankings (Dynasty Mode D3).
+ *
+ * This module is deliberately pure: Convex supplies persisted team records
+ * and the previous poll, while this code owns every scoring and damping rule.
+ */
+
+/** A team may move at most this many places between consecutive polls. */
+export const MAX_WEEKLY_RANK_MOVEMENT = 2;
+
+/** Point differential is useful signal, but one blowout must not own the poll. */
+export const POINT_DIFFERENTIAL_CAP_PER_GAME = 21;
+
+export interface PowerRankingRecord {
+  teamId: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  pointsFor: number;
+  pointsAgainst: number;
+  headToHeadJson: string;
+  lastResults: string[];
+  gamesCounted: number;
+}
+
+export interface PreviousPowerRanking {
+  teamId: string;
+  rank: number;
+}
+
+export interface PowerRanking {
+  teamId: string;
+  rank: number;
+  previousRank: number | null;
+  /** Composite poll score on a 0–1000 scale. */
+  points: number;
+  record: {
+    wins: number;
+    losses: number;
+    ties: number;
+  };
+  trend: "up" | "down" | "same" | "new";
+}
+
+interface ScoredTeam {
+  record: PowerRankingRecord;
+  points: number;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function gamesPlayed(record: PowerRankingRecord): number {
+  return record.wins + record.losses + record.ties;
+}
+
+function winPercentage(record: PowerRankingRecord): number {
+  const games = gamesPlayed(record);
+  return games === 0 ? 0.5 : (record.wins + record.ties * 0.5) / games;
+}
+
+function parseOpponentIds(headToHeadJson: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(headToHeadJson);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    return Object.keys(parsed);
+  } catch {
+    return [];
+  }
+}
+
+function strengthOfSchedule(
+  record: PowerRankingRecord,
+  recordsByTeam: ReadonlyMap<string, PowerRankingRecord>,
+): number {
+  const opponents = parseOpponentIds(record.headToHeadJson)
+    .map((teamId) => recordsByTeam.get(teamId))
+    .filter((opponent): opponent is PowerRankingRecord => Boolean(opponent));
+  if (opponents.length === 0) return 0.5;
+  return (
+    opponents.reduce((sum, opponent) => sum + winPercentage(opponent), 0) /
+    opponents.length
+  );
+}
+
+function recencyScore(lastResults: readonly string[]): number {
+  const recent = lastResults.slice(0, 5);
+  if (recent.length === 0) return 0.5;
+  const weights = [5, 4, 3, 2, 1];
+  let weightedScore = 0;
+  let weightTotal = 0;
+  for (const [index, result] of recent.entries()) {
+    const weight = weights[index] ?? 1;
+    weightedScore +=
+      weight * (result === "W" ? 1 : result === "T" ? 0.5 : 0);
+    weightTotal += weight;
+  }
+  return weightTotal === 0 ? 0.5 : weightedScore / weightTotal;
+}
+
+function compositePoints(
+  record: PowerRankingRecord,
+  recordsByTeam: ReadonlyMap<string, PowerRankingRecord>,
+): number {
+  const games = Math.max(1, record.gamesCounted || gamesPlayed(record));
+  const differentialPerGame =
+    (record.pointsFor - record.pointsAgainst) / games;
+  const cappedDifferential = clamp(
+    differentialPerGame,
+    -POINT_DIFFERENTIAL_CAP_PER_GAME,
+    POINT_DIFFERENTIAL_CAP_PER_GAME,
+  );
+  const normalizedDifferential =
+    (cappedDifferential + POINT_DIFFERENTIAL_CAP_PER_GAME) /
+    (POINT_DIFFERENTIAL_CAP_PER_GAME * 2);
+
+  // Results lead, while schedule and recent form keep equal records distinct.
+  return Math.round(
+    1000 *
+      (winPercentage(record) * 0.45 +
+        normalizedDifferential * 0.2 +
+        strengthOfSchedule(record, recordsByTeam) * 0.2 +
+        recencyScore(record.lastResults) * 0.15),
+  );
+}
+
+function canOccupyIndex(
+  teamId: string,
+  nextIndex: number,
+  previousIndexByTeam: ReadonlyMap<string, number>,
+): boolean {
+  const previousIndex = previousIndexByTeam.get(teamId);
+  return (
+    previousIndex === undefined ||
+    Math.abs(nextIndex - previousIndex) <= MAX_WEEKLY_RANK_MOVEMENT
+  );
+}
+
+/**
+ * Move toward the raw order through bounded adjacent swaps.
+ *
+ * Starting from last week's permutation and swapping only adjacent inverted
+ * pairs makes the damping visible: a great week can earn places, but never
+ * more than MAX_WEEKLY_RANK_MOVEMENT. The output remains a permutation by
+ * construction because teams are reordered, never regenerated.
+ */
+function dampedOrder(
+  scored: readonly ScoredTeam[],
+  previous: readonly PreviousPowerRanking[],
+): ScoredTeam[] {
+  const rawOrder = [...scored].sort(
+    (a, b) =>
+      b.points - a.points || a.record.teamId.localeCompare(b.record.teamId),
+  );
+  if (previous.length === 0) return rawOrder;
+
+  const rawIndexByTeam = new Map(
+    rawOrder.map((team, index) => [team.record.teamId, index]),
+  );
+  const previousRankByTeam = new Map(
+    previous
+      .filter((row) => Number.isInteger(row.rank) && row.rank > 0)
+      .map((row) => [row.teamId, row.rank]),
+  );
+  const previousIndexByTeam = new Map(
+    [...previousRankByTeam].map(([teamId, rank]) => [teamId, rank - 1]),
+  );
+  const order = [...scored].sort((a, b) => {
+    const aPrevious =
+      previousRankByTeam.get(a.record.teamId) ?? Number.MAX_SAFE_INTEGER;
+    const bPrevious =
+      previousRankByTeam.get(b.record.teamId) ?? Number.MAX_SAFE_INTEGER;
+    return (
+      aPrevious - bPrevious ||
+      (rawIndexByTeam.get(a.record.teamId) ?? Number.MAX_SAFE_INTEGER) -
+        (rawIndexByTeam.get(b.record.teamId) ?? Number.MAX_SAFE_INTEGER)
+    );
+  });
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let index = 0; index < order.length - 1; index += 1) {
+      const left = order[index]!;
+      const right = order[index + 1]!;
+      const leftDesired = rawIndexByTeam.get(left.record.teamId) ?? index;
+      const rightDesired =
+        rawIndexByTeam.get(right.record.teamId) ?? index + 1;
+      if (leftDesired <= rightDesired) continue;
+      if (
+        !canOccupyIndex(
+          left.record.teamId,
+          index + 1,
+          previousIndexByTeam,
+        ) ||
+        !canOccupyIndex(right.record.teamId, index, previousIndexByTeam)
+      ) {
+        continue;
+      }
+      order[index] = right;
+      order[index + 1] = left;
+      changed = true;
+    }
+  }
+  return order;
+}
+
+/**
+ * Rank one record per team. Duplicate team ids are rejected because silently
+ * dropping either row would violate the poll's permutation contract.
+ */
+export function computePowerRankings(
+  records: readonly PowerRankingRecord[],
+  previous: readonly PreviousPowerRanking[] = [],
+): PowerRanking[] {
+  const recordsByTeam = new Map<string, PowerRankingRecord>();
+  for (const record of records) {
+    if (recordsByTeam.has(record.teamId)) {
+      throw new Error(`duplicate_power_ranking_team:${record.teamId}`);
+    }
+    recordsByTeam.set(record.teamId, record);
+  }
+
+  const scored = records.map((record) => ({
+    record,
+    points: compositePoints(record, recordsByTeam),
+  }));
+  const previousRankByTeam = new Map(
+    previous.map((row) => [row.teamId, row.rank]),
+  );
+
+  return dampedOrder(scored, previous).map((team, index): PowerRanking => {
+    const rank = index + 1;
+    const previousRank = previousRankByTeam.get(team.record.teamId) ?? null;
+    const trend =
+      previousRank === null
+        ? "new"
+        : previousRank > rank
+          ? "up"
+          : previousRank < rank
+            ? "down"
+            : "same";
+    return {
+      teamId: team.record.teamId,
+      rank,
+      previousRank,
+      points: team.points,
+      record: {
+        wins: team.record.wins,
+        losses: team.record.losses,
+        ties: team.record.ties,
+      },
+      trend,
+    };
+  });
+}

--- a/apps/web/convex/lib/weeklyPolls.ts
+++ b/apps/web/convex/lib/weeklyPolls.ts
@@ -1,0 +1,110 @@
+import type { MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import {
+  computePowerRankings,
+  type PowerRanking,
+  type PreviousPowerRanking,
+} from "./powerRankings";
+
+export interface WeeklyPollWriteResult {
+  rankings: number;
+  written: boolean;
+}
+
+function parsePreviousRankings(json: string | null): PreviousPowerRanking[] {
+  if (!json) return [];
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((row): PreviousPowerRanking[] => {
+      if (
+        !row ||
+        typeof row !== "object" ||
+        typeof (row as { teamId?: unknown }).teamId !== "string" ||
+        typeof (row as { rank?: unknown }).rank !== "number"
+      ) {
+        return [];
+      }
+      return [
+        {
+          teamId: (row as { teamId: string }).teamId,
+          rank: (row as { rank: number }).rank,
+        },
+      ];
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Materialize one week's poll from the persisted F2 cache.
+ *
+ * The only competition source read here is seasonTeamRecords. In particular,
+ * this never touches fixtures or results: one indexed collect yields roughly
+ * one document per team, plus the prior poll needed for damping.
+ */
+export async function computeWeeklyPollForSeason(
+  ctx: MutationCtx,
+  args: {
+    leagueId: Id<"leagues">;
+    seasonId: Id<"seasons">;
+    week: number;
+  },
+): Promise<WeeklyPollWriteResult> {
+  const records = await ctx.db
+    .query("seasonTeamRecords")
+    .withIndex("by_seasonId", (q) => q.eq("seasonId", args.seasonId))
+    .collect();
+  const leagueRecords = records.filter(
+    (record) => record.leagueId === args.leagueId,
+  );
+  if (leagueRecords.length === 0) {
+    return { rankings: 0, written: false };
+  }
+
+  const previousPoll =
+    args.week > 1
+      ? await ctx.db
+          .query("weeklyPolls")
+          .withIndex("by_seasonId_week", (q) =>
+            q.eq("seasonId", args.seasonId).eq("week", args.week - 1),
+          )
+          .unique()
+      : null;
+  const rankings: PowerRanking[] = computePowerRankings(
+    leagueRecords.map((record) => ({
+      teamId: record.teamId,
+      wins: record.wins,
+      losses: record.losses,
+      ties: record.ties,
+      pointsFor: record.pointsFor,
+      pointsAgainst: record.pointsAgainst,
+      headToHeadJson: record.headToHeadJson,
+      lastResults: record.lastResults,
+      gamesCounted: record.gamesCounted,
+    })),
+    parsePreviousRankings(previousPoll?.rankingsJson ?? null),
+  );
+  const rankingsJson = JSON.stringify(rankings);
+  const publishedAt = new Date().toISOString();
+  const existing = await ctx.db
+    .query("weeklyPolls")
+    .withIndex("by_seasonId_week", (q) =>
+      q.eq("seasonId", args.seasonId).eq("week", args.week),
+    )
+    .unique();
+  const payload = {
+    leagueId: args.leagueId,
+    seasonId: args.seasonId,
+    week: args.week,
+    rankingsJson,
+    publishedAt,
+  };
+  if (existing) {
+    await ctx.db.replace(existing._id, payload);
+  } else {
+    await ctx.db.insert("weeklyPolls", payload);
+  }
+  return { rankings: rankings.length, written: true };
+}

--- a/apps/web/convex/tables/history.ts
+++ b/apps/web/convex/tables/history.ts
@@ -8,6 +8,20 @@ import { v } from "convex/values";
  * Season: a career and a record book only become meaningful across seasons.
  */
 export const historyTables = {
+  weeklyPolls: defineTable({
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    week: v.number(),
+    /**
+     * JSON `PowerRanking[]`: teamId, rank, previousRank, points, record and
+     * trend. Keeping the slate atomic prevents readers seeing half a poll.
+     */
+    rankingsJson: v.string(),
+    publishedAt: v.string(),
+  })
+    .index("by_seasonId_week", ["seasonId", "week"])
+    .index("by_seasonId", ["seasonId"]),
+
   awards: defineTable({
     leagueId: v.id("leagues"),
     seasonId: v.id("seasons"),

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -153,6 +153,29 @@ export async function seedAwardsFixture(
   });
 }
 
+const seedRankingsFixtureRef = makeFunctionReference<
+  "mutation",
+  {
+    leagueId: string;
+    seasonId: string;
+    homeTeamId: string;
+    awayTeamId: string;
+  },
+  { rankingsCreated: number }
+>("e2eSeed:seedRankingsFixture");
+
+export async function seedRankingsFixture(
+  fixture: ScheduleFixtureResult,
+): Promise<{ rankingsCreated: number }> {
+  const client = getSeedClient();
+  return client.mutation(seedRankingsFixtureRef, {
+    leagueId: fixture.leagueId,
+    seasonId: fixture.seasonId,
+    homeTeamId: fixture.homeTeamId,
+    awayTeamId: fixture.awayTeamId,
+  });
+}
+
 const seedProspectClassRef = makeFunctionReference<
   "mutation",
   any,

--- a/apps/web/e2e/tests/rankings.spec.ts
+++ b/apps/web/e2e/tests/rankings.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedRankingsFixture,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+test.describe("Weekly power rankings (D3)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "season-rankings";
+  let fixture: ScheduleFixtureResult | null = null;
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E Rankings Home",
+      awayTeamName: "E2E Rankings Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+
+    const seeded = await seedRankingsFixture(fixture);
+    expect(seeded.rankingsCreated).toBe(2);
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("renders the weekly poll and both seeded teams", async ({ page }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/seasons/${fixture.seasonId}/rankings`);
+    const rankings = page.getByTestId("season-rankings");
+    await expect(rankings).toBeVisible({ timeout: 30_000 });
+    // `CardTitle` renders a div, not a heading element, so `getByRole("heading")`
+    // never matches it. Assert on the text, scoped to the container.
+    await expect(rankings.getByText("Week 1 poll", { exact: true })).toBeVisible();
+    await expect(
+      rankings.getByRole("link", {
+        name: fixture.homeTeamName,
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      rankings.getByRole("link", {
+        name: fixture.awayTeamName,
+        exact: true,
+      }),
+    ).toBeVisible();
+    const header = rankings.getByTestId("resource-header-season");
+    await expect(
+      header.getByRole("link", { name: "Rankings", exact: true }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/__tests__/simulate-actions.test.ts
@@ -25,6 +25,7 @@ const {
   mockListTeamPrograms,
   mockListCoachesByLeague,
   mockListFixtureGameplans,
+  mockComputeWeeklyPoll,
 } = vi.hoisted(() => ({
   mockSchedulesStandingsV1: vi.fn(),
   mockAuth: vi.fn(),
@@ -48,6 +49,7 @@ const {
   mockListTeamPrograms: vi.fn(),
   mockListCoachesByLeague: vi.fn(),
   mockListFixtureGameplans: vi.fn(),
+  mockComputeWeeklyPoll: vi.fn(),
 }));
 
 vi.mock("@/lib/flags", () => ({
@@ -62,6 +64,7 @@ vi.mock("@/lib/data-api", () => ({
   listTeamPrograms: mockListTeamPrograms,
   listCoachesByLeague: mockListCoachesByLeague,
   listFixtureGameplans: mockListFixtureGameplans,
+  computeWeeklyPoll: mockComputeWeeklyPoll,
   getFixture: mockGetFixture,
   recordGameResult: mockRecordGameResult,
   upsertGamePlayLog: mockUpsertGamePlayLog,
@@ -146,6 +149,7 @@ function authorize() {
   mockListTeamPrograms.mockResolvedValue([]);
   mockListCoachesByLeague.mockResolvedValue([]);
   mockListFixtureGameplans.mockResolvedValue([]);
+  mockComputeWeeklyPoll.mockResolvedValue({ rankings: 2, written: true });
   mockAuth.mockResolvedValue({ userId: USER });
   mockResolveOrgContext.mockResolvedValue({ visibleLeagueIds: [LEAGUE] });
   mockGetLeague.mockResolvedValue({ id: LEAGUE, name: "League" });
@@ -195,6 +199,7 @@ describe("simulateGameAction (PBP Slice B)", () => {
       // default settings, every Epic A mechanic is live.
       simContext: {
         leagueId: LEAGUE,
+        pollsEnabled: true,
         features: {
           scoringV2: true,
           penalties: true,
@@ -247,6 +252,30 @@ describe("simulateWeekAction", () => {
       bulkStats: true,
       profileCache: expect.any(Map),
     });
+    expect(mockComputeWeeklyPoll).toHaveBeenCalledWith({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      week: 1,
+    });
+  });
+
+  it("writes no poll row when polls are disabled", async () => {
+    mockGetDynastyConfig.mockResolvedValue({
+      ...DYNASTY_CONFIG_DEFAULTS,
+      pollsEnabled: false,
+    });
+    mockListFixturesBySeason.mockResolvedValue([
+      fixture({ id: "w1a", week: 1 }),
+    ]);
+
+    const res = await simulateWeekAction({
+      leagueId: LEAGUE,
+      seasonId: SEASON,
+      week: 1,
+    });
+
+    expect(res).toEqual({ ok: true, simulated: 1 });
+    expect(mockComputeWeeklyPoll).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -15,6 +15,7 @@ import {
   generatePlayoffBracket,
   getPlayoffBracket,
   recordGameResult,
+  computeWeeklyPoll,
 } from "@/lib/data-api";
 import type { PlayoffMatchupDto } from "@/lib/data-api";
 import type { OrgContext } from "@/lib/org-context";
@@ -611,6 +612,14 @@ export async function simulateWeekAction(input: {
         simContext,
       });
       simulated += 1;
+    }
+    if (simContext.pollsEnabled) {
+      await computeWeeklyPoll({
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+        week: input.week,
+      });
+      revalidatePath(`/dashboard/seasons/${input.seasonId}/rankings`);
     }
     revalidateSchedulePaths(input.leagueId, input.seasonId);
     return { ok: true, simulated };

--- a/apps/web/src/app/dashboard/seasons/[id]/awards/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/awards/page.tsx
@@ -92,6 +92,7 @@ export default async function SeasonAwardsPage({
           statsEnabled,
           offseasonEnabled: offseasonEnabled && season.status === "upcoming",
           awardsEnabled: true,
+          rankingsEnabled: true,
         })}
       />
 

--- a/apps/web/src/app/dashboard/seasons/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/page.tsx
@@ -254,6 +254,7 @@ export default async function SeasonHubPage({
           // Only an upcoming season has an offseason to prepare.
           offseasonEnabled: offseasonEnabled && isUpcomingSeason,
           awardsEnabled: historyEnabled,
+          rankingsEnabled: historyEnabled,
         })}
       />
       <WorkspaceNav links={links} />

--- a/apps/web/src/app/dashboard/seasons/[id]/rankings/page.tsx
+++ b/apps/web/src/app/dashboard/seasons/[id]/rankings/page.tsx
@@ -1,0 +1,184 @@
+import { auth } from "@clerk/nextjs/server";
+import { ArrowDown, ArrowUp, Minus } from "lucide-react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ResourceHeader } from "@/components/workspace/ResourceHeader";
+import {
+  buildSeasonSiblingLinks,
+  seasonHomeHref,
+} from "@/components/workspace/resource-navigation";
+import { syncActiveLeagueForResource } from "@/lib/active-league-server";
+import { getLeague, getSeason, getWeeklyPoll } from "@/lib/data-api";
+import {
+  dynastyHistoryV1,
+  dynastyOffseasonV2,
+  pageGuard,
+  playoffsV1,
+  schedulesStandingsV1,
+  statKeepingV1,
+} from "@/lib/flags";
+import { resolveOrgContext } from "@/lib/org-context";
+
+function recordLabel(record: {
+  wins: number;
+  losses: number;
+  ties: number;
+}): string {
+  return record.ties > 0
+    ? `${record.wins}-${record.losses}-${record.ties}`
+    : `${record.wins}-${record.losses}`;
+}
+
+function Movement({
+  rank,
+  previousRank,
+}: {
+  rank: number;
+  previousRank: number | null;
+}) {
+  if (previousRank === null) {
+    return <span className="text-xs text-muted-foreground">New</span>;
+  }
+  const movement = previousRank - rank;
+  if (movement > 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-600">
+        <ArrowUp className="h-4 w-4" aria-hidden />
+        <span>{movement}</span>
+        <span className="sr-only">Up {movement}</span>
+      </span>
+    );
+  }
+  if (movement < 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-red-600">
+        <ArrowDown className="h-4 w-4" aria-hidden />
+        <span>{Math.abs(movement)}</span>
+        <span className="sr-only">Down {Math.abs(movement)}</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center text-muted-foreground">
+      <Minus className="h-4 w-4" aria-hidden />
+      <span className="sr-only">No change</span>
+    </span>
+  );
+}
+
+export default async function SeasonRankingsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await pageGuard(dynastyHistoryV1);
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  const { id: seasonId } = await params;
+  const orgContext = await resolveOrgContext(userId);
+  const season = await getSeason(seasonId, orgContext).catch(() => null);
+  if (!season) notFound();
+  const league = await getLeague(season.leagueId, orgContext).catch(() => null);
+  if (!league) notFound();
+  await syncActiveLeagueForResource(league.id);
+
+  const [
+    poll,
+    scheduleEnabled,
+    playoffsEnabled,
+    statsEnabled,
+    offseasonEnabled,
+  ] = await Promise.all([
+    getWeeklyPoll(season.id).catch(() => null),
+    schedulesStandingsV1(),
+    playoffsV1(),
+    statKeepingV1(),
+    dynastyOffseasonV2(),
+  ]);
+
+  return (
+    <div className="space-y-4" data-testid="season-rankings">
+      <ResourceHeader
+        kind="season"
+        title="Power rankings"
+        homeHref={seasonHomeHref(season.id)}
+        context={`${season.name} · ${league.name}`}
+        siblings={buildSeasonSiblingLinks({
+          seasonId: season.id,
+          scheduleEnabled,
+          playoffsEnabled,
+          statsEnabled,
+          offseasonEnabled: offseasonEnabled && season.status === "upcoming",
+          awardsEnabled: true,
+          rankingsEnabled: true,
+        })}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {poll ? `Week ${poll.week} poll` : "Weekly poll"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className={poll ? "p-0" : undefined}>
+          {!poll || poll.rankings.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Rankings publish after a week of games is simulated.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16 text-center">Rank</TableHead>
+                  <TableHead>Program</TableHead>
+                  <TableHead className="text-center">Movement</TableHead>
+                  <TableHead className="text-center">Record</TableHead>
+                  <TableHead className="text-right">Points</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {poll.rankings.map((ranking) => (
+                  <TableRow key={ranking.teamId}>
+                    <TableCell className="text-center text-lg font-semibold">
+                      {ranking.rank}
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        href={`/dashboard/teams/${ranking.teamId}`}
+                        className="font-medium hover:underline"
+                      >
+                        {ranking.teamName}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Movement
+                        rank={ranking.rank}
+                        previousRank={ranking.previousRank}
+                      />
+                    </TableCell>
+                    <TableCell className="text-center tabular-nums">
+                      {recordLabel(ranking.record)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {ranking.points}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
+++ b/apps/web/src/components/workspace/__tests__/resource-navigation.test.ts
@@ -120,6 +120,9 @@ describe("resource-navigation helpers", () => {
     expect(seasonSubpageHref("s1", "awards")).toBe(
       "/dashboard/seasons/s1/awards",
     );
+    expect(seasonSubpageHref("s1", "rankings")).toBe(
+      "/dashboard/seasons/s1/rankings",
+    );
   });
 });
 
@@ -228,6 +231,21 @@ describe("buildSeasonSiblingLinks", () => {
     });
     expect(enabled.map((link) => link.label)).toEqual(["Overview", "Awards"]);
     expect(enabled[1]!.href).toBe("/dashboard/seasons/s1/awards");
+  });
+
+  it("gates the Rankings sibling independently", () => {
+    const enabled = buildSeasonSiblingLinks({
+      seasonId: "s1",
+      scheduleEnabled: false,
+      playoffsEnabled: false,
+      statsEnabled: false,
+      rankingsEnabled: true,
+    });
+    expect(enabled.map((link) => link.label)).toEqual([
+      "Overview",
+      "Rankings",
+    ]);
+    expect(enabled[1]!.href).toBe("/dashboard/seasons/s1/rankings");
   });
 });
 

--- a/apps/web/src/components/workspace/resource-navigation.ts
+++ b/apps/web/src/components/workspace/resource-navigation.ts
@@ -114,7 +114,8 @@ export function seasonSubpageHref(
     | "playoffs"
     | "stats"
     | "offseason"
-    | "awards",
+    | "awards"
+    | "rankings",
 ): string {
   return `/dashboard/seasons/${seasonId}/${subpage}`;
 }
@@ -224,6 +225,7 @@ export function buildSeasonSiblingLinks({
   statsEnabled,
   offseasonEnabled = false,
   awardsEnabled = false,
+  rankingsEnabled = false,
 }: {
   seasonId: string;
   scheduleEnabled: boolean;
@@ -237,6 +239,8 @@ export function buildSeasonSiblingLinks({
   offseasonEnabled?: boolean;
   /** Epic D history flag; awards remain a Season-owned read surface. */
   awardsEnabled?: boolean;
+  /** Epic D history flag; rankings remain a Season-owned read surface. */
+  rankingsEnabled?: boolean;
 }): ResourceSiblingLink[] {
   const links: (ResourceSiblingLink | false)[] = [
     { label: "Overview", href: seasonHomeHref(seasonId) },
@@ -259,6 +263,10 @@ export function buildSeasonSiblingLinks({
     statsEnabled && {
       label: "Stat leaders",
       href: seasonSubpageHref(seasonId, "stats"),
+    },
+    rankingsEnabled && {
+      label: "Rankings",
+      href: seasonSubpageHref(seasonId, "rankings"),
     },
     awardsEnabled && {
       label: "Awards",

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -129,6 +129,9 @@ const listProgramRecordsRef = historyRef.query<ProgramRecordDto[]>(
 const listSeasonAwardsRef = historyRef.query<AwardDto[]>("listSeasonAwards");
 const listPlayerAwardsRef = historyRef.query<AwardDto[]>("listPlayerAwards");
 const listCoachAwardsRef = historyRef.query<AwardDto[]>("listCoachAwards");
+const getWeeklyPollRef = historyRef.query<WeeklyPollDto | null>(
+  "getWeeklyPoll",
+);
 
 /** A single bracket node (WSM-000164). Team/score fields are null until played. */
 export interface PlayoffMatchupDto {
@@ -213,6 +216,31 @@ export interface AwardDto {
   divisionName: string | null;
   positionGroup: string | null;
   scoreValue: number;
+}
+
+export interface WeeklyPollRankingDto {
+  teamId: string;
+  teamName: string;
+  rank: number;
+  previousRank: number | null;
+  points: number;
+  record: {
+    wins: number;
+    losses: number;
+    ties: number;
+  };
+  trend: "up" | "down" | "same" | "new";
+}
+
+export interface WeeklyPollDto {
+  week: number;
+  publishedAt: string;
+  rankings: WeeklyPollRankingDto[];
+}
+
+export interface WeeklyPollWriteResult {
+  rankings: number;
+  written: boolean;
 }
 
 const refs = {
@@ -1297,6 +1325,28 @@ export async function listPlayerAwards(
 
 export async function listCoachAwards(coachId: string): Promise<AwardDto[]> {
   return queryConvex(listCoachAwardsRef, { coachId });
+}
+
+export async function getWeeklyPoll(
+  seasonId: string,
+  week?: number,
+): Promise<WeeklyPollDto | null> {
+  return queryConvex(getWeeklyPollRef, {
+    seasonId,
+    ...(week !== undefined ? { week } : {}),
+  });
+}
+
+export async function computeWeeklyPoll(input: {
+  leagueId: string;
+  seasonId: string;
+  week: number;
+}): Promise<WeeklyPollWriteResult> {
+  const client = getConvexClient();
+  return client.mutation(
+    historyRef.mutation<WeeklyPollWriteResult>("computeWeeklyPoll"),
+    input,
+  );
 }
 
 export async function getTeam(

--- a/apps/web/src/lib/history/__tests__/power-rankings.test.ts
+++ b/apps/web/src/lib/history/__tests__/power-rankings.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePowerRankings,
+  MAX_WEEKLY_RANK_MOVEMENT,
+  type PowerRankingRecord,
+} from "@/lib/history/power-rankings";
+
+function record(
+  teamId: string,
+  patch: Partial<PowerRankingRecord> = {},
+): PowerRankingRecord {
+  return {
+    teamId,
+    wins: 4,
+    losses: 4,
+    ties: 0,
+    pointsFor: 160,
+    pointsAgainst: 160,
+    headToHeadJson: "{}",
+    lastResults: ["W", "L", "W", "L"],
+    gamesCounted: 8,
+    ...patch,
+  };
+}
+
+describe("computePowerRankings", () => {
+  it("limits a single blowout to the weekly damping constant", () => {
+    const records = Array.from({ length: 8 }, (_, index) =>
+      record(`team_${index + 1}`),
+    );
+    const previous = records.map((team, index) => ({
+      teamId: team.teamId,
+      rank: index + 1,
+    }));
+    const afterBlowout = records.map((team) =>
+      team.teamId === "team_8"
+        ? record(team.teamId, {
+            wins: 5,
+            losses: 4,
+            pointsFor: 240,
+            pointsAgainst: 160,
+            lastResults: ["W", "W", "L", "W", "L"],
+            gamesCounted: 9,
+          })
+        : team,
+    );
+
+    const poll = computePowerRankings(afterBlowout, previous);
+    const formerLast = poll.find((team) => team.teamId === "team_8")!;
+
+    expect(8 - formerLast.rank).toBeGreaterThan(0);
+    expect(8 - formerLast.rank).toBeLessThanOrEqual(
+      MAX_WEEKLY_RANK_MOVEMENT,
+    );
+  });
+
+  it("property: random result sets always produce a complete rank permutation", () => {
+    let state = 0x632d3;
+    const randomInt = (max: number) => {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      return state % max;
+    };
+
+    for (let sample = 0; sample < 100; sample += 1) {
+      const teamCount = 2 + randomInt(19);
+      const records = Array.from({ length: teamCount }, (_, index) => {
+        const games = 1 + randomInt(12);
+        const wins = randomInt(games + 1);
+        const ties = randomInt(games - wins + 1);
+        const losses = games - wins - ties;
+        const results = Array.from({ length: Math.min(10, games) }, () =>
+          ["W", "L", "T"][randomInt(3)]!,
+        );
+        return record(`sample_${sample}_team_${index}`, {
+          wins,
+          losses,
+          ties,
+          pointsFor: randomInt(games * 50 + 1),
+          pointsAgainst: randomInt(games * 50 + 1),
+          lastResults: results,
+          gamesCounted: games,
+        });
+      });
+
+      const weekOne = computePowerRankings(records);
+      expect(weekOne.map((row) => row.rank).sort((a, b) => a - b)).toEqual(
+        Array.from({ length: teamCount }, (_, index) => index + 1),
+      );
+      expect(new Set(weekOne.map((row) => row.teamId))).toEqual(
+        new Set(records.map((row) => row.teamId)),
+      );
+      expect(weekOne.every((row) => row.previousRank === null)).toBe(true);
+
+      const nextRecords = records.map((row) => ({
+        ...row,
+        wins: row.wins + randomInt(2),
+        losses: row.losses + randomInt(2),
+        pointsFor: row.pointsFor + randomInt(50),
+        pointsAgainst: row.pointsAgainst + randomInt(50),
+        gamesCounted: row.gamesCounted + 1,
+      }));
+      const weekTwo = computePowerRankings(
+        nextRecords,
+        weekOne.map(({ teamId, rank }) => ({ teamId, rank })),
+      );
+      expect(weekTwo.map((row) => row.rank).sort((a, b) => a - b)).toEqual(
+        Array.from({ length: teamCount }, (_, index) => index + 1),
+      );
+      expect(new Set(weekTwo.map((row) => row.teamId))).toEqual(
+        new Set(records.map((row) => row.teamId)),
+      );
+    }
+  });
+});

--- a/apps/web/src/lib/history/power-rankings.ts
+++ b/apps/web/src/lib/history/power-rankings.ts
@@ -1,0 +1,1 @@
+export * from "../../../convex/lib/powerRankings";

--- a/apps/web/src/lib/sim-context.ts
+++ b/apps/web/src/lib/sim-context.ts
@@ -32,6 +32,12 @@ import { resolveAggression } from "@/lib/program/resolveProgram";
 /** Everything a run of the simulator needs beyond the fixtures themselves. */
 export interface SeasonSimContext {
   leagueId: string;
+  /**
+   * D3 is not an engine feature, but the weekly action already resolves this
+   * config once per run. Carrying it here avoids a second settings read after
+   * the games finish.
+   */
+  pollsEnabled: boolean;
   /** Resolved once per run — every fixture in the run simulates alike. */
   features: PbpFeatureGates;
   /** `pairKey` → intensity, for the rivalry lookup (A5). */
@@ -126,6 +132,7 @@ export async function loadSeasonSimContext(input: {
   );
   return {
     leagueId: input.leagueId,
+    pollsEnabled: config?.pollsEnabled ?? false,
     features,
     injurySeverityScale: config?.injurySeverityScale ?? 1,
     rivalries: new Map(
@@ -176,6 +183,7 @@ export async function loadSeasonSimContext(input: {
 export function emptySimContext(leagueId: string): SeasonSimContext {
   return {
     leagueId,
+    pollsEnabled: false,
     features: {},
     rivalries: new Map(),
     injurySeverityScale: 1,


### PR DESCRIPTION
Closes #632. Third slice of Epic D, stacked on #665.

When a week of games finishes there is a ranking that moves like a poll — last week's position visible, movement damped — so climbing the rankings across a season reads as a storyline rather than a re-sort.

## The design point that carries the slice
**A poll is not a sort.** Movement is capped at two places per week, so one blowout nudges a team instead of teleporting it. Without that damping this feature is `ORDER BY win_pct` with extra steps; the cap is what makes it feel like a poll.

## What landed
- `computePowerRankings` blends win rate (45%), capped point differential (20%), strength of schedule (20%) and recency (15%), damped against the previous week. Differential is capped at 21/game so a 60-point rout does not distort the season.
- Week 1 previous ranks are `null` — honest absence, not 0 and not self-referential.
- The poll computes **inline** after the week simulation, reading only `seasonTeamRecords` — roughly a dozen documents, no fixture scan, pinned by a read spy.
- `/dashboard/seasons/[id]/rankings` renders the poll with movement arrows.
- `dynastyConfig.pollsEnabled` off skips computation **entirely** — no rows written, rather than rows written and hidden.

## Verification
- `vitest run` — 234 files, 1865 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean

A property test asserts ranks are always a complete permutation of the league's teams across random result sets, and a separate test pins the blowout bound.