### PR TITLE
feat: Hall of Fame induction (#634)

### DIFF
--- a/apps/web/convex/__tests__/hallOfFame.test.ts
+++ b/apps/web/convex/__tests__/hallOfFame.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.*s");
+
+describe("Hall of Fame induction", () => {
+  it("creates exactly one class when the same season is rolled over twice", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const leagueId = await ctx.db.insert("leagues", {
+        name: "Long Running League",
+        orgId: "org_hof",
+        isPublic: false,
+        inviteToken: null,
+      });
+      const teamId = await ctx.db.insert("teams", {
+        name: "Legends",
+        leagueId,
+        divisionId: null,
+        city: "History",
+        stadium: "Legacy Field",
+        foundedYear: null,
+        location: "History, HS",
+        logoUrl: null,
+        rosterLimit: 53,
+      });
+      const seasonIds = [];
+      for (let year = 2030; year <= 2033; year++) {
+        seasonIds.push(
+          await ctx.db.insert("seasons", {
+            name: String(year),
+            leagueId,
+            startDate: `${year}-09-01`,
+            endDate: null,
+            status: "completed",
+            rosterLocked: false,
+          }),
+        );
+      }
+      const playerId = await ctx.db.insert("players", {
+        name: "First Ballot",
+        leagueId,
+        teamId,
+        position: "QB",
+        positionGroup: "QB",
+        jerseyNumber: 12,
+        dateOfBirth: null,
+        status: "graduated",
+        headshotUrl: null,
+      });
+      const totals = { passing: { yards: 4_000, td: 45 } };
+      await ctx.db.insert("playerCareerTotals", {
+        leagueId,
+        playerId,
+        totalsJson: JSON.stringify(totals),
+        seasonTotalsJson: JSON.stringify({
+          [seasonIds[0] as string]: totals,
+        }),
+        peakOverall: 96,
+        championshipSeasonIds: [seasonIds[0]!],
+        updatedAt: new Date(0).toISOString(),
+      });
+      return {
+        leagueId,
+        playerId,
+        sourceSeasonId: seasonIds.at(-1)!,
+      };
+    });
+
+    const firstRollover = await t.mutation(
+      internal.sports.beginSeasonRollover,
+      { sourceSeasonId: seeded.sourceSeasonId },
+    );
+    await t.mutation(internal.history.inductHallOfFameClass, {
+      leagueId: seeded.leagueId,
+      inductedSeasonId: seeded.sourceSeasonId,
+    });
+    const retryRollover = await t.mutation(
+      internal.sports.beginSeasonRollover,
+      { sourceSeasonId: seeded.sourceSeasonId },
+    );
+    await t.mutation(internal.history.inductHallOfFameClass, {
+      leagueId: seeded.leagueId,
+      inductedSeasonId: seeded.sourceSeasonId,
+    });
+
+    expect(retryRollover.rolloverId).toBe(firstRollover.rolloverId);
+    const rows = await t.query(api.history.listHallOfFame, {
+      leagueId: seeded.leagueId,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      recipientId: seeded.playerId,
+      recipientName: "First Ballot",
+      classLabel: "Hall of Fame Class of 2033",
+    });
+  });
+});

--- a/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
+++ b/apps/web/convex/__tests__/writeMutationsAreInternal.test.ts
@@ -235,9 +235,11 @@ void api.history.listPlayerAwards;
 void api.history.listCoachAwards;
 void api.history.getWeeklyPoll;
 void api.history.listSeasonRecaps;
+void api.history.listHallOfFame;
 void internal.history.finalizeSeasonHistory;
 void internal.history.computeWeeklyPoll;
 void internal.history.finalizeSeasonRecap;
+void internal.history.inductHallOfFameClass;
 
 type AllowedPublicDynastyReads =
   | "moduleStatus"
@@ -295,7 +297,8 @@ type AllowedPublicHistoryReads =
   | "listPlayerAwards"
   | "listCoachAwards"
   | "getWeeklyPoll"
-  | "listSeasonRecaps";
+  | "listSeasonRecaps"
+  | "listHallOfFame";
 
 type LeakedPublicDynastyWrites = Exclude<
   keyof typeof api.dynasty,

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -6,6 +6,7 @@ import { finalizeSeasonHistoryForSeason } from "./lib/historyFinalize";
 import { computeWeeklyPollForSeason } from "./lib/weeklyPolls";
 import { emitDynastyEvent } from "./lib/events";
 import { finalizeSeasonRecapForSeason } from "./lib/seasonRecaps";
+import { renderHallOfFameCitation } from "./lib/narrative";
 
 /*
  * e2e seed fixtures (WSM-000139, fast-follow to WSM-000096).
@@ -251,6 +252,14 @@ async function cascadeDeleteLeague(
     .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
     .collect()) as Array<{ _id: Id<"playerCareerTotals"> }>;
   for (const row of careerTotals) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
+  const hallOfFameRows = (await ctx.db
+    .query("hallOfFame")
+    .withIndex("by_leagueId", (q: any) => q.eq("leagueId", leagueId))
+    .collect()) as Array<{ _id: Id<"hallOfFame"> }>;
+  for (const row of hallOfFameRows) {
     await ctx.db.delete(row._id);
     deleted += 1;
   }
@@ -699,6 +708,77 @@ export const seedHistoryFixture = internalMutation({
       created += 2;
     }
     return { created };
+  },
+});
+
+/** D5 route fixture: one inductee from each fixture Team in one class. */
+export const seedHallOfFameFixture = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    seasonId: v.id("seasons"),
+    homeTeamId: v.id("teams"),
+    awayTeamId: v.id("teams"),
+  },
+  returns: v.object({ created: v.number(), classLabel: v.string() }),
+  handler: async (ctx, args) => {
+    assertSeedEnabled();
+    const [season, homeTeam, awayTeam] = await Promise.all([
+      ctx.db.get(args.seasonId),
+      ctx.db.get(args.homeTeamId),
+      ctx.db.get(args.awayTeamId),
+    ]);
+    if (
+      !season ||
+      season.leagueId !== args.leagueId ||
+      !homeTeam ||
+      homeTeam.leagueId !== args.leagueId ||
+      !awayTeam ||
+      awayTeam.leagueId !== args.leagueId
+    ) {
+      throw new Error("hall_of_fame_fixture_scope_mismatch");
+    }
+
+    const classLabel = `Hall of Fame Class of ${season.name}`;
+    const inductedAt = new Date().toISOString();
+    const recipients = [
+      { name: "E2E Home Legend", teamId: args.homeTeamId, score: 2_500 },
+      { name: "E2E Away Legend", teamId: args.awayTeamId, score: 2_250 },
+    ];
+    let created = 0;
+    for (const [index, recipient] of recipients.entries()) {
+      const playerId = await ctx.db.insert("players", {
+        name: recipient.name,
+        leagueId: args.leagueId,
+        teamId: recipient.teamId,
+        position: "ATH",
+        positionGroup: "ATH",
+        jerseyNumber: 90 + index,
+        dateOfBirth: null,
+        status: "graduated",
+        headshotUrl: null,
+      });
+      await ctx.db.insert("hallOfFame", {
+        leagueId: args.leagueId,
+        playerId,
+        coachId: null,
+        inductedSeasonId: args.seasonId,
+        classLabel,
+        citation: renderHallOfFameCitation({
+          recipientName: recipient.name,
+          kind: "player",
+          seasonsPlayed: 4,
+          careerProduction: 7_500 - index * 500,
+          careerWins: 0,
+          accolades: 2,
+          championships: 1,
+          peakOverall: 94 - index,
+        }),
+        score: recipient.score,
+        inductedAt,
+      });
+      created += 1;
+    }
+    return { created, classLabel };
   },
 });
 

--- a/apps/web/convex/history.ts
+++ b/apps/web/convex/history.ts
@@ -1,6 +1,6 @@
 import { v, type Infer } from "convex/values";
 import { internalMutation, query, type QueryCtx } from "./_generated/server";
-import type { Doc } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { DYNASTY_MODULES, moduleStatusValidator } from "./lib/moduleStatus";
 import {
   RECORD_CATEGORY_LABELS,
@@ -14,6 +14,15 @@ import { computeWeeklyPollForSeason } from "./lib/weeklyPolls";
 import type { PowerRanking } from "./lib/powerRankings";
 import { finalizeSeasonRecapForSeason } from "./lib/seasonRecaps";
 import type { StorylineBlock } from "./lib/recap";
+import {
+  parseCareerSeasonTotals,
+  parseCareerStatLine,
+} from "./lib/careerTotals";
+import {
+  eligibleClass,
+  type HallOfFameCandidate,
+} from "./lib/hallOfFame";
+import { renderHallOfFameCitation } from "./lib/narrative";
 
 /*
  * Dynasty Mode — history, awards and narrative (Epic D).
@@ -488,5 +497,315 @@ export const listCoachAwards = query({
       .withIndex("by_coachId", (q) => q.eq("coachId", args.coachId))
       .collect();
     return hydrateAwards(ctx, rows);
+  },
+});
+
+const hallOfFameWriteResultValidator = v.object({
+  classLabel: v.union(v.string(), v.null()),
+  inducted: v.number(),
+});
+type HallOfFameWriteResultDto = Infer<
+  typeof hallOfFameWriteResultValidator
+>;
+
+type HydratedHofCandidate = HallOfFameCandidate & {
+  recipientName: string;
+  careerProduction: number;
+  careerWins: number;
+};
+
+function careerProduction(totals: Record<string, Record<string, number>>) {
+  return Object.values(totals).reduce(
+    (sum, group) =>
+      sum +
+      Object.values(group).reduce(
+        (groupSum, value) =>
+          groupSum +
+          (Number.isFinite(value) ? Math.max(0, value) : 0),
+        0,
+      ),
+    0,
+  );
+}
+
+/**
+ * Persist one retry-safe Hall of Fame class during rollover.
+ *
+ * Convex mutations are serializable: concurrent attempts that read the same
+ * empty season class conflict and retry, at which point this mutation returns
+ * the already-persisted rows.
+ */
+export const inductHallOfFameClass = internalMutation({
+  args: {
+    leagueId: v.id("leagues"),
+    inductedSeasonId: v.id("seasons"),
+  },
+  returns: hallOfFameWriteResultValidator,
+  handler: async (ctx, args): Promise<HallOfFameWriteResultDto> => {
+    const inductedSeason = await ctx.db.get(args.inductedSeasonId);
+    if (!inductedSeason || inductedSeason.leagueId !== args.leagueId) {
+      throw new Error("hall_of_fame_season_scope_mismatch");
+    }
+
+    const existingClass = (
+      await ctx.db
+        .query("hallOfFame")
+        .withIndex("by_inductedSeasonId", (q) =>
+          q.eq("inductedSeasonId", args.inductedSeasonId),
+        )
+        .collect()
+    ).filter((row) => row.leagueId === args.leagueId);
+    if (existingClass.length > 0) {
+      return {
+        classLabel: existingClass[0]?.classLabel ?? null,
+        inducted: existingClass.length,
+      };
+    }
+
+    const [seasons, careerRows, awards, players, coaches, priorInductees] =
+      await Promise.all([
+        ctx.db
+          .query("seasons")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+        ctx.db
+          .query("playerCareerTotals")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+        ctx.db
+          .query("awards")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+        ctx.db
+          .query("players")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+        ctx.db
+          .query("coaches")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+        ctx.db
+          .query("hallOfFame")
+          .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+          .collect(),
+      ]);
+    const completedSeasons = seasons
+      .filter((season) => season.status === "completed")
+      .sort((a, b) => a._creationTime - b._creationTime);
+    const inductionSeasonIndex = completedSeasons.findIndex(
+      (season) => season._id === args.inductedSeasonId,
+    );
+    if (inductionSeasonIndex < 0) {
+      throw new Error("hall_of_fame_season_not_completed");
+    }
+    const seasonIndex = new Map(
+      completedSeasons.map((season, index) => [season._id as string, index]),
+    );
+    const playerNames = new Map(
+      players.map((player) => [player._id as string, player.name]),
+    );
+    const playerAccolades = new Map<string, number>();
+    const coachAccolades = new Map<string, number>();
+    for (const award of awards) {
+      if (award.playerId) {
+        playerAccolades.set(
+          award.playerId as string,
+          (playerAccolades.get(award.playerId as string) ?? 0) + 1,
+        );
+      }
+      if (award.coachId) {
+        coachAccolades.set(
+          award.coachId as string,
+          (coachAccolades.get(award.coachId as string) ?? 0) + 1,
+        );
+      }
+    }
+
+    const candidates: HydratedHofCandidate[] = [];
+    for (const row of careerRows) {
+      const seasonTotals = parseCareerSeasonTotals(row.seasonTotalsJson);
+      const playedSeasonIndexes = Object.keys(seasonTotals)
+        .map((seasonId) => seasonIndex.get(seasonId))
+        .filter((index): index is number => index !== undefined);
+      const production = careerProduction(
+        parseCareerStatLine(row.totalsJson),
+      );
+      candidates.push({
+        recipientId: row.playerId as string,
+        recipientName:
+          playerNames.get(row.playerId as string) ?? "Unknown player",
+        kind: "player",
+        seasonsPlayed: playedSeasonIndexes.length,
+        lastPlayedSeasonIndex:
+          playedSeasonIndexes.length > 0
+            ? Math.max(...playedSeasonIndexes)
+            : inductionSeasonIndex,
+        careerTotals: production,
+        careerProduction: production,
+        careerWins: 0,
+        accolades: playerAccolades.get(row.playerId as string) ?? 0,
+        championships: row.championshipSeasonIds?.length ?? 0,
+        peakOverall: row.peakOverall ?? 0,
+      });
+    }
+
+    const coachSeasonRows = (
+      await Promise.all(
+        completedSeasons.map((season) =>
+          ctx.db
+            .query("coachSeasons")
+            .withIndex("by_season_team", (q) =>
+              q.eq("seasonId", season._id),
+            )
+            .collect(),
+        ),
+      )
+    ).flat();
+    const coachSeasonsById = new Map<
+      string,
+      typeof coachSeasonRows
+    >();
+    for (const row of coachSeasonRows) {
+      const rows = coachSeasonsById.get(row.coachId as string) ?? [];
+      rows.push(row);
+      coachSeasonsById.set(row.coachId as string, rows);
+    }
+    for (const coach of coaches) {
+      const rows = coachSeasonsById.get(coach._id as string) ?? [];
+      const playedSeasonIndexes = rows
+        .map((row) => seasonIndex.get(row.seasonId as string))
+        .filter((index): index is number => index !== undefined);
+      const wins = rows.reduce((sum, row) => sum + Math.max(0, row.wins), 0);
+      candidates.push({
+        recipientId: coach._id as string,
+        recipientName: coach.displayName,
+        kind: "coach",
+        seasonsPlayed: playedSeasonIndexes.length,
+        lastPlayedSeasonIndex:
+          playedSeasonIndexes.length > 0
+            ? Math.max(...playedSeasonIndexes)
+            : inductionSeasonIndex,
+        careerTotals: wins * 100,
+        careerProduction: 0,
+        careerWins: wins,
+        accolades: coachAccolades.get(coach._id as string) ?? 0,
+        championships: rows.filter((row) =>
+          row.playoffResult?.toLowerCase().includes("champion"),
+        ).length,
+        peakOverall: coach.prestige,
+      });
+    }
+
+    const inductedRecipientIds = new Set(
+      priorInductees.flatMap((row) =>
+        row.playerId
+          ? [row.playerId as string]
+          : row.coachId
+            ? [row.coachId as string]
+            : [],
+      ),
+    );
+    const selected = eligibleClass(candidates, {
+      inductionSeasonIndex,
+      inductedRecipientIds,
+    });
+    const classLabel = `Hall of Fame Class of ${inductedSeason.name}`;
+    const inductedAt = new Date().toISOString();
+
+    for (const candidate of selected) {
+      await ctx.db.insert("hallOfFame", {
+        leagueId: args.leagueId,
+        playerId:
+          candidate.kind === "player"
+            ? (candidate.recipientId as Id<"players">)
+            : null,
+        coachId:
+          candidate.kind === "coach"
+            ? (candidate.recipientId as Id<"coaches">)
+            : null,
+        inductedSeasonId: args.inductedSeasonId,
+        classLabel,
+        citation: renderHallOfFameCitation(candidate),
+        score: candidate.score,
+        inductedAt,
+      });
+    }
+    return {
+      classLabel: selected.length > 0 ? classLabel : null,
+      inducted: selected.length,
+    };
+  },
+});
+
+const hallOfFameDtoValidator = v.object({
+  id: v.string(),
+  recipientType: v.union(v.literal("player"), v.literal("coach")),
+  recipientId: v.string(),
+  recipientName: v.string(),
+  inductedSeasonId: v.string(),
+  inductedSeasonName: v.string(),
+  classLabel: v.string(),
+  citation: v.string(),
+  score: v.number(),
+});
+type HallOfFameDto = Infer<typeof hallOfFameDtoValidator>;
+
+export const listHallOfFame = query({
+  args: { leagueId: v.id("leagues") },
+  returns: v.array(hallOfFameDtoValidator),
+  handler: async (ctx, args): Promise<HallOfFameDto[]> => {
+    const rows = await ctx.db
+      .query("hallOfFame")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+      .collect();
+    if (rows.length === 0) return [];
+    const [players, coaches, seasons] = await Promise.all([
+      ctx.db
+        .query("players")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+      ctx.db
+        .query("coaches")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+      ctx.db
+        .query("seasons")
+        .withIndex("by_leagueId", (q) => q.eq("leagueId", args.leagueId))
+        .collect(),
+    ]);
+    const playerNames = new Map(
+      players.map((row) => [row._id as string, row.name]),
+    );
+    const coachNames = new Map(
+      coaches.map((row) => [row._id as string, row.displayName]),
+    );
+    const seasonNames = new Map(
+      seasons.map((row) => [row._id as string, row.name]),
+    );
+    return rows
+      .map((row): HallOfFameDto => {
+        const recipientType = row.playerId ? "player" : "coach";
+        const recipientId = (row.playerId ?? row.coachId) as string;
+        return {
+          id: row._id,
+          recipientType,
+          recipientId,
+          recipientName: row.playerId
+            ? (playerNames.get(row.playerId as string) ?? "Unknown player")
+            : (coachNames.get(row.coachId as string) ?? "Unknown coach"),
+          inductedSeasonId: row.inductedSeasonId,
+          inductedSeasonName:
+            seasonNames.get(row.inductedSeasonId as string) ?? "Unknown season",
+          classLabel: row.classLabel,
+          citation: row.citation,
+          score: row.score,
+        };
+      })
+      .sort(
+        (a, b) =>
+          b.inductedSeasonName.localeCompare(a.inductedSeasonName) ||
+          b.score - a.score ||
+          a.recipientName.localeCompare(b.recipientName),
+      );
   },
 });

--- a/apps/web/convex/lib/hallOfFame.ts
+++ b/apps/web/convex/lib/hallOfFame.ts
@@ -1,0 +1,83 @@
+export const HOF_WAITING_SEASONS = 3;
+export const HOF_CLASS_SIZE = 3;
+
+export interface HofScoreInput {
+  careerTotals: number;
+  accolades: number;
+  championships: number;
+  peakOverall: number;
+}
+
+export interface HallOfFameCandidate extends HofScoreInput {
+  recipientId: string;
+  kind: "player" | "coach";
+  seasonsPlayed: number;
+  lastPlayedSeasonIndex: number;
+}
+
+export interface EligibleClassOptions {
+  inductionSeasonIndex: number;
+  inductedRecipientIds: ReadonlySet<string> | readonly string[];
+  waitingSeasons?: number;
+  classSize?: number;
+}
+
+function nonNegativeFinite(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+/**
+ * A transparent, monotonic Hall of Fame score.
+ *
+ * Career production is already normalized by each candidate producer (raw
+ * player production; coach wins × 100). The positive weights make every input
+ * independently monotonic: improving one dimension can never lower the score.
+ */
+export function hofScore(input: HofScoreInput): number {
+  return (
+    nonNegativeFinite(input.careerTotals) +
+    nonNegativeFinite(input.accolades) * 250 +
+    nonNegativeFinite(input.championships) * 500 +
+    nonNegativeFinite(input.peakOverall) * 2
+  );
+}
+
+/**
+ * Select one deterministic class from candidates whose careers ended at least
+ * three completed seasons ago. Existing inductees and zero-season players are
+ * excluded before ranking, so retries and future classes cannot duplicate one.
+ */
+export function eligibleClass<T extends HallOfFameCandidate>(
+  candidates: readonly T[],
+  options: EligibleClassOptions,
+): Array<T & { score: number }> {
+  const inducted =
+    options.inductedRecipientIds instanceof Set
+      ? options.inductedRecipientIds
+      : new Set(options.inductedRecipientIds);
+  const waitingSeasons = Math.max(
+    0,
+    Math.floor(options.waitingSeasons ?? HOF_WAITING_SEASONS),
+  );
+  const classSize = Math.max(
+    0,
+    Math.floor(options.classSize ?? HOF_CLASS_SIZE),
+  );
+
+  return candidates
+    .filter(
+      (candidate) =>
+        !inducted.has(candidate.recipientId) &&
+        candidate.seasonsPlayed > 0 &&
+        options.inductionSeasonIndex - candidate.lastPlayedSeasonIndex >=
+          waitingSeasons,
+    )
+    .map((candidate) => ({ ...candidate, score: hofScore(candidate) }))
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.kind.localeCompare(b.kind) ||
+        a.recipientId.localeCompare(b.recipientId),
+    )
+    .slice(0, classSize);
+}

--- a/apps/web/convex/lib/historyFinalize.ts
+++ b/apps/web/convex/lib/historyFinalize.ts
@@ -20,6 +20,28 @@ export interface FinalizeSeasonHistoryResult {
   recordsBroken: number;
 }
 
+function championTeamId(
+  format: string,
+  matchups: Doc<"playoffMatchups">[],
+): Id<"teams"> | null {
+  if (format === "double") {
+    return (
+      matchups.find((matchup) => matchup.bracketType === "grandFinal")
+        ?.winnerTeamId ?? null
+    );
+  }
+  return (
+    matchups.reduce<Doc<"playoffMatchups"> | null>(
+      (best, matchup) =>
+        (matchup.bracketType ?? "winners") === "winners" &&
+        matchup.round > (best?.round ?? -1)
+          ? matchup
+          : best,
+      null,
+    )?.winnerTeamId ?? null
+  );
+}
+
 function recordEntryFromRow(
   row: Doc<"programRecords">,
 ): ProgramRecordEntry {
@@ -162,10 +184,37 @@ export async function finalizeSeasonHistoryForSeason(
     teamRecords,
   );
 
-  const careerRows = await ctx.db
-    .query("playerCareerTotals")
-    .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
-    .collect();
+  const [careerRows, seasonAttributes, bracket] = await Promise.all([
+    ctx.db
+      .query("playerCareerTotals")
+      .withIndex("by_leagueId", (q) => q.eq("leagueId", leagueId))
+      .collect(),
+    ctx.db
+      .query("playerAttributes")
+      .withIndex("by_seasonId_positionGroup", (q) =>
+        q.eq("seasonId", seasonId),
+      )
+      .collect(),
+    ctx.db
+      .query("playoffBrackets")
+      .withIndex("by_seasonId", (q) => q.eq("seasonId", seasonId))
+      .first(),
+  ]);
+  const playoffMatchups = bracket
+    ? await ctx.db
+        .query("playoffMatchups")
+        .withIndex("by_bracketId", (q) => q.eq("bracketId", bracket._id))
+        .collect()
+    : [];
+  const championId = bracket
+    ? championTeamId(bracket.format ?? "single", playoffMatchups)
+    : null;
+  const overallByPlayerId = new Map(
+    seasonAttributes.map((row) => [
+      row.playerId as string,
+      row.weightedOverall,
+    ]),
+  );
   const existingRecordRows = await ctx.db
     .query("programRecords")
     .withIndex("by_leagueId_category_rank", (q) =>
@@ -187,15 +236,37 @@ export async function finalizeSeasonHistoryForSeason(
     seasons[seasonId as string] = parseCareerStatLine(aggregate.totalsJson);
     const seasonTotalsJson = serializeCareerSeasonTotals(seasons);
     const totalsJson = JSON.stringify(sumCareerSeasonTotals(seasons));
+    const currentOverall =
+      overallByPlayerId.get(aggregate.playerId as string) ?? null;
+    const peakOverall =
+      currentOverall === null
+        ? existing?.peakOverall
+        : Math.max(existing?.peakOverall ?? 0, currentOverall);
+    const championshipSeasonIds = new Set(
+      existing?.championshipSeasonIds ?? [],
+    );
+    if (championId === aggregate.teamId) {
+      championshipSeasonIds.add(seasonId);
+    } else {
+      championshipSeasonIds.delete(seasonId);
+    }
+    const nextChampionshipSeasonIds = [...championshipSeasonIds].sort((a, b) =>
+      String(a).localeCompare(String(b)),
+    );
 
     if (existing) {
       if (
         existing.seasonTotalsJson !== seasonTotalsJson ||
-        existing.totalsJson !== totalsJson
+        existing.totalsJson !== totalsJson ||
+        existing.peakOverall !== peakOverall ||
+        JSON.stringify(existing.championshipSeasonIds ?? []) !==
+          JSON.stringify(nextChampionshipSeasonIds)
       ) {
         await ctx.db.patch(existing._id, {
           seasonTotalsJson,
           totalsJson,
+          peakOverall,
+          championshipSeasonIds: nextChampionshipSeasonIds,
           updatedAt: now,
         });
         careerTotalsUpdated += 1;
@@ -206,6 +277,8 @@ export async function finalizeSeasonHistoryForSeason(
         playerId: aggregate.playerId,
         totalsJson,
         seasonTotalsJson,
+        peakOverall,
+        championshipSeasonIds: nextChampionshipSeasonIds,
         updatedAt: now,
       });
       careerByPlayerId.set(aggregate.playerId as string, {
@@ -215,6 +288,8 @@ export async function finalizeSeasonHistoryForSeason(
         playerId: aggregate.playerId,
         totalsJson,
         seasonTotalsJson,
+        peakOverall,
+        championshipSeasonIds: nextChampionshipSeasonIds,
         updatedAt: now,
       });
       careerTotalsUpdated += 1;

--- a/apps/web/convex/lib/narrative.ts
+++ b/apps/web/convex/lib/narrative.ts
@@ -240,3 +240,38 @@ export function seasonCompletedDedupeKey(seasonId: string): string {
 export function transferResolvedDedupeKey(transferId: string): string {
   return `transfer_resolved:${transferId}`;
 }
+
+export interface HallOfFameCitationInput {
+  recipientName: string;
+  kind: "player" | "coach";
+  seasonsPlayed: number;
+  careerProduction: number;
+  careerWins: number;
+  accolades: number;
+  championships: number;
+  peakOverall: number;
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/**
+ * Hall of Fame citations share the narrative template library used by the
+ * recap and news feed. Stored copy is deterministic and makes no network call.
+ */
+export function renderHallOfFameCitation(
+  input: HallOfFameCitationInput,
+): string {
+  const seasons = countLabel(input.seasonsPlayed, "season");
+  const honors = countLabel(input.accolades, "career honor");
+  const titles = countLabel(input.championships, "championship");
+  if (input.kind === "coach") {
+    return `${input.recipientName} is inducted after ${seasons}, ${countLabel(input.careerWins, "win")}, ${honors}, and ${titles}.`;
+  }
+  const peak =
+    input.peakOverall > 0
+      ? ` and a peak overall of ${input.peakOverall}`
+      : "";
+  return `${input.recipientName} is inducted after ${seasons}, ${input.careerProduction.toLocaleString("en-US")} career production, ${honors}, and ${titles}${peak}.`;
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -2371,6 +2371,7 @@ const rolloverStageOrder = [
   "freshmen_created",
   "injuries_healed",
   "prospects_generated",
+  "hall_of_fame_inducted",
   "completed",
 ] as const;
 

--- a/apps/web/convex/tables/history.ts
+++ b/apps/web/convex/tables/history.ts
@@ -46,6 +46,7 @@ export const historyTables = {
     createdAt: v.string(),
     updatedAt: v.string(),
   })
+    .index("by_leagueId", ["leagueId"])
     .index("by_seasonId", ["seasonId"])
     .index("by_seasonId_type", ["seasonId", "type"])
     .index("by_playerId", ["playerId"])
@@ -61,10 +62,30 @@ export const historyTables = {
      * re-summing is what makes season finalization retry-safe.
      */
     seasonTotalsJson: v.string(),
+    /** D5 metadata, optional for career rows materialized before HoF shipped. */
+    peakOverall: v.optional(v.number()),
+    championshipSeasonIds: v.optional(v.array(v.id("seasons"))),
     updatedAt: v.string(),
   })
     .index("by_playerId", ["playerId"])
     .index("by_leagueId", ["leagueId"]),
+
+  hallOfFame: defineTable({
+    leagueId: v.id("leagues"),
+    /** Exactly one recipient reference is non-null on every induction row. */
+    playerId: v.union(v.id("players"), v.null()),
+    coachId: v.union(v.id("coaches"), v.null()),
+    inductedSeasonId: v.id("seasons"),
+    classLabel: v.string(),
+    citation: v.string(),
+    /** Exact output of `lib/hallOfFame.ts`, retained for explainability. */
+    score: v.number(),
+    inductedAt: v.string(),
+  })
+    .index("by_leagueId", ["leagueId"])
+    .index("by_inductedSeasonId", ["inductedSeasonId"])
+    .index("by_playerId", ["playerId"])
+    .index("by_coachId", ["coachId"]),
 
   programRecords: defineTable({
     leagueId: v.id("leagues"),

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -130,6 +130,29 @@ export async function seedHistoryFixture(
   });
 }
 
+const seedHallOfFameFixtureRef = makeFunctionReference<
+  "mutation",
+  {
+    leagueId: string;
+    seasonId: string;
+    homeTeamId: string;
+    awayTeamId: string;
+  },
+  { created: number; classLabel: string }
+>("e2eSeed:seedHallOfFameFixture");
+
+export async function seedHallOfFameFixture(
+  fixture: ScheduleFixtureResult,
+): Promise<{ created: number; classLabel: string }> {
+  const client = getSeedClient();
+  return client.mutation(seedHallOfFameFixtureRef, {
+    leagueId: fixture.leagueId,
+    seasonId: fixture.seasonId,
+    homeTeamId: fixture.homeTeamId,
+    awayTeamId: fixture.awayTeamId,
+  });
+}
+
 const seedAwardsFixtureRef = makeFunctionReference<
   "mutation",
   {

--- a/apps/web/e2e/tests/hall-of-fame.spec.ts
+++ b/apps/web/e2e/tests/hall-of-fame.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  seedHallOfFameFixture,
+  withScheduleFixture,
+  type ScheduleFixtureResult,
+} from "../helpers/seed-schedule";
+import { getTestOrgId } from "../helpers/seed-roster";
+
+test.describe("League Hall of Fame (D5)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const FIXTURE_KEY = "history-hall-of-fame";
+  let fixture: ScheduleFixtureResult | null = null;
+  let classLabel = "";
+  let teardown: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async () => {
+    const orgId = getTestOrgId();
+    test.skip(!orgId, "E2E_CLERK_ORG_ID not set");
+    const handle = await withScheduleFixture({
+      fixtureKey: FIXTURE_KEY,
+      clerkOrgId: orgId,
+      homeTeamName: "E2E HoF Home",
+      awayTeamName: "E2E HoF Away",
+    });
+    fixture = handle.fixture;
+    teardown = handle.teardown;
+    const seeded = await seedHallOfFameFixture(fixture);
+    classLabel = seeded.classLabel;
+  });
+
+  test.afterAll(async () => {
+    if (teardown) await teardown();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+  });
+
+  test("renders its class on League history", async ({ page }) => {
+    if (!fixture) {
+      test.skip();
+      return;
+    }
+
+    await page.goto(`/dashboard/leagues/${fixture.leagueId}/history`);
+    const hall = page.getByTestId("hall-of-fame");
+    await expect(hall).toBeVisible({ timeout: 30_000 });
+    await expect(
+      hall.getByRole("heading", { name: "Hall of Fame", exact: true }),
+    ).toBeVisible();
+    await expect(hall.getByText(classLabel, { exact: true })).toBeVisible();
+    await expect(hall.getByText("E2E Home Legend", { exact: true })).toBeVisible();
+    await expect(hall.getByText("E2E Away Legend", { exact: true })).toBeVisible();
+  });
+});

--- a/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/dynasty.test.ts
@@ -23,6 +23,7 @@ const {
   mockCreateProspectClass,
   mockGetDynastyConfig,
   mockListCoachesByLeague,
+  mockInductHallOfFameClass,
 } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
   mockResolveOrgContext: vi.fn(),
@@ -46,6 +47,7 @@ const {
   mockCreateProspectClass: vi.fn(),
   mockGetDynastyConfig: vi.fn(),
   mockListCoachesByLeague: vi.fn(),
+  mockInductHallOfFameClass: vi.fn(),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mockAuth }));
@@ -73,6 +75,7 @@ vi.mock("@/lib/data-api", () => ({
   createProspectClass: mockCreateProspectClass,
   getDynastyConfig: mockGetDynastyConfig,
   listCoachesByLeague: mockListCoachesByLeague,
+  inductHallOfFameClass: mockInductHallOfFameClass,
 }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
@@ -119,6 +122,10 @@ beforeEach(() => {
   mockGetLeagueOrgId.mockResolvedValue(ORG);
   mockResolveOrgRole.mockResolvedValue("admin");
   mockListCoachesByLeague.mockResolvedValue([]);
+  mockInductHallOfFameClass.mockResolvedValue({
+    classLabel: null,
+    inducted: 0,
+  });
   mockGetSeasons.mockResolvedValue([ACTIVE]);
   mockBeginSeasonRollover.mockResolvedValue({
     rolloverId: "rollover_1",
@@ -166,7 +173,9 @@ beforeEach(() => {
                     ? "freshmen_created"
                     : stage === "prospects_generated"
                       ? "injuries_healed"
-                      : "prospects_generated",
+                      : stage === "hall_of_fame_inducted"
+                        ? "prospects_generated"
+                        : "hall_of_fame_inducted",
         status: "in_progress",
         graduatedPlayerIds: [],
         advancedPlayerIds: ["p1"],
@@ -691,9 +700,9 @@ describe("startNextSeasonAction success path", () => {
   });
 
   /*
-   * Recruiting class generation (B3, #621). The stage runs LAST, after the
-   * backfill has already filled every roster — the class is talent on top of a
-   * playable floor, not a replacement for one.
+   * Recruiting class generation (B3, #621). The stage runs after the backfill
+   * has filled every roster — the class is talent on top of a playable floor,
+   * not a replacement for one.
    */
   describe("prospects_generated stage", () => {
     it("builds a class for the TARGET season and records the count", async () => {
@@ -765,6 +774,24 @@ describe("startNextSeasonAction success path", () => {
       const res = await startNextSeasonAction({ leagueId: LEAGUE });
 
       expect(mockCreateProspectClass).not.toHaveBeenCalled();
+      expect(res).toMatchObject({ ok: true });
+    });
+  });
+
+  describe("hall_of_fame_inducted stage", () => {
+    it("inducts against the completed source season before checkpointing", async () => {
+      const res = await startNextSeasonAction({ leagueId: LEAGUE });
+
+      expect(mockInductHallOfFameClass).toHaveBeenCalledWith({
+        leagueId: LEAGUE,
+        inductedSeasonId: ACTIVE.id,
+      });
+      expect(mockAdvanceSeasonRollover).toHaveBeenCalledWith({
+        rolloverId: "rollover_1",
+        stage: "hall_of_fame_inducted",
+        summaryJson: expect.any(String),
+        ownerId: expect.any(String),
+      });
       expect(res).toMatchObject({ ok: true });
     });
   });

--- a/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
+++ b/apps/web/src/app/dashboard/_actions/__tests__/rollover-stages.test.ts
@@ -76,6 +76,15 @@ describe("rollover stage order", () => {
     );
   });
 
+  it("inducts the Hall of Fame class after season mechanics and before completion", () => {
+    expect(clientStages.indexOf("hall_of_fame_inducted")).toBeGreaterThan(
+      clientStages.indexOf("prospects_generated"),
+    );
+    expect(clientStages.indexOf("hall_of_fame_inducted")).toBeLessThan(
+      clientStages.indexOf("completed"),
+    );
+  });
+
   it("keeps `completed` terminal", () => {
     expect(clientStages.at(-1)).toBe("completed");
     expect(serverStages.at(-1)).toBe("completed");

--- a/apps/web/src/app/dashboard/_actions/dynasty.ts
+++ b/apps/web/src/app/dashboard/_actions/dynasty.ts
@@ -24,6 +24,7 @@ import {
   createProspectClass,
   getDynastyConfig,
   listCoachesByLeague,
+  inductHallOfFameClass,
 } from "@/lib/data-api";
 import { activeNonGraduatedNames } from "@/lib/dynasty";
 import {
@@ -57,6 +58,7 @@ const ROLLOVER_STAGES = [
   "freshmen_created",
   "injuries_healed",
   "prospects_generated",
+  "hall_of_fame_inducted",
   "completed",
 ] as const;
 
@@ -601,6 +603,36 @@ export async function startNextSeasonAction(input: {
       }
     }
 
+    /*
+     * Induct the source season's Hall of Fame class (D5).
+     *
+     * This is a durable rollover stage, not a best-effort side effect: a lost
+     * response retries the idempotent mutation, while a real failure releases
+     * the existing stage lease so the same rollover can resume safely.
+     */
+    if (!hasReachedRolloverStage(stage, "hall_of_fame_inducted")) {
+      const acquired = await claimStage("hall_of_fame_inducted");
+      if (acquired) {
+        try {
+          await inductHallOfFameClass({
+            leagueId: input.leagueId,
+            inductedSeasonId: activeSeason.id,
+          });
+          const checkpoint = await advanceSeasonRollover({
+            rolloverId: rollover.rolloverId,
+            stage: "hall_of_fame_inducted",
+            summaryJson: serializeRolloverSummary(summary),
+            ownerId,
+          });
+          stage = checkpoint.stage;
+          summary = parseRolloverSummary(checkpoint.summaryJson, summary);
+        } catch (err) {
+          await releaseClaimedStage("hall_of_fame_inducted", err);
+          throw err;
+        }
+      }
+    }
+
     if (!hasReachedRolloverStage(stage, "completed")) {
       const acquired = await claimStage("completed");
       if (acquired) {
@@ -620,6 +652,7 @@ export async function startNextSeasonAction(input: {
     }
 
     revalidatePath(`/dashboard/leagues/${input.leagueId}`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/history`);
     revalidatePath("/dashboard/seasons");
     revalidatePath(`/dashboard/seasons/${nextSeasonId}`);
 

--- a/apps/web/src/app/dashboard/leagues/[id]/history/page.tsx
+++ b/apps/web/src/app/dashboard/leagues/[id]/history/page.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from "next/navigation";
 import {
   getLeague,
   getTeamsByLeague,
+  listHallOfFame,
   listProgramRecords,
   type ProgramRecordDto,
 } from "@/lib/data-api";
@@ -65,7 +66,10 @@ export default async function LeagueHistoryPage({
   if (!league) notFound();
   await syncActiveLeagueForResource(league.id);
 
-  const teams = await getTeamsByLeague(id, orgContext).catch(() => []);
+  const [teams, hallOfFame] = await Promise.all([
+    getTeamsByLeague(id, orgContext).catch(() => []),
+    listHallOfFame(id, orgContext).catch(() => []),
+  ]);
   const requestedTeamId =
     typeof query.team === "string" ? query.team : null;
   const selectedTeam =
@@ -177,6 +181,50 @@ export default async function LeagueHistoryPage({
           )}
         </CardContent>
       </Card>
+
+      <section aria-labelledby="hall-of-fame-heading" data-testid="hall-of-fame">
+        <Card>
+          <CardHeader>
+            <h2 id="hall-of-fame-heading" className="text-lg font-semibold">
+              Hall of Fame
+            </h2>
+          </CardHeader>
+          <CardContent>
+            {hallOfFame.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No Hall of Fame class has been inducted yet.
+              </p>
+            ) : (
+              <div className="space-y-6">
+                {Array.from(
+                  hallOfFame.reduce((classes, inductee) => {
+                    const rows = classes.get(inductee.classLabel) ?? [];
+                    rows.push(inductee);
+                    classes.set(inductee.classLabel, rows);
+                    return classes;
+                  }, new Map<string, typeof hallOfFame>()),
+                ).map(([classLabel, inductees]) => (
+                  <div className="rounded-lg border p-4" key={classLabel}>
+                    <h3 className="font-semibold">{classLabel}</h3>
+                    <ul className="mt-3 space-y-3">
+                      {inductees.map((inductee) => (
+                        <li key={inductee.id}>
+                          <div className="font-medium">
+                            {inductee.recipientName}
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {inductee.citation}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/lib/data-api.ts
+++ b/apps/web/src/lib/data-api.ts
@@ -135,6 +135,10 @@ const getWeeklyPollRef = historyRef.query<WeeklyPollDto | null>(
 );
 const listSeasonRecapsRef =
   historyRef.query<SeasonRecapDto[]>("listSeasonRecaps");
+const listHallOfFameRef =
+  historyRef.query<HallOfFameDto[]>("listHallOfFame");
+const inductHallOfFameClassRef =
+  historyRef.mutation<HallOfFameWriteResult>("inductHallOfFameClass");
 const listDynastyEventsRef =
   sportsRef.query<DynastyEventDto[]>("listDynastyEvents");
 
@@ -274,6 +278,23 @@ export interface SeasonRecapDto {
     body: string;
     eventIds: string[];
   }>;
+}
+
+export interface HallOfFameDto {
+  id: string;
+  recipientType: "player" | "coach";
+  recipientId: string;
+  recipientName: string;
+  inductedSeasonId: string;
+  inductedSeasonName: string;
+  classLabel: string;
+  citation: string;
+  score: number;
+}
+
+export interface HallOfFameWriteResult {
+  classLabel: string | null;
+  inducted: number;
 }
 
 const refs = {
@@ -1342,6 +1363,21 @@ export async function listProgramRecords(
     leagueId,
     ...(teamId ? { teamId } : {}),
   });
+}
+
+export async function listHallOfFame(
+  leagueId: string,
+  orgContext: OrgContext,
+): Promise<HallOfFameDto[]> {
+  requireLeagueAccessLocal(leagueId, orgContext);
+  return queryConvex(listHallOfFameRef, { leagueId });
+}
+
+export async function inductHallOfFameClass(input: {
+  leagueId: string;
+  inductedSeasonId: string;
+}): Promise<HallOfFameWriteResult> {
+  return mutateConvex(inductHallOfFameClassRef, input);
 }
 
 export async function listSeasonAwards(

--- a/apps/web/src/lib/history/__tests__/hall-of-fame.test.ts
+++ b/apps/web/src/lib/history/__tests__/hall-of-fame.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  eligibleClass,
+  hofScore,
+  type HallOfFameCandidate,
+  type HofScoreInput,
+} from "@/lib/history/hall-of-fame";
+
+const baseline: HofScoreInput = {
+  careerTotals: 1_000,
+  accolades: 2,
+  championships: 1,
+  peakOverall: 88,
+};
+
+describe("hofScore", () => {
+  for (const [field, increase] of [
+    ["careerTotals", 1],
+    ["accolades", 1],
+    ["championships", 1],
+    ["peakOverall", 1],
+  ] as const) {
+    it(`is monotonic in ${field}`, () => {
+      expect(
+        hofScore({ ...baseline, [field]: baseline[field] + increase }),
+      ).toBeGreaterThanOrEqual(hofScore(baseline));
+    });
+  }
+});
+
+describe("eligibleClass", () => {
+  it("never repeats a player or selects a zero-season player across many classes", () => {
+    for (let history = 0; history < 40; history++) {
+      let state = (history + 1) * 0x9e3779b1;
+      const random = () => {
+        state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+        return state / 2 ** 32;
+      };
+      const candidates: HallOfFameCandidate[] = Array.from(
+        { length: 90 },
+        (_, index) => ({
+          recipientId: `history-${history}-player-${index}`,
+          kind: "player",
+          seasonsPlayed: index % 11 === 0 ? 0 : 1 + Math.floor(random() * 4),
+          lastPlayedSeasonIndex: Math.floor(random() * 24),
+          careerTotals: Math.floor(random() * 8_000),
+          accolades: Math.floor(random() * 6),
+          championships: Math.floor(random() * 3),
+          peakOverall: 60 + Math.floor(random() * 40),
+        }),
+      );
+      const inducted = new Set<string>();
+
+      for (let season = 0; season < 30; season++) {
+        const selected = eligibleClass(candidates, {
+          inductionSeasonIndex: season,
+          inductedRecipientIds: inducted,
+        });
+        for (const candidate of selected) {
+          expect(candidate.seasonsPlayed).toBeGreaterThan(0);
+          expect(inducted.has(candidate.recipientId)).toBe(false);
+          inducted.add(candidate.recipientId);
+        }
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/history/hall-of-fame.ts
+++ b/apps/web/src/lib/history/hall-of-fame.ts
@@ -1,0 +1,16 @@
+/**
+ * Hall of Fame rules live under convex/lib so rollover persistence and the
+ * Next test surface use exactly the same pure implementation.
+ */
+export {
+  HOF_CLASS_SIZE,
+  HOF_WAITING_SEASONS,
+  eligibleClass,
+  hofScore,
+} from "../../../convex/lib/hallOfFame";
+
+export type {
+  EligibleClassOptions,
+  HallOfFameCandidate,
+  HofScoreInput,
+} from "../../../convex/lib/hallOfFame";


### PR DESCRIPTION
Closes #634. Final slice of Epic D — and the last of the 26-slice Dynasty Mode roadmap.

When enough years have passed the league inducts a Hall of Fame class from its greatest players and coaches, so a long-running dynasty keeps a permanent record of who mattered.

## What landed
- `hallOfFame` with a player or coach reference, induction season, class label, citation and score.
- `hofScore` and `eligibleClass` are pure, and the score is **monotonic** in career totals, accolades, championships and peak overall — improving any input can never lower it.
- Induction never selects the same person twice and never selects a player who never played a season, asserted by a property test over repeated inductions across many seasons.
- It runs at rollover through the **existing** `seasonRollovers` lease and stage pattern rather than a second concurrency idiom, and is idempotent: rolling over twice creates exactly one class.
- The Hall renders as a section of the league history page D1 built — no new route, no new nav destination.

Citations come from the same deterministic template library as the recap and news feed. No second copy, no generated prose.

## Verification
- `vitest run` — 238 files, 1876 tests passed
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean
- Diff is 722 insertions / 12 deletions — additive, as a slice like this should be.

## One product choice
Eligibility waits **three completed seasons** after a career ends, so a league inducts its first class in its fourth completed season and never enshrines an active player. That number was unspecified by the issue and is a tuning knob, not a structural decision.