### PR TITLE
fix: require a week on a fixture and block per-week double-booking

### DIFF
--- a/apps/web/convex/__tests__/fixtureWeekValidation.test.ts
+++ b/apps/web/convex/__tests__/fixtureWeekValidation.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+const modules = import.meta.glob("../**/*.*s");
+
+async function seedLeague(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const leagueId = await ctx.db.insert("leagues", {
+      name: "Week Rules League",
+      orgId: "org_1",
+      isPublic: false,
+      inviteToken: null,
+    });
+    const teamIds: Id<"teams">[] = [];
+    for (const name of ["A", "B", "C", "D"]) {
+      teamIds.push(
+        await ctx.db.insert("teams", {
+          name: `Team ${name}`,
+          leagueId,
+          divisionId: null,
+          city: "City",
+          stadium: "Stadium",
+          foundedYear: null,
+          location: "Location",
+          logoUrl: null,
+          rosterLimit: null,
+        }),
+      );
+    }
+    const seasonId = await ctx.db.insert("seasons", {
+      name: "2026",
+      leagueId,
+      startDate: null,
+      endDate: null,
+      status: "active",
+      rosterLocked: false,
+    });
+    return { seasonId, teamIds };
+  });
+}
+
+function createFixtureArgs(
+  seasonId: Id<"seasons">,
+  homeTeamId: Id<"teams">,
+  awayTeamId: Id<"teams">,
+  week: number | null,
+) {
+  return {
+    seasonId,
+    homeTeamId,
+    awayTeamId,
+    scheduledAt: null,
+    week,
+    venue: null,
+    actorUserId: "user_1",
+  };
+}
+
+describe("fixture week validation", () => {
+  it("createFixture requires a valid week", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, teamIds } = await seedLeague(t);
+
+    await expect(
+      t.mutation(
+        internal.sports.createFixture,
+        createFixtureArgs(seasonId, teamIds[0], teamIds[1], null),
+      ),
+    ).rejects.toThrow("week_required");
+  });
+
+  it("createFixture rejects either candidate side when already booked", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, teamIds } = await seedLeague(t);
+    await t.mutation(
+      internal.sports.createFixture,
+      createFixtureArgs(seasonId, teamIds[0], teamIds[1], 1),
+    );
+
+    await expect(
+      t.mutation(
+        internal.sports.createFixture,
+        createFixtureArgs(seasonId, teamIds[0], teamIds[2], 1),
+      ),
+    ).rejects.toThrow("team_already_scheduled_that_week");
+    await expect(
+      t.mutation(
+        internal.sports.createFixture,
+        createFixtureArgs(seasonId, teamIds[2], teamIds[1], 1),
+      ),
+    ).rejects.toThrow("team_already_scheduled_that_week");
+  });
+
+  it("createFixture succeeds when both teams are free that week", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, teamIds } = await seedLeague(t);
+    await t.mutation(
+      internal.sports.createFixture,
+      createFixtureArgs(seasonId, teamIds[0], teamIds[1], 1),
+    );
+
+    const fixture = await t.mutation(
+      internal.sports.createFixture,
+      createFixtureArgs(seasonId, teamIds[0], teamIds[2], 2),
+    );
+    expect(fixture.week).toBe(2);
+  });
+
+  it("updateFixture blocks occupied and missing weeks but allows itself", async () => {
+    const t = convexTest(schema, modules);
+    const { seasonId, teamIds } = await seedLeague(t);
+    const weekOne = await t.mutation(
+      internal.sports.createFixture,
+      createFixtureArgs(seasonId, teamIds[0], teamIds[1], 1),
+    );
+    const weekTwo = await t.mutation(
+      internal.sports.createFixture,
+      createFixtureArgs(seasonId, teamIds[0], teamIds[2], 2),
+    );
+
+    await expect(
+      t.mutation(internal.sports.updateFixture, {
+        fixtureId: weekTwo.id as Id<"fixtures">,
+        week: 1,
+      }),
+    ).rejects.toThrow("team_already_scheduled_that_week");
+    await expect(
+      t.mutation(internal.sports.updateFixture, {
+        fixtureId: weekTwo.id as Id<"fixtures">,
+        week: null,
+      }),
+    ).rejects.toThrow("week_required");
+
+    const resaved = await t.mutation(internal.sports.updateFixture, {
+      fixtureId: weekOne.id as Id<"fixtures">,
+      week: 1,
+    });
+    expect(resaved?.week).toBe(1);
+  });
+});

--- a/apps/web/convex/__tests__/roundRobin.test.ts
+++ b/apps/web/convex/__tests__/roundRobin.test.ts
@@ -85,6 +85,22 @@ describe("roundRobinSchedule (WSM-000153)", () => {
     }
   });
 
+  it.each([3, 4, 5, 6, 7, 8])(
+    "pins one game per team per week for odd and even counts (%i teams)",
+    (n) => {
+      const teamsByWeek = new Map<number, string[]>();
+      for (const pairing of roundRobinSchedule(ids(n))) {
+        const teams = teamsByWeek.get(pairing.week) ?? [];
+        teams.push(pairing.homeTeamId, pairing.awayTeamId);
+        teamsByWeek.set(pairing.week, teams);
+      }
+
+      for (const teams of teamsByWeek.values()) {
+        expect(new Set(teams).size).toBe(teams.length);
+      }
+    },
+  );
+
   it("never pairs a team against itself", () => {
     for (const p of roundRobinSchedule(ids(7))) {
       expect(p.homeTeamId).not.toBe(p.awayTeamId);

--- a/apps/web/convex/__tests__/scheduleConflicts.test.ts
+++ b/apps/web/convex/__tests__/scheduleConflicts.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  findWeekConflict,
+  isValidWeek,
+  type WeekFixture,
+} from "../lib/scheduleConflicts";
+
+const weekThree: WeekFixture[] = [
+  {
+    id: "fixture-1",
+    week: 3,
+    homeTeamId: "team-a",
+    awayTeamId: "team-b",
+  },
+];
+
+describe("schedule conflicts", () => {
+  it.each([0, -1, -20, 1.5, null])("rejects invalid week %s", (week) => {
+    expect(isValidWeek(week)).toBe(false);
+  });
+
+  it("accepts positive integer weeks", () => {
+    expect(isValidWeek(1)).toBe(true);
+    expect(isValidWeek(12)).toBe(true);
+  });
+
+  it("detects a conflict for the candidate home team", () => {
+    expect(
+      findWeekConflict(weekThree, {
+        week: 3,
+        homeTeamId: "team-a",
+        awayTeamId: "team-c",
+      }),
+    ).toBe("team-a");
+  });
+
+  it("detects a conflict for the candidate away team", () => {
+    expect(
+      findWeekConflict(weekThree, {
+        week: 3,
+        homeTeamId: "team-c",
+        awayTeamId: "team-b",
+      }),
+    ).toBe("team-b");
+  });
+
+  it("ignores the fixture being edited", () => {
+    expect(
+      findWeekConflict(weekThree, {
+        week: 3,
+        homeTeamId: "team-a",
+        awayTeamId: "team-b",
+        excludeFixtureId: "fixture-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when both teams are free", () => {
+    expect(
+      findWeekConflict(weekThree, {
+        week: 4,
+        homeTeamId: "team-a",
+        awayTeamId: "team-c",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/convex/e2eSeed.ts
+++ b/apps/web/convex/e2eSeed.ts
@@ -560,6 +560,8 @@ const scheduleFixtureResultValidator = v.object({
   awayTeamId: v.id("teams"),
   homeTeamName: v.string(),
   awayTeamName: v.string(),
+  extraTeamIds: v.array(v.id("teams")),
+  extraTeamNames: v.array(v.string()),
 });
 
 export const createScheduleFixture = internalMutation({
@@ -568,6 +570,12 @@ export const createScheduleFixture = internalMutation({
     clerkOrgId: v.union(v.string(), v.null()),
     homeTeamName: v.optional(v.string()),
     awayTeamName: v.optional(v.string()),
+    /*
+     * Additional teams beyond the home/away pair. A two-team league can only
+     * hold one game per week now that a team cannot be booked twice in a week,
+     * so any spec needing two fixtures in the SAME week needs a second pair.
+     */
+    extraTeamNames: v.optional(v.array(v.string())),
   },
   returns: scheduleFixtureResultValidator,
   handler: async (ctx, args) => {
@@ -617,6 +625,24 @@ export const createScheduleFixture = internalMutation({
       rosterLimit: 53,
     });
 
+    const extraTeamNames = args.extraTeamNames ?? [];
+    const extraTeamIds: Id<"teams">[] = [];
+    for (const name of extraTeamNames) {
+      extraTeamIds.push(
+        await ctx.db.insert("teams", {
+          name,
+          leagueId,
+          divisionId: null,
+          city: "Extra City",
+          stadium: "Extra Stadium",
+          foundedYear: null,
+          location: "Extra City, EC",
+          logoUrl: null,
+          rosterLimit: 53,
+        }),
+      );
+    }
+
     return {
       fixtureKey: args.fixtureKey,
       leagueId,
@@ -625,6 +651,8 @@ export const createScheduleFixture = internalMutation({
       awayTeamId,
       homeTeamName,
       awayTeamName,
+      extraTeamIds,
+      extraTeamNames,
     };
   },
 });

--- a/apps/web/convex/lib/scheduleConflicts.ts
+++ b/apps/web/convex/lib/scheduleConflicts.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure fixture scheduling rules shared by Convex writes and schedule forms.
+ * Keep this module free of Convex imports so both runtimes use identical rules.
+ */
+
+export interface WeekFixture {
+  id: string;
+  week: unknown;
+  homeTeamId: string;
+  awayTeamId: string;
+}
+
+export interface WeekFixtureCandidate {
+  week: unknown;
+  homeTeamId: string;
+  awayTeamId: string;
+  excludeFixtureId?: string;
+}
+
+/** A schedulable week is a positive integer. */
+export function isValidWeek(week: unknown): week is number {
+  return typeof week === "number" && Number.isInteger(week) && week > 0;
+}
+
+/**
+ * Return the candidate team already playing in the requested week, or null
+ * when both teams are free. An edited fixture can exclude its own persisted id.
+ */
+export function findWeekConflict(
+  existing: readonly WeekFixture[],
+  candidate: WeekFixtureCandidate,
+): string | null {
+  if (!isValidWeek(candidate.week)) return null;
+
+  for (const fixture of existing) {
+    if (fixture.id === candidate.excludeFixtureId) continue;
+    if (fixture.week !== candidate.week) continue;
+
+    if (
+      fixture.homeTeamId === candidate.homeTeamId ||
+      fixture.awayTeamId === candidate.homeTeamId
+    ) {
+      return candidate.homeTeamId;
+    }
+    if (
+      fixture.homeTeamId === candidate.awayTeamId ||
+      fixture.awayTeamId === candidate.awayTeamId
+    ) {
+      return candidate.awayTeamId;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/convex/sports.ts
+++ b/apps/web/convex/sports.ts
@@ -37,6 +37,7 @@ import {
 } from "./lib/hsSprt";
 import { applyScore, isLiveStatus, isNonNegInt } from "./lib/liveScore";
 import { isValidPeriod } from "./lib/gamePeriods";
+import { findWeekConflict, isValidWeek } from "./lib/scheduleConflicts";
 import {
   roundRobinSchedule,
   doubleRoundRobinSchedule,
@@ -4496,13 +4497,42 @@ const fixtureDtoValidator = v.object({
   createdBy: v.string(),
 });
 
+async function assertFixtureWeekAvailable(
+  ctx: MutationCtx,
+  candidate: {
+    seasonId: Id<"seasons">;
+    week: number;
+    homeTeamId: Id<"teams">;
+    awayTeamId: Id<"teams">;
+    excludeFixtureId?: Id<"fixtures">;
+  },
+): Promise<void> {
+  const fixturesThatWeek = await ctx.db
+    .query("fixtures")
+    .withIndex("by_seasonId_week", (q) =>
+      q.eq("seasonId", candidate.seasonId).eq("week", candidate.week),
+    )
+    .collect();
+
+  const conflict = findWeekConflict(
+    fixturesThatWeek.map((fixture) => ({
+      id: fixture._id,
+      week: fixture.week,
+      homeTeamId: fixture.homeTeamId,
+      awayTeamId: fixture.awayTeamId,
+    })),
+    candidate,
+  );
+  if (conflict) throw new Error("team_already_scheduled_that_week");
+}
+
 export const createFixture = internalMutationGeneric({
   args: {
     seasonId: v.id("seasons"),
     homeTeamId: v.id("teams"),
     awayTeamId: v.id("teams"),
     scheduledAt: v.union(v.string(), v.null()),
-    week: v.union(v.number(), v.null()),
+    week: v.optional(v.union(v.number(), v.null())),
     venue: v.union(v.string(), v.null()),
     actorUserId: v.string(),
   },
@@ -4513,6 +4543,7 @@ export const createFixture = internalMutationGeneric({
     }
 
     const season = await assertSeasonWritable(ctx, args.seasonId);
+    if (!isValidWeek(args.week)) throw new Error("week_required");
 
     const home = await ctx.db.get(args.homeTeamId);
     const away = await ctx.db.get(args.awayTeamId);
@@ -4523,6 +4554,13 @@ export const createFixture = internalMutationGeneric({
     ) {
       throw new Error("teams_outside_league");
     }
+
+    await assertFixtureWeekAvailable(ctx, {
+      seasonId: args.seasonId,
+      week: args.week,
+      homeTeamId: args.homeTeamId,
+      awayTeamId: args.awayTeamId,
+    });
 
     const createdAt = new Date().toISOString();
     const id = await ctx.db.insert("fixtures", {
@@ -4568,6 +4606,17 @@ export const updateFixture = internalMutationGeneric({
     const existing = await ctx.db.get(args.fixtureId);
     if (!existing) return null;
     await assertSeasonWritable(ctx, existing.seasonId);
+
+    if (args.week !== undefined) {
+      if (!isValidWeek(args.week)) throw new Error("week_required");
+      await assertFixtureWeekAvailable(ctx, {
+        seasonId: existing.seasonId,
+        week: args.week,
+        homeTeamId: existing.homeTeamId,
+        awayTeamId: existing.awayTeamId,
+        excludeFixtureId: existing._id,
+      });
+    }
 
     const patch: Record<string, unknown> = {};
     if (args.scheduledAt !== undefined) patch.scheduledAt = args.scheduledAt;

--- a/apps/web/e2e/helpers/seed-schedule.ts
+++ b/apps/web/e2e/helpers/seed-schedule.ts
@@ -18,6 +18,12 @@ export interface ScheduleFixtureConfig {
   clerkOrgId: string | null;
   homeTeamName?: string;
   awayTeamName?: string;
+  /**
+   * Teams beyond the home/away pair. A two-team league can hold only one game
+   * per week now that a team cannot be booked twice in the same week, so a
+   * spec that needs two fixtures in ONE week must seed a second pair.
+   */
+  extraTeamNames?: string[];
 }
 
 export interface ScheduleFixtureResult {
@@ -28,6 +34,8 @@ export interface ScheduleFixtureResult {
   awayTeamId: string;
   homeTeamName: string;
   awayTeamName: string;
+  extraTeamIds: string[];
+  extraTeamNames: string[];
 }
 
 const createFixtureRef = makeFunctionReference<

--- a/apps/web/e2e/tests/schedules-standings.spec.ts
+++ b/apps/web/e2e/tests/schedules-standings.spec.ts
@@ -202,6 +202,13 @@ const ACCORDION_KEY = "schedule-accordion";
 const ACC_LEAGUE_NAME = `E2E:${ACCORDION_KEY}`;
 const ACC_HOME = "E2E Acc Home";
 const ACC_AWAY = "E2E Acc Away";
+/*
+ * A "mixed" week needs one final game and one scheduled game in the SAME week,
+ * which takes four teams: a team can no longer be booked twice in one week, so
+ * the original pair cannot supply both fixtures.
+ */
+const ACC_HOME_2 = "E2E Acc Home 2";
+const ACC_AWAY_2 = "E2E Acc Away 2";
 
 test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
   let fixture: ScheduleFixtureResult | null = null;
@@ -215,6 +222,7 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
       clerkOrgId: orgId,
       homeTeamName: ACC_HOME,
       awayTeamName: ACC_AWAY,
+      extraTeamNames: [ACC_HOME_2, ACC_AWAY_2],
     });
     fixture = handle.fixture;
     teardown = handle.teardown;
@@ -296,8 +304,10 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
     await expect(page.getByText("21 – 7")).toBeHidden();
     await expect(weekCard(page, 2).getByText("Scheduled")).toBeVisible();
 
-    // Add a second Week 1 game → the week becomes MIXED and opens.
-    await createFixture(page, 1, ACC_AWAY, ACC_HOME);
+    // Add a second Week 1 game → the week becomes MIXED and opens. It uses the
+    // second pair of teams: the original two already play in Week 1, and a team
+    // can no longer be booked twice in the same week.
+    await createFixture(page, 1, ACC_HOME_2, ACC_AWAY_2);
     await page.reload();
     await expect(week1Trigger).toHaveAttribute("aria-expanded", "true");
 
@@ -335,8 +345,8 @@ test.describe("Schedule lifecycle accordion (WSM-000239)", () => {
     await recordResult(
       page,
       weekCard(page, 1),
-      new RegExp(`${ACC_AWAY} \\(home\\)`),
-      new RegExp(`${ACC_HOME} \\(away\\)`),
+      new RegExp(`${ACC_HOME_2} \\(home\\)`),
+      new RegExp(`${ACC_AWAY_2} \\(away\\)`),
       10,
       13,
     );

--- a/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
+++ b/apps/web/src/app/dashboard/leagues/[id]/schedule/actions.ts
@@ -6,6 +6,7 @@ import { schedulesStandingsV1 } from "@/lib/flags";
 import {
   createFixture,
   deleteFixture,
+  updateFixture,
   generateSeasonSchedule,
   getLeague,
   getLeagueOrgId,
@@ -130,6 +131,56 @@ export async function createFixtureAction(
     return { ok: true, id: fixture.id };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("week_required")) {
+      return { ok: false, error: "week_required" };
+    }
+    if (message.includes("team_already_scheduled_that_week")) {
+      return { ok: false, error: "team_already_scheduled_that_week" };
+    }
+    if (message.includes("season_completed")) {
+      return { ok: false, error: "season_completed" };
+    }
+    return { ok: false, error: message };
+  }
+}
+
+export async function assignFixtureWeekAction(input: {
+  leagueId: string;
+  fixtureId: string;
+  week: number;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const guard = await authorizeManagerAction(input.leagueId);
+  if (!guard.ok) return guard;
+
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const fixture = await getFixture(input.fixtureId).catch(() => null);
+  if (!fixture) return { ok: false, error: "fixture_not_found" };
+
+  const orgContext = await resolveOrgContext(userId);
+  const seasonGuard = await assertSeasonBelongsToLeague(
+    fixture.seasonId,
+    input.leagueId,
+    orgContext,
+  );
+  if (!seasonGuard.ok) return seasonGuard;
+
+  try {
+    await updateFixture({ fixtureId: input.fixtureId, week: input.week });
+    revalidatePath(`/dashboard/seasons/${fixture.seasonId}/schedule`);
+    revalidatePath(`/dashboard/seasons/${fixture.seasonId}/standings`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/schedule`);
+    revalidatePath(`/dashboard/leagues/${input.leagueId}/standings`);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("week_required")) {
+      return { ok: false, error: "week_required" };
+    }
+    if (message.includes("team_already_scheduled_that_week")) {
+      return { ok: false, error: "team_already_scheduled_that_week" };
+    }
     if (message.includes("season_completed")) {
       return { ok: false, error: "season_completed" };
     }

--- a/apps/web/src/components/schedule/AssignFixtureWeekDialog.tsx
+++ b/apps/web/src/components/schedule/AssignFixtureWeekDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { assignFixtureWeekAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { isValidWeek } from "@/lib/schedule/schedule-conflicts";
+
+export default function AssignFixtureWeekDialog({
+  leagueId,
+  fixtureId,
+  homeTeamName,
+  awayTeamName,
+}: {
+  leagueId: string;
+  fixtureId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [week, setWeek] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setWeek("");
+      setError(null);
+    }
+  }
+
+  function handleSubmit() {
+    const weekNumber = Number(week);
+    if (week.trim() === "" || !isValidWeek(weekNumber)) {
+      setError("Enter a positive whole-number week.");
+      return;
+    }
+
+    setError(null);
+    startTransition(async () => {
+      const result = await assignFixtureWeekAction({
+        leagueId,
+        fixtureId,
+        week: weekNumber,
+      });
+      if (result.ok) {
+        toast.success(`Fixture assigned to Week ${weekNumber}.`);
+        handleOpenChange(false);
+      } else {
+        setError(mapError(result.error));
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          Assign week
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Assign week</DialogTitle>
+          <DialogDescription>
+            Schedule {awayTeamName} at {homeTeamName} into a numbered week.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2 py-2">
+          <Label htmlFor={`assign-week-${fixtureId}`}>Week</Label>
+          <Input
+            id={`assign-week-${fixtureId}`}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            step={1}
+            required
+            placeholder="1"
+            value={week}
+            aria-invalid={error !== null}
+            aria-describedby={error ? `assign-week-error-${fixtureId}` : undefined}
+            onChange={(event) => {
+              setWeek(event.target.value);
+              setError(null);
+            }}
+          />
+          {error ? (
+            <p
+              id={`assign-week-error-${fixtureId}`}
+              className="text-sm text-destructive"
+            >
+              {error}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => handleOpenChange(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={pending}>
+            {pending ? "Assigning…" : "Assign week"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function mapError(code: string): string {
+  switch (code) {
+    case "week_required":
+      return "Enter a positive whole-number week.";
+    case "team_already_scheduled_that_week":
+      return "One of these teams already has a game that week.";
+    case "fixture_not_found":
+      return "Fixture not found.";
+    case "season_completed":
+      return "Completed seasons cannot be changed.";
+    case "season_league_mismatch":
+    case "league_not_found":
+    case "league_not_owned":
+      return "League access denied.";
+    case "unauthorized":
+      return "Sign in required.";
+    case "not_authorized":
+      return "You do not have permission to edit this schedule.";
+    default:
+      return code;
+  }
+}

--- a/apps/web/src/components/schedule/FixtureFormDialog.tsx
+++ b/apps/web/src/components/schedule/FixtureFormDialog.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { createFixtureAction } from "@/app/dashboard/leagues/[id]/schedule/actions";
+import { isValidWeek } from "@/lib/schedule/schedule-conflicts";
 
 export interface FixtureFormDialogProps {
   leagueId: string;
@@ -39,6 +40,7 @@ export default function FixtureFormDialog({
   const [awayTeamId, setAwayTeamId] = useState<string>("");
   const [scheduledAt, setScheduledAt] = useState<string>("");
   const [week, setWeek] = useState<string>("");
+  const [weekError, setWeekError] = useState<string | null>(null);
   const [venue, setVenue] = useState<string>("");
   const [pending, startTransition] = useTransition();
 
@@ -47,6 +49,7 @@ export default function FixtureFormDialog({
     setAwayTeamId("");
     setScheduledAt("");
     setWeek("");
+    setWeekError(null);
     setVenue("");
   }
 
@@ -60,11 +63,12 @@ export default function FixtureFormDialog({
       return;
     }
 
-    const weekNum = week.trim() === "" ? null : Number(week);
-    if (weekNum !== null && !Number.isFinite(weekNum)) {
-      toast.error("Week must be a number.");
+    const weekNum = Number(week);
+    if (week.trim() === "" || !isValidWeek(weekNum)) {
+      setWeekError("Enter a positive whole-number week.");
       return;
     }
+    setWeekError(null);
 
     startTransition(async () => {
       const result = await createFixtureAction({
@@ -136,11 +140,25 @@ export default function FixtureFormDialog({
               <Label htmlFor="fix-week">Week</Label>
               <Input
                 id="fix-week"
+                type="number"
                 inputMode="numeric"
+                min={1}
+                step={1}
+                required
                 placeholder="1"
                 value={week}
-                onChange={(e) => setWeek(e.target.value)}
+                aria-invalid={weekError !== null}
+                aria-describedby={weekError ? "fix-week-error" : undefined}
+                onChange={(e) => {
+                  setWeek(e.target.value);
+                  setWeekError(null);
+                }}
               />
+              {weekError ? (
+                <p id="fix-week-error" className="text-sm text-destructive">
+                  {weekError}
+                </p>
+              ) : null}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="fix-date">Date / time</Label>
@@ -200,6 +218,10 @@ function mapError(code: string): string {
       return "Team not found.";
     case "teams_outside_league":
       return "Both teams must belong to this league.";
+    case "week_required":
+      return "Enter a positive whole-number week.";
+    case "team_already_scheduled_that_week":
+      return "One of those teams already has a game that week.";
     default:
       return code;
   }

--- a/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
+++ b/apps/web/src/components/schedule/ScheduleFixtureRow.tsx
@@ -12,6 +12,7 @@ import { WeatherChip } from "@/components/dynasty/WeatherChip";
 import { deriveWeather } from "@/lib/pbp/weather";
 import RecordResultDialog from "@/components/schedule/RecordResultDialog";
 import DeleteFixtureButton from "@/components/schedule/DeleteFixtureButton";
+import AssignFixtureWeekDialog from "@/components/schedule/AssignFixtureWeekDialog";
 import GoLiveControl from "@/components/schedule/GoLiveControl";
 import ClipsControl from "@/components/schedule/ClipsControl";
 import { SimulateGameButton } from "@/components/schedule/SimulateControls";
@@ -191,6 +192,14 @@ export function ScheduleFixtureRow({
               ) : null}
               {canMutate && fixture.status === "scheduled" ? (
                 <SimulateGameButton
+                  leagueId={leagueId}
+                  fixtureId={fixture.id}
+                  homeTeamName={fixture.homeTeamName}
+                  awayTeamName={fixture.awayTeamName}
+                />
+              ) : null}
+              {canMutate && fixture.week === null ? (
+                <AssignFixtureWeekDialog
                   leagueId={leagueId}
                   fixtureId={fixture.id}
                   homeTeamName={fixture.homeTeamName}

--- a/apps/web/src/lib/schedule/schedule-conflicts.ts
+++ b/apps/web/src/lib/schedule/schedule-conflicts.ts
@@ -1,0 +1,10 @@
+/**
+ * Fixture scheduling rules — canonical implementation lives under `convex/`
+ * because writes enforce the same week constraints server-side.
+ */
+export {
+  findWeekConflict,
+  isValidWeek,
+  type WeekFixture,
+  type WeekFixtureCandidate,
+} from "../../../convex/lib/scheduleConflicts";


### PR DESCRIPTION
Closes the scheduling defect found while dogfooding.

## What was actually wrong
A league showed Weeks 1–15 with 8 games each (all played) **plus** a separate "Unscheduled" bucket of 7 fixtures with `week: null`. One team appeared in three of them, which read as double-booking.

**It wasn't double-booking, and round-robin was not the cause.** `roundRobin.ts` uses the circle method, so one game per team per round is structural. Two real gaps produced it:

1. `FixtureFormDialog` mapped an empty week input to `null` and `createFixture` accepted it — so a fixture could be created with no week and stayed in the TBD bucket forever. Simulating it sets a result but never a week, which is why simming the season didn't clear it.
2. Nothing rejected a second fixture for a team in a week that already had one.

## What changed
- **`convex/lib/scheduleConflicts.ts`** — pure rules (`isValidWeek`, `findWeekConflict`), re-exported from `src/lib/schedule/schedule-conflicts.ts`.
- **`createFixture`** rejects a missing/invalid week (`week_required`) and a booked team (`team_already_scheduled_that_week`).
- **`updateFixture`** applies both when the week changes, excluding the fixture itself so an edit can re-save; nulling a week back out is refused.
- Lookup uses the **`by_seasonId_week` index** — one indexed read, no scan, no `ctx.db.get` per fixture.
- **Week is now required** in the fixture dialog, with the server errors surfaced as readable messages.
- **"Assign week"** on week-less rows, so the existing 7 games can be repaired instead of being permanently stuck.

## Deliberately unchanged
- **The schema field stays nullable.** Existing rows legitimately have no week and must keep loading — this is a new-writes rule, not a migration. Your 7 stray games stay until you assign or delete them.
- Bulk generation and playoff creation insert directly rather than through `createFixture`, so they're unaffected.

## Verification
- `vitest run` — 241 files, 1905 tests passed (+20)
- `pnpm turbo type-check --force` — 5/5
- `lint` — clean
- diff is +152/−5 across 10 files

A round-robin invariant test now pins one-game-per-team-per-week across odd and even team counts — pinning a property that was already true, so a future change can't break it silently.